### PR TITLE
Mes 1777 display not authorised message

### DIFF
--- a/src/pages/login/__tests__/login.spec.ts
+++ b/src/pages/login/__tests__/login.spec.ts
@@ -90,6 +90,22 @@ describe('LoginPage', () => {
       expect(splashScreen.hide).toHaveBeenCalled();
     }));
 
+    it('should login successfully but display a message when the user is not authorised ', fakeAsync(() => {
+      component.platform.ready =
+        jasmine.createSpy('platform.ready').and.returnValue(Promise.resolve());
+      component.authenticationProvider.login =
+        jasmine.createSpy('authenticationProvider.login').and.returnValue(Promise.resolve());
+      component.appConfigProvider.loadRemoteConfig =
+        jasmine.createSpy('appConfigProvider.loadRemoteConfig')
+          .and.returnValue(Promise.reject('user not authorised'));
+      component.login();
+      tick();
+      expect(appConfigProvider.loadRemoteConfig).toHaveBeenCalled();
+      expect(component.hasUserLoggedOut).toBeFalsy();
+      expect(component.authenticationError === AuthenticationError.USER_NOT_AUTHORISED);
+      expect(splashScreen.hide).toHaveBeenCalled();
+    }));
+
     it('should return true for isInternetConnectError when criteria is met', () => {
       component.authenticationError = AuthenticationError.NO_INTERNET;
       component.hasUserLoggedOut = false;
@@ -146,6 +162,13 @@ describe('LoginPage', () => {
 
       expect(component.isUnknownError()).toBeFalsy();
     });
+
+    it('should return true for isUserNotAuthorised when criteria is met', () => {
+      component.authenticationError = AuthenticationError.USER_NOT_AUTHORISED;
+      component.hasUserLoggedOut = false;
+
+      expect(component.isUserNotAuthorised()).toBeTruthy();
+    });
   });
 
   describe('DOM', () => {
@@ -186,6 +209,16 @@ describe('LoginPage', () => {
       const tags = fixture.debugElement.queryAll(By.css('h2'));
       expect(tags.length).toBe(1);
       expect((tags[0].nativeElement as HTMLElement).textContent).toContain('Sorry, something went wrong');
+    });
+
+    it('should show the correct div if user is not authorised to use the app', () => {
+      component.hasUserLoggedOut = false;
+      component.authenticationError = AuthenticationError.USER_NOT_AUTHORISED;
+      fixture.detectChanges();
+
+      const tags = fixture.debugElement.queryAll(By.css('h2'));
+      expect(tags.length).toBe(1);
+      expect((tags[0].nativeElement as HTMLElement).textContent).toContain('not authorised to use this app');
     });
 
   });

--- a/src/pages/login/login.html
+++ b/src/pages/login/login.html
@@ -24,5 +24,9 @@
       <h2>Unsupported device</h2>
       <h3>Install the application on an approved device</h3>
     </div>
+    <div *ngIf="isUserNotAuthorised()">
+      <h2>You're not authorised to use this app</h2>
+      <h3>If you think you should have access,<br/> you can try to <span class="link" (click)="login()">sign in</span> again.</h3>
+    </div>
   </div>
 </ion-content>

--- a/src/pages/login/login.html
+++ b/src/pages/login/login.html
@@ -26,7 +26,8 @@
     </div>
     <div *ngIf="isUserNotAuthorised()">
       <h2>You're not authorised to use this app</h2>
-      <h3>If you think you should have access,<br/> you can try to <span class="link" (click)="login()">sign in</span> again.</h3>
+      <h3>Speak to your line manager if you want to use this app.</h3>
+      <h3>If you think you’re already authorised,<br/> you can try to <span class="link" (click)="login()">sign in</span> again.</h3>
     </div>
   </div>
 </ion-content>

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -64,6 +64,9 @@ export class LoginPage extends BasePageComponent {
         if (error === AuthenticationError.USER_CANCELLED) {
           this.analytics.logException(error, true);
         }
+        if (error === AuthenticationError.USER_NOT_AUTHORISED) {
+          this.authenticationProvider.logout();
+        }
         this.authenticationError = error;
         console.log(error);
       })
