### PR TITLE
Mes 1834 double slot changed to single slot

### DIFF
--- a/src/pages/candidate-details/__tests__/candidate-details.selector.spec.ts
+++ b/src/pages/candidate-details/__tests__/candidate-details.selector.spec.ts
@@ -190,7 +190,7 @@ describe('Candidate Details Selector', () => {
 
   describe('getSlotType', () => {
     describe('vehicleSlotTypeCode is 6 and specialNeedsCode not NONE', () => {
-      it('should return Double Slot (Special Needs)', () => {
+      it('should return Single Slot (Special Needs)', () => {
         const slot = {
           vehicleSlotTypeCode: 6,
           booking: {
@@ -200,7 +200,7 @@ describe('Candidate Details Selector', () => {
           },
         };
         const result = getSlotType(slot);
-        expect(result).toBe('Double Slot (Special Needs)');
+        expect(result).toBe('Single Slot (Special Needs)');
       });
     });
 

--- a/src/pages/candidate-details/candidate-details.selector.ts
+++ b/src/pages/candidate-details/candidate-details.selector.ts
@@ -45,7 +45,7 @@ export const getSlotType = (slot: any): string => {
   // Jira ticket is available here for more details: https://jira.i-env.net/browse/MES-1698
   if (vehicleSlotTypeCode === 6) {
     if (specialNeedsCode !== SpecialNeedsCode.NONE) {
-      return 'Double Slot (Special Needs)';
+      return 'Single Slot (Special Needs)';
     }
   }
 

--- a/test/e2e/features/02-journal.feature
+++ b/test/e2e/features/02-journal.feature
@@ -28,11 +28,11 @@ Feature: Journal
      When I view candidate details for "Mr James Brown"
      Then I should see the "Slot type" contains "Extended Test Special Needs"
 
-   Scenario: Examiner is informed that the test is Double Slot (Special Needs)
+   Scenario: Examiner is informed that the test is Single Slot (Special Needs)
     Given I am on the journal page as "mobexaminer1"
      When I navigate to next day
       And I view candidate details for "Mr Bill Pots"
-     Then I should see the "Slot type" contains "Double Slot (Special Needs)"
+     Then I should see the "Slot type" contains "Single Slot (Special Needs)"
 
    Scenario: Examiner is informed that the test is Single Slot (Special Needs)
     Given I am on the journal page as "mobexaminer1"


### PR DESCRIPTION
## Description and relevant Jira numbers

After discussing with the POs they would prefer having Single Slot instead of Double Slot so this PR is introducing that change.

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
