### PR TITLE
Guard against the special needs text being null

### DIFF
--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -16,7 +16,7 @@
     {
       "slotDetail": {
         "slotId": 8165,
-        "start": "2019-02-15T08:00:00+00:00",
+        "start": "2019-02-19T08:00:00+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -64,7 +64,7 @@
     {
       "slotDetail": {
         "slotId": 9620,
-        "start": "2019-02-15T08:58:03+00:00",
+        "start": "2019-02-19T08:58:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -112,7 +112,7 @@
     {
       "slotDetail": {
         "slotId": 6887,
-        "start": "2019-02-15T09:56:00+00:00",
+        "start": "2019-02-19T09:56:00+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -160,7 +160,7 @@
     {
       "slotDetail": {
         "slotId": 2396,
-        "start": "2019-02-15T11:25:03+00:00",
+        "start": "2019-02-19T11:25:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -208,7 +208,7 @@
     {
       "slotDetail": {
         "slotId": 1813,
-        "start": "2019-02-15T12:10:03+00:00",
+        "start": "2019-02-19T12:10:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -256,7 +256,7 @@
     {
       "slotDetail": {
         "slotId": 7027,
-        "start": "2019-02-15T13:00:03+00:00",
+        "start": "2019-02-19T13:00:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -304,7 +304,7 @@
     {
       "slotDetail": {
         "slotId": 9134,
-        "start": "2019-02-15T14:35:03+00:00",
+        "start": "2019-02-19T14:35:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -352,7 +352,7 @@
     {
       "slotDetail": {
         "slotId": 9593,
-        "start": "2019-02-15T15:50:03+00:00",
+        "start": "2019-02-19T15:50:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -400,7 +400,7 @@
     {
       "slotDetail": {
         "slotId": 7386,
-        "start": "2019-02-16T07:11:01+00:00",
+        "start": "2019-02-20T07:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -448,7 +448,7 @@
     {
       "slotDetail": {
         "slotId": 8143,
-        "start": "2019-02-16T08:11:01+00:00",
+        "start": "2019-02-20T08:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -496,7 +496,7 @@
     {
       "slotDetail": {
         "slotId": 2853,
-        "start": "2019-02-16T09:11:01+00:00",
+        "start": "2019-02-20T09:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -544,7 +544,7 @@
     {
       "slotDetail": {
         "slotId": 9123,
-        "start": "2019-02-16T10:11:01+00:00",
+        "start": "2019-02-20T10:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -592,7 +592,7 @@
     {
       "slotDetail": {
         "slotId": 7919,
-        "start": "2019-02-16T13:11:01+00:00",
+        "start": "2019-02-20T13:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -640,7 +640,7 @@
     {
       "slotDetail": {
         "slotId": 1868,
-        "start": "2019-02-16T14:11:01+00:00",
+        "start": "2019-02-20T14:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -688,7 +688,7 @@
     {
       "slotDetail": {
         "slotId": 2379,
-        "start": "2019-02-16T15:11:01+00:00",
+        "start": "2019-02-20T15:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -736,7 +736,7 @@
     {
       "slotDetail": {
         "slotId": 9483,
-        "start": "2019-02-16T16:11:01+00:00",
+        "start": "2019-02-20T16:11:01+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -784,7 +784,7 @@
     {
       "slotDetail": {
         "slotId": 6623,
-        "start": "2019-02-19T08:23:37+00:00",
+        "start": "2019-02-23T08:23:37+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -832,7 +832,7 @@
     {
       "slotDetail": {
         "slotId": 8342,
-        "start": "2019-02-19T09:13:37+00:00",
+        "start": "2019-02-23T09:13:37+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -880,7 +880,7 @@
     {
       "slotDetail": {
         "slotId": 9137,
-        "start": "2019-02-19T10:00:37+00:00",
+        "start": "2019-02-23T10:00:37+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -928,7 +928,7 @@
     {
       "slotDetail": {
         "slotId": 3522,
-        "start": "2019-02-19T11:23:37+00:00",
+        "start": "2019-02-23T11:23:37+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -976,7 +976,7 @@
     {
       "slotDetail": {
         "slotId": 8556,
-        "start": "2019-02-19T12:53:37+00:00",
+        "start": "2019-02-23T12:53:37+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1024,7 +1024,7 @@
     {
       "slotDetail": {
         "slotId": 2946,
-        "start": "2019-02-19T14:00:37+00:00",
+        "start": "2019-02-23T14:00:37+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1072,7 +1072,7 @@
     {
       "slotDetail": {
         "slotId": 3696,
-        "start": "2019-02-23T08:00:03+00:00",
+        "start": "2019-02-27T08:00:03+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1120,7 +1120,7 @@
     {
       "slotDetail": {
         "slotId": 3385,
-        "start": "2019-02-23T08:59:43+00:00",
+        "start": "2019-02-27T08:59:43+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1168,7 +1168,7 @@
     {
       "slotDetail": {
         "slotId": 1338,
-        "start": "2019-02-23T09:55:43+00:00",
+        "start": "2019-02-27T09:55:43+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1216,7 +1216,7 @@
     {
       "slotDetail": {
         "slotId": 5956,
-        "start": "2019-02-23T11:00:43+00:00",
+        "start": "2019-02-27T11:00:43+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1264,7 +1264,7 @@
     {
       "slotDetail": {
         "slotId": 6008,
-        "start": "2019-02-23T13:00:43+00:00",
+        "start": "2019-02-27T13:00:43+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1312,7 +1312,7 @@
     {
       "slotDetail": {
         "slotId": 6659,
-        "start": "2019-02-23T13:59:43+00:00",
+        "start": "2019-02-27T13:59:43+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1360,7 +1360,7 @@
     {
       "slotDetail": {
         "slotId": 9260,
-        "start": "2019-02-28T11:25:10+00:00",
+        "start": "2019-03-04T11:25:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1408,7 +1408,7 @@
     {
       "slotDetail": {
         "slotId": 1681,
-        "start": "2019-02-28T13:00:10+00:00",
+        "start": "2019-03-04T13:00:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1456,7 +1456,7 @@
     {
       "slotDetail": {
         "slotId": 4558,
-        "start": "2019-02-28T13:55:10+00:00",
+        "start": "2019-03-04T13:55:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1504,7 +1504,7 @@
     {
       "slotDetail": {
         "slotId": 7201,
-        "start": "2019-02-28T14:39:10+00:00",
+        "start": "2019-03-04T14:39:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1552,7 +1552,7 @@
     {
       "slotDetail": {
         "slotId": 5841,
-        "start": "2019-02-28T15:15:10+00:00",
+        "start": "2019-03-04T15:15:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1600,7 +1600,7 @@
     {
       "slotDetail": {
         "slotId": 1048,
-        "start": "2019-02-28T16:43:10+00:00",
+        "start": "2019-03-04T16:43:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1648,7 +1648,7 @@
     {
       "slotDetail": {
         "slotId": 6655,
-        "start": "2019-02-28T17:05:10+00:00",
+        "start": "2019-03-04T17:05:10+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1696,7 +1696,7 @@
     {
       "slotDetail": {
         "slotId": 1570,
-        "start": "2019-03-06T09:00:44+00:00",
+        "start": "2019-03-11T09:00:44+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1744,7 +1744,7 @@
     {
       "slotDetail": {
         "slotId": 5527,
-        "start": "2019-03-06T09:33:44+00:00",
+        "start": "2019-03-11T09:33:44+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1792,7 +1792,7 @@
     {
       "slotDetail": {
         "slotId": 2379,
-        "start": "2019-03-06T09:55:44+00:00",
+        "start": "2019-03-11T09:55:44+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1840,7 +1840,7 @@
     {
       "slotDetail": {
         "slotId": 4039,
-        "start": "2019-03-06T11:25:44+00:00",
+        "start": "2019-03-11T11:25:44+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1888,7 +1888,7 @@
     {
       "slotDetail": {
         "slotId": 8182,
-        "start": "2019-03-06T13:25:44+00:00",
+        "start": "2019-03-11T13:25:44+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1936,7 +1936,7 @@
     {
       "slotDetail": {
         "slotId": 6825,
-        "start": "2019-03-06T15:25:44+00:00",
+        "start": "2019-03-11T15:25:44+00:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -1985,7 +1985,7 @@
   "personalCommitments": [
     {
       "commitmentId": 123400,
-      "startDate": "2019-02-15",
+      "startDate": "2019-02-19",
       "startTime": "10:00:00+01:00",
       "endDate": "2019-01-21",
       "endTime": "11:00:00+01:00",
@@ -1994,7 +1994,7 @@
     },
     {
       "commitmentId": 123401,
-      "startDate": "2019-02-15",
+      "startDate": "2019-02-19",
       "endDate": "2019-01-20",
       "activityCode": "081",
       "activityDescription": "Annual Leave"
@@ -2004,7 +2004,7 @@
     {
       "slotDetail": {
         "slotId": 1001,
-        "start": "2019-02-15T08:40:00+00:00",
+        "start": "2019-02-19T08:40:00+00:00",
         "duration": 57
       },
       "activityCode": "091",
@@ -2018,7 +2018,7 @@
     {
       "slotDetail": {
         "slotId": 1100,
-        "start": "2019-02-15T11:45:00+00:00",
+        "start": "2019-02-19T11:45:00+00:00",
         "duration": 57
       },
       "activityCode": "091",
@@ -2032,7 +2032,7 @@
     {
       "slotDetail": {
         "slotId": 1193,
-        "start": "2019-02-21T11:11:00+00:00",
+        "start": "2019-02-26T11:11:00+00:00",
         "duration": 57
       },
       "activityCode": "091",
@@ -2047,7 +2047,7 @@
   "advanceTestSlots": [
     {
       "slotId": 1300,
-      "start": "2019-02-15T06:00:00+00:00",
+      "start": "2019-02-19T06:00:00+00:00",
       "duration": 90,
       "centreId": 76543,
       "centreName": "Example Test Centre 3",

--- a/src/pages/journal/components/test-slot/__tests__/test-slot.spec.ts
+++ b/src/pages/journal/components/test-slot/__tests__/test-slot.spec.ts
@@ -182,6 +182,21 @@ describe('TestSlotComponent', () => {
         expect(component.isPortrait()).toBeFalsy();
       });
     });
+
+    describe('isSpecialNeedsSlot', () => {
+      it('should return true if there is a non-empty special needs string', () => {
+        component.slot.booking.application.specialNeeds = 'something';
+        expect(component.isSpecialNeedsSlot()).toBe(true);
+      });
+      it('should return false if special needs is an empty string', () => {
+        component.slot.booking.application.specialNeeds = '';
+        expect(component.isSpecialNeedsSlot()).toBe(false);
+      });
+      it('should return false if special needs is null', () => {
+        component.slot.booking.application.specialNeeds = null;
+        expect(component.isSpecialNeedsSlot()).toBe(false);
+      });
+    });
   });
 
   describe('DOM', () => {

--- a/src/pages/journal/components/test-slot/test-slot.ts
+++ b/src/pages/journal/components/test-slot/test-slot.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { get } from 'lodash';
+import { get, isNil } from 'lodash';
 import { SlotComponent } from '../slot/slot';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { vehicleDetails } from './test-slot.constants';
@@ -22,14 +22,15 @@ export class TestSlotComponent implements SlotComponent {
   constructor(public screenOrientation: ScreenOrientation) {}
 
   isIndicatorNeededForSlot(): boolean {
-    const specialNeeds:boolean = get(this.slot, 'booking.application.specialNeeds', '').length > 0;
-    const checkNeeded:boolean = this.slot.booking.application.entitlementCheck || false;
+    const specialNeeds: boolean = this.isSpecialNeedsSlot();
+    const checkNeeded: boolean = this.slot.booking.application.entitlementCheck || false;
 
     return specialNeeds || checkNeeded;
   }
 
   isSpecialNeedsSlot(): boolean {
-    return get(this.slot, 'booking.application.specialNeeds', '').length > 0;
+    const specialNeeds = get(this.slot, 'booking.application.specialNeeds', '');
+    return !isNil(specialNeeds) && specialNeeds.length > 0;
   }
 
   isPortrait() : boolean {


### PR DESCRIPTION
* Journal poller (MES-1477) puts `null` into `specialNeeds` as we can't store blank string in DynamoDB.
* Guard against this property being null.