### PR TITLE
Fix failing journal effects tests by changing 2-day date differential to 1 day

### DIFF
--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -293,7 +293,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1007,
-        "start": "2019-04-03T14:32:00+01:00"
+        "start": "2019-04-02T14:32:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,


### PR DESCRIPTION
## Description and relevant Jira numbers
* Journal effects tests were expecting slots tomorrow, but a 1 day gap had appeared between the slots
* Remove this gap to fix the tests

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
