### PR TITLE
MES 1096 - add provisional license check radio buttons on debrief

### DIFF
--- a/src/modules/tests/pass-completion/__tests__/pass-completion.reducer.spec.ts
+++ b/src/modules/tests/pass-completion/__tests__/pass-completion.reducer.spec.ts
@@ -1,0 +1,34 @@
+import { passCompletionReducer, initialState } from '../pass-completion.reducer';
+import {
+  PassCertificateNumberChanged,
+  ProvisionalLicenseReceived,
+  ProvisionalLicenseNotReceived,
+} from '../pass-completion.actions';
+
+describe('pass completion reducer', () => {
+  it('should put the pass certificate number into the state on pass certificate number changed action', () => {
+    const result = passCompletionReducer(initialState, new PassCertificateNumberChanged('ABC123'));
+    expect(result.passCertificateNumber).toBe('ABC123');
+  });
+
+  it('should put that the provisional license was received into state when yes selected', () => {
+    let result;
+    result = passCompletionReducer(result, new ProvisionalLicenseReceived());
+    expect(result.provisionalLicenceProvided).toBe(true);
+  });
+
+  it('should put that the provisional license was not received into state when no selected', () => {
+    let result;
+    result = passCompletionReducer(result, new ProvisionalLicenseNotReceived());
+    expect(result.provisionalLicenceProvided).toBe(false);
+  });
+
+  it('should toggle whether the provisional license was received', () => {
+    let result;
+    result = passCompletionReducer(initialState, new ProvisionalLicenseReceived());
+    expect(result.provisionalLicenceProvided).toBe(true);
+    result = passCompletionReducer(result, new ProvisionalLicenseNotReceived());
+    expect(result.provisionalLicenceProvided).toBe(false);
+  });
+
+});

--- a/src/modules/tests/pass-completion/__tests__/pass-completion.selector.spec.ts
+++ b/src/modules/tests/pass-completion/__tests__/pass-completion.selector.spec.ts
@@ -1,5 +1,9 @@
 import { PassCompletion } from '@dvsa/mes-test-schema/categories/B';