@@ -95,6 +98,11 @@ export class LoginPage extends BasePageComponent {
     return !this.hasUserLoggedOut &&
       this.authenticationError &&
       this.authenticationError.valueOf() !== AuthenticationError.USER_CANCELLED &&
-      this.authenticationError.valueOf() !== AuthenticationError.NO_INTERNET;
+      this.authenticationError.valueOf() !== AuthenticationError.NO_INTERNET &&
+      this.authenticationError.valueOf() !== AuthenticationError.USER_NOT_AUTHORISED;
+  }
+
+  isUserNotAuthorised = (): boolean => {
+    return !this.hasUserLoggedOut && this.authenticationError === AuthenticationError.USER_NOT_AUTHORISED;
   }
 }

--- a/src/providers/app-config/app-config.constants.ts
+++ b/src/providers/app-config/app-config.constants.ts
@@ -1,0 +1,3 @@
+export enum AppConfigError {
+  UNKNOWN_ERROR = 'error getting remote config',
+}

--- a/src/providers/app-config/app-config.ts
+++ b/src/providers/app-config/app-config.ts
@@ -33,10 +33,10 @@ export class AppConfigProvider {
     this.getRemoteData()
       .then(data => this.mapRemoteConfig(data))
       .catch((error) => {
-        console.log('Error Getting Remote Config', JSON.stringify(error));
-        // if (error.Message === 'User is not authorized to access this resource with an explicit deny') {
-        return Promise.reject('user not authorised');
-        // }
+        if (error && error.status === 403) {
+          return Promise.reject('user not authorised');
+        }
+        return Promise.reject('error getting remote config');
       })
 
   private getRemoteData = (): Promise<any> =>

--- a/src/providers/app-config/app-config.ts
+++ b/src/providers/app-config/app-config.ts
@@ -7,6 +7,8 @@ import { environment } from '../../environment/environment';
 import { EnvironmentFile } from '../../environment/models/environment.model';
 import { DataStoreProvider } from '../data-store/data-store';
 import { NetworkStateProvider, ConnectionStatus } from '../network-state/network-state';
+import { AppConfigError } from './app-config.constants';
+import { AuthenticationError } from './../authentication/authentication.constants';
 
 @Injectable()
 export class AppConfigProvider {
@@ -34,9 +36,9 @@ export class AppConfigProvider {
       .then(data => this.mapRemoteConfig(data))
       .catch((error) => {
         if (error && error.status === 403) {
-          return Promise.reject('user not authorised');
+          return Promise.reject(AuthenticationError.USER_NOT_AUTHORISED);
         }
-        return Promise.reject('error getting remote config');
+        return Promise.reject(AppConfigError.UNKNOWN_ERROR);
       })
 
   private getRemoteData = (): Promise<any> =>

--- a/src/providers/app-config/app-config.ts
+++ b/src/providers/app-config/app-config.ts
@@ -32,7 +32,12 @@ export class AppConfigProvider {
   public loadRemoteConfig = (): Promise<any> =>
     this.getRemoteData()
       .then(data => this.mapRemoteConfig(data))
-      .catch(error => console.log('Error Getting Remote Config', error))
+      .catch((error) => {
+        console.log('Error Getting Remote Config', JSON.stringify(error));
+        // if (error.Message === 'User is not authorized to access this resource with an explicit deny') {
+        return Promise.reject('user not authorised');
+        // }
+      })
 
   private getRemoteData = (): Promise<any> =>
     new Promise((resolve, reject) => {

--- a/src/providers/authentication/authentication.constants.ts
+++ b/src/providers/authentication/authentication.constants.ts
@@ -2,4 +2,5 @@ export enum AuthenticationError {
   NO_INTERNET = 'The Internet connection appears to be offline.',
   USER_CANCELLED = 'User cancelled authentication flow',
   NO_RESPONSE = 'application did not receive response from broker',
+  USER_NOT_AUTHORISED = 'user not authorised',
 }


### PR DESCRIPTION
## Description and relevant Jira numbers
Show a not authorised page when the user is not allowed to access the app (doesn't exist in the users table in dynamoDB)

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

![IMG_E7CD942961CF-1](https://user-images.githubusercontent.com/8069071/54430795-89ea4980-471c-11e9-95d3-4b7bf97b2a1a.jpeg)
