### PR TITLE
MES-1054 - Added the ability to put Components in the Help Module

### DIFF
--- a/src/help/components/components.module.ts
+++ b/src/help/components/components.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { IonicModule } from 'ionic-angular';
+import { HelpHeader } from './help-header/help-header';
+
+@NgModule({
+  declarations: [HelpHeader],
+  imports: [IonicModule],
+  exports: [HelpHeader]
+})
+export class HelpComponentsModule {}

--- a/src/help/components/help-header/help-header.html
+++ b/src/help/components/help-header/help-header.html
@@ -1,0 +1,18 @@
+<ion-navbar hideBackButton no-padding class="mes-header-lg">
+    <ion-grid>
+        <ion-row align-items-center>
+            <ion-col>
+                <ion-icon name="ios-help-circle-outline" class="header-help-icon"></ion-icon>
+                <span>{{title}}</span>
+            </ion-col>
+            <ion-col>
+                <ion-buttons end>
+                    <button ion-button="bar-button" icon-start class="header-close-button" (click)="closePopup()" (press)="closePopup()">
+                        <ion-icon name="ios-close" class="header-close-icon"></ion-icon>
+                        <span>Close</span>
+                    </button>
+                </ion-buttons>
+            </ion-col>
+        </ion-row>
+    </ion-grid>
+</ion-navbar>

--- a/src/help/components/help-header/help-header.scss
+++ b/src/help/components/help-header/help-header.scss
@@ -1,0 +1,19 @@
+help-header {
+  color: map-get($colors, gds-black);
+
+  .toolbar-background {
+    background: linear-gradient(-180deg, #edc628 0%, #c2a11f 100%);
+  }
+  .header-help-icon {
+    font-size: 24px !important;
+    font-weight: bold !important;
+    margin: 0 12px 0 8px;
+  }
+  .header-close-button {
+    color: map-get($colors, gds-black);
+    font-weight: bold;
+  }
+  .header-close-icon {
+    font-weight: bold !important;
+  }
+}

--- a/src/help/components/help-header/help-header.ts
+++ b/src/help/components/help-header/help-header.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from '@angular/core';
+import { NavController } from 'ionic-angular';
+
+@Component({
+  selector: 'help-header',
+  templateUrl: 'help-header.html'
+})
+export class HelpHeader {
+  @Input()
+  title: string;
+
+  constructor(public navCtrl: NavController) {}
+
+  closePopup(): void {
+    this.navCtrl.pop();
+  }
+}

--- a/src/help/help.module.ts
+++ b/src/help/help.module.ts
@@ -7,6 +7,7 @@ import { NgModule } from '@angular/core';
 import { IonicModule } from 'ionic-angular';
 import { HelpDebriefPage } from './pages/help-debrief/help-debrief';
 import { ComponentsModule } from '../components/components.module';
+import { HelpComponentsModule } from './components/components.module';
 
 @NgModule({
   declarations: [
@@ -17,7 +18,7 @@ import { ComponentsModule } from '../components/components.module';
     HelpTestReportPage,
     HelpWaitingRoomToCarPage
   ],
-  imports: [IonicModule.forRoot(HelpSectionPage), ComponentsModule],
+  imports: [IonicModule.forRoot(HelpSectionPage), ComponentsModule, HelpComponentsModule],
   entryComponents: [
     HelpDebriefPage,
     HelpFinalisationSubmissionPage,


### PR DESCRIPTION
## Description and relevant Jira numbers

This is a quick PR so that both devs in appy tappers can create any custom components needed for the help pages in the help module.

This PR also includes a part completed help-header which is not visible on any pages as of yet

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