-import { getPassCertificateNumber, getProvisionalLicenseProvided } from '../pass-completion.selector';
+import {
+  getPassCertificateNumber,
+  provisionalLicenseProvided,
+  provisionalLicenseNotProvided,
+} from '../pass-completion.selector';
 
 describe('pass completion selector', () => {
   const state: PassCompletion = {
@@ -13,9 +17,15 @@ describe('pass completion selector', () => {
     });
   });
 
-  describe('getProvisionalLicenseProvided', () => {
+  describe('provisionalLicenseProvided', () => {
     it('should retrieve whether the provisional license was provided', () => {
-      expect(getProvisionalLicenseProvided(state)).toBe(true);
+      expect(provisionalLicenseProvided(state)).toBe(true);
+    });
+  });
+
+  describe('provisionalLicenseNotProvided', () => {
+    it('should retrieve whether the provisional license was provided', () => {
+      expect(provisionalLicenseNotProvided(state)).toBe(false);
     });
   });
 });

--- a/src/modules/tests/pass-completion/__tests__/pass-completion.selector.spec.ts
+++ b/src/modules/tests/pass-completion/__tests__/pass-completion.selector.spec.ts
@@ -1,0 +1,21 @@
+import { PassCompletion } from '@dvsa/mes-test-schema/categories/B';
+import { getPassCertificateNumber, getProvisionalLicenseProvided } from '../pass-completion.selector';
+
+describe('pass completion selector', () => {
+  const state: PassCompletion = {
+    provisionalLicenceProvided: true,
+    passCertificateNumber: 'ABC123',
+  };
+
+  describe('getPassCertificateNumber', () => {
+    it('should retrieve the pass certificate number', () => {
+      expect(getPassCertificateNumber(state)).toBe('ABC123');
+    });
+  });
+
+  describe('getProvisionalLicenseProvided', () => {
+    it('should retrieve whether the provisional license was provided', () => {
+      expect(getProvisionalLicenseProvided(state)).toBe(true);
+    });
+  });
+});

--- a/src/modules/tests/pass-completion/__tests__/pass-completion.selector.spec.ts
+++ b/src/modules/tests/pass-completion/__tests__/pass-completion.selector.spec.ts
@@ -1,8 +1,8 @@
 import { PassCompletion } from '@dvsa/mes-test-schema/categories/B';
 import {
   getPassCertificateNumber,
-  provisionalLicenseProvided,
-  provisionalLicenseNotProvided,
+  isProvisionalLicenseProvided,
+  isProvisionalLicenseNotProvided,
 } from '../pass-completion.selector';
 
 describe('pass completion selector', () => {
@@ -19,13 +19,13 @@ describe('pass completion selector', () => {
 
   describe('provisionalLicenseProvided', () => {
     it('should retrieve whether the provisional license was provided', () => {
-      expect(provisionalLicenseProvided(state)).toBe(true);
+      expect(isProvisionalLicenseProvided(state)).toBe(true);
     });
   });
 
   describe('provisionalLicenseNotProvided', () => {
     it('should retrieve whether the provisional license was provided', () => {
-      expect(provisionalLicenseNotProvided(state)).toBe(false);
+      expect(isProvisionalLicenseNotProvided(state)).toBe(false);
     });
   });
 });

--- a/src/modules/tests/pass-completion/pass-completion.actions.ts
+++ b/src/modules/tests/pass-completion/pass-completion.actions.ts
@@ -1,11 +1,23 @@
 import { Action } from '@ngrx/store';
 
 export const PASS_CERTIFICATE_NUMBER_CHANGED = '[Pass Completion] Pass certificate number changed';
+export const PROVISIONAL_LICENSE_RECEIVED = '[Pass Completion] Provisional license received';
+export const PROVISIONAL_LICENSE_NOT_RECEIVED = '[Pass Completion] Provisional license not received';
 
 export class PassCertificateNumberChanged implements Action {
   readonly type = PASS_CERTIFICATE_NUMBER_CHANGED;
   constructor(public passCertificateNumber: string) {}
 }
 
+export class ProvisionalLicenseReceived implements Action {
+  readonly type = PROVISIONAL_LICENSE_RECEIVED;
+}
+
+export class ProvisionalLicenseNotReceived implements Action {
+  readonly type = PROVISIONAL_LICENSE_NOT_RECEIVED;
+}
+
 export type Types =
-  | PassCertificateNumberChanged;
+  | PassCertificateNumberChanged
+  | ProvisionalLicenseReceived
+  | ProvisionalLicenseNotReceived;

--- a/src/modules/tests/pass-completion/pass-completion.reducer.ts
+++ b/src/modules/tests/pass-completion/pass-completion.reducer.ts
@@ -2,7 +2,7 @@ import * as passCompletionActions from './pass-completion.actions';
 import { PassCompletion } from '@dvsa/mes-test-schema/categories/B';
 import { createFeatureSelector } from '@ngrx/store';
 
-const initialState: PassCompletion = {
+export const initialState: PassCompletion = {
   provisionalLicenceProvided: null,
   passCertificateNumber: null,
 };
@@ -13,6 +13,16 @@ export const passCompletionReducer = (state = initialState, action: passCompleti
       return {
         ...state,
         passCertificateNumber: action.passCertificateNumber,
+      };
+    case passCompletionActions.PROVISIONAL_LICENSE_RECEIVED:
+      return {
+        ...state,
+        provisionalLicenceProvided: true,
+      };
+    case passCompletionActions.PROVISIONAL_LICENSE_NOT_RECEIVED:
+      return {
+        ...state,
+        provisionalLicenceProvided: false,
       };
     default:
       return state;

--- a/src/modules/tests/pass-completion/pass-completion.selector.ts
+++ b/src/modules/tests/pass-completion/pass-completion.selector.ts
@@ -1,3 +1,5 @@
 import { PassCompletion } from '@dvsa/mes-test-schema/categories/B';
 
 export const getPassCertificateNumber = (passCompletion: PassCompletion) => passCompletion.passCertificateNumber;
+export const getProvisionalLicenseProvided =
+  (passCompletion: PassCompletion) => passCompletion.provisionalLicenceProvided;

--- a/src/modules/tests/pass-completion/pass-completion.selector.ts
+++ b/src/modules/tests/pass-completion/pass-completion.selector.ts
@@ -1,5 +1,7 @@
 import { PassCompletion } from '@dvsa/mes-test-schema/categories/B';
 
 export const getPassCertificateNumber = (passCompletion: PassCompletion) => passCompletion.passCertificateNumber;
-export const getProvisionalLicenseProvided =
-  (passCompletion: PassCompletion) => passCompletion.provisionalLicenceProvided;
+export const provisionalLicenseProvided =
+  (passCompletion: PassCompletion) => passCompletion.provisionalLicenceProvided === true;
+export const provisionalLicenseNotProvided =
+  (passCompletion: PassCompletion) => passCompletion.provisionalLicenceProvided === false;

--- a/src/modules/tests/pass-completion/pass-completion.selector.ts
+++ b/src/modules/tests/pass-completion/pass-completion.selector.ts
@@ -1,7 +1,8 @@
 import { PassCompletion } from '@dvsa/mes-test-schema/categories/B';
 
 export const getPassCertificateNumber = (passCompletion: PassCompletion) => passCompletion.passCertificateNumber;
-export const provisionalLicenseProvided =
-  (passCompletion: PassCompletion) => passCompletion.provisionalLicenceProvided === true;
-export const provisionalLicenseNotProvided =
-  (passCompletion: PassCompletion) => passCompletion.provisionalLicenceProvided === false;
+export const isProvisionalLicenseProvided =
+  (passCompletion: PassCompletion) => passCompletion.provisionalLicenceProvided;
+export const isProvisionalLicenseNotProvided =
+  (passCompletion: PassCompletion) => passCompletion.provisionalLicenceProvided !== null
+  && !passCompletion.provisionalLicenceProvided;

--- a/src/pages/pass-finalisation/pass-finalisation.html
+++ b/src/pages/pass-finalisation/pass-finalisation.html
@@ -27,11 +27,11 @@
             <label>Provisional license received</label>
           </ion-col>
           <ion-col col-23>
-            <input type="radio" name="license" id="license-received" value="yes" [(ngModel)]="pageState.provisionalLicenseValue" class="gds-radio-button" (click)="provisionalLicenseReceived()">
+            <input type="radio" name="license" id="license-received" value="yes" [checked]="pageState.provisionalLicenseProvidedRadioChecked$ | async" class="gds-radio-button" (click)="provisionalLicenseReceived()">
             <label for="license-received" class="radio-label">Yes</label>
           </ion-col>
           <ion-col>
-            <input type="radio" name="license" id="license-not-received" value="no" [(ngModel)]="pageState.provisionalLicenseValue" class="gds-radio-button" (click)="provisionalLicenseNotReceived()">
+            <input type="radio" name="license" id="license-not-received" value="no" [checked]="pageState.provisionalLicenseNotProvidedRadioChecked$ | async" class="gds-radio-button" (click)="provisionalLicenseNotReceived()">
             <label for="license-not-received" class="radio-label">No</label>
           </ion-col>
         </ion-row>

--- a/src/pages/pass-finalisation/pass-finalisation.html
+++ b/src/pages/pass-finalisation/pass-finalisation.html
@@ -20,7 +20,6 @@
           </ion-col>
           <ion-col>
               <span class="mes-data">{{pageState.applicationNumber$ | async }}</span>
-              <!-- <span class="mes-data">{{pageState.provisionalLicenseProvided$ | async}}</span> -->
             </ion-col>
         </ion-row>
         <ion-row class="mes-full-width-card" id="provisional-license-card" align-items-center>

--- a/src/pages/pass-finalisation/pass-finalisation.html
+++ b/src/pages/pass-finalisation/pass-finalisation.html
@@ -20,6 +20,7 @@
           </ion-col>
           <ion-col>
               <span class="mes-data">{{pageState.applicationNumber$ | async }}</span>
+              <!-- <span class="mes-data">{{pageState.provisionalLicenseProvided$ | async}}</span> -->
             </ion-col>
         </ion-row>
         <ion-row class="mes-full-width-card" id="provisional-license-card" align-items-center>
@@ -27,11 +28,11 @@
             <label>Provisional license received</label>
           </ion-col>
           <ion-col col-23>
-            <input type="radio" name="license" id="license-received" class="gds-radio-button" (click)="provisionalLicenseReceived()">
+            <input type="radio" name="license" id="license-received" value="yes" [(ngModel)]="pageState.provisionalLicenseValue" class="gds-radio-button" (click)="provisionalLicenseReceived()">
             <label for="license-received" class="radio-label">Yes</label>
           </ion-col>
           <ion-col>
-            <input type="radio" name="license" id="license-not-received" class="gds-radio-button" (click)="provisionalLicenseNotReceived()">
+            <input type="radio" name="license" id="license-not-received" value="no" [(ngModel)]="pageState.provisionalLicenseValue" class="gds-radio-button" (click)="provisionalLicenseNotReceived()">
             <label for="license-not-received" class="radio-label">No</label>
           </ion-col>
         </ion-row>

--- a/src/pages/pass-finalisation/pass-finalisation.html
+++ b/src/pages/pass-finalisation/pass-finalisation.html
@@ -26,6 +26,14 @@
           <ion-col col-36>
             <label>Provisional license received</label>
           </ion-col>
+          <ion-col col-23>
+            <input type="radio" name="license" id="license-received" class="gds-radio-button" (click)="provisionalLicenseReceived()">
+            <label for="license-received" class="radio-label">Yes</label>
+          </ion-col>
+          <ion-col>
+            <input type="radio" name="license" id="license-not-received" class="gds-radio-button" (click)="provisionalLicenseNotReceived()">
+            <label for="license-not-received" class="radio-label">No</label>
+          </ion-col>
         </ion-row>
         <ion-row class="mes-full-width-card" id="pass-certificate-number-card" align-items-center>
           <ion-col col-36>

--- a/src/pages/pass-finalisation/pass-finalisation.ts
+++ b/src/pages/pass-finalisation/pass-finalisation.ts
@@ -7,9 +7,16 @@ import { StoreModel } from '../../shared/models/store.model';
 import {
   PassFinalisationViewDidEnter,
 } from './pass-finalisation.actions';
-import { PassCertificateNumberChanged } from '../../modules/tests/pass-completion/pass-completion.actions';
+import {
+  PassCertificateNumberChanged,
+  ProvisionalLicenseReceived,
+  ProvisionalLicenseNotReceived,
+} from '../../modules/tests/pass-completion/pass-completion.actions';
 import { getPassCompletion } from '../../modules/tests/pass-completion/pass-completion.reducer';
-import { getPassCertificateNumber } from '../../modules/tests/pass-completion/pass-completion.selector';
+import {
+  getPassCertificateNumber,
+  getProvisionalLicenseProvided,
+} from '../../modules/tests/pass-completion/pass-completion.selector';
 import { Observable } from 'rxjs/Observable';
 import { getCandidate } from '../../modules/tests/candidate/candidate.reducer';
 import {
@@ -30,6 +37,7 @@ interface PassFinalisationPageState {
   candidateUntitledName$: Observable<string>;
   candidateDriverNumber$: Observable<string>;
   applicationNumber$: Observable<string>;
+  provisionalLicenseProvided$: Observable<boolean>;
   passCertificateNumber$: Observable<string>;
 }
 
@@ -83,6 +91,12 @@ export class PassFinalisationPage extends BasePageComponent {
         select(getApplicationReference),
         select(getApplicationNumber),
       ),
+      provisionalLicenseProvided$: this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getPassCompletion),
+        select(getProvisionalLicenseProvided),
+      ),
       passCertificateNumber$: this.store$.pipe(
         select(getTests),
         select(getCurrentTest),
@@ -101,6 +115,14 @@ export class PassFinalisationPage extends BasePageComponent {
 
   ionViewDidEnter(): void {
     this.store$.dispatch(new PassFinalisationViewDidEnter());
+  }
+
+  provisionalLicenseReceived(): void {
+    this.store$.dispatch(new ProvisionalLicenseReceived());
+  }
+
+  provisionalLicenseNotReceived(): void {
+    this.store$.dispatch(new ProvisionalLicenseNotReceived());
   }
 
   /**

--- a/src/pages/pass-finalisation/pass-finalisation.ts
+++ b/src/pages/pass-finalisation/pass-finalisation.ts
@@ -15,7 +15,8 @@ import {
 import { getPassCompletion } from '../../modules/tests/pass-completion/pass-completion.reducer';
 import {
   getPassCertificateNumber,
-  getProvisionalLicenseProvided,
+  provisionalLicenseProvided,
+  provisionalLicenseNotProvided,
 } from '../../modules/tests/pass-completion/pass-completion.selector';
 import { Observable } from 'rxjs/Observable';
 import { getCandidate } from '../../modules/tests/candidate/candidate.reducer';
@@ -37,7 +38,8 @@ interface PassFinalisationPageState {
   candidateUntitledName$: Observable<string>;
   candidateDriverNumber$: Observable<string>;
   applicationNumber$: Observable<string>;
-  provisionalLicenseValue: string;
+  provisionalLicenseProvidedRadioChecked$: Observable<boolean>;
+  provisionalLicenseNotProvidedRadioChecked$: Observable<boolean>;
   passCertificateNumber$: Observable<string>;
 }
 
@@ -92,19 +94,27 @@ export class PassFinalisationPage extends BasePageComponent {
         select(getApplicationReference),
         select(getApplicationNumber),
       ),
+      provisionalLicenseProvidedRadioChecked$: this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getPassCompletion),
+        map(provisionalLicenseProvided),
+      ),
+      provisionalLicenseNotProvidedRadioChecked$: this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getPassCompletion),
+        map(provisionalLicenseNotProvided),
+      ),
       passCertificateNumber$: this.store$.pipe(
         select(getTests),
         select(getCurrentTest),
         select(getPassCompletion),
         select(getPassCertificateNumber),
       ),
-      provisionalLicenseValue: null,
     };
     this.inputSubscriptions = [
       this.inputChangeSubscriptionDispatchingAction(this.passCertificateNumberInput, PassCertificateNumberChanged),
-    ];
-    this.initialStateSubscriptions = [
-      this.provisionalLicenseSubscription(),
     ];
   }
 
@@ -125,11 +135,6 @@ export class PassFinalisationPage extends BasePageComponent {
     this.store$.dispatch(new ProvisionalLicenseNotReceived());
   }
 
-  setProvisionalLicenseValue = (provisionalLicenseValue: boolean): void => {
-    if (provisionalLicenseValue === null) return;
-    this.pageState.provisionalLicenseValue = provisionalLicenseValue ? 'yes' : 'no';
-  }
-
   /**
    * Returns a subscription to the debounced changes of a particular input fields.
    * Dispatches the provided action type to the store when a new value is yielded.
@@ -144,16 +149,6 @@ export class PassFinalisationPage extends BasePageComponent {
       );
     const subscription = changeStream$
       .subscribe((newVal: string) => this.store$.dispatch(new actionType(newVal)));
-    return subscription;
-  }
-
-  provisionalLicenseSubscription(): Subscription {
-    const subscription = this.store$
-      .select(getTests)
-      .select(getCurrentTest)
-      .select(getPassCompletion)
-      .select(getProvisionalLicenseProvided)
-      .subscribe(this.setProvisionalLicenseValue);
     return subscription;
   }
 

--- a/src/pages/pass-finalisation/pass-finalisation.ts
+++ b/src/pages/pass-finalisation/pass-finalisation.ts
@@ -68,47 +68,39 @@ export class PassFinalisationPage extends BasePageComponent {
   }
 
   ngOnInit(): void {
+
+    const currentTest$ = this.store$.pipe(
+      select(getTests),
+      select(getCurrentTest),
+    );
+
     this.pageState = {
-      candidateName$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      candidateName$: currentTest$.pipe(
         select(getCandidate),
         select(getCandidateName),
       ),
-      candidateUntitledName$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      candidateUntitledName$: currentTest$.pipe(
         select(getCandidate),
         select(getUntitledCandidateName),
       ),
-      candidateDriverNumber$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      candidateDriverNumber$: currentTest$.pipe(
         select(getCandidate),
         select(getCandidateDriverNumber),
         map(formatDriverNumber),
       ),
-      applicationNumber$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      applicationNumber$: currentTest$.pipe(
         select(getApplicationReference),
         select(getApplicationNumber),
       ),
-      provisionalLicenseProvidedRadioChecked$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      provisionalLicenseProvidedRadioChecked$: currentTest$.pipe(
         select(getPassCompletion),
         map(isProvisionalLicenseProvided),
       ),
-      provisionalLicenseNotProvidedRadioChecked$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      provisionalLicenseNotProvidedRadioChecked$: currentTest$.pipe(
         select(getPassCompletion),
         map(isProvisionalLicenseNotProvided),
       ),
-      passCertificateNumber$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      passCertificateNumber$: currentTest$.pipe(
         select(getPassCompletion),
         select(getPassCertificateNumber),
       ),

--- a/src/pages/pass-finalisation/pass-finalisation.ts
+++ b/src/pages/pass-finalisation/pass-finalisation.ts
@@ -15,8 +15,8 @@ import {
 import { getPassCompletion } from '../../modules/tests/pass-completion/pass-completion.reducer';
 import {
   getPassCertificateNumber,
-  provisionalLicenseProvided,
-  provisionalLicenseNotProvided,
+  isProvisionalLicenseProvided,
+  isProvisionalLicenseNotProvided,
 } from '../../modules/tests/pass-completion/pass-completion.selector';
 import { Observable } from 'rxjs/Observable';
 import { getCandidate } from '../../modules/tests/candidate/candidate.reducer';
@@ -98,13 +98,13 @@ export class PassFinalisationPage extends BasePageComponent {
         select(getTests),
         select(getCurrentTest),
         select(getPassCompletion),
-        map(provisionalLicenseProvided),
+        map(isProvisionalLicenseProvided),
       ),
       provisionalLicenseNotProvidedRadioChecked$: this.store$.pipe(
         select(getTests),
         select(getCurrentTest),
         select(getPassCompletion),
-        map(provisionalLicenseNotProvided),
+        map(isProvisionalLicenseNotProvided),
       ),
       passCertificateNumber$: this.store$.pipe(
         select(getTests),

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.ts
@@ -89,52 +89,42 @@ export class WaitingRoomToCarPage extends BasePageComponent{
   }
 
   ngOnInit(): void {
+
+    const currentTest$ = this.store$.pipe(
+      select(getTests),
+      select(getCurrentTest),
+    );
+
     this.pageState = {
-      candidateName$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      candidateName$: currentTest$.pipe(
         select(getCandidate),
         select(getUntitledCandidateName),
       ),
-      registrationNumber$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      registrationNumber$: currentTest$.pipe(
         select(getVehicleDetails),
         select(getRegistrationNumber),
       ),
-      transmission$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      transmission$: currentTest$.pipe(
         select(getVehicleDetails),
         select(getGearboxCategory),
       ),
-      schoolCar$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      schoolCar$: currentTest$.pipe(
         select(getVehicleDetails),
         select(getSchoolCar),
       ),
-      dualControls$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      dualControls$: currentTest$.pipe(
         select(getVehicleDetails),
         select(getDualControls),
       ),
-      instructorAccompaniment$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      instructorAccompaniment$: currentTest$.pipe(
         select(getAccompaniment),
         select(getInstructorAccompaniment),
       ),
-      supervisorAccompaniment$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      supervisorAccompaniment$: currentTest$.pipe(
         select(getAccompaniment),
         select(getSupervisorAccompaniment),
       ),
-      otherAccompaniment$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      otherAccompaniment$: currentTest$.pipe(
         select(getAccompaniment),
         select(getOtherAccompaniment),
       ),

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -97,40 +97,33 @@ export class WaitingRoomPage extends BasePageComponent {
     this.signatureArea.signHereText = 'Sign here';
     this.signatureArea.retryButtonText = 'Retry';
 
+    const currentTest$ = this.store$.pipe(
+      select(getTests),
+      select(getCurrentTest),
+    );
+
     this.pageState = {
-      insuranceDeclarationAccepted$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      insuranceDeclarationAccepted$: currentTest$.pipe(
         select(getPreTestDeclarations),
         select(getInsuranceDeclarationStatus),
       ),
-      residencyDeclarationAccepted$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      residencyDeclarationAccepted$: currentTest$.pipe(
         select(getPreTestDeclarations),
         select(getResidencyDeclarationStatus),
       ),
-      signature$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      signature$: currentTest$.pipe(
         select(getPreTestDeclarations),
         select(getSignatureStatus),
       ),
-      candidateName$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      candidateName$: currentTest$.pipe(
         select(getCandidate),
         select(getCandidateName),
       ),
-      candidateUntitledName$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      candidateUntitledName$: currentTest$.pipe(
         select(getCandidate),
         select(getUntitledCandidateName),
       ),
-      candidateDriverNumber$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      candidateDriverNumber$: currentTest$.pipe(
         select(getCandidate),
         select(getCandidateDriverNumber),
         map(formatDriverNumber),


### PR DESCRIPTION
## Description and relevant Jira numbers
- Updated pass completion reducer and selector, created tests
- Added radio buttons to record whether provisional license has been provided
- Radio buttons are unselected initially to allow validation in future story (MES-1922)
- Value of radio buttons is set from store on page init

**There's possibly a better way to set the value of radio buttons on page init. Maybe using `RadioControlValueAccessor`? Would appreciate another pair of eye on my approach.**


## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

<img width="646" alt="Screenshot 2019-04-01 at 11 09 12" src="https://user-images.githubusercontent.com/8069071/55320346-bfa66680-546e-11e9-893f-b6f1478b9f3e.png">
