### PR TITLE
Implementing driving fault summary

### DIFF
--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -47,7 +47,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1001,
-        "start": "2019-03-27T08:10:00+00:00"
+        "start": "2019-03-28T08:10:00+00:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -95,7 +95,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1003,
-        "start": "2019-03-27T10:14:00+00:00"
+        "start": "2019-03-28T10:14:00+00:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -144,7 +144,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1004,
-        "start": "2019-03-27T11:11:00+00:00"
+        "start": "2019-03-28T11:11:00+00:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -195,7 +195,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1005,
-        "start": "2019-03-27T12:38:00+00:00"
+        "start": "2019-03-28T12:38:00+00:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -248,7 +248,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1006,
-        "start": "2019-03-27T13:35:00+00:00"
+        "start": "2019-03-28T13:35:00+00:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -293,7 +293,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1007,
-        "start": "2019-03-28T14:32:00+00:00"
+        "start": "2019-03-29T14:32:00+00:00"
       },
       "testCentre": {
         "centreId": 54321,

--- a/src/modules/tests/__tests__/tests.selector.spec.ts
+++ b/src/modules/tests/__tests__/tests.selector.spec.ts
@@ -30,7 +30,7 @@ describe('testsSelector', () => {
         tests: { startedTests: { 123: currentTest }, currentTest: { slotId: '123' } },
       };
 
-      const result = getCurrentTest(state);
+      const result = getCurrentTest(state.tests);
 
       expect(result).toBe(currentTest);
     });

--- a/src/modules/tests/test_data/test-data.selector.ts
+++ b/src/modules/tests/test_data/test-data.selector.ts
@@ -2,3 +2,15 @@ import { TestData } from '@dvsa/mes-test-schema/categories/B';
 import { Competencies } from './test-data.constants';
 
 export const getDrivingFaultCount = (data: TestData, competency: Competencies) => data.drivingFaults[competency];
+
+export const getDrivingFaultSummaryCount = (data: TestData): number => {
+
+  // The way how we store the driving faults differs for certain competencies
+  // Because of this we need to pay extra attention on summing up all of them
+
+  const drivingFaultSumOfSimpleCompetencies =
+    Object.values(data.drivingFaults).reduce((acc, numberOfFaults) => acc + numberOfFaults, 0);
+
+  const result = drivingFaultSumOfSimpleCompetencies;
+  return result;
+};

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -65,7 +65,7 @@ export const testsReducer = (
   };
 };
 
