### PR TITLE
Fix scrolling of journal page on long dates

### DIFF
--- a/src/components/journal-header/journal-header.html
+++ b/src/components/journal-header/journal-header.html
@@ -1,30 +1,30 @@
 <div>
   <ion-row align-items-center>
-    <ion-col col-4>
+    <ion-col>
       <div>
         <span class="journal-header-day-navigation">◄ Previous day</span>
       </div>
     </ion-col>
-    <ion-col col-4>
+    <ion-col col-5>
       <div>
         <span class="journal-header-today-title">Today</span>
       </div>
     </ion-col>
-    <ion-col col-4>
+    <ion-col>
       <div>
         <span class="journal-header-day-navigation">Next day ►</span>
       </div>
     </ion-col>
   </ion-row>
   <ion-row>
-    <ion-col col-4>
+    <ion-col>
     </ion-col>
-    <ion-col col-4>
+    <ion-col col-5>
       <div>
         <span class="mes-header-lg">{{getDate()}}</span>
       </div>
     </ion-col>
-    <ion-col col-4>
+    <ion-col>
       <div>
         <span class="mes-text-md">Last sync: {{getLastSyncTime()}}</span>
       </div>


### PR DESCRIPTION
On long days, there was wrapping occurring on the date at the top of the journal page, causing the page to scroll. Increase the size the centre column to prevent this.