### PR TITLE
MES-76: Add unit test for hammer wrappers invoking provided callbacks (MES-1951)

### DIFF
--- a/src/providers/hammer/__tests__/hammer.spec.ts
+++ b/src/providers/hammer/__tests__/hammer.spec.ts
@@ -1,0 +1,50 @@
+import { async, TestBed, ComponentFixture } from '@angular/core/testing';
+import { HammerProvider } from '../hammer';
+import { CompetencyComponent } from '../../../pages/test-report/components/competency/competency';
+
+describe('HammerProvider', () => {
+  let fixture: ComponentFixture<CompetencyComponent>;
+  let hammerProvider: HammerProvider;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        CompetencyComponent,
+      ],
+      providers: [
+        HammerProvider,
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        hammerProvider = TestBed.get(HammerProvider);
+        fixture = TestBed.createComponent(CompetencyComponent);
+      });
+  }));
+
+  describe('addPressAndHoldEvent', () => {
+    it('should invoke the provided callback when "pressAndHold" is emitted', () => {
+      const { elementRef } = fixture;
+      hammerProvider.init(elementRef);
+      const postHoldCallback = jasmine.createSpy('someCallback');
+      hammerProvider.addPressAndHoldEvent(postHoldCallback);
+
+      hammerProvider.hammerManager.emit('pressAndHold', {});
+
+      expect(postHoldCallback).toHaveBeenCalled();
+    });
+  });
+
+  describe('addPressEvent', () => {
+    it('should invoke the provided callback when "press" is emitted', () => {
+      const { elementRef } = fixture;
+      hammerProvider.init(elementRef);
+      const pressCallback = jasmine.createSpy('someCallback');
+      hammerProvider.addPressEvent(pressCallback);
+
+      hammerProvider.hammerManager.emit('press', {});
+
+      expect(pressCallback).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description and relevant Jira numbers
Simple tests where hammer events are directly invoked to ensure that configured callbacks are called as expected.

This is a workaround for not being able to make emulated press+hold events trigger the callbacks as originally intended.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
