### PR TITLE
MES-1371 mock staff ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,14 +91,6 @@
         "tslib": "^1.7.1"
       }
     },
-    "@auth0/angular-jwt": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@auth0/angular-jwt/-/angular-jwt-1.2.0.tgz",
-      "integrity": "sha512-T2t8ed4/g/w5aniVmOJ7AieTrQ9iU7urAbzRBx5OToY4UeEzzng+yP4yk114Xwoi3iV9AS4zhqMqgKcQ3vNvxA==",
-      "requires": {
-        "url": "^0.11.0"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -16661,6 +16653,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -16669,7 +16662,8 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -815,6 +815,11 @@
       "integrity": "sha512-NVQEMviDWjuen3UW+mU1J6fZ0WhOfG1yRce/2OTcbaz+fgmTw2cahx6N2wh0Yl+a+hg2UZj/oElZmtULWyGIsA==",
       "dev": true
     },
+    "@types/jwt-decode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-2.2.1.tgz",
+      "integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A=="
+    },
     "@types/lodash": {
       "version": "4.14.118",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.118.tgz",
@@ -10454,6 +10459,11 @@
           "dev": true
         }
       }
+    },
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
     },
     "kind-of": {
       "version": "3.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,14 @@
         "tslib": "^1.7.1"
       }
     },
