### PR TITLE
MES-1147 Solving the multiple driving fault bug on Manoeuvres 

### DIFF
--- a/src/components/all-on-one-form-sub-element-hold-no-modal/all-on-one-form-sub-element-hold-no-modal.ts
+++ b/src/components/all-on-one-form-sub-element-hold-no-modal/all-on-one-form-sub-element-hold-no-modal.ts
@@ -79,7 +79,12 @@ export class AllOnOneFormSubElementHoldNoModalComponent {
       return;
     }
     // Prevent more than one fault being added to controlled stop
-    if ((this.section === 'controlledStop' || this.section === 'showMe') && this.faultCounter > 0)
+    if (
+      (this.section === 'controlledStop' ||
+        this.section === 'showMe' ||
+        this.section.startsWith('manoeuvre')) &&
+      this.faultCounter > 0
+    )
       return;
     this.faultStore.addFault(this.section, 'fault');
   }


### PR DESCRIPTION
## Description and relevant Jira numbers

Jira ticket number MES-1147

Making sure that DE can only record one driving fault against Manoeuvres _Control_ and _Observations_ actions.

Screenshot would not be applicable here.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [x] PO's approval
