### PR TITLE
Mes-2038 - show eta in debrief

### DIFF
--- a/src/modules/tests/test_data/__tests__/test-data.selector.spec.ts
+++ b/src/modules/tests/test_data/__tests__/test-data.selector.spec.ts
@@ -1,5 +1,11 @@
 import { TestData } from '@dvsa/mes-test-schema/categories/B';
-import { getDrivingFaultCount, hasSeriousFault, getTestRequirements, hasDangerousFault } from '../test-data.selector';
+import {
+  getDrivingFaultCount,
+  hasSeriousFault,
+  getTestRequirements,
+  hasDangerousFault,
+  getETAFaultText,
+} from '../test-data.selector';
 import { Competencies } from '../test-data.constants';
 
 describe('TestDataSelectors', () => {
@@ -18,6 +24,10 @@ describe('TestDataSelectors', () => {
       normalStart2: true,
       angledStart: true,
       hillStart: true,
+    },
+    ETA: {
+      physical: false,
+      verbal: false,
     },
   };
 
@@ -56,6 +66,31 @@ describe('TestDataSelectors', () => {
       expect(result.normalStart2).toBeTruthy();
       expect(result.angledStart).toBeTruthy();
       expect(result.hillStart).toBeTruthy();
+    });
+  });
+
+  describe('getETAFaultText', () => {
+    it('should return null if no ETA faults', () => {
+      const result = getETAFaultText(state.ETA);
+      expect(result).toBeUndefined();
+    });
+    it('should return `Physical and Verbal` if both ETA faults', () => {
+      state.ETA.physical = true;
+      state.ETA.verbal = true;
+      const result = getETAFaultText(state.ETA);
+      expect(result).toEqual('Physical and Verbal');
+    });
+    it('should return `Physical` if just physical ETA fault', () => {
+      state.ETA.physical = true;
+      state.ETA.verbal = false;
+      const result = getETAFaultText(state.ETA);
+      expect(result).toEqual('Physical');
+    });
+    it('should return `Verbal` if just verbal ETA fault', () => {
+      state.ETA.physical = false;
+      state.ETA.verbal = true;
+      const result = getETAFaultText(state.ETA);
+      expect(result).toEqual('Verbal');
     });
   });
 });

--- a/src/modules/tests/test_data/test-data.selector.ts
+++ b/src/modules/tests/test_data/test-data.selector.ts
@@ -25,3 +25,9 @@ export const getTestRequirements = (data: TestData) => data.testRequirements;
 export const getETA = (data: TestData) => data.ETA;
 export const getETAVerbal = (data: ETA) => data.verbal;
 export const getETAPhysical = (data: ETA) => data.physical;
+export const getETAFaultText = (data: ETA) => {
+  if (data.physical && !data.verbal) return 'Physical';
+  if (!data.physical && data.verbal) return 'Verbal';
+  if (data.physical && data.verbal) return 'Physical and Verbal';
+  return;
+};

--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -16,6 +16,8 @@ import {
   AddDangerousFault,
   AddSeriousFault,
   AddDrivingFault,
+  ToggleVerbalEta,
+  TogglePhysicalEta,
 } from '../../../modules/tests/test_data/test-data.actions';
 import { Competencies } from '../../../modules/tests/test_data/test-data.constants';
 
@@ -47,6 +49,7 @@ describe('DebriefPage', () => {
                   manoeuvres: {},
                   seriousFaults: {},
                   testRequirements: {},
+                  ETA: {},
                 },
               },
             },
@@ -98,6 +101,11 @@ describe('DebriefPage', () => {
       expect(fixture.debugElement.query(By.css('.passed'))).toBeNull();
     });
 
