### PR TITLE
MES-2039 - Added eco buttons to test report and debrief

### DIFF
--- a/src/modules/tests/test_data/__tests__/test-data.reducer.spec.ts
+++ b/src/modules/tests/test_data/__tests__/test-data.reducer.spec.ts
@@ -8,6 +8,8 @@ import {
   ToggleAngledStart,
   ToggleHillStart,
   AddDangerousFault,
+  ToggleControlEco,
+  TogglePlanningEco,
 } from '../test-data.actions';
 import { Competencies } from '../test-data.constants';
 import { TestData } from '@dvsa/mes-test-schema/categories/B';
@@ -218,6 +220,46 @@ describe('TestDataReducer reducer', () => {
       const result = testDataReducer(modifiedState, new ToggleHillStart());
 
       expect(result.testRequirements.hillStart).toBeFalsy();
+
+    });
+  });
+
+  describe('TOGGLE_CONTROL_ECO', () => {
+    it('should toggle control eco fault (true when dispatched first time)', () => {
+      const state: TestData = {
+        eco: {},
+      };
+      const result = testDataReducer(state, new ToggleControlEco());
+      expect(result.eco.adviceGivenControl).toBeTruthy();
+    });
+
+    it('should toggle control eco fault (false when dispatched second time)', () => {
+      const state: TestData = {
+        eco: {},
+      };
+      const modifiedState = testDataReducer(state, new ToggleControlEco());
+      const result = testDataReducer(modifiedState, new ToggleControlEco());
+      expect(result.eco.adviceGivenControl).toBeFalsy();
+    });
+  });
+
+  describe('TOGGLE_PLANNING_ECO', () => {
+    it('should toggle the planning eco fault (true when dispatched first time)', () => {
+      const state: TestData = {
+        eco: {},
+      };
+      const result = testDataReducer(state, new TogglePlanningEco());
+      expect(result.eco.adviceGivenPlanning).toBeTruthy();
+    });
+
+    it('should toggle planning eco fault (false when dispatched second time)', () => {
+      const state: TestData = {
+        eco: {},
+      };
+      const modifiedState = testDataReducer(state, new TogglePlanningEco());
+      const result = testDataReducer(modifiedState, new TogglePlanningEco());
+
+      expect(result.eco.adviceGivenPlanning).toBeFalsy();
 
     });
   });

--- a/src/modules/tests/test_data/__tests__/test-data.selector.spec.ts
+++ b/src/modules/tests/test_data/__tests__/test-data.selector.spec.ts
@@ -5,6 +5,7 @@ import {
   getTestRequirements,
   hasDangerousFault,
   getETAFaultText,
+  getEcoFaultText,
 } from '../test-data.selector';
 import { Competencies } from '../test-data.constants';
 
@@ -28,6 +29,10 @@ describe('TestDataSelectors', () => {
     ETA: {
       physical: false,
       verbal: false,
+    },
+    eco: {
+      adviceGivenControl: false,
+      adviceGivenPlanning: false,
     },
   };
 
@@ -91,6 +96,31 @@ describe('TestDataSelectors', () => {
       state.ETA.verbal = true;
       const result = getETAFaultText(state.ETA);
       expect(result).toEqual('Verbal');
+    });
+  });
+
+  describe('getEcoFaultText', () => {
+    it('should return null if no eco faults', () => {
+      const result = getEcoFaultText(state.eco);
+      expect(result).toBeUndefined();
+    });
+    it('should return `Control and Planning` if both eco faults', () => {
+      state.eco.adviceGivenControl = true;
+      state.eco.adviceGivenPlanning = true;
+      const result = getEcoFaultText(state.eco);
+      expect(result).toEqual('Control and Planning');
+    });
+    it('should return `Control` if just control eco fault', () => {
+      state.eco.adviceGivenControl = true;
+      state.eco.adviceGivenPlanning = false;
+      const result = getEcoFaultText(state.eco);
+      expect(result).toEqual('Control');
+    });
+    it('should return `Planning` if just planning eco fault', () => {
+      state.eco.adviceGivenControl = false;
+      state.eco.adviceGivenPlanning = true;
+      const result = getEcoFaultText(state.eco);
+      expect(result).toEqual('Planning');
     });
   });
 });

