### PR TITLE
MES-936/932 - Prevent proceeding beyond declaration consent after clearing signature + remove recording consent

### DIFF
--- a/src/pages/declaration-consent/declaration-consent.html
+++ b/src/pages/declaration-consent/declaration-consent.html
@@ -40,14 +40,6 @@
         <label for="check-residence">I confirm</label>
       </div>
       <div class="mes-divider"></div>
-      <br>
-      <span class="mes-text-md">Debrief audio recording Lorem ipsum, dolor sit amet consectetur adipisicing elit. Molestiae ipsum libero odit totam.
-        Fugiat, tempora cumque nostrum quas facere temporibus (optional).</span>
-      <div>
-        <input type="checkbox" name="debrief" id="check-debrief" [checked]="checkDebrief" (change)="updateValidation('checkDebrief')">
-        <label for="check-debrief">I confirm</label>
-      </div>
-      <div class="mes-divider"></div>
     </ion-card-content>
   </ion-card>
   <ion-card text-center>

--- a/src/pages/declaration-consent/declaration-consent.ts
+++ b/src/pages/declaration-consent/declaration-consent.ts
@@ -6,7 +6,6 @@ import { AppConfigProvider } from '../../providers/app-config/app-config';
 import { PretestChecksPage } from '../pretest-checks/pretest-checks';
 import { EndTestReasonPage } from '../end-test-reason/end-test-reason';
 import { Page } from 'ionic-angular/navigation/nav-util';
-import { FaultStoreProvider } from '../../providers/fault-store/fault-store';
 
 import { SignaturePad } from 'angular2-signaturepad/signature-pad';
 
@@ -29,7 +28,6 @@ export class DeclarationConsentPage {
 
   checkInsurance: boolean = false;
   checkResidence: boolean = false;
-  checkDebrief: boolean = false;
 
   @ViewChild(SignaturePad) signaturePad: SignaturePad;
 
@@ -37,8 +35,7 @@ export class DeclarationConsentPage {
     public navCtrl: NavController,
     public navParams: NavParams,
     public configService: AppConfigProvider,
-    private deviceAuth: DeviceAuthentication,
-    private faultStore: FaultStoreProvider
+    private deviceAuth: DeviceAuthentication
   ) {
     this.signaturePadOptions = configService.getSignaturePadOptions();
   }
@@ -81,13 +78,11 @@ export class DeclarationConsentPage {
       .runAuthentication('Please authenticate yourself to proceed')
       .then((isAuthenticated: boolean) => {
         if (isAuthenticated) {
-          this.faultStore.setDebriefConsentStatus(this.checkDebrief);
           this.navCtrl.push(this.pretestChecksPage);
         }
       })
       .catch((errorMsg: string) => {
         if (errorMsg === 'cordova_not_available' || errorMsg === 'plugin_not_installed') {
-          this.faultStore.setDebriefConsentStatus(this.checkDebrief);
           this.navCtrl.push(this.pretestChecksPage);
         }
       });

--- a/src/pages/declaration-consent/declaration-consent.ts
+++ b/src/pages/declaration-consent/declaration-consent.ts
@@ -56,6 +56,7 @@ export class DeclarationConsentPage {
 
   clearSignaturePad() {
     this.signaturePad.clear();
+    this.signature = null;
   }
 
   drawStart() {}

--- a/src/pages/test-result/test-result.ts
+++ b/src/pages/test-result/test-result.ts
@@ -1,7 +1,7 @@
 import { TestSummaryMetadataProvider } from './../../providers/test-summary-metadata/test-summary-metadata';
 import { AudioRecorderProvider } from './../../providers/audio-recorder/audio-recorder';
 import { Component } from '@angular/core';
-import { NavController, NavParams, ToastController, Platform } from 'ionic-angular';
+import { NavController, NavParams, Platform } from 'ionic-angular';
 import { Page } from 'ionic-angular/navigation/nav-util';
 import { PostTestSummaryPage } from '../post-test-summary/post-test-summary';
 import { FaultStoreProvider } from '../../providers/fault-store/fault-store';
@@ -30,14 +30,12 @@ export class TestResultPage {
   isRecording;
   fileLength;
   isCordova: boolean;
-  debriefConsent = false;
 
   constructor(
     public navCtrl: NavController,
     public navParams: NavParams,
     private faultStore: FaultStoreProvider,
     private summaryMetadataService: TestSummaryMetadataProvider,
-    private toastCtrl: ToastController,
     private audioRecorder: AudioRecorderProvider,
     private platform: Platform
   ) {
@@ -46,17 +44,7 @@ export class TestResultPage {
       .subscribe((faultSummaries) => (this.faultSummaries = faultSummaries));
     this.testResult = this.faultStore.getTestResult();
     this.summaryMetadata = this.summaryMetadataService.getMetadata();
-    this.debriefConsent = this.faultStore.getDebriefConsentStatus();
     this.isCordova = this.platform.is('cordova');
-
-    if (this.debriefConsent && this.isCordova) {
-      const toast = this.toastCtrl.create({
-        message: 'Candidate has given permission to be recorded',
-        position: 'bottom',
-        duration: 3000
-      });
-      toast.present();
-    }
 
     this.audioRecorder.isRecordingChange.subscribe((newValue) => {
       this.isRecording = newValue;

--- a/src/providers/fault-store/fault-store.ts
+++ b/src/providers/fault-store/fault-store.ts
@@ -30,7 +30,6 @@ export class FaultStoreProvider {
   drivingFaultsNumber = 0;
   seriousFaultsNumber = 0;
   dangerousFaultsNumber = 0;
-  debriefConsent = false;
 
   constructor(
     private store: NgRedux<IState>,
@@ -76,14 +75,6 @@ export class FaultStoreProvider {
     }
 
     return key;
-  }
-
-  getDebriefConsentStatus() {
-    return this.debriefConsent;
-  }
-
-  setDebriefConsentStatus(status: boolean) {
-    this.debriefConsent = status;
   }
 
   calculateFaultTotals(): ITestResults {


### PR DESCRIPTION
The enabled state of the continue button is determined by a combination of the insurance/residency checkboxes and the signature. Fixing failure to unset signature in component after clearing signature pad.