### PR TITLE
Component library typography improvements

### DIFF
--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -16,7 +16,7 @@
     {
       "slotDetail": {
         "slotId": 8165,
-        "start": "2019-01-24T08:00:00+00:00",
+        "start": "2019-01-25T08:00:00+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -64,7 +64,7 @@
     {
       "slotDetail": {
         "slotId": 9620,
-        "start": "2019-01-23T08:58:03+00:00",
+        "start": "2019-01-24T08:58:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -112,7 +112,7 @@
     {
       "slotDetail": {
         "slotId": 6887,
-        "start": "2019-01-23T09:56:00+00:00",
+        "start": "2019-01-24T09:56:00+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -160,7 +160,7 @@
     {
       "slotDetail": {
         "slotId": 2396,
-        "start": "2019-01-23T11:25:03+00:00",
+        "start": "2019-01-24T11:25:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -208,7 +208,7 @@
     {
       "slotDetail": {
         "slotId": 1813,
-        "start": "2019-01-23T12:10:03+00:00",
+        "start": "2019-01-24T12:10:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -256,7 +256,7 @@
     {
       "slotDetail": {
         "slotId": 7027,
-        "start": "2019-01-23T13:00:03+00:00",
+        "start": "2019-01-24T13:00:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -304,7 +304,7 @@
     {
       "slotDetail": {
         "slotId": 9134,
-        "start": "2019-01-23T14:35:03+00:00",
+        "start": "2019-01-24T14:35:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -352,7 +352,7 @@
     {
       "slotDetail": {
         "slotId": 9593,
-        "start": "2019-01-23T15:50:03+00:00",
+        "start": "2019-01-24T15:50:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -400,7 +400,7 @@
     {
       "slotDetail": {
         "slotId": 7386,
-        "start": "2019-01-24T07:11:01+00:00",
+        "start": "2019-01-25T07:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -448,7 +448,7 @@
     {
       "slotDetail": {
         "slotId": 8143,
-        "start": "2019-01-24T08:11:01+00:00",
+        "start": "2019-01-25T08:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -496,7 +496,7 @@
     {
       "slotDetail": {
         "slotId": 2853,
-        "start": "2019-01-24T09:11:01+00:00",
+        "start": "2019-01-25T09:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -544,7 +544,7 @@
     {
       "slotDetail": {
         "slotId": 9123,
-        "start": "2019-01-24T10:11:01+00:00",
+        "start": "2019-01-25T10:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -592,7 +592,7 @@
     {
       "slotDetail": {
         "slotId": 7919,
-        "start": "2019-01-24T13:11:01+00:00",
+        "start": "2019-01-25T13:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -640,7 +640,7 @@
     {
       "slotDetail": {
         "slotId": 1868,
-        "start": "2019-01-24T14:11:01+00:00",
+        "start": "2019-01-25T14:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -688,7 +688,7 @@
     {
       "slotDetail": {
         "slotId": 2379,
-        "start": "2019-01-24T15:11:01+00:00",
+        "start": "2019-01-25T15:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -736,7 +736,7 @@
     {
       "slotDetail": {
         "slotId": 9483,
-        "start": "2019-01-24T16:11:01+00:00",
+        "start": "2019-01-25T16:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -784,7 +784,7 @@
     {
       "slotDetail": {
         "slotId": 6623,
-        "start": "2019-01-25T08:23:37+00:00",
+        "start": "2019-01-26T08:23:37+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -832,7 +832,7 @@
     {
       "slotDetail": {
         "slotId": 8342,
-        "start": "2019-01-25T09:13:37+00:00",
+        "start": "2019-01-26T09:13:37+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -880,7 +880,7 @@
     {
       "slotDetail": {
         "slotId": 9137,
-        "start": "2019-01-25T10:00:37+00:00",
+        "start": "2019-01-26T10:00:37+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -928,7 +928,7 @@
     {
       "slotDetail": {
         "slotId": 3522,
-        "start": "2019-01-25T11:23:37+00:00",
+        "start": "2019-01-26T11:23:37+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -976,7 +976,7 @@
     {
       "slotDetail": {
         "slotId": 8556,
-        "start": "2019-01-25T12:53:37+00:00",
+        "start": "2019-01-26T12:53:37+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1024,7 +1024,7 @@
     {
       "slotDetail": {
         "slotId": 2946,
-        "start": "2019-01-25T14:00:37+00:00",
+        "start": "2019-01-26T14:00:37+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1072,7 +1072,7 @@
     {
       "slotDetail": {
         "slotId": 3696,
-        "start": "2019-01-26T08:00:03+00:00",
+        "start": "2019-01-27T08:00:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1120,7 +1120,7 @@
     {
       "slotDetail": {
         "slotId": 3385,
-        "start": "2019-01-26T08:59:43+00:00",
+        "start": "2019-01-27T08:59:43+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1168,7 +1168,7 @@
     {
       "slotDetail": {
         "slotId": 1338,
-        "start": "2019-01-26T09:55:43+00:00",
+        "start": "2019-01-27T09:55:43+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1216,7 +1216,7 @@
     {
       "slotDetail": {
         "slotId": 5956,
-        "start": "2019-01-26T11:00:43+00:00",
+        "start": "2019-01-27T11:00:43+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1264,7 +1264,7 @@
     {
       "slotDetail": {
         "slotId": 6008,
-        "start": "2019-01-26T13:00:43+00:00",
+        "start": "2019-01-27T13:00:43+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1312,7 +1312,7 @@
     {
       "slotDetail": {
         "slotId": 6659,
-        "start": "2019-01-26T13:59:43+00:00",
+        "start": "2019-01-27T13:59:43+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1360,7 +1360,7 @@
     {
       "slotDetail": {
         "slotId": 9260,
-        "start": "2019-01-27T11:25:10+00:00",
+        "start": "2019-01-28T11:25:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1408,7 +1408,7 @@
     {
       "slotDetail": {
         "slotId": 1681,
-        "start": "2019-01-27T13:00:10+00:00",
+        "start": "2019-01-28T13:00:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1456,7 +1456,7 @@
     {
       "slotDetail": {
         "slotId": 4558,
-        "start": "2019-01-27T13:55:10+00:00",
+        "start": "2019-01-28T13:55:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1504,7 +1504,7 @@
     {
       "slotDetail": {
         "slotId": 7201,
-        "start": "2019-01-27T14:39:10+00:00",
+        "start": "2019-01-28T14:39:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1552,7 +1552,7 @@
     {
       "slotDetail": {
         "slotId": 5841,
-        "start": "2019-01-27T15:15:10+00:00",
+        "start": "2019-01-28T15:15:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1600,7 +1600,7 @@
     {
       "slotDetail": {
         "slotId": 1048,
-        "start": "2019-01-27T16:43:10+00:00",
+        "start": "2019-01-28T16:43:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1648,7 +1648,7 @@
     {
       "slotDetail": {
         "slotId": 6655,
-        "start": "2019-01-27T17:05:10+00:00",
+        "start": "2019-01-28T17:05:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1696,7 +1696,7 @@
     {
       "slotDetail": {
         "slotId": 1570,
-        "start": "2019-01-28T09:00:44+00:00",
+        "start": "2019-01-29T09:00:44+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1744,7 +1744,7 @@
     {
       "slotDetail": {
         "slotId": 5527,
-        "start": "2019-01-28T09:33:44+00:00",
+        "start": "2019-01-29T09:33:44+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1792,7 +1792,7 @@
     {
       "slotDetail": {
         "slotId": 2379,
-        "start": "2019-01-28T09:55:44+00:00",
+        "start": "2019-01-29T09:55:44+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1840,7 +1840,7 @@
     {
       "slotDetail": {
         "slotId": 4039,
-        "start": "2019-01-28T11:25:44+00:00",
+        "start": "2019-01-29T11:25:44+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1888,7 +1888,7 @@
     {
       "slotDetail": {
         "slotId": 8182,
-        "start": "2019-01-28T13:25:44+00:00",
+        "start": "2019-01-29T13:25:44+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1936,7 +1936,7 @@
     {
       "slotDetail": {
         "slotId": 6825,
-        "start": "2019-01-28T15:25:44+00:00",
+        "start": "2019-01-29T15:25:44+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1985,7 +1985,7 @@
   "personalCommitments": [
     {
       "commitmentId": 123400,
-      "startDate": "2019-01-24",
+      "startDate": "2019-01-25",
       "startTime": "10:00:00+01:00",
       "endDate": "2019-01-21",
       "endTime": "11:00:00+01:00",
@@ -1994,7 +1994,7 @@
     },
     {
       "commitmentId": 123401,
-      "startDate": "2019-01-22",
+      "startDate": "2019-01-23",
       "endDate": "2019-01-20",
       "activityCode": "081",
       "activityDescription": "Annual Leave"
@@ -2004,7 +2004,7 @@
     {
       "slotDetail": {
         "slotId": 1001,
-        "start": "2019-01-24T08:40:00+00:00",
+        "start": "2019-01-25T08:40:00+00:00",
         "duration": 57
       },
       "activityCode": "091",
@@ -2018,7 +2018,7 @@
     {
       "slotDetail": {
         "slotId": 1100,
-        "start": "2019-01-24T11:45:00+00:00",
+        "start": "2019-01-25T11:45:00+00:00",
         "duration": 57
       },
       "activityCode": "091",
@@ -2032,7 +2032,7 @@
     {
       "slotDetail": {
         "slotId": 1193,
-        "start": "2019-01-25T11:11:00+00:00",
+        "start": "2019-01-26T11:11:00+00:00",
         "duration": 57
       },
       "activityCode": "091",
@@ -2047,7 +2047,7 @@
   "advanceTestSlots": [
     {
       "slotId": 1300,
-      "start": "2019-01-24T06:00:00+00:00",
+      "start": "2019-01-25T06:00:00+00:00",
       "duration": 90,
       "centreId": 76543,
       "centreName": "Example Test Centre 3",

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -14,6 +14,8 @@
 // for the .md, .ios, or .wp mode classes. The mode class is
 // automatically applied to the <body> element in the app.
 
+@import '../theme/sass-partials/reset.scss';
+
 @import '../theme/mixins/_box-shadow.scss';
 @import '../theme/sass-partials/_typography.scss';
 @import '../theme/sass-partials/_fonts.scss';

--- a/src/pages/candidate-details/candidate-details.html
+++ b/src/pages/candidate-details/candidate-details.html
@@ -19,7 +19,7 @@
   
   <ion-card>
     <ion-card-header>
-      <h3>Candidate details</h3>
+      <h4>Candidate details</h4>
     </ion-card-header>
     <ion-card-content>
       <ion-grid>
@@ -83,7 +83,7 @@
   </ion-card>
   <ion-card>
     <ion-card-header>
-      <h3>Contact details</h3>
+      <h4>Contact details</h4>
     </ion-card-header>
     <ion-card-content>
       <ion-grid>

--- a/src/pages/component-library/component-library.html
+++ b/src/pages/component-library/component-library.html
@@ -6,7 +6,7 @@
 
 <ion-content padding>
   <typography></typography>
-  <!-- <buttons></buttons>
+  <buttons></buttons>
   <data-rows></data-rows>
-  <color-palette></color-palette> -->
+  <color-palette></color-palette>
 </ion-content>

--- a/src/pages/component-library/component-library.html
+++ b/src/pages/component-library/component-library.html
@@ -6,7 +6,7 @@
 
 <ion-content padding>
   <typography></typography>
-  <buttons></buttons>
+  <!-- <buttons></buttons>
   <data-rows></data-rows>
-  <color-palette></color-palette>
+  <color-palette></color-palette> -->
 </ion-content>

--- a/src/pages/component-library/components/typography/typography.html
+++ b/src/pages/component-library/components/typography/typography.html
@@ -39,24 +39,16 @@
       </ion-row>
       <ion-row>
         <ion-col>
-          <h5>H5 header</h5>
+          <a>This is a link</a>
         </ion-col>
         <ion-col>
-          <code>h5 html tag</code>
-        </ion-col>
-      </ion-row>
-      <ion-row>
-        <ion-col>
-          <h5>H6 header</h5>
-        </ion-col>
-        <ion-col>
-          <code>h6 html tag</code>
+          <code>a html tag</code>
         </ion-col>
       </ion-row>
     </ion-grid>
   </ion-card-content>
 
-  <ion-card-header>
+  <!-- <ion-card-header>
     <ion-card-title>Paragraph</ion-card-title>
   </ion-card-header>
   <ion-card-content>
@@ -74,5 +66,5 @@
       <div>
         <i>italic element</i>
       </div>
-    </ion-card-content>
+    </ion-card-content> -->
 </ion-card>

--- a/src/pages/component-library/components/typography/typography.html
+++ b/src/pages/component-library/components/typography/typography.html
@@ -45,26 +45,22 @@
           <code>a html tag</code>
         </ion-col>
       </ion-row>
+      <ion-row>
+        <ion-col>
+          <label>label in a row</label>
+        </ion-col>
+        <ion-col>
+          <code>label html tag</code>
+        </ion-col>
+      </ion-row>
+      <ion-row>
+        <ion-col>
+          <div class="mes-data">data in a row</div>
+        </ion-col>
+        <ion-col>
+          <code>mes-data class on div tag</code>
+        </ion-col>
+      </ion-row>
     </ion-grid>
   </ion-card-content>
-
-  <!-- <ion-card-header>
-    <ion-card-title>Paragraph</ion-card-title>
-  </ion-card-header>
-  <ion-card-content>
-    <div style="margin-bottom: 16px;">This is a simple html p element</div>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque consectetur leo non ante gravida, at pretium lorem porta. Ut eget massa dictum, posuere tellus et, lacinia ipsum. Proin blandit neque id porta malesuada. Maecenas rutrum fermentum hendrerit. Curabitur eu sapien vitae purus vehicula aliquet vitae eget augue. Aliquam erat tortor, vestibulum vitae facilisis dignissim, pulvinar eu ante. Mauris vestibulum sed ante vitae fermentum. Curabitur ut tristique sem, non convallis ipsum. In auctor, turpis ut egestas scelerisque, libero orci sollicitudin turpis, nec accumsan nunc nulla quis dui.</p>
-  </ion-card-content>
-
-  <ion-card-header>
-      <ion-card-title>Inline elements</ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <div>
-        <a>anchor element</a>
-      </div>
-      <div>
-        <i>italic element</i>
-      </div>
-    </ion-card-content> -->
 </ion-card>

--- a/src/pages/journal/components/activity-slot/activity-slot.html
+++ b/src/pages/journal/components/activity-slot/activity-slot.html
@@ -10,10 +10,10 @@
       </div>
     </ion-col>
     <ion-col class="title-column" col-auto>
-      <h5 class="title">{{getTitle()}}</h5>
+      <h3 class="title">{{getTitle()}}</h3>
     </ion-col>
     <ion-col class="activity-code-column">
-      <h4 class="activity-code">{{formatActivityCode()}}</h4>
+      <h2 class="activity-code">{{formatActivityCode()}}</h2>
     </ion-col>
   </ion-row>
 </ion-card>

--- a/src/pages/journal/components/candidate-link/__tests__/candidate-link.spec.ts
+++ b/src/pages/journal/components/candidate-link/__tests__/candidate-link.spec.ts
@@ -43,7 +43,7 @@ describe('CandidateLinkComponent', () => {
   describe('DOM', () => {
 
     it('should display candidate name', () => {
-      const nameSpan: HTMLElement = fixture.debugElement.query(By.css('ion-row:first-child h5'))
+      const nameSpan: HTMLElement = fixture.debugElement.query(By.css('ion-row:first-child h3'))
         .nativeElement;
       fixture.detectChanges();
       expect(nameSpan.textContent).toBe('Mr Joe Bloggs');

--- a/src/pages/journal/components/candidate-link/candidate-link.html
+++ b/src/pages/journal/components/candidate-link/candidate-link.html
@@ -2,7 +2,7 @@
   <ion-grid>
     <ion-row align-items-left [ngClass]="{'candidate-grid-row' : isPortrait}">
       <ion-col>
-        <h5 class="candidate-name">{{name.title}} {{name.firstName}} {{name.lastName}}</h5>
+        <h3 class="candidate-name">{{name.title}} {{name.firstName}} {{name.lastName}}</h3>
       </ion-col>
       <ion-col col-auto *ngIf="welshLanguage">
         <img src="assets/imgs/journal/Welsh.png" class="welsh-language-indicator" />

--- a/src/pages/journal/components/time/__tests__/time.spec.ts
+++ b/src/pages/journal/components/time/__tests__/time.spec.ts
@@ -38,7 +38,7 @@ describe('TimeComponent', () => {
 
     describe('Time output ', () => {
       it('should be displayed', () => {
-        const timeSpan: HTMLElement = componentEl.query(By.css('ion-row:first-child span'))
+        const timeSpan: HTMLElement = componentEl.query(By.css('ion-row:first-child h2'))
           .nativeElement;
         fixture.detectChanges();
         expect(timeSpan.textContent).toBe('10:04');
@@ -48,7 +48,7 @@ describe('TimeComponent', () => {
     describe('class if test complete ', () => {
       it('should be time-test-complete-text', () => {
         fixture.detectChanges();
-        const timeSpan: any = componentEl.query(By.css('ion-row:first-child span'));
+        const timeSpan: any = componentEl.query(By.css('ion-row:first-child h2'));
         expect(timeSpan.classes['time-test-complete-text']).toBeTruthy();
       });
     });

--- a/src/pages/journal/components/time/time.html
+++ b/src/pages/journal/components/time/time.html
@@ -2,7 +2,7 @@
   <ion-grid>
     <ion-row align-items-left>
       <ion-col>
-        <span class="time-text" [ngClass]="{'time-test-complete-text': testComplete}">{{time | date: "HH:mm" }}</span>
+        <h2 [ngClass]="{'time-test-complete-text': testComplete}">{{time | date: "HH:mm" }}</h2>
       </ion-col>
     </ion-row>
   </ion-grid>

--- a/src/pages/journal/components/time/time.scss
+++ b/src/pages/journal/components/time/time.scss
@@ -2,8 +2,4 @@ time {
     &.time-test-complete-text {
         color: map-get($colors-gds, gds-grey-1);
       }
-      .time-text {
-        font-weight: bold;
-        font-size: 28px;
-      }
 }

--- a/src/pages/login/login.html
+++ b/src/pages/login/login.html
@@ -5,20 +5,20 @@
 <ion-content>
   <div class="login-grid">
     <div *ngIf="hasUserLoggedOut">
-      <h2> You've signed out</h2>
-      <h5> <span class="link" (click)="login()">Sign in</span> again.</h5>
+      <h2>You've signed out</h2>
+      <h3> <span class="link" (click)="login()">Sign in</span> again.</h3>
     </div>
     <div *ngIf="isInternetConnectionError()">
       <h2>You're offline</h2>
-      <h5>Close the app, turn on mobile data or wifi, and then try again.</h5>
+      <h3>Close the app, turn on mobile data or wifi, and then try again.</h3>
     </div>
     <div *ngIf="isUserCancelledError()">
       <h2>You've cancelled sign in</h2>
-      <h5><span class="link" (click)="login()">Sign in</span> to continue.</h5>
+      <h3><span class="link" (click)="login()">Sign in</span> to continue.</h3>
     </div>
     <div *ngIf="isUnknownError()">
         <h2>Sorry, something went wrong</h2>
-        <h5>Please try again later.</h5>
+        <h3>Please try again later.</h3>
     </div>
   </div>
 </ion-content>

--- a/src/theme/sass-partials/_reset.scss
+++ b/src/theme/sass-partials/_reset.scss
@@ -1,0 +1,11 @@
+
+h1, h2, h3, h4, a, a:hover, label {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+  vertical-align: baseline;
+  text-decoration: none;
+  color: black;
+}

--- a/src/theme/sass-partials/_typography.scss
+++ b/src/theme/sass-partials/_typography.scss
@@ -1,50 +1,62 @@
-.bold-family {
-  font-family: GDSTransportWebsite-Bold;
+
+.heavy-font-family {
+  font-family: "Roboto";
+  font-weight: 900;
 }
 
-.normal-family {
-  font-family: GDSTransportWebsite;
+.semibold-font-family {
+  font-family: "Roboto";
+  font-weight: 500;
 }
+
+.regular-font-family {
+  font-family: "Roboto";
+  font-weight: 400;
+};
 
 h1 {
-  @extend .bold-family;
-  font-size: 48px;
-  margin-bottom: 36px;
+  @extend .heavy-font-family;
+  font-size: 40px;
 }
 
 h2 {
-  @extend .bold-family;
-  font-size: 44px;
+  @extend .heavy-font-family;
+  font-size: 28px;
 }
 
 h3 {
-  @extend .bold-family;
-  font-size: 36px;
+  @extend .semibold-font-family;
+  font-size: 20px;
 }
 
 h4 {
-  @extend .normal-family;
+  @extend .heavy-font-family;
   font-size: 24px;
 }
 
-h5 {
-  @extend .normal-family;
-  font-size: 19px;
+a {
+  @extend .semibold-font-family;
+  font-size: 20px;
 }
 
-h6 {
-  @extend .normal-family;
-  font-size: 16px;
+a:hover {
+  @extend .semibold-font-family;
+  font-size: 20px;
 }
 
 label {
-  @extend .bold-family;
-  font-size: 19px;
+  @extend .semibold-font-family;
+  font-size: 20px;
 }
 
 .mes-data {
-  @extend .normal-family;
-  font-size: 19px;
+  @extend .regular-font-family;
+  font-size: 20px;
+}
+
+p {
+  @extend .regular-font-family;
+  font-size: 15px;
 }
 
 // Override some ionic defaults. There will be more to follow


### PR DESCRIPTION
## Description and relevant Jira numbers

Implementing typography in the component library. Also cleaning up the application where these changes apply.

We are using Roboto font-family for the time being. Because San Francisco font is restricted only for iOS devices. So we need to find out how the licensing applies here before we start using it.

This is a weekly activity what we are doing with Oli - next week we are planning to take a look at the colour palette and implement the correct design for a card. Also will extend the component library page so that it has more information about the different components (when to use it, how to use it etc.)

<img width="655" alt="screenshot 2019-01-25 at 16 12 57" src="https://user-images.githubusercontent.com/7311745/51757735-19c82b80-20bc-11e9-84ff-4da9e7ce920c.png">

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