--- a/src/modules/tests/test_data/test-data.actions.ts
+++ b/src/modules/tests/test_data/test-data.actions.ts
@@ -1,5 +1,5 @@
 import {
-   ManoeuvreTypes,
+  ManoeuvreTypes,
 } from './../../../pages/test-report/components/manoeuvres-popover/manoeuvres-popover.constants';
 import { Action } from '@ngrx/store';
 import { FaultPayload } from './test-data.models';
@@ -18,6 +18,8 @@ export const TOGGLE_ANGLED_START = '[Legal Requirements] Toggle Angled Start';
 export const TOGGLE_HILL_START = '[Legal Requirements] Toggle Hill Start';
 export const TOGGLE_VERBAL_ETA = '[Eta] Toggle Verbal Eta';
 export const TOGGLE_PHYSICAL_ETA = '[Eta] Toggle Physical Eta';
+export const TOGGLE_CONTROL_ECO = '[Eco] Toggle Control Eco';
+export const TOGGLE_PLANNING_ECO = '[Eco] Toggle Planning Eco';
 
 export class RecordManoeuvresSelection implements Action {
   constructor(public manoeuvre: ManoeuvreTypes) { }
@@ -68,6 +70,12 @@ export class ToggleVerbalEta implements Action {
 export class TogglePhysicalEta implements Action {
   readonly type = TOGGLE_PHYSICAL_ETA;
 }
+export class ToggleControlEco implements Action {
+  readonly type = TOGGLE_CONTROL_ECO;
+}
+export class TogglePlanningEco implements Action {
+  readonly type = TOGGLE_PLANNING_ECO;
+}
 
 export type Types =
   | RecordManoeuvresSelection
@@ -82,4 +90,6 @@ export type Types =
   | ToggleAngledStart
   | ToggleHillStart
   | ToggleVerbalEta
-  | TogglePhysicalEta;
+  | TogglePhysicalEta
+  | ToggleControlEco
+  | TogglePlanningEco;

--- a/src/modules/tests/test_data/test-data.reducer.ts
+++ b/src/modules/tests/test_data/test-data.reducer.ts
@@ -9,6 +9,7 @@ export const initialState: TestData = {
   seriousFaults: {},
   testRequirements: {},
   ETA: {},
+  eco: {},
 };
 
 export function testDataReducer(
@@ -117,6 +118,22 @@ export function testDataReducer(
         ETA: {
           ...state.ETA,
           physical: !state.ETA.physical,
+        },
+      };
+    case testDataActions.TOGGLE_CONTROL_ECO:
+      return {
+        ...state,
+        eco: {
+          ...state.eco,
+          adviceGivenControl: !state.eco.adviceGivenControl,
+        },
+      };
+    case testDataActions.TOGGLE_PLANNING_ECO:
+      return {
+        ...state,
+        eco: {
+          ...state.eco,
+          adviceGivenPlanning: !state.eco.adviceGivenPlanning,
         },
       };
 

--- a/src/modules/tests/test_data/test-data.selector.ts
+++ b/src/modules/tests/test_data/test-data.selector.ts
@@ -1,5 +1,5 @@
 
-import { TestData, ETA } from '@dvsa/mes-test-schema/categories/B';
+import { TestData, ETA, Eco } from '@dvsa/mes-test-schema/categories/B';
 import { Competencies } from './test-data.constants';
 
 export const getDrivingFaultCount = (data: TestData, competency: Competencies) => data.drivingFaults[competency];
@@ -26,8 +26,17 @@ export const getETA = (data: TestData) => data.ETA;
 export const getETAVerbal = (data: ETA) => data.verbal;
 export const getETAPhysical = (data: ETA) => data.physical;
 export const getETAFaultText = (data: ETA) => {
+  if (!data) return;
   if (data.physical && !data.verbal) return 'Physical';
   if (!data.physical && data.verbal) return 'Verbal';
   if (data.physical && data.verbal) return 'Physical and Verbal';
+  return;
+};
+export const getEco = (data: TestData) => data.eco;
+export const getEcoFaultText = (data: Eco) => {
+  if (!data) return;
+  if (data.adviceGivenControl && !data.adviceGivenPlanning) return 'Control';
+  if (!data.adviceGivenControl && data.adviceGivenPlanning) return 'Planning';
+  if (data.adviceGivenControl && data.adviceGivenPlanning) return 'Control and Planning';
   return;
 };

--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -17,6 +17,7 @@ import {
   AddSeriousFault,
   AddDrivingFault,
   TogglePhysicalEta,
+  TogglePlanningEco,
 } from '../../../modules/tests/test_data/test-data.actions';
 import { Competencies } from '../../../modules/tests/test_data/test-data.constants';
 
@@ -49,6 +50,7 @@ describe('DebriefPage', () => {
                   seriousFaults: {},
                   testRequirements: {},
                   ETA: {},
+                  eco: {},
                 },
               },
             },
@@ -120,7 +122,12 @@ describe('DebriefPage', () => {
       expect(fixture.debugElement.query(By.css('#driving-fault'))).toBeNull();
     });
 
-    it('should display the ETA faults are any', () => {
+    it('should not display eco fault container if there are no eco faults', () => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#eco'))).toBeNull();
+    });
+
+    it('should display the ETA faults if there are any', () => {
       store$.dispatch(new TogglePhysicalEta());
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css('#ETA'))).toBeDefined();
@@ -143,6 +150,13 @@ describe('DebriefPage', () => {
       store$.dispatch(new AddDrivingFault({ competency: Competencies.controlsClutch, newFaultCount: 1 }));
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css('#driving-fault'))).toBeDefined();
+    });
+
+    it('should display the eco faults if there are any', () => {
+      store$.dispatch(new TogglePlanningEco());
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#eco'))).toBeDefined();
+      expect(fixture.debugElement.query(By.css('#ecoFaults'))).toBeDefined();
     });
 
     describe('endDebrief', () => {

--- a/src/pages/debrief/debrief.html
+++ b/src/pages/debrief/debrief.html
@@ -111,6 +111,22 @@
     </ion-card-content>
   </ion-card>
 
+  <ion-card id="eco" *ngIf="(pageState.ecoFaults$ | async)">
+    <ion-card-content>
+      <ion-grid>
+        <ion-row align-items-start class="mes-data">
+          <ion-col col-3></ion-col>
+          <ion-col col-34>
+            <h4 class="fault-heading">ECO</h4>
+          </ion-col>
+          <ion-col align-self-start>
+            <div id="ecoFaults">{{pageState.ecoFaults$ | async}}</div>
+          </ion-col>
+        </ion-row>
+      </ion-grid>
+    </ion-card-content>
+  </ion-card>
+
 </ion-content>
 <ion-footer>
   <div id="end-debrief-background">

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -8,7 +8,7 @@ import { getCurrentTest } from '../../modules/tests/tests.selector';
 import { Observable } from 'rxjs/Observable';
 import { getTests } from '../../modules/tests/tests.reducer';
 import { getTestData } from '../../modules/tests/test_data/test-data.reducer';
-import { getETA, getETAFaultText } from '../../modules/tests/test_data/test-data.selector';
+import { getETA, getETAFaultText, getEco, getEcoFaultText } from '../../modules/tests/test_data/test-data.selector';
 import { map } from 'rxjs/operators';
 import { Component } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
@@ -22,6 +22,7 @@ interface DebriefPageState {
   drivingFaults$: Observable<FaultCount[]>;
   drivingFaultCount$: Observable<number>;
   etaFaults$: Observable<string>;
+  ecoFaults$: Observable<string>;
 }
 
 @IonicPage()
@@ -86,16 +87,23 @@ export class DebriefPage extends BasePageComponent {
         select(getETA),
         select(getETAFaultText),
       ),
-
+      ecoFaults$: this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getTestData),
+        select(getEco),
+        select(getEcoFaultText),
+      ),
     };
 
