### PR TITLE
MES-2020: Populate show me question selector (MES-1907)

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { DataStoreProvider } from '../providers/data-store/data-store';
 import { SecureStorage } from '@ionic-native/secure-storage';
 import { TestsModule } from '../modules/tests/tests.module';
 import { DeviceAuthenticationProvider } from '../providers/device-authentication/device-authentication';
+import { QuestionProvider } from '../providers/question/question';
 
 @NgModule({
   declarations: [App],
@@ -76,6 +77,7 @@ import { DeviceAuthenticationProvider } from '../providers/device-authentication
     SecureStorage,
     DataStoreProvider,
     DeviceAuthenticationProvider,
+    QuestionProvider,
   ],
 })
 export class AppModule {}

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -17,6 +17,7 @@
 @import '../theme/sass-partials/reset.scss';
 
 @import '../theme/mixins/_box-shadow.scss';
+@import '../theme/sass-partials/_alert.scss';
 @import '../theme/sass-partials/_typography.scss';
 @import '../theme/sass-partials/_fonts.scss';
 @import '../theme/sass-partials/_colors.scss';

--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
@@ -31,6 +31,8 @@ import {
   EyesightResultPasssed,
   EyesightResultReset,
 } from '../../../modules/tests/eyesight-test-result/eyesight-test-result.actions';
