### PR TITLE
Mes 1829 location not always displayed before slot

### DIFF
--- a/src/pages/journal/components/activity-slot/__tests__/activity-slot.spec.ts
+++ b/src/pages/journal/components/activity-slot/__tests__/activity-slot.spec.ts
@@ -7,6 +7,7 @@ import { AppConfigProvider } from '../../../../../providers/app-config/app-confi
 import { AppConfigProviderMock } from '../../../../../providers/app-config/__mocks__/app-config.mock';
 import { ConfigMock } from 'ionic-mocks';
 import { By } from '@angular/platform-browser';
+import { LocationComponent } from '../../location/location';
 
 describe('ActivitySlotComponent', () => {
   let fixture: ComponentFixture<ActivitySlotComponent>;
@@ -17,6 +18,7 @@ describe('ActivitySlotComponent', () => {
       declarations: [
         ActivitySlotComponent,
         MockComponent(TimeComponent),
+        MockComponent(LocationComponent),
       ],
       providers: [
         { provide: AppConfigProvider, useClass: AppConfigProviderMock },

--- a/src/pages/journal/components/activity-slot/__tests__/activity-slot.spec.ts
+++ b/src/pages/journal/components/activity-slot/__tests__/activity-slot.spec.ts
@@ -86,5 +86,20 @@ describe('ActivitySlotComponent', () => {
         .query(By.directive(MockComponent(TimeComponent))).componentInstance as TimeComponent;
       expect(timeSubComponent.time).toBe(12345);
     });
+    it('should pass something to sub-component location input', () => {
+      component.showLocation = true;
+      component.slot = {
+        slotDetail: {
+          start: 12345,
+        },
+        testCentre: {
+          centreName: 'Example Test Centre',
+        },
+      };
+      fixture.detectChanges();
+      const subByDirective = fixture.debugElement.query(
+        By.directive(MockComponent(LocationComponent))).componentInstance;
+      expect(subByDirective.location).toBe('Example Test Centre');
+    });
   });
 });

--- a/src/pages/journal/components/activity-slot/activity-slot.html
+++ b/src/pages/journal/components/activity-slot/activity-slot.html
@@ -1,3 +1,6 @@
+<location *ngIf="showLocation"
+  [location]="slot.testCentre.centreName">
+</location>
 <ion-card class="activity-slot" [ngClass]="{ 'travel-slot': isTravelSlot() }">
   <ion-row class="slot-row" align-items-center nowrap>
     <ion-col class="time-column">

--- a/src/pages/journal/components/empty-slot/__tests__/empty-slot.spec.ts
+++ b/src/pages/journal/components/empty-slot/__tests__/empty-slot.spec.ts
@@ -100,6 +100,13 @@ describe('EmptySlotComponent', () => {
         const subByDirective = fixture.debugElement.query(By.directive(MockComponent(TimeComponent))).componentInstance;
         expect(subByDirective.time).toBe('2018-12-10T09:07:00+00:00');
       });
+      it('should pass something to sub-component location input', () => {
+        component.showLocation = true;
+        fixture.detectChanges();
+        const subByDirective = fixture.debugElement.query(
+          By.directive(MockComponent(LocationComponent))).componentInstance;
+        expect(subByDirective.location).toBe('Example Test Centre');
+      });
     });
   });
 });

--- a/src/pages/journal/components/empty-slot/__tests__/empty-slot.spec.ts
+++ b/src/pages/journal/components/empty-slot/__tests__/empty-slot.spec.ts
@@ -8,6 +8,7 @@ import { cloneDeep } from 'lodash';
 import { TimeComponent } from '../../time/time';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { ScreenOrientationMock } from '../../../../../shared/mocks/screen-orientation.mock';
+import { LocationComponent } from '../../location/location';
 
 describe('EmptySlotComponent', () => {
   let fixture: ComponentFixture<EmptySlotComponent>;
@@ -77,6 +78,7 @@ describe('EmptySlotComponent', () => {
       declarations: [
         EmptySlotComponent,
         MockComponent(TimeComponent),
+        MockComponent(LocationComponent),
       ],
       imports: [IonicModule],
       providers: [

--- a/src/pages/journal/components/empty-slot/empty-slot.html
+++ b/src/pages/journal/components/empty-slot/empty-slot.html
@@ -1,3 +1,6 @@
+<location *ngIf="showLocation"
+  [location]="slot.testCentre.centreName">
+</location>
 <ion-card class="transparent-bg" [ngClass]="{'empty-slot-portrait-mode': isPortrait()}">
   <ion-row class="slot-row" align-items-center nowrap>
     <ion-col class="time-column">


### PR DESCRIPTION
## Description and relevant Jira numbers
Add location element to display before empty slots and activity slots

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