-    const { seriousFaults$, dangerousFaults$, drivingFaults$, etaFaults$ } = this.pageState;
+    const { seriousFaults$, dangerousFaults$, drivingFaults$, etaFaults$, ecoFaults$ } = this.pageState;
 
     const merged$ = merge(
       seriousFaults$,
       dangerousFaults$,
       drivingFaults$,
       etaFaults$,
+      ecoFaults$,
     );
 
     this.subscription = merged$.subscribe();

--- a/src/pages/test-report/test-report.html
+++ b/src/pages/test-report/test-report.html
@@ -1,5 +1,9 @@
 <ion-header>
   <ion-navbar hideBackButton>
+    <ion-buttons start>
+      <button ion-button (click)="toggleControl()">Control</button>
+      <button ion-button (click)="togglePlanning()">Planning</button>
+    </ion-buttons>
     <ion-title>Test Report - {{pageState.candidateUntitledName$ | async}}</ion-title>
     <ion-buttons end>
       <button ion-button (click)="pass()">Pass Test</button>
@@ -32,8 +36,9 @@
         </ion-row>
         <ion-row>
           <ion-col>
-            <competency-with-modal [completed]="manoeuvresCompleted" [controlLabel]="'Manoeuvres'" [clickCallback]="getCallback()">
-                <manoeuvres-popover></manoeuvres-popover>
+            <competency-with-modal [completed]="manoeuvresCompleted" [controlLabel]="'Manoeuvres'"
+              [clickCallback]="getCallback()">
+              <manoeuvres-popover></manoeuvres-popover>
             </competency-with-modal>
           </ion-col>
         </ion-row>