+import { QuestionProvider } from '../../../providers/question/question';
+import { QuestionProviderMock } from '../../../providers/question/__mocks__/question.mock';
 
 describe('WaitingRoomToCarPage', () => {
   let fixture: ComponentFixture<WaitingRoomToCarPage>;
@@ -70,6 +72,7 @@ describe('WaitingRoomToCarPage', () => {
         { provide: Platform, useFactory: () => PlatformMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
+        { provide: QuestionProvider, useClass: QuestionProviderMock },
       ],
     })
       .compileComponents()
@@ -85,6 +88,9 @@ describe('WaitingRoomToCarPage', () => {
     // Unit tests for the components TypeScript class
     it('should create', () => {
       expect(component).toBeDefined();
+    });
+    it('should get tell me question from the question provider', () => {
+      expect(component.tellMeQuestions.length).toBe(2);
     });
   });
 

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.html
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.html
@@ -33,7 +33,7 @@
               <ion-col col-32>
                 <label>Tell me question</label>
               </ion-col>
-              <ion-col>
+              <ion-col col-42>
                 <ion-select value="tell-me-question" okText="Submit" cancelText="Cancel" placeholder="Select a question" (ionChange)="tellMeQuestionChanged($event)">
                   <ion-option [value]="tellMeQuestion.tellMeQuestionCode" *ngFor="let tellMeQuestion of tellMeQuestions">
                     {{tellMeQuestion.tellMeQuestionCode}} - {{tellMeQuestion.tellMeQuestionShortName}}

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.html
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.html
@@ -33,6 +33,14 @@
               <ion-col col-32>
                 <label>Tell me question</label>
               </ion-col>
+              <ion-col>
+                <ion-select value="tell-me-question" okText="Submit" cancelText="Cancel" placeholder="Select a question">
+                  <ion-option value="t1">T1</ion-option>
+                  <ion-option value="t2">T2</ion-option>
+                  <ion-option value="t3">T3</ion-option>
+                  <ion-option value="t4">T4</ion-option>
+                </ion-select>
+              </ion-col>
             </ion-row>
             <ion-row class="mes-full-width-card" id="registration-card" align-items-center>
               <ion-col col-32>

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.html
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.html
@@ -34,8 +34,8 @@
                 <label>Tell me question</label>
               </ion-col>
               <ion-col>
-                <ion-select value="tell-me-question" okText="Submit" cancelText="Cancel" placeholder="Select a question">
-                  <ion-option value="tellMeQuestion.tellMeQuestionCode" *ngFor="let tellMeQuestion of tellMeQuestions">
+                <ion-select value="tell-me-question" okText="Submit" cancelText="Cancel" placeholder="Select a question" (ionChange)="tellMeQuestionChanged($event)">
+                  <ion-option [value]="tellMeQuestion.tellMeQuestionCode" *ngFor="let tellMeQuestion of tellMeQuestions">
                     {{tellMeQuestion.tellMeQuestionCode}} - {{tellMeQuestion.tellMeQuestionShortName}}
                   </ion-option>
                 </ion-select>

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.html
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.html
@@ -50,7 +50,7 @@
               <ion-col class="component-label" col-32>
                 <label>Tell me question</label>
               </ion-col>
-              <ion-col col-37>
+              <ion-col col-40>
                   <ion-row class="spacing-row"></ion-row>
                   <ion-row class="component-row" align-items-center justify-content-start >
                     <ion-select value="tell-me-question" okText="Submit" cancelText="Cancel" placeholder="Select a question" (ionChange)="tellMeQuestionChanged($event)" formControlName="tellMeQuestionCtrl">

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.html
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.html
@@ -19,7 +19,7 @@
         <ion-col>
           <ion-row class="spacing-row"></ion-row>
           <ion-row class="component-row" align-items-center justify-content-start >
-              <ion-col col-32>
+              <ion-col col-37>
                   <input type="radio" formControlName="eyesightCtrl" name="eyesightCtrl" id="eyesight-pass"
                   class="gds-radio-button" [class.ng-invalid]="isCtrlDirtyAndInvalid('eyesightCtrl')"
                   (click)="eyesightPassPressed()" [checked]="pageState.eyesightPassRadioChecked$ | async" value="P">
@@ -50,7 +50,7 @@
               <ion-col class="component-label" col-32>
                 <label>Tell me question</label>
               </ion-col>
-              <ion-col col-42>
+              <ion-col col-37>
                   <ion-row class="spacing-row"></ion-row>
                   <ion-row class="component-row" align-items-center justify-content-start >
                     <ion-select value="tell-me-question" okText="Submit" cancelText="Cancel" placeholder="Select a question" (ionChange)="tellMeQuestionChanged($event)">

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.html
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.html
@@ -11,77 +11,82 @@
   <div>
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <ion-grid>
-      <ion-row class="mes-row" id="eyesight-test-card" align-items-center>
+        <ion-row class="mes-row" id="eyesight-test-card" align-items-center>
           <div class="row-validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('eyesightCtrl')"></div>
           <ion-col class="component-label" col-32>
             <label>Eyesight test</label>
-        </ion-col>
-        <ion-col>
-          <ion-row class="spacing-row"></ion-row>
-          <ion-row class="component-row" align-items-center justify-content-start >
+          </ion-col>
+          <ion-col>
+            <ion-row class="spacing-row"></ion-row>
+            <ion-row class="component-row" align-items-center justify-content-start>
               <ion-col col-37>
-                  <input type="radio" formControlName="eyesightCtrl" name="eyesightCtrl" id="eyesight-pass"
+                <input type="radio" formControlName="eyesightCtrl" name="eyesightCtrl" id="eyesight-pass"
                   class="gds-radio-button" [class.ng-invalid]="isCtrlDirtyAndInvalid('eyesightCtrl')"
                   (click)="eyesightPassPressed()" [checked]="pageState.eyesightPassRadioChecked$ | async" value="P">
                 <label for="eyesight-pass" class="radio-label">Pass</label>
               </ion-col>
               <ion-col col-32>
-                  <input type="radio" formControlName="eyesightCtrl" name="eyesightCtrl" id="eyesight-fail"
+                <input type="radio" formControlName="eyesightCtrl" name="eyesightCtrl" id="eyesight-fail"
                   class="gds-radio-button" [class.ng-invalid]="isCtrlDirtyAndInvalid('eyesightCtrl')"
                   (click)="eyesightFailPressed()" [checked]="pageState.eyesightFailRadioChecked$ | async" value="F">
                 <label for="eyesight-fail" class="radio-label">Fail</label>
               </ion-col>
-          </ion-row>
-          <ion-row class="validation-message-row" align-items-center justify-content-start>
-                  <div id="waiting-room-insurance-validation-text" class="validation-text"
-                  [class.ng-invalid]="isCtrlDirtyAndInvalid('eyesightCtrl')">
-                  Select the eyesight test outcome
-                  </div>
-          </ion-row>
-        </ion-col>
-      </ion-row>
+            </ion-row>
+            <ion-row class="validation-message-row" align-items-center justify-content-start>
+              <div id="waiting-room-insurance-validation-text" class="validation-text"
+                [class.ng-invalid]="isCtrlDirtyAndInvalid('eyesightCtrl')">
+                Select the eyesight test outcome
+              </div>
+            </ion-row>
+          </ion-col>
+        </ion-row>
         <ion-row *ngIf="pageState.eyesightFailRadioChecked$ | async">
           <eyesight-failure-confirmation [cancelFn]="eyesightFailCancelled"></eyesight-failure-confirmation>
         </ion-row>
         <ion-row no-padding [hidden]="pageState.eyesightFailRadioChecked$ | async" id="post-eyesight-form-content">
           <ion-col no-padding>
+
             <ion-row class="mes-row" id="tell-me-card" align-items-center justify-content-start>
               <div class="row-validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('tellMeQuestionCtrl')"></div>
               <ion-col class="component-label" col-32>
                 <label>Tell me question</label>
               </ion-col>
               <ion-col col-40>
-                  <ion-row class="spacing-row"></ion-row>
-                  <ion-row class="component-row" align-items-center justify-content-start >
-                    <ion-select value="tell-me-question" okText="Submit" cancelText="Cancel" placeholder="Select a question" (ionChange)="tellMeQuestionChanged($event)" formControlName="tellMeQuestionCtrl">
-                      <ion-option [value]="tellMeQuestion.tellMeQuestionCode" *ngFor="let tellMeQuestion of tellMeQuestions">
-                        {{tellMeQuestion.tellMeQuestionCode}} - {{tellMeQuestion.tellMeQuestionShortName}}
-                      </ion-option>
-                    </ion-select>
-                  </ion-row>
-                  <ion-row class="validation-message-row" align-items-center justify-content-start>
-                    <div id="waiting-room-insurance-validation-text" class="validation-text"
-                      [class.ng-invalid]="isCtrlDirtyAndInvalid('tellMeQuestionCtrl')">
-                      Select a 'Tell me' question
-                    </div>
-                  </ion-row>
-              </ion-col>  
-              </ion-row>
+                <ion-row class="spacing-row"></ion-row>
+                <ion-row class="component-row" align-items-center justify-content-start>
+                  <ion-select value="tell-me-question" okText="Submit" cancelText="Cancel"
+                    placeholder="Select a question" (ionChange)="tellMeQuestionChanged($event)"
+                    formControlName="tellMeQuestionCtrl">
+                    <ion-option [value]="tellMeQuestion.tellMeQuestionCode"
+                      *ngFor="let tellMeQuestion of tellMeQuestions">
+                      {{tellMeQuestion.tellMeQuestionCode}} - {{tellMeQuestion.tellMeQuestionShortName}}
+                    </ion-option>
+                  </ion-select>
+                </ion-row>
+                <ion-row class="validation-message-row" align-items-center justify-content-start>
+                  <div id="waiting-room-insurance-validation-text" class="validation-text"
+                    [class.ng-invalid]="isCtrlDirtyAndInvalid('tellMeQuestionCtrl')">
+                    Select a 'Tell me' question
+                  </div>
+                </ion-row>
+              </ion-col>
+            </ion-row>
 
             <ion-row class="mes-row" id="registration-card" align-items-center>
-                <div class="row-validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('registrationNumberCtrl')"></div>
-                <ion-col class="component-label" col-32>
-                  <label>Vehicle registration number</label>
+              <div class="row-validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('registrationNumberCtrl')">
+              </div>
+              <ion-col class="component-label" col-32>
+                <label>Vehicle registration number</label>
               </ion-col>
               <ion-col>
                 <ion-row class="spacing-row"></ion-row>
-                <ion-row class="component-row" align-items-center justify-content-start >
-                    <ion-col col-32>
-                        <input #registrationInput type="text" id="registration" formControlName="registrationNumberCtrl"
-                        class="vehicle-reg-input" autocapitalize="characters" uppercaseAlphanumOnly
-                        [class.ng-invalid]="isCtrlDirtyAndInvalid('registrationNumberCtrl')"
-                        [value]="pageState.registrationNumber$ | async">
-                      </ion-col>
+                <ion-row class="component-row" align-items-center justify-content-start>
+                  <ion-col col-32>
+                    <input #registrationInput type="text" id="registration" formControlName="registrationNumberCtrl"
+                      class="vehicle-reg-input" autocapitalize="characters" uppercaseAlphanumOnly
+                      [class.ng-invalid]="isCtrlDirtyAndInvalid('registrationNumberCtrl')"
+                      [value]="pageState.registrationNumber$ | async">
+                  </ion-col>
                 </ion-row>
                 <ion-row class="validation-message-row" align-items-center justify-content-start>
                   <div id="waiting-room-insurance-validation-text" class="validation-text"
@@ -93,35 +98,36 @@
             </ion-row>
 
             <ion-row class="mes-row" id="transmission-card" align-items-center>
-                <div class="row-validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('transmissionRadioGroupCtrl')"></div>
-                <ion-col class="component-label" col-32>
-                  <label>Transmission</label>
+              <div class="row-validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('transmissionRadioGroupCtrl')">
+              </div>
+              <ion-col class="component-label" col-32>
+                <label>Transmission</label>
               </ion-col>
               <ion-col>
                 <ion-row class="spacing-row"></ion-row>
-                <ion-row class="component-row" align-items-center justify-content-start >
-                    <ion-col col-32>
-                        <input type="radio" formControlName="transmissionRadioGroupCtrl" name="transmissionRadioGroupCtrl"
-                        id="transmission-manual" class="gds-radio-button"
-                        [class.ng-invalid]="isCtrlDirtyAndInvalid('transmissionRadioGroupCtrl')"
-                        (click)="manualTransmission()" [checked]="pageState.gearboxManualRadioChecked$ | async"
-                        value='Manual'>
-                      <label for="transmission-manual" class="radio-label">Manual</label>
-                      </ion-col>
-                    <ion-col col-32>
-                        <input type="radio" formControlName="transmissionRadioGroupCtrl" name="transmissionRadioGroupCtrl"
-                        id="transmission-automatic" class="gds-radio-button"
-                        [class.ng-invalid]="isCtrlDirtyAndInvalid('transmissionRadioGroupCtrl')"
-                        (click)="automaticTransmission()" [checked]="pageState.gearboxAutomaticRadioChecked$ | async"
-                        value='Automatic'>
-                      <label for="transmission-automatic" class="radio-label">Automatic</label>
-                      </ion-col>
-                    </ion-row>
+                <ion-row class="component-row" align-items-center justify-content-start>
+                  <ion-col col-32>
+                    <input type="radio" formControlName="transmissionRadioGroupCtrl" name="transmissionRadioGroupCtrl"
+                      id="transmission-manual" class="gds-radio-button"
+                      [class.ng-invalid]="isCtrlDirtyAndInvalid('transmissionRadioGroupCtrl')"
+                      (click)="manualTransmission()" [checked]="pageState.gearboxManualRadioChecked$ | async"
+                      value='Manual'>
+                    <label for="transmission-manual" class="radio-label">Manual</label>
+                  </ion-col>
+                  <ion-col col-32>
+                    <input type="radio" formControlName="transmissionRadioGroupCtrl" name="transmissionRadioGroupCtrl"
+                      id="transmission-automatic" class="gds-radio-button"
+                      [class.ng-invalid]="isCtrlDirtyAndInvalid('transmissionRadioGroupCtrl')"
+                      (click)="automaticTransmission()" [checked]="pageState.gearboxAutomaticRadioChecked$ | async"
+                      value='Automatic'>
+                    <label for="transmission-automatic" class="radio-label">Automatic</label>
+                  </ion-col>
+                </ion-row>
                 <ion-row class="validation-message-row" align-items-center justify-content-start>
-                        <div id="waiting-room-insurance-validation-text" class="validation-text"
-                        [class.ng-invalid]="isCtrlDirtyAndInvalid('transmissionRadioGroupCtrl')">
-                        Select the transmission of the vehicle
-                        </div>
+                  <div id="waiting-room-insurance-validation-text" class="validation-text"
+                    [class.ng-invalid]="isCtrlDirtyAndInvalid('transmissionRadioGroupCtrl')">
+                    Select the transmission of the vehicle
+                  </div>
                 </ion-row>
               </ion-col>
             </ion-row>
@@ -132,18 +138,18 @@
                 <label>Instructor registration number (optional)</label>
               </ion-col>
               <ion-col>
-                  <ion-row class="spacing-row"></ion-row>
-                    <ion-row class="component-row" align-items-center justify-content-start>
-                        <ion-col><input #instructorRegistrationInput type="number" id="instructor-registration" numbersOnly
-                          [value]="pageState.instructorRegistrationNumber$ | async"></ion-col>
-                    </ion-row>
-                    <ion-row class="validation-message-row" align-items-center justify-content-start>
-                    </ion-row>
+                <ion-row class="spacing-row"></ion-row>
+                <ion-row class="component-row" align-items-center justify-content-start>
+                  <ion-col><input #instructorRegistrationInput type="number" id="instructor-registration" numbersOnly
+                      [value]="pageState.instructorRegistrationNumber$ | async"></ion-col>
+                </ion-row>
+                <ion-row class="validation-message-row" align-items-center justify-content-start>
+                </ion-row>
               </ion-col>
             </ion-row>
 
             <ion-row class="mes-row" id="accompaniment-card" align-items-center>
-                <div class="row-validation-bar"></div>
+              <div class="row-validation-bar"></div>
               <ion-col class="component-label" col-32>
                 <label>Accompanied by (optional)</label>
               </ion-col>
@@ -167,18 +173,18 @@
                   </ion-col>
                 </ion-row>
                 <ion-row class="validation-message-row" align-items-center justify-content-start>
-                  </ion-row>
+                </ion-row>
               </ion-col>
             </ion-row>
-            
+
             <ion-row class="mes-row" id="vehicle-details-card" align-items-center>
-                <div class="row-validation-bar"></div>
+              <div class="row-validation-bar"></div>
               <ion-col class="component-label" col-32>
                 <label>Vehicle details (optional)</label>
               </ion-col>
               <ion-col>
-                  <ion-row class="spacing-row"></ion-row>
-                  <ion-row class="component-row" align-items-center justify-content-start>
+                <ion-row class="spacing-row"></ion-row>
+                <ion-row class="component-row" align-items-center justify-content-start>
                   <ion-col col-32>
                     <input type="checkbox" id="school-car" class="gds-checkbox" [checked]="pageState.schoolCar$ | async"
                       (click)="schoolCarToggled()">
@@ -191,12 +197,14 @@
                   </ion-col>
                 </ion-row>
                 <ion-row class="validation-message-row" align-items-center justify-content-start>
-                  </ion-row>
+                </ion-row>
               </ion-col>
             </ion-row>
 
             <ion-row class="mes-full-width-card">
-              <button type="submit" class="mes-primary-button" id="continue-to-test-report" ion-button>Continue to test report</button>
+              <button type="submit" class="mes-primary-button" id="continue-to-test-report" ion-button>
+                Continue to test report
+              </button>
             </ion-row>
           </ion-col>
         </ion-row>

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.html
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.html
@@ -35,10 +35,9 @@
               </ion-col>
               <ion-col>
                 <ion-select value="tell-me-question" okText="Submit" cancelText="Cancel" placeholder="Select a question">
-                  <ion-option value="t1">T1</ion-option>
-                  <ion-option value="t2">T2</ion-option>
-                  <ion-option value="t3">T3</ion-option>
-                  <ion-option value="t4">T4</ion-option>
+                  <ion-option value="tellMeQuestion.tellMeQuestionCode" *ngFor="let tellMeQuestion of tellMeQuestions">
+                    {{tellMeQuestion.tellMeQuestionCode}} - {{tellMeQuestion.tellMeQuestionShortName}}
+                  </ion-option>
                 </ion-select>
               </ion-col>
             </ion-row>

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.html
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.html
@@ -46,20 +46,24 @@
         <ion-row no-padding [hidden]="pageState.eyesightFailRadioChecked$ | async" id="post-eyesight-form-content">
           <ion-col no-padding>
             <ion-row class="mes-row" id="tell-me-card" align-items-center justify-content-start>
-              <div class="row-validation-bar"></div>
+              <div class="row-validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('tellMeQuestionCtrl')"></div>
               <ion-col class="component-label" col-32>
                 <label>Tell me question</label>
               </ion-col>
               <ion-col col-37>
                   <ion-row class="spacing-row"></ion-row>
                   <ion-row class="component-row" align-items-center justify-content-start >
-                    <ion-select value="tell-me-question" okText="Submit" cancelText="Cancel" placeholder="Select a question" (ionChange)="tellMeQuestionChanged($event)">
+                    <ion-select value="tell-me-question" okText="Submit" cancelText="Cancel" placeholder="Select a question" (ionChange)="tellMeQuestionChanged($event)" formControlName="tellMeQuestionCtrl">
                       <ion-option [value]="tellMeQuestion.tellMeQuestionCode" *ngFor="let tellMeQuestion of tellMeQuestions">
                         {{tellMeQuestion.tellMeQuestionCode}} - {{tellMeQuestion.tellMeQuestionShortName}}
                       </ion-option>
                     </ion-select>
                   </ion-row>
                   <ion-row class="validation-message-row" align-items-center justify-content-start>
+                    <div id="waiting-room-insurance-validation-text" class="validation-text"
+                      [class.ng-invalid]="isCtrlDirtyAndInvalid('tellMeQuestionCtrl')">
+                      Select a 'Tell me' question
+                    </div>
                   </ion-row>
               </ion-col>  
               </ion-row>
@@ -80,10 +84,10 @@
                       </ion-col>
                 </ion-row>
                 <ion-row class="validation-message-row" align-items-center justify-content-start>
-                        <div id="waiting-room-insurance-validation-text" class="validation-text"
-                        [class.ng-invalid]="isCtrlDirtyAndInvalid('registrationNumberCtrl')">
-                        Enter the registration number
-                        </div>
+                  <div id="waiting-room-insurance-validation-text" class="validation-text"
+                    [class.ng-invalid]="isCtrlDirtyAndInvalid('registrationNumberCtrl')">
+                    Enter the registration number
+                  </div>
                 </ion-row>
               </ion-col>
             </ion-row>

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.scss
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.scss
@@ -5,6 +5,9 @@ page-waiting-room-to-car {
       position: relative;
       min-height: 120px;
       border-bottom: 2px solid map-get($colors-gds, 'gds-grey-5');
+      ion-select {
+        width: 100%;
+      }
       .spacing-row {
         height: 32px;
       }

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.ts
@@ -46,6 +46,8 @@ import {
 } from '../../modules/tests/eyesight-test-result/eyesight-test-result.actions';
 import { getEyesightTestResult } from '../../modules/tests/eyesight-test-result/eyesight-test-result.reducer';
 import { isFailed, isPassed } from '../../modules/tests/eyesight-test-result/eyesight-test-result.selector';
+import { TellMeQuestion } from '../../providers/question/tell-me-question.model';
+import { QuestionProvider } from '../../providers/question/question';
 
 interface WaitingRoomToCarPageState {
   candidateName$: Observable<string>;
@@ -78,14 +80,18 @@ export class WaitingRoomToCarPage extends BasePageComponent{
 
   showEyesightFailureConfirmation: boolean = false;
 
+  tellMeQuestions: TellMeQuestion[];
+
   constructor(
     private store$: Store<StoreModel>,
     public navCtrl: NavController,
     public navParams: NavParams,
     public platform: Platform,
     public authenticationProvider: AuthenticationProvider,
+    public questionProvider: QuestionProvider,
   ) {
     super(platform, navCtrl, authenticationProvider);
+    this.tellMeQuestions = questionProvider.getTellMeQuestions();
   }
 
   ngOnInit(): void {

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.ts
@@ -224,4 +224,8 @@ export class WaitingRoomToCarPage extends BasePageComponent{
   eyesightFailCancelled = () => {
     this.store$.dispatch(new EyesightResultReset());
   }
+
+  tellMeQuestionChanged(e): void {
+    console.log(e);
+  }
 }

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.ts
@@ -226,6 +226,5 @@ export class WaitingRoomToCarPage extends BasePageComponent{
   }
 
   tellMeQuestionChanged(e): void {
-    console.log(e);
   }
 }

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.ts
@@ -235,6 +235,7 @@ export class WaitingRoomToCarPage extends BasePageComponent{
 
   getFormValidation(): { [key: string]: FormControl } {
     return {
+      tellMeQuestionCtrl: new FormControl('', [Validators.required]),
       transmissionRadioGroupCtrl: new FormControl('', [Validators.required]),
       registrationNumberCtrl: new FormControl('', [Validators.required]),
       eyesightCtrl: new FormControl('', [Validators.required]),

--- a/src/providers/question/__mocks__/question.mock.ts
+++ b/src/providers/question/__mocks__/question.mock.ts
@@ -1,0 +1,10 @@
+import { TellMeQuestion } from '../tell-me-question.model';
+
+export class QuestionProviderMock {
+  getTellMeQuestions(): TellMeQuestion[] {
+    return [
+      { tellMeQuestionCode: 'T1', tellMeQuestionDescription: 'What time is it?',  tellMeQuestionShortName: 'Time' },
+      { tellMeQuestionCode: 'T2', tellMeQuestionDescription: 'Where are we?', tellMeQuestionShortName: 'Where' },
+    ];
+  }
+}

--- a/src/providers/question/question.ts
+++ b/src/providers/question/question.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { TellMeQuestion } from './tell-me-question.model';
+import { default as tellMeQuestions } from './tell-me-question.constants';
+
+@Injectable()
+export class QuestionProvider {
+  getTellMeQuestions(): TellMeQuestion[] {
+    return tellMeQuestions;
+  }
+}

--- a/src/providers/question/tell-me-question.constants.ts
+++ b/src/providers/question/tell-me-question.constants.ts
@@ -1,0 +1,77 @@
+/* tslint:disable */
+import { TellMeQuestion } from './tell-me-question.model';
+
+const tellMeQuestions: TellMeQuestion[] = [
+  {
+    tellMeQuestionCode: 'T1',
+    tellMeQuestionDescription: 'Tell me how you would check that the brakes are working before starting a journey.',
+    tellMeQuestionShortName: 'Brakes',
+  },
+  {
+    tellMeQuestionCode: 'T2',
+    tellMeQuestionDescription: 'Tell me where you would find the information for the recommended tyre pressures for this car and how tyre pressures should be checked.',
+    tellMeQuestionShortName: 'Tyre pressures',
+  },
+  {
+    tellMeQuestionCode: 'T3',
+    tellMeQuestionDescription: 'Tell me how you make sure your head restraint is correctly adjusted so it provides the best protection in the event of a crash.',
+    tellMeQuestionShortName: 'Head restraint',
+  },
+  {
+    tellMeQuestionCode: 'T4',
+    tellMeQuestionDescription: 'Tell me how you would check the tyres to ensure that they have sufficient tread depth and that their general condition is safe to use on the road.',
+    tellMeQuestionShortName: 'Sufficient tread',
+  },
+  {
+    tellMeQuestionCode: 'T5',
+    tellMeQuestionDescription: 'Tell me how you would check that the headlights & tail lights are working. (No need to exit vehicle)',
+    tellMeQuestionShortName: 'Headlights & tail lights',
+  },
+  {
+    tellMeQuestionCode: 'T6',
+    tellMeQuestionDescription: 'Tell me how you would know if there was a problem with your antilock braking system.',
+    tellMeQuestionShortName: 'Antilock braking system',
+  },
+  {
+    tellMeQuestionCode: 'T7',
+    tellMeQuestionDescription: 'Tell me how you would check the direction indicators are working. (No need to exit the vehicle)',
+    tellMeQuestionShortName: 'Direction indicators',
+  },
+  {
+    tellMeQuestionCode: 'T8',
+    tellMeQuestionDescription: 'Tell me how you would check the brake lights are working on this car.',
+    tellMeQuestionShortName: 'Brake lights',
+  },
+  {
+    tellMeQuestionCode: 'T9',
+    tellMeQuestionDescription: 'Tell me how you would check the power assisted steering is working before starting a journey.',
+    tellMeQuestionShortName: 'Power assisted steering',
+  },
+  {
+    tellMeQuestionCode: 'T10',
+    tellMeQuestionDescription: 'Tell me how you would switch on the rear fog light(s) and explain when you would use it/them, (no need to exit vehicle).',
+    tellMeQuestionShortName: 'Rear fog light(s)',
+  },
+  {
+    tellMeQuestionCode: 'T11',
+    tellMeQuestionDescription: 'Tell me how you switch your headlight from dipped to main beam and explain how you would know the main beam is on.',
+    tellMeQuestionShortName: 'Dipped to main beam',
+  },
+  {
+    tellMeQuestionCode: 'T12',
+    tellMeQuestionDescription: 'Open the bonnet and tell me how you would check that the engine has sufficient oil.',
+    tellMeQuestionShortName: 'Engine has sufficient oil',
+  },
+  {
+    tellMeQuestionCode: 'T13',
+    tellMeQuestionDescription: 'Open the bonnet and tell me how you would check that the engine has sufficient engine coolant.',
+    tellMeQuestionShortName: 'Engine coolant',
+  },
+  {
+    tellMeQuestionCode: 'T14',
+    tellMeQuestionDescription: 'Open the bonnet and tell me how you would check that you have a safe level of hydraulic brake fluid.',
+    tellMeQuestionShortName: 'Brake fluid',
+  },
+];
+
+export default tellMeQuestions;

--- a/src/providers/question/tell-me-question.constants.ts
+++ b/src/providers/question/tell-me-question.constants.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { TellMeQuestion } from './tell-me-question.model';
 
-const tellMeQuestions: TellMeQuestion[] = [
+export default [
   {
     tellMeQuestionCode: 'T1',
     tellMeQuestionDescription: 'Tell me how you would check that the brakes are working before starting a journey.',
@@ -72,6 +72,4 @@ const tellMeQuestions: TellMeQuestion[] = [
     tellMeQuestionDescription: 'Open the bonnet and tell me how you would check that you have a safe level of hydraulic brake fluid.',
     tellMeQuestionShortName: 'Brake fluid',
   },
-];
-
-export default tellMeQuestions;
+] as TellMeQuestion[];

--- a/src/providers/question/tell-me-question.model.ts
+++ b/src/providers/question/tell-me-question.model.ts
@@ -1,0 +1,6 @@
+import { VehicleChecks } from '@dvsa/mes-test-schema/categories/B';
+
+export type TellMeQuestion = Pick<VehicleChecks,
+  | 'tellMeQuestionCode'
+  | 'tellMeQuestionDescription'
+> & { tellMeQuestionShortName: string };

--- a/src/theme/sass-partials/_alert.scss
+++ b/src/theme/sass-partials/_alert.scss
@@ -1,0 +1,37 @@
+// Lots of manipulation of the DOM inside the alert to style the select dialog to our liking
+// Beware, this could be brittle...
+.alert-wrapper {
+  font-size: 19px;
+  // Action buttons at the very bottom
+  justify-content: space-between;
+  .alert-head, .alert-message {
+    display: none;
+  }
+  div.alert-radio-group {
+    // Ensure the buttons in the radio group occupy all available space
+    max-height: 100%;
+    // Bold the selected item
+    button[aria-checked="true"] {
+      div.alert-radio-label {
+        font-weight: bold;
+        color: map-get($colors-gds, gds-black);
+      }
+      // Checkmark
+      div.alert-radio-inner {
+        border-color: map-get($colors-gds, gds-green);
+        width: 10px;
+        height: 18px;
+        border-width: 0 5px 5px 0;
+      }
+    }
+  }
+  div.alert-button-group {
+    height: 56px;
+    button {
+      height: 100%;
+      span.button-inner {
+        color: map-get($colors-gds, gds-black)
+      }
+    }
+  }
+}

--- a/src/theme/sass-partials/_input.scss
+++ b/src/theme/sass-partials/_input.scss
@@ -1,8 +1,16 @@
 input[type="text"],
-input[type="number"] {
+input[type="number"],
+ion-select {
   border-radius: 6px;
   border: 2px solid #222222;
   box-shadow: inset 0 3px 3px 0 #A5A2A2;
   height: 48px;
   padding: 10px;
+}
+
+// Don't dim select placeholders
+ion-select.select {
+  .select-placeholder {
+    color: inherit;
+  }
 }

--- a/src/theme/sass-partials/_input.scss
+++ b/src/theme/sass-partials/_input.scss
@@ -10,6 +10,8 @@ ion-select {
 
 // Don't dim select placeholders
 ion-select.select {
+  max-width: 100%;
+  align-items: center;
   .select-placeholder {
     color: inherit;
   }

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -78,6 +78,8 @@ $toolbar-background: map-get($colors, mes-toolbar-background);
 $grid-padding-width: 8px;
 $grid-columns: 96;
 
+$alert-min-width: 400px;
+
 // App iOS Variables
 // --------------------------------------------------
 // iOS only Sass variables can go here


### PR DESCRIPTION
## Description and relevant Jira numbers
* Use reference data for Tell Me questions as defined on Confluence and expose through new QuestionProvider
* Add `ion-select` to allow selection of a Tell Me question
* Restyle `ion-alert` to fit with the Tell Me dialog designs (please forgive me...)

![image](https://user-images.githubusercontent.com/41190821/55397864-21ce9c80-553f-11e9-9cbe-f8f8d31a6c65.png)
![image](https://user-images.githubusercontent.com/41190821/55397870-25622380-553f-11e9-9c25-4060585cdb8f.png)

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [x] PO's approval