+    "@auth0/angular-jwt": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@auth0/angular-jwt/-/angular-jwt-1.2.0.tgz",
+      "integrity": "sha512-T2t8ed4/g/w5aniVmOJ7AieTrQ9iU7urAbzRBx5OToY4UeEzzng+yP4yk114Xwoi3iV9AS4zhqMqgKcQ3vNvxA==",
+      "requires": {
+        "url": "^0.11.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -16653,7 +16661,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -16662,8 +16669,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@ionic/storage": "2.2.0",
     "@ngrx/effects": "^5.2.0",
     "@ngrx/store": "^5.2.0",
+    "@types/jwt-decode": "^2.2.1",
     "aws-sdk": "^2.382.0",
     "aws4": "^1.8.0",
     "cordova-ios": "4.5.5",
@@ -69,6 +70,7 @@
     "ionic-angular": "3.9.2",
     "ionicons": "3.0.0",
     "moment": "^2.23.0",
+    "jwt-decode": "^2.2.0",
     "rxjs": "^5.5.11",
     "sw-toolbox": "3.6.0",
     "zone.js": "0.8.26"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@angular/http": "5.2.11",
     "@angular/platform-browser": "5.2.11",
     "@angular/platform-browser-dynamic": "5.2.11",
+    "@auth0/angular-jwt": "^1.2.0",
     "@ionic-native/core": "~4.17.0",
     "@ionic-native/in-app-browser": "^4.18.0",
     "@ionic-native/ms-adal": "^4.18.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@angular/http": "5.2.11",
     "@angular/platform-browser": "5.2.11",
     "@angular/platform-browser-dynamic": "5.2.11",
-    "@auth0/angular-jwt": "^1.2.0",
     "@ionic-native/core": "~4.17.0",
     "@ionic-native/in-app-browser": "^4.18.0",
     "@ionic-native/ms-adal": "^4.18.0",

--- a/src/environment/environment.dev.ts
+++ b/src/environment/environment.dev.ts
@@ -12,6 +12,7 @@ export const environment : EnvironmentFile = {
     logoutUrl: 'https://login.windows.net/6c448d90-4ca1-4caf-ab59-0a2aa67d7801/oauth2/logout',
     openIdConnectUrl: 'sts.windows.net/6c448d90-4ca1-4caf-ab59-0a2aa67d7801',
     identityPoolId: 'eu-west-1:f5a0346e-9bbb-4153-affd-bbe59cd5b7a3',
+    employeeIdKey: 'extn.employeeId'
   },
   aws: {
     region: 'eu-west-1',

--- a/src/environment/environment.staging.ts
+++ b/src/environment/environment.staging.ts
@@ -10,6 +10,7 @@ export const environment: EnvironmentFile = {
     clientId: '',
     redirectUrl: '',
     logoutUrl: '',
+    employeeIdKey: ''
   },
   journal: {
     journalUrl: '',

--- a/src/environment/models/environment.model.ts
+++ b/src/environment/models/environment.model.ts
@@ -11,6 +11,7 @@ export type EnvironmentFile = {
     logoutUrl: string,
     openIdConnectUrl?: string,
     identityPoolId?: string,
+    employeeIdKey: string
   },
   aws?: {
     region: string;

--- a/src/pages/journal/journal.html
+++ b/src/pages/journal/journal.html
@@ -23,6 +23,7 @@
   </button>
   <button ion-button navPush="ContactDetailsPage">Contact Details</button>
   <button ion-button navPush="WaitingRoomPage">Waiting Room</button>
+  <span>Employee Id: {{employeeId}}</span>
   <ion-list>
     <ng-template #slotContainer></ng-template>
   </ion-list>

--- a/src/pages/journal/journal.ts
+++ b/src/pages/journal/journal.ts
@@ -39,6 +39,7 @@ export class JournalPage extends BasePageComponent implements OnInit, OnDestroy 
 
   toast: Toast;
   subscription: Subscription;
+  employeeId: string;
   start = '2018-12-10T08:10:00+00:00';
 
   constructor(
@@ -53,6 +54,7 @@ export class JournalPage extends BasePageComponent implements OnInit, OnDestroy 
     private resolver: ComponentFactoryResolver
   ) {
     super(platform, navController, authenticationProvider);
+    this.employeeId = this.authenticationProvider.getEmployeeId();
   }
 
   ngOnInit(): void {

--- a/src/providers/app-config/__mocks__/app-config.mock.ts
+++ b/src/providers/app-config/__mocks__/app-config.mock.ts
@@ -24,6 +24,7 @@ export class AppConfigProviderMock {
         logoutUrl: localEnvironmentMock.authentication.logoutUrl,
         openIdConnectUrl: localEnvironmentMock.authentication.openIdConnectUrl,
         identityPoolId: localEnvironmentMock.authentication.identityPoolId,
+        employeeIdKey: localEnvironmentMock.authentication.employeeIdKey
       },
       aws: {
         region: localEnvironmentMock.aws.region

--- a/src/providers/app-config/__mocks__/environment.mock.ts
+++ b/src/providers/app-config/__mocks__/environment.mock.ts
@@ -17,6 +17,7 @@ export const localEnvironmentMock: EnvironmentFile = {
     logoutUrl: 'local-logout-url',
     openIdConnectUrl: 'local-openIdConnectUrl',
     identityPoolId: 'local-identityPoolId',
+    employeeIdKey: 'local-employeeIdKey'
   },
   aws: {
     region: 'aws-region'

--- a/src/providers/app-config/app-config.model.ts
+++ b/src/providers/app-config/app-config.model.ts
@@ -9,6 +9,7 @@ export type AppConfig = {
     logoutUrl: string,
     openIdConnectUrl?: string,
     identityPoolId?: string,
+    employeeIdKey: string
   },
   aws?: {
     region: string,

--- a/src/providers/app-config/app-config.ts
+++ b/src/providers/app-config/app-config.ts
@@ -54,6 +54,7 @@ export class AppConfigProvider {
         logoutUrl: data.authentication.logoutUrl,
         openIdConnectUrl: data.authentication.openIdConnectUrl,
         identityPoolId: data.authentication.identityPoolId,
+        employeeIdKey: data.authentication.employeeIdKey
       },
       aws: {
         region: data.aws.region,

--- a/src/providers/authentication/__mocks__/authentication.mock.ts
+++ b/src/providers/authentication/__mocks__/authentication.mock.ts
@@ -4,6 +4,8 @@ export class AuthenticationProviderMock {
 
   getAuthenticationToken = jest.fn().mockReturnValue('token');
 
+  getEmployeeId = jest.fn().mockReturnValue('a');
+
   login = jest.fn(() => {
     return new Promise(() => {});
   })

--- a/src/providers/authentication/__mocks__/ms-adal.mock.ts
+++ b/src/providers/authentication/__mocks__/ms-adal.mock.ts
@@ -12,7 +12,7 @@ export class AuthenticationContextMock {
   acquireTokenSilentAsync(resourceUrl: string, clientId: string, emptyString: string) {
     return new Promise((resolve, reject) => {
       resolve({
-        accessToken: 'SILENT AYSNC TEST TOKEN'
+        accessToken: 'U0lMRU5UIEFZU05DIFRFU1QgVE9LRU4'
       });
     })
   }
@@ -26,7 +26,7 @@ export class AuthenticationContextMock {
   ) {
     return new Promise((resolve, reject) => {
       resolve({
-        accessToken: 'AYSNC TEST TOKEN'
+        accessToken: 'QVlTTkMgVEVTVCBUT0tFTg=='
       });
     });
   }

--- a/src/providers/authentication/__tests__/authentication.spec.ts
+++ b/src/providers/authentication/__tests__/authentication.spec.ts
@@ -27,6 +27,9 @@ describe('Authentication', () => {
 
   beforeEach(() => {
     authenticationProvider = TestBed.get(AuthenticationProvider)
+    authenticationProvider.jwtDecode = () => ({
+      'local-employeeIdKey': ['a']
+    });
   });
 
   describe('Provider', () => {
@@ -47,14 +50,21 @@ describe('Authentication', () => {
       await authenticationProvider.login();
 
       expect(authenticationProvider.isAuthenticated()).toEqual(true);
-      expect(authenticationProvider.getAuthenticationToken()).toEqual('SILENT AYSNC TEST TOKEN')
+      expect(authenticationProvider.getAuthenticationToken()).toEqual('U0lMRU5UIEFZU05DIFRFU1QgVE9LRU4')
     });
 
     it('should sign in with credetials', async() => {
       await authenticationProvider.loginWithCredentials();
 
       expect(authenticationProvider.isAuthenticated()).toEqual(true);
-      expect(authenticationProvider.getAuthenticationToken()).toEqual('AYSNC TEST TOKEN');
+      expect(authenticationProvider.getAuthenticationToken()).toEqual('QVlTTkMgVEVTVCBUT0tFTg==');
+    });
+
+    it('should set the correct employeeId', async() => {
+      await authenticationProvider.login();
+
+      expect(authenticationProvider.isAuthenticated()).toEqual(true);
+      expect(authenticationProvider.getEmployeeId()).toEqual('a');
     });
 
     it('should do something when login fails', async () => {

--- a/src/providers/authentication/authentication.ts
+++ b/src/providers/authentication/authentication.ts
@@ -3,14 +3,16 @@ import { MSAdal, AuthenticationContext, AuthenticationResult } from '@ionic-nati
 import { InAppBrowser, InAppBrowserOptions } from '@ionic-native/in-app-browser';
 import { AppConfigProvider } from '../app-config/app-config';
 import { ToastController } from 'ionic-angular';
-import { JwtHelperService } from '@auth0/angular-jwt';
+import jwtDecode from 'jwt-decode';
 
 @Injectable()
 export class AuthenticationProvider {
 
   public authenticationSettings: any;
+  private employeeIdKey: string;
   private employeeId: string;
   private authenticationToken: string;
+  public jwtDecode: any;
 
   constructor(
     private msAdal: MSAdal,
@@ -18,6 +20,8 @@ export class AuthenticationProvider {
     public toastController: ToastController,
     appConfig: AppConfigProvider) {
     this.authenticationSettings = appConfig.getAppConfig().authentication;
+    this.employeeIdKey = appConfig.getAppConfig().authentication.employeeIdKey;
+    this.jwtDecode = jwtDecode;
   }
 
   isAuthenticated = (): boolean => {
@@ -102,9 +106,8 @@ export class AuthenticationProvider {
 
   private successfulLogin = (authResponse: AuthenticationResult) => {
     const { accessToken } = authResponse;
-    const helper: JwtHelperService = new JwtHelperService();
-    const decodedToken = helper.decodeToken(accessToken);
-    const employeeId = decodedToken['extn.employeeId'][0];
+    const decodedToken = this.jwtDecode(accessToken);
+    const employeeId = decodedToken[this.employeeIdKey][0];
     this.authenticationToken = accessToken;
     this.employeeId = employeeId;
   };

--- a/src/providers/authentication/authentication.ts
+++ b/src/providers/authentication/authentication.ts
@@ -3,12 +3,13 @@ import { MSAdal, AuthenticationContext, AuthenticationResult } from '@ionic-nati
 import { InAppBrowser, InAppBrowserOptions } from '@ionic-native/in-app-browser';
 import { AppConfigProvider } from '../app-config/app-config';
 import { ToastController } from 'ionic-angular';
+import { JwtHelperService } from '@auth0/angular-jwt';
 
 @Injectable()
 export class AuthenticationProvider {
 
   public authenticationSettings: any;
-  
+  private employeeId: string;
   private authenticationToken: string;
 
   constructor(
@@ -25,6 +26,10 @@ export class AuthenticationProvider {
 
   getAuthenticationToken = (): string => {
     return this.authenticationToken;
+  };
+
+  getEmployeeId = (): string => {
+    return this.employeeId;
   };
 
   login = () => {
@@ -96,7 +101,12 @@ export class AuthenticationProvider {
   };
 
   private successfulLogin = (authResponse: AuthenticationResult) => {
-    this.authenticationToken = authResponse.accessToken;
+    const { accessToken } = authResponse;
+    const helper: JwtHelperService = new JwtHelperService();
+    const decodedToken = helper.decodeToken(accessToken);
+    const employeeId = decodedToken['extn.employeeId'][0];
+    this.authenticationToken = accessToken;
+    this.employeeId = employeeId;
   };
 
   private failedLogin = (error: any) => {


### PR DESCRIPTION
## Description and relevant Jira numbers

Pulls in a new package to help decode the JWT from Azure AD allowing us to retrieve `employeeId`. This is pulled into the journal screen and displayed as an example.

As part of the this work, I created 8 different user accounts with different employee Ids which we can use in the [future story](https://jira.i-env.net/browse/MES-1421) to retrieve journal data based on employee id.

The full list of user accounts, credentials and employee ids are available [here](https://wiki.i-env.net/display/MES/Azure+AD+%28dev%29+test+users+and+staff+id%27s). You can add these accounts to your Authenticator app and then switch between them easily when logging into the app -

![img_d606d588ec4b-1](https://user-images.githubusercontent.com/33695049/50963621-226a1080-14c5-11e9-9399-5ffa81e04ef2.jpeg)

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [x] Tested by QA
- [ ] PO's approval