@@ -366,5 +371,6 @@
       </ion-col>
     </ion-row>
   </ion-grid>
-  <div  class="report-overlay" [class.contract]="isSeriousMode || isDangerousMode" [class.show-overlay]="displayOverlay" [class.hide-overlay]="!displayOverlay"></div>
+  <div class="report-overlay" [class.contract]="isSeriousMode || isDangerousMode" [class.show-overlay]="displayOverlay"
+    [class.hide-overlay]="!displayOverlay"></div>
 </ion-content>

--- a/src/pages/test-report/test-report.ts
+++ b/src/pages/test-report/test-report.ts
@@ -23,6 +23,7 @@ import { getTests } from '../../modules/tests/tests.reducer';
 import { getTestReportState } from './test-report.reducer';
 import { isRemoveFaultMode, isSeriousMode, isDangerousMode } from './test-report.selector';
 import { getManoeuvres } from '../../modules/tests/test_data/test-data.selector';
+import { ToggleControlEco, TogglePlanningEco } from '../../modules/tests/test_data/test-data.actions';
 
 interface TestReportPageState {
   candidateUntitledName$: Observable<string>;
@@ -153,6 +154,12 @@ export class TestReportPage extends BasePageComponent {
     return this.isRemoveFaultMode ? 'remove-mode'
     : this.isSeriousMode ? 'serious-mode'
     : this.isDangerousMode ? 'dangerous-mode' : '';
+  }
+  toggleControl(): void {
+    this.store$.dispatch(new ToggleControlEco());
+  }
+  togglePlanning(): void {
+    this.store$.dispatch(new TogglePlanningEco());
   }
 }
 export interface OverlayCallback {


### PR DESCRIPTION
## Description and relevant Jira numbers

Added the ECO faults to the debrief summary, also ended up creating the button on test report page to toggle the ECO faults.
https://jira.i-env.net/browse/MES-2039

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
<img width="530" alt="Screen Shot 2019-04-09 at 11 38 07" src="https://user-images.githubusercontent.com/47523567/55793952-fd813b80-5abb-11e9-81d9-2ce64f1e1ad5.png">
