### PR TITLE
Ensure selected journal day can't be before today

### DIFF
--- a/src/common/__tests__/date-time.spec.ts
+++ b/src/common/__tests__/date-time.spec.ts
@@ -13,4 +13,17 @@ describe('DateTime', () => {
     expect(today.daysDiff(tomorrowString)).toBe(1);
     expect(today.daysDiff(yesterdayString)).toBe(-1);
   });
+
+  it('should construct from text and calculate the difference of a future date', () => {
+    expect(DateTime.at('2019-02-13').daysUntil('2019-02-14')).toBe(1);
+  });
+
+  it('should construct from text and calculate the difference of a past date', () => {
+    expect(DateTime.at('2019-02-13').daysUntil('2019-02-12')).toBe(-1);
+  });
+
+  it('should construct from default and calculate the difference of a future date', () => {
+    const futureDate = DateTime.now().add(1, Duration.DAY);
+    expect(DateTime.now().daysUntil(futureDate)).toBe(1);
+  });
 });

--- a/src/common/date-time.ts
+++ b/src/common/date-time.ts
@@ -50,6 +50,11 @@ export class DateTime {
   toString(): string {
     return this.moment.toString();
   }
+
+  daysUntil(targetDate: DateTime | string | Date): number {
+    const date = new DateTime(targetDate);
+    return date.moment.startOf(Duration.DAY).diff(this.moment.startOf(Duration.DAY), Duration.DAY);
+  }
 }
 
 export enum Duration {

--- a/src/pages/journal/__tests__/journal.reducer.spec.ts
+++ b/src/pages/journal/__tests__/journal.reducer.spec.ts
@@ -1,7 +1,9 @@
 import { initialState, journalReducer } from '../journal.reducer';
 import { LoadJournal, LoadJournalSuccess, UnloadJournal, UnsetError, ClearChangedSlot } from '../journal.actions';
 import { SlotItem } from '../../../providers/slot-selector/slot-item';
-import { DateTime } from '../../../common/date-time';
+import { DateTime, Duration } from '../../../common/date-time';
+
+const today = DateTime.now().format('YYYY-MM-DD');
 
 describe('Journal Reducer', () => {
 
@@ -30,7 +32,7 @@ describe('Journal Reducer', () => {
   describe('[JournalPage] Load Journal Success', () => {
     it('should toggle loading state and populate slots', () => {
       const actionPayload = {
-        '2019-01-17': [{
+        [`${today}`]: [{
           hasSlotChanged: false,
           slotData: {},
         },
@@ -44,7 +46,7 @@ describe('Journal Reducer', () => {
         isLoading: false,
         lastRefreshed: jasmine.any(Date),
         slots: {
-          '2019-01-17': [{
+          [`${today}`]: [{
             hasSlotChanged: false,
             slotData: {},
           },
@@ -52,11 +54,32 @@ describe('Journal Reducer', () => {
         },
       });
     });
+
+    it('should set the selected date to today if it was yesterday', () => {
+      const yesterday = DateTime.now().add(-1, Duration.DAY).format('YYYY-MM-DD');
+      const actionPayload = {
+        [`${today}`]: [{
+          hasSlotChanged: false,
+          slotData: {},
+        },
+        ],
+      };
+      const stateWithYesterdaysDate = {
+        ...initialState,
+        slots: {
+          [`${yesterday}`] : [new SlotItem({ slotDetail: { slotId:1234 } }, true)],
+        },
+        selectedDate: yesterday,
+      };
+      const action = new LoadJournalSuccess(actionPayload);
+      const result = journalReducer(stateWithYesterdaysDate, action);
+      expect(result.selectedDate).toEqual(today);
+    });
   });
 
   describe('[JournalPage] Unload Journal', () => {
     it('should clear the journal slots', () => {
-      const stateWithJournals = { ...initialState, slots: { '2019-01-21': [new SlotItem({}, false)] } };
+      const stateWithJournals = { ...initialState, slots: { [`${today}`]: [new SlotItem({}, false)] } };
       const action = new UnloadJournal();
       const result = journalReducer(stateWithJournals, action);
       expect(result.slots).toEqual({});

--- a/src/pages/journal/journal.reducer.ts
+++ b/src/pages/journal/journal.reducer.ts
@@ -21,9 +21,14 @@ export function journalReducer(state = initialState, action: journalActions.Type
         error: { message: '', status: 0, statusText: '' },
       };
     case journalActions.LOAD_JOURNAL_SUCCESS:
+      const date = DateTime.now().daysUntil(state.selectedDate) < 0
+      ? DateTime.now().format('YYYY-MM-DD')
+      : state.selectedDate;
+
       return {
         ...state,
         lastRefreshed: new Date(),
+        selectedDate: date,
         isLoading: false,
         slots: action.payload,
       };


### PR DESCRIPTION
Add a method to calculate difference between dates; ensure selected day is always today or greater

## Description and relevant Jira numbers

## Pull Request checklist:

- [X] [WIP] tag removed from PR title
- [X] PR has an understandable description

## Git feature branch checklist:

- [X] branch name comply with our branching strategy
- [X] git branch contains relevant JIRA ticket number
- [X] branch rebased against the latest develop
- [X] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
