### PR TITLE
Fix issue where preTest declarations are persisting between candidates

### DIFF
--- a/src/modules/test/pre-test-declarations/__tests__/pre-test-declarations.reducer.spec.ts
+++ b/src/modules/test/pre-test-declarations/__tests__/pre-test-declarations.reducer.spec.ts
@@ -1,5 +1,9 @@
 import { preTestDeclarationsReducer, initialState } from '../pre-test-declarations.reducer';
-import { ToggleInsuranceDeclaration, ToggleResidencyDeclaration } from '../pre-test-declarations.actions';
+import {
+  ToggleInsuranceDeclaration,
+  ToggleResidencyDeclaration,
+  ClearPreTestDeclarations,
+} from '../pre-test-declarations.actions';
 
 describe('PreTestDeclarations reducer', () => {
   it('should toggle the residency status when the toggle action is received', () => {
@@ -10,5 +14,16 @@ describe('PreTestDeclarations reducer', () => {
   it('should toggle the insurance status when the toggle action is received', () => {
     const result = preTestDeclarationsReducer(initialState, new ToggleResidencyDeclaration);
     expect(result.residencyDeclarationAccepted).toBe(true);
+  });
+
+  it('should reset to the initial state when the clear action is received', () => {
+    const dirtyState = {
+      insuranceDeclarationAccepted: true,
+      residencyDeclarationAccepted: true,
+      signature: 'sig',
+    };
+    const result = preTestDeclarationsReducer(dirtyState, new ClearPreTestDeclarations());
+
+    expect(result).toBe(initialState);
   });
 });

--- a/src/modules/test/pre-test-declarations/pre-test-declarations.actions.ts
+++ b/src/modules/test/pre-test-declarations/pre-test-declarations.actions.ts
@@ -1,7 +1,12 @@
 import { Action } from '@ngrx/store';
 
+export const CLEAR_PRE_TEST_DECLARATIONS = '[PreTestDeclarations] Clear';
 export const TOGGLE_INSURANCE_DECLARATION = '[PreTestDeclarations] Insurance declaration toggled';
 export const TOGGLE_RESIDENCY_DECLARATION = '[PreTestDeclarations] Residency declaration toggled';
+
+export class ClearPreTestDeclarations implements Action {
+  readonly type = CLEAR_PRE_TEST_DECLARATIONS;
+}
 
 export class ToggleInsuranceDeclaration implements Action {
   readonly type = TOGGLE_INSURANCE_DECLARATION;
@@ -12,5 +17,6 @@ export class ToggleResidencyDeclaration implements Action {
 }
 
 export type Types =
+  | ClearPreTestDeclarations
   | ToggleInsuranceDeclaration
   | ToggleResidencyDeclaration;

--- a/src/modules/test/pre-test-declarations/pre-test-declarations.reducer.ts
+++ b/src/modules/test/pre-test-declarations/pre-test-declarations.reducer.ts
@@ -23,6 +23,8 @@ export function preTestDeclarationsReducer(
         ...state,
         residencyDeclarationAccepted: !state.residencyDeclarationAccepted,
       };
+    case preTestDeclarationActions.CLEAR_PRE_TEST_DECLARATIONS:
+      return initialState;
     default:
       return state;
   }

--- a/src/pages/waiting-room/__tests__/waiting-room.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.spec.ts
@@ -12,6 +12,7 @@ import { By } from '@angular/platform-browser';
 import {
   ToggleResidencyDeclaration,
   ToggleInsuranceDeclaration,
+  ClearPreTestDeclarations,
 } from '../../../modules/test/pre-test-declarations/pre-test-declarations.actions';
 import { PreTestDeclarationsModule } from '../../../modules/test/pre-test-declarations/pre-test-declarations.module';
 import { DeviceProvider } from '../../../providers/device/device';
@@ -85,17 +86,24 @@ describe('WaitingRoomPage', () => {
         component.ionViewDidEnter();
         expect(deviceProvider.enableSingleAppMode).toHaveBeenCalled();
       });
-      describe('ionViewDidLeave', () => {
-        it('should disable single app mode if on ios', () => {
-          component.ionViewDidLeave();
-          expect(deviceProvider.disableSingleAppMode).toHaveBeenCalled();
-        });
+    });
+    describe('ionViewDidLeave', () => {
+      it('should disable single app mode if on ios', () => {
+        component.ionViewDidLeave();
+        expect(deviceProvider.disableSingleAppMode).toHaveBeenCalled();
       });
     });
+    describe('ionViewWillUnload', () => {
+      it('should dispatch a ClearPreTestDeclarations action', () => {
+        component.ionViewWillUnload();
+        expect(store$.dispatch).toHaveBeenCalledWith(new ClearPreTestDeclarations());
+      });
+    });
+  });
 
-    describe('DOM', () => {
-      describe('Declaration checkboxes', () => {
-        it('should call residency change handler when residency declaration is (un)checked', fakeAsync(() => {
+  describe('DOM', () => {
+    describe('Declaration checkboxes', () => {
+      it('should call residency change handler when residency declaration is (un)checked', fakeAsync(() => {
         fixture.detectChanges();
         spyOn(component, 'residencyDeclarationChanged');
         const residencyCb = fixture.debugElement.query(By.css('#residency-declaration-checkbox'));
@@ -104,7 +112,7 @@ describe('WaitingRoomPage', () => {
         fixture.detectChanges();
         expect(component.residencyDeclarationChanged).toHaveBeenCalled();
       }));
-        it('should call insurance change handler when insurance declaration is (un)checked', fakeAsync(() => {
+      it('should call insurance change handler when insurance declaration is (un)checked', fakeAsync(() => {
         fixture.detectChanges();
         spyOn(component, 'insuranceDeclarationChanged');
         const insuranceCb = fixture.debugElement.query(By.css('#insurance-declaration-checkbox'));
@@ -113,7 +121,6 @@ describe('WaitingRoomPage', () => {
         fixture.detectChanges();
         expect(component.insuranceDeclarationChanged).toHaveBeenCalled();
       }));
-      });
     });
   });
 });

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -62,6 +62,10 @@ export class WaitingRoomPage extends BasePageComponent {
     }
   }
 
+  ionViewWillUnload(): void {
+    this.store$.dispatch(new preTestDeclarationsActions.ClearPreTestDeclarations());
+  }
+
   ngOnInit(): void {
     this.pageState = {
       insuranceDeclarationAccepted$: this.store$.pipe(


### PR DESCRIPTION
## Description and relevant Jira numbers
* Waiting room page state was propagating to different test slots when pressing back
* Ensure we clear down the `preTestDeclarations` state when "Back" is pressed
* Confirmed that "Back" will not be available beyond the Waiting Room page. As such, state accumulated later in the test can be cleared down at one of the defined test exit points (pass/fail/terminate)

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