+    it('should not display ETA fault container if there are no ETA faults', () => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#ETA'))).toBeNull();
+    });
+
     it('should not display dangerous faults container if there are no dangerous faults', () => {
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css('#dangerous-fault'))).toBeNull();
@@ -111,6 +119,37 @@ describe('DebriefPage', () => {
     it('should not display driving faults container if there are no driving faults', () => {
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css('#driving-fault'))).toBeNull();
+    });
+
+    it('should display ETA fault container if there are ETA faults', () => {
+      store$.dispatch(new TogglePhysicalEta());
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#ETA'))).toBeDefined();
+    });
+
+    it('should display `Physical` text if there is a phyiscal ETA fault', () => {
+      store$.dispatch(new TogglePhysicalEta());
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#physical'))).toBeDefined();
+      expect(fixture.debugElement.query(By.css('#verbal'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('#physicalverbal'))).toBeNull();
+    });
+
+    it('should display `Verbal` text if there is a phyiscal ETA fault', () => {
+      store$.dispatch(new ToggleVerbalEta());
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#verbal'))).toBeDefined();
+      expect(fixture.debugElement.query(By.css('#physical'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('#physicalverbal'))).toBeNull();
+    });
+
+    it('should display `Physical and Verbal` text if there are phyiscal & verbal ETA faults', () => {
+      store$.dispatch(new TogglePhysicalEta());
+      store$.dispatch(new ToggleVerbalEta());
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#physicalverbal'))).toBeDefined();
+      expect(fixture.debugElement.query(By.css('#verbal'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('#physical'))).toBeNull();
     });
 
     it('should display dangerous faults container if there are dangerous faults', () => {

--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -16,7 +16,6 @@ import {
   AddDangerousFault,
   AddSeriousFault,
   AddDrivingFault,
-  ToggleVerbalEta,
   TogglePhysicalEta,
 } from '../../../modules/tests/test_data/test-data.actions';
 import { Competencies } from '../../../modules/tests/test_data/test-data.constants';
@@ -121,35 +120,11 @@ describe('DebriefPage', () => {
       expect(fixture.debugElement.query(By.css('#driving-fault'))).toBeNull();
     });
 
-    it('should display ETA fault container if there are ETA faults', () => {
+    it('should display the ETA faults are any', () => {
       store$.dispatch(new TogglePhysicalEta());
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css('#ETA'))).toBeDefined();
-    });
-
-    it('should display `Physical` text if there is a phyiscal ETA fault', () => {
-      store$.dispatch(new TogglePhysicalEta());
-      fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('#physical'))).toBeDefined();
-      expect(fixture.debugElement.query(By.css('#verbal'))).toBeNull();
-      expect(fixture.debugElement.query(By.css('#physicalverbal'))).toBeNull();
-    });
-
-    it('should display `Verbal` text if there is a phyiscal ETA fault', () => {
-      store$.dispatch(new ToggleVerbalEta());
-      fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('#verbal'))).toBeDefined();
-      expect(fixture.debugElement.query(By.css('#physical'))).toBeNull();
-      expect(fixture.debugElement.query(By.css('#physicalverbal'))).toBeNull();
-    });
-
-    it('should display `Physical and Verbal` text if there are phyiscal & verbal ETA faults', () => {
-      store$.dispatch(new TogglePhysicalEta());
-      store$.dispatch(new ToggleVerbalEta());
-      fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('#physicalverbal'))).toBeDefined();
-      expect(fixture.debugElement.query(By.css('#verbal'))).toBeNull();
-      expect(fixture.debugElement.query(By.css('#physical'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('#etaFaults'))).toBeDefined();
     });
 
     it('should display dangerous faults container if there are dangerous faults', () => {

--- a/src/pages/debrief/debrief.html
+++ b/src/pages/debrief/debrief.html
@@ -19,82 +19,97 @@
 
 <ion-content>
 
+  <ion-card id="ETA" *ngIf="(pageState.etaVerbal$ | async) || (pageState.etaPhysical$ | async)">
+    <ion-card-content>
+      <ion-grid>
+        <ion-row align-items-start class="mes-data">
+          <ion-col col-3></ion-col>
+          <ion-col col-34>
+            <h4 class="fault-heading">ETA</h4>
+          </ion-col>
+          <ion-col align-self-start>
+            <div *ngIf="!(pageState.etaVerbal$ | async) && (pageState.etaPhysical$ | async)">Physical</div>
+            <div *ngIf="(pageState.etaVerbal$ | async) && !(pageState.etaPhysical$ | async)">Verbal</div>
+            <div *ngIf="(pageState.etaVerbal$ | async) && (pageState.etaPhysical$ | async)">Physical and Verbal</div>
+          </ion-col>
+        </ion-row>
+      </ion-grid>
+    </ion-card-content>
+  </ion-card>
+
   <ion-card id="dangerous-fault" *ngIf="(pageState.dangerousFaults$ | async).length > 0">
     <ion-card-header>
       <ion-card-title>
-        <h1 class="fault-heading">{{(pageState.dangerousFaults$ | async).length}}</h1> <h4 class="fault-heading">Dangerous</h4>
+        <h1 class="fault-heading">{{(pageState.dangerousFaults$ | async).length}}</h1>
+        <h4 class="fault-heading">Dangerous</h4>
       </ion-card-title>
     </ion-card-header>
     <ion-card-content>
-        <ion-grid>
-            <ion-row align-items-center *ngFor="let dangerousFault of (pageState.dangerousFaults$ | async)" class="mes-data">
-              <ion-col col-32></ion-col>
-              <ion-col col-2>
-              <div class="counter-icon">
-                <dangerous-fault-badge [showBadge]="true"></dangerous-fault-badge>
-              </div>
-            </ion-col>
-             <ion-col col-3></ion-col>
-              <ion-col><div class="counter-label">{{dangerousFault}}</div></ion-col>
-            </ion-row>
-          </ion-grid>
+      <ion-grid>
+        <ion-row align-items-center *ngFor="let dangerousFault of (pageState.dangerousFaults$ | async)"
+          class="mes-data">
+          <ion-col col-32></ion-col>
+          <ion-col col-2>
+            <div class="counter-icon">
+              <dangerous-fault-badge [showBadge]="true"></dangerous-fault-badge>
+            </div>
+          </ion-col>
+          <ion-col col-3></ion-col>
+          <ion-col>
+            <div class="counter-label">{{dangerousFault}}</div>
+          </ion-col>
+        </ion-row>
+      </ion-grid>
     </ion-card-content>
   </ion-card>
 
   <ion-card id="serious-fault" *ngIf="(pageState.seriousFaults$ | async).length > 0">
     <ion-card-header>
       <ion-card-title>
-        <h1 class="fault-heading">{{(pageState.seriousFaults$ | async).length}}</h1> <h4 class="fault-heading">Serious</h4>
+        <h1 class="fault-heading">{{(pageState.seriousFaults$ | async).length}}</h1>
+        <h4 class="fault-heading">Serious</h4>
       </ion-card-title>
     </ion-card-header>
     <ion-card-content>
-        <ion-grid>
-            <ion-row align-items-center *ngFor="let seriousFault of (pageState.seriousFaults$ | async)" class="mes-data">
-              <ion-col col-32></ion-col>
-              <ion-col col-2>
-              <div class="counter-icon">
-                <serious-fault-badge [showBadge]="true"></serious-fault-badge>
-              </div>
-            </ion-col>
-             <ion-col col-3></ion-col>
-              <ion-col><div class="counter-label">{{seriousFault}}</div></ion-col>
-            </ion-row>
-          </ion-grid>
+      <ion-grid>
+        <ion-row align-items-center *ngFor="let seriousFault of (pageState.seriousFaults$ | async)" class="mes-data">
+          <ion-col col-32></ion-col>
+          <ion-col col-2>
+            <div class="counter-icon">
+              <serious-fault-badge [showBadge]="true"></serious-fault-badge>
+            </div>
+          </ion-col>
+          <ion-col col-3></ion-col>
+          <ion-col>
+            <div class="counter-label">{{seriousFault}}</div>
+          </ion-col>
+        </ion-row>
+      </ion-grid>
     </ion-card-content>
   </ion-card>
 
   <ion-card id="driving-fault" *ngIf="(pageState.drivingFaultCount$ | async) > 0">
     <ion-card-header>
       <ion-card-title>
-        <h1 class="fault-heading">{{pageState.drivingFaultCount$ | async}}</h1> <h4 class="fault-heading">Driving Faults</h4>
+        <h1 class="fault-heading">{{pageState.drivingFaultCount$ | async}}</h1>
+        <h4 class="fault-heading">Driving Faults</h4>
       </ion-card-title>
     </ion-card-header>
     <ion-card-content>
       <ion-grid>
-      <ion-row align-items-center *ngFor="let drivingFault of (pageState.drivingFaults$ | async)" class="mes-data">
-        <ion-col col-32></ion-col>
-        <ion-col col-2>
-        <div class="counter-icon">
-          <fault-counter class="counter driving-faults" [count]="drivingFault.count"></fault-counter>
-        </div>
-      </ion-col>
-       <ion-col col-3></ion-col>
-        <ion-col><div class="counter-label">{{drivingFault.name}}</div></ion-col>
-      </ion-row>
-    </ion-grid>
-    </ion-card-content>
-  </ion-card>
-
-  <ion-card>
-    <ion-card-header>
-      <ion-card-title>
-        Debrief
-      </ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <button ion-button navPush="PassFinalisationPage">Pass Test</button>
-      <button ion-button navPush="OfficePage">Fail Test</button>
-      <button ion-button navPush="TerminateTestPage">Terminate Test</button>
+        <ion-row align-items-center *ngFor="let drivingFault of (pageState.drivingFaults$ | async)" class="mes-data">
+          <ion-col col-32></ion-col>
+          <ion-col col-2>
+            <div class="counter-icon">
+              <fault-counter class="counter driving-faults" [count]="drivingFault.count"></fault-counter>
+            </div>
+          </ion-col>
+          <ion-col col-3></ion-col>
+          <ion-col>
+            <div class="counter-label">{{drivingFault.name}}</div>
+          </ion-col>
+        </ion-row>
+      </ion-grid>
     </ion-card-content>
   </ion-card>
 

--- a/src/pages/debrief/debrief.html
+++ b/src/pages/debrief/debrief.html
@@ -19,7 +19,7 @@
 
 <ion-content>
 
-  <ion-card id="ETA" *ngIf="(pageState.etaVerbal$ | async) || (pageState.etaPhysical$ | async)">
+  <ion-card id="ETA" *ngIf="(pageState.etaFaults$ | async)">
     <ion-card-content>
       <ion-grid>
         <ion-row align-items-start class="mes-data">
@@ -28,9 +28,7 @@
             <h4 class="fault-heading">ETA</h4>
           </ion-col>
           <ion-col align-self-start>
-            <div id="physical" *ngIf="!(pageState.etaVerbal$ | async) && (pageState.etaPhysical$ | async)">Physical</div>
-            <div id="verbal" *ngIf="(pageState.etaVerbal$ | async) && !(pageState.etaPhysical$ | async)">Verbal</div>
-            <div id="physicalverbal" *ngIf="(pageState.etaVerbal$ | async) && (pageState.etaPhysical$ | async)">Physical and Verbal</div>
+            <div id="etaFaults">{{pageState.etaFaults$ | async}}</div>
           </ion-col>
         </ion-row>
       </ion-grid>

--- a/src/pages/debrief/debrief.html
+++ b/src/pages/debrief/debrief.html
@@ -28,9 +28,9 @@
             <h4 class="fault-heading">ETA</h4>
           </ion-col>
           <ion-col align-self-start>
-            <div *ngIf="!(pageState.etaVerbal$ | async) && (pageState.etaPhysical$ | async)">Physical</div>
-            <div *ngIf="(pageState.etaVerbal$ | async) && !(pageState.etaPhysical$ | async)">Verbal</div>
-            <div *ngIf="(pageState.etaVerbal$ | async) && (pageState.etaPhysical$ | async)">Physical and Verbal</div>
+            <div id="physical" *ngIf="!(pageState.etaVerbal$ | async) && (pageState.etaPhysical$ | async)">Physical</div>
+            <div id="verbal" *ngIf="(pageState.etaVerbal$ | async) && !(pageState.etaPhysical$ | async)">Verbal</div>
+            <div id="physicalverbal" *ngIf="(pageState.etaVerbal$ | async) && (pageState.etaPhysical$ | async)">Physical and Verbal</div>
           </ion-col>
         </ion-row>
       </ion-grid>

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -8,6 +8,7 @@ import { getCurrentTest } from '../../modules/tests/tests.selector';
 import { Observable } from 'rxjs/Observable';
 import { getTests } from '../../modules/tests/tests.reducer';
 import { getTestData } from '../../modules/tests/test_data/test-data.reducer';
+import { getETAVerbal, getETAPhysical, getETA } from '../../modules/tests/test_data/test-data.selector';
 import { map } from 'rxjs/operators';
 import { Component } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
@@ -20,6 +21,8 @@ interface DebriefPageState {
   dangerousFaults$: Observable<string[]>;
   drivingFaults$: Observable<FaultCount[]>;
   drivingFaultCount$: Observable<number>;
+  etaVerbal$: Observable<boolean>;
+  etaPhysical$: Observable<boolean>;
 }
 
 @IonicPage()
@@ -50,7 +53,7 @@ export class DebriefPage extends BasePageComponent {
 
   ngOnInit(): void {
     this.pageState = {
-      seriousFaults$:  this.store$.pipe(
+      seriousFaults$: this.store$.pipe(
         select(getTests),
         select(getCurrentTest),
         select(getTestData),
@@ -72,19 +75,36 @@ export class DebriefPage extends BasePageComponent {
         select(getTests),
         select(getCurrentTest),
         select(getTestData),
-        map((data) =>  {
+        map((data) => {
           const faults = getDrivingFaults(data.drivingFaults);
           return faults.reduce((sum, c) => sum + c.count, 0);
         }),
       ),
+      etaPhysical$: this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getTestData),
+        select(getETA),
+        select(getETAPhysical),
+      ),
+      etaVerbal$: this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getTestData),
+        select(getETA),
+        select(getETAVerbal),
+      ),
+
     };
 
-    const { seriousFaults$, dangerousFaults$, drivingFaults$ } = this.pageState;
+    const { seriousFaults$, dangerousFaults$, drivingFaults$, etaPhysical$, etaVerbal$ } = this.pageState;
 
     const merged$ = merge(
       seriousFaults$,
       dangerousFaults$,
       drivingFaults$,
+      etaPhysical$,
+      etaVerbal$,
     );
 
     this.subscription = merged$.subscribe();

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -8,7 +8,7 @@ import { getCurrentTest } from '../../modules/tests/tests.selector';
 import { Observable } from 'rxjs/Observable';
 import { getTests } from '../../modules/tests/tests.reducer';
 import { getTestData } from '../../modules/tests/test_data/test-data.reducer';
-import { getETAVerbal, getETAPhysical, getETA } from '../../modules/tests/test_data/test-data.selector';
+import { getETA, getETAFaultText } from '../../modules/tests/test_data/test-data.selector';
 import { map } from 'rxjs/operators';
 import { Component } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
@@ -21,8 +21,7 @@ interface DebriefPageState {
   dangerousFaults$: Observable<string[]>;
   drivingFaults$: Observable<FaultCount[]>;
   drivingFaultCount$: Observable<number>;
-  etaVerbal$: Observable<boolean>;
-  etaPhysical$: Observable<boolean>;
+  etaFaults$: Observable<string>;
 }
 
 @IonicPage()
@@ -80,31 +79,23 @@ export class DebriefPage extends BasePageComponent {
           return faults.reduce((sum, c) => sum + c.count, 0);
         }),
       ),
-      etaPhysical$: this.store$.pipe(
+      etaFaults$: this.store$.pipe(
         select(getTests),
         select(getCurrentTest),
         select(getTestData),
         select(getETA),
-        select(getETAPhysical),
-      ),
-      etaVerbal$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
-        select(getTestData),
-        select(getETA),
-        select(getETAVerbal),
+        select(getETAFaultText),
       ),
 
     };
 
-    const { seriousFaults$, dangerousFaults$, drivingFaults$, etaPhysical$, etaVerbal$ } = this.pageState;
+    const { seriousFaults$, dangerousFaults$, drivingFaults$, etaFaults$ } = this.pageState;
 
     const merged$ = merge(
       seriousFaults$,
       dangerousFaults$,
       drivingFaults$,
-      etaPhysical$,
-      etaVerbal$,
+      etaFaults$,
     );
 
     this.subscription = merged$.subscribe();


### PR DESCRIPTION
## Description and relevant Jira numbers

Displaying the ETA faults in the debrief page
https://jira.i-env.net/browse/MES-2038

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [x] Tested by QA
- [ ] PO's approval

<img width="517" alt="Screen Shot 2019-04-04 at 15 19 39" src="https://user-images.githubusercontent.com/47523567/55563214-68fa9000-56ed-11e9-9c9c-6db4485ec043.png">

<img width="518" alt="Screen Shot 2019-04-04 at 15 20 12" src="https://user-images.githubusercontent.com/47523567/55563229-6e57da80-56ed-11e9-8f29-b398c342fae7.png">