-const deriveSlotId = (state: TestsModel, action): string | null => {
+const deriveSlotId = (state: TestsModel, action: Action): string | null => {
   if (action instanceof testOutcomeActions.TestOutcomeStartTest) {
     return `${action.payload.slotDetail.slotId}`;
   }

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -1,7 +1,7 @@
 import * as testOutcomeActions from '../../pages/journal/components/test-outcome/test-outcome.actions';
 import { preTestDeclarationsReducer } from './pre-test-declarations/pre-test-declarations.reducer';
 import { candidateReducer } from './candidate/candidate.reducer';
-import { combineReducers, Action } from '@ngrx/store';
+import { combineReducers, Action, createFeatureSelector } from '@ngrx/store';
 import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
 import { testDataReducer } from './test_data/test-data.reducer';
 import { vehicleDetailsReducer } from './vehicle-details/vehicle-details.reducer';
@@ -71,3 +71,5 @@ const deriveSlotId = (state: TestsModel, action): string | null => {
   }
   return (state.currentTest && state.currentTest.slotId) ? state.currentTest.slotId : null;
 };
+
+export const getTests = createFeatureSelector<TestsModel>('tests');

--- a/src/modules/tests/tests.selector.ts
+++ b/src/modules/tests/tests.selector.ts
@@ -1,6 +1,6 @@
-import { StoreModel } from '../../shared/models/store.model';
+import { TestsModel } from './tests.reducer';
 
-export const getCurrentTest = (rootState: StoreModel) => {
-  const currentTestSlotId = rootState.tests.currentTest.slotId;
-  return rootState.tests.startedTests[currentTestSlotId];
+export const getCurrentTest = (tests: TestsModel) => {
+  const currentTestSlotId = tests.currentTest.slotId;
+  return tests.startedTests[currentTestSlotId];
 };

--- a/src/pages/test-report/__tests__/test-report.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.spec.ts
@@ -16,7 +16,7 @@ import { DeviceProvider } from '../../../providers/device/device';
 import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
 import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
-import { DrivingFaultSummary } from '../components/driving-fault-summary/driving-fault-summary';
+import { DrivingFaultSummaryComponent } from '../components/driving-fault-summary/driving-fault-summary';
 
 describe('TestReportPage', () => {
   let fixture: ComponentFixture<TestReportPage>;
@@ -30,7 +30,7 @@ describe('TestReportPage', () => {
       declarations: [
         TestReportPage,
         MockComponent(CompetencyComponent),
-        MockComponent(DrivingFaultSummary),
+        MockComponent(DrivingFaultSummaryComponent),
       ],
       imports: [IonicModule, AppModule],
       providers: [

--- a/src/pages/test-report/__tests__/test-report.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.spec.ts
@@ -16,6 +16,7 @@ import { DeviceProvider } from '../../../providers/device/device';
 import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
 import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
+import { DrivingFaultSummary } from '../components/driving-fault-summary/driving-fault-summary';
 
 describe('TestReportPage', () => {
   let fixture: ComponentFixture<TestReportPage>;
@@ -26,7 +27,11 @@ describe('TestReportPage', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [TestReportPage, MockComponent(CompetencyComponent)],
+      declarations: [
+        TestReportPage,
+        MockComponent(CompetencyComponent),
+        MockComponent(DrivingFaultSummary),
+      ],
       imports: [IonicModule, AppModule],
       providers: [
         { provide: NavController, useFactory: () => NavControllerMock.instance() },

--- a/src/pages/test-report/components/competency/competency.ts
+++ b/src/pages/test-report/components/competency/competency.ts
@@ -13,6 +13,7 @@ import { competencyLabels } from './competency.constants';
 import { getCurrentTest } from '../../../../modules/tests/tests.selector';
 import { getTestData } from '../../../../modules/tests/test_data/test-data.reducer';
 import { getDrivingFaultCount } from '../../../../modules/tests/test_data/test-data.selector';
+import { getTests } from '../../../../modules/tests/tests.reducer';
 
 enum CssClassesEnum {
   DRIVING_FAULT = 'driving-fault',
@@ -54,6 +55,7 @@ export class CompetencyComponent {
 
     this.competencyState = {
       drivingFaultCount$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getTestData),
         select(testData => getDrivingFaultCount(testData, this.competency))),

--- a/src/pages/test-report/components/driving-fault-summary/__tests__/driving-fault-summay.spec.ts
+++ b/src/pages/test-report/components/driving-fault-summary/__tests__/driving-fault-summay.spec.ts
@@ -1,0 +1,74 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { DrivingFaultSummaryComponent } from '../driving-fault-summary';
+import { Store, StoreModule } from '@ngrx/store';
+import { StoreModel } from '../../../../../shared/models/store.model';
+import { IonicModule, Config } from 'ionic-angular';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { ConfigMock } from 'ionic-mocks';
+import { Subscription } from 'rxjs/Subscription';
+import { testsReducer } from '../../../../../modules/tests/tests.reducer';
+import { TestOutcomeStartTest } from '../../../../journal/components/test-outcome/test-outcome.actions';
+import { AddDrivingFault } from '../../../../../modules/tests/test_data/test-data.actions';
+import { Competencies } from '../../../../../modules/tests/test_data/test-data.constants';
+
+fdescribe('DrivingFaultSummary', () => {
+  let fixture: ComponentFixture<DrivingFaultSummaryComponent>;
+  let component: DrivingFaultSummaryComponent;
+  let store$: Store<StoreModel>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        DrivingFaultSummaryComponent,
+      ],
+      imports: [
+        IonicModule,
+        StoreModule.forRoot({ tests: testsReducer }),
+      ],
+      providers: [
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+      ],
+    }).compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(DrivingFaultSummaryComponent);
+        component = fixture.componentInstance;
+        component.subscription = new Subscription();
+      });
+
+    store$ = TestBed.get(Store);
+  }));
+
+  describe('Class', () => {
+    it('should create', () => {
+      expect(component).toBeDefined();
+    });
+  });
+
+  describe('DOM', () => {
+    let componentEl: DebugElement;
+
+    beforeEach(() => {
+      componentEl = fixture.debugElement;
+
+      store$.dispatch(new TestOutcomeStartTest({ slotDetail: { slotId: 103 } }));
+    });
+
+    it('should display 0 driving faults', () => {
+      fixture.detectChanges();
+      const summaryCount: HTMLElement = componentEl.query(By.css('#summary-count')).nativeElement;
+      expect(summaryCount.textContent).toBe('0');
+    });
+
+    it('should display 3 driving faults', () => {
+      store$.dispatch(new AddDrivingFault({ competency: Competencies.clearance, newFaultCount: 1 }));
+      store$.dispatch(new AddDrivingFault({ competency: Competencies.controlsSteering, newFaultCount: 1 }));
+      store$.dispatch(new AddDrivingFault({ competency: Competencies.moveOffControl, newFaultCount: 1 }));
+
+      fixture.detectChanges();
+
+      const summaryCount: HTMLElement = componentEl.query(By.css('#summary-count')).nativeElement;
+      expect(summaryCount.textContent).toBe('3');
+    });
+  });
+});

--- a/src/pages/test-report/components/driving-fault-summary/__tests__/driving-fault-summay.spec.ts
+++ b/src/pages/test-report/components/driving-fault-summary/__tests__/driving-fault-summay.spec.ts
@@ -12,7 +12,7 @@ import { TestOutcomeStartTest } from '../../../../journal/components/test-outcom
 import { AddDrivingFault } from '../../../../../modules/tests/test_data/test-data.actions';
 import { Competencies } from '../../../../../modules/tests/test_data/test-data.constants';
 
-fdescribe('DrivingFaultSummary', () => {
+describe('DrivingFaultSummary', () => {
   let fixture: ComponentFixture<DrivingFaultSummaryComponent>;
   let component: DrivingFaultSummaryComponent;
   let store$: Store<StoreModel>;

--- a/src/pages/test-report/components/driving-fault-summary/__tests__/driving-fault-summay.spec.ts
+++ b/src/pages/test-report/components/driving-fault-summary/__tests__/driving-fault-summay.spec.ts
@@ -54,13 +54,13 @@ describe('DrivingFaultSummary', () => {
       store$.dispatch(new TestOutcomeStartTest({ slotDetail: { slotId: 103 } }));
     });
 
-    it('should display 0 driving faults', () => {
+    it('should display 0 driving faults for a new test', () => {
       fixture.detectChanges();
       const summaryCount: HTMLElement = componentEl.query(By.css('#summary-count')).nativeElement;
       expect(summaryCount.textContent).toBe('0');
     });
 
-    it('should display 3 driving faults', () => {
+    it('should display 3 driving faults when 3 driving faults have been marked', () => {
       store$.dispatch(new AddDrivingFault({ competency: Competencies.clearance, newFaultCount: 1 }));
       store$.dispatch(new AddDrivingFault({ competency: Competencies.controlsSteering, newFaultCount: 1 }));
       store$.dispatch(new AddDrivingFault({ competency: Competencies.moveOffControl, newFaultCount: 1 }));

--- a/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.html
+++ b/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.html
@@ -1,0 +1,6 @@
+<span>
+  D/F:
+  <span id="summary-count-badge">
+    <span id="summary-count">{{ componentState.count$ | async }}</span>
+  </span>
+</span>

--- a/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.scss
+++ b/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.scss
@@ -8,7 +8,7 @@ driving-fault-summary {
     padding-top: 9px;
     border-radius: 30px;
     
-    background-color: #0B0C0C;
+    background-color: map-get($colors-gds, 'gds-black');;
     color: map-get($colors, 'mes-white');
     text-align: center;
 

--- a/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.scss
+++ b/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.scss
@@ -1,0 +1,21 @@
+driving-fault-summary {
+  #summary-count-badge {
+    display: inline-block;
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    
+    padding-top: 9px;
+    border-radius: 30px;
+    
+    background-color: #0B0C0C;
+    color: map-get($colors, 'mes-white');
+    text-align: center;
+
+    #summary-count {
+      font-size: 21px;
+      font-weight: 600;
+      line-height: 20px;
+    }
+  }
+}

--- a/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.ts
+++ b/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.ts
@@ -6,6 +6,7 @@ import { getCurrentTest } from '../../../../modules/tests/tests.selector';
 import { getTestData } from '../../../../modules/tests/test_data/test-data.reducer';
 import { getDrivingFaultSummaryCount } from '../../../../modules/tests/test_data/test-data.selector';
 import { Subscription } from 'rxjs/Subscription';
+import { getTests } from '../../../../modules/tests/tests.reducer';
 
 interface DrivingFaultSummaryState {
   count$: Observable<number>;
@@ -15,7 +16,7 @@ interface DrivingFaultSummaryState {
   selector: 'driving-fault-summary',
   templateUrl: 'driving-fault-summary.html',
 })
-export class DrivingFaultSummary implements OnInit, OnDestroy {
+export class DrivingFaultSummaryComponent implements OnInit, OnDestroy {
 
   componentState: DrivingFaultSummaryState;
   subscription: Subscription;
@@ -25,6 +26,7 @@ export class DrivingFaultSummary implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.componentState = {
       count$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getTestData),
         select(getDrivingFaultSummaryCount),

--- a/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.ts
+++ b/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.ts
@@ -1,0 +1,43 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { Store, select } from '@ngrx/store';
+import { StoreModel } from '../../../../shared/models/store.model';
+import { getCurrentTest } from '../../../../modules/tests/tests.selector';
+import { getTestData } from '../../../../modules/tests/test_data/test-data.reducer';
+import { getDrivingFaultSummaryCount } from '../../../../modules/tests/test_data/test-data.selector';
+import { Subscription } from 'rxjs/Subscription';
+
+interface DrivingFaultSummaryState {
+  count$: Observable<number>;
+}
+
+@Component({
+  selector: 'driving-fault-summary',
+  templateUrl: 'driving-fault-summary.html',
+})
+export class DrivingFaultSummary implements OnInit, OnDestroy {
+
+  componentState: DrivingFaultSummaryState;
+  subscription: Subscription;
+
+  constructor(private store$: Store<StoreModel>) {}
+
+  ngOnInit(): void {
+    this.componentState = {
+      count$: this.store$.pipe(
+        select(getCurrentTest),
+        select(getTestData),
+        select(getDrivingFaultSummaryCount),
+      ),
+    };
+
+    const { count$ } = this.componentState;
+
+    this.subscription = count$.subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+
+}

--- a/src/pages/test-report/test-report.html
+++ b/src/pages/test-report/test-report.html
@@ -8,8 +8,8 @@
 </ion-header>
 
 <ion-content no-padding no-bounce>
-  <div style="background: white; height: 68px; padding: 0">
-    Temp Top Header
+  <div id="test-report-header" style="background: white; height: 68px; padding: 12px 17px 12px 17px;">
+    <driving-fault-summary></driving-fault-summary>
   </div>
   <ion-grid no-padding padding-left padding-right>
     <ion-row>

--- a/src/pages/test-report/test-report.html
+++ b/src/pages/test-report/test-report.html
@@ -8,7 +8,7 @@
 </ion-header>
 
 <ion-content no-padding no-bounce>
-  <div id="test-report-header" style="background: white; height: 68px; padding: 12px 17px 12px 17px;">
+  <div id="test-report-header">
     <driving-fault-summary></driving-fault-summary>
   </div>
   <ion-grid no-padding padding-left padding-right>

--- a/src/pages/test-report/test-report.module.ts
+++ b/src/pages/test-report/test-report.module.ts
@@ -8,14 +8,14 @@ import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
 import { CompetencyComponent } from './components/competency/competency';
 import { FaultCounterComponent } from './components/fault-counter/fault-counter';
-import { DrivingFaultSummary } from './components/driving-fault-summary/driving-fault-summary';
+import { DrivingFaultSummaryComponent } from './components/driving-fault-summary/driving-fault-summary';
 
 @NgModule({
   declarations: [
     TestReportPage,
     CompetencyComponent,
     FaultCounterComponent,
-    DrivingFaultSummary,
+    DrivingFaultSummaryComponent,
   ],
   imports: [
     IonicPageModule.forChild(TestReportPage),

--- a/src/pages/test-report/test-report.module.ts
+++ b/src/pages/test-report/test-report.module.ts
@@ -8,12 +8,14 @@ import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
 import { CompetencyComponent } from './components/competency/competency';
 import { FaultCounterComponent } from './components/fault-counter/fault-counter';
+import { DrivingFaultSummary } from './components/driving-fault-summary/driving-fault-summary';
 
 @NgModule({
   declarations: [
     TestReportPage,
     CompetencyComponent,
     FaultCounterComponent,
+    DrivingFaultSummary,
   ],
   imports: [
     IonicPageModule.forChild(TestReportPage),

--- a/src/pages/test-report/test-report.scss
+++ b/src/pages/test-report/test-report.scss
@@ -22,8 +22,8 @@ page-test-report {
 
   #test-report-header {
     height: 68px;
-    padding: 12px 17px 12px 17px;
-    background: white;
+    padding: 12px 17px;
+    background: map-get($colors, 'mes-white');
   }
 
 }

--- a/src/pages/test-report/test-report.scss
+++ b/src/pages/test-report/test-report.scss
@@ -20,4 +20,10 @@ page-test-report {
     margin: 4px 8px;
   }
 
+  #test-report-header {
+    height: 68px;
+    padding: 12px 17px 12px 17px;
+    background: white;
+  }
+
 }

--- a/src/pages/test-report/test-report.ts
+++ b/src/pages/test-report/test-report.ts
@@ -16,6 +16,7 @@ import { getCandidate } from '../../modules/tests/candidate/candidate.reducer';
 import { TestReportViewDidEnter } from './test-report.actions';
 import { getCurrentTest } from '../../modules/tests/tests.selector';
 import { Competencies } from '../../modules/tests/test_data/test-data.constants';
+import { getTests } from '../../modules/tests/tests.reducer';
 
 interface TestReportPageState {
   candidateUntitledName$: Observable<string>;
@@ -48,6 +49,7 @@ export class TestReportPage extends BasePageComponent {
   ngOnInit(): void {
     this.pageState = {
       candidateUntitledName$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getCandidate),
         select(getUntitledCandidateName),

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.ts
@@ -38,6 +38,7 @@ import {
 } from '../../modules/tests/accompaniment/accompaniment.selector';
 import { getCandidate } from '../../modules/tests/candidate/candidate.reducer';
 import { getUntitledCandidateName } from '../../modules/tests/candidate/candidate.selector';
+import { getTests } from '../../modules/tests/tests.reducer';
 
 interface WaitingRoomToCarPageState {
   candidateName$: Observable<string>;
@@ -79,41 +80,49 @@ export class WaitingRoomToCarPage extends BasePageComponent{
   ngOnInit(): void {
     this.pageState = {
       candidateName$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getCandidate),
         select(getUntitledCandidateName),
       ),
       registrationNumber$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getVehicleDetails),
         select(getRegistrationNumber),
       ),
       transmission$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getVehicleDetails),
         select(getGearboxCategory),
       ),
       schoolCar$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getVehicleDetails),
         select(getSchoolCar),
       ),
       dualControls$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getVehicleDetails),
         select(getDualControls),
       ),
       instructorAccompaniment$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getAccompaniment),
         select(getInstructorAccompaniment),
       ),
       supervisorAccompaniment$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getAccompaniment),
         select(getSupervisorAccompaniment),
       ),
       otherAccompaniment$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getAccompaniment),
         select(getOtherAccompaniment),

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -23,6 +23,7 @@ import { map } from 'rxjs/operators';
 import { DeviceProvider } from '../../providers/device/device';
 import { getCurrentTest } from '../../modules/tests/tests.selector';
 import { DeviceAuthenticationProvider } from '../../providers/device-authentication/device-authentication';
+import { getTests } from '../../modules/tests/tests.reducer';
 
 interface WaitingRoomPageState {
   insuranceDeclarationAccepted$: Observable<boolean>;
@@ -98,31 +99,37 @@ export class WaitingRoomPage extends BasePageComponent {
 
     this.pageState = {
       insuranceDeclarationAccepted$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getPreTestDeclarations),
         select(getInsuranceDeclarationStatus),
       ),
       residencyDeclarationAccepted$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getPreTestDeclarations),
         select(getResidencyDeclarationStatus),
       ),
       signature$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getPreTestDeclarations),
         select(getSignatureStatus),
       ),
       candidateName$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getCandidate),
         select(getCandidateName),
       ),
       candidateUntitledName$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getCandidate),
         select(getUntitledCandidateName),
       ),
       candidateDriverNumber$: this.store$.pipe(
+        select(getTests),
         select(getCurrentTest),
         select(getCandidate),
         select(getCandidateDriverNumber),


### PR DESCRIPTION
#### Jira Ticket: MES-1089 Display summary count of CAT B driving faults

Implementing a component which displays the summary of driving faults recorded against certain competencies (not all just yet, for example driving faults on Manoeuvres has to be included later on)