### PR TITLE
MES-2047: Setup test lifecycle, moving to started once progressing beyond Waiting Room (MES-2028)

### DIFF
--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -47,7 +47,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1001,
-        "start": "2019-04-05T08:10:00+01:00"
+        "start": "2019-04-09T08:10:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -95,7 +95,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1003,
-        "start": "2019-04-05T10:14:00+01:00"
+        "start": "2019-04-09T10:14:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -144,7 +144,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1004,
-        "start": "2019-04-05T11:11:00+01:00"
+        "start": "2019-04-09T11:11:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -195,7 +195,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1005,
-        "start": "2019-04-05T12:38:00+01:00"
+        "start": "2019-04-09T12:38:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -248,7 +248,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1006,
-        "start": "2019-04-05T13:35:00+01:00"
+        "start": "2019-04-09T13:35:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -293,7 +293,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1007,
-        "start": "2019-04-06T14:32:00+01:00"
+        "start": "2019-04-10T14:32:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,

--- a/src/modules/tests/__tests__/tests.selector.spec.ts
+++ b/src/modules/tests/__tests__/tests.selector.spec.ts
@@ -27,7 +27,7 @@ describe('testsSelector', () => {
         journal,
         appInfo,
         logs,
-        tests: { startedTests: { 123: currentTest }, currentTest: { slotId: '123' } },
+        tests: { startedTests: { 123: currentTest }, currentTest: { slotId: '123' }, testLifecycles: {} },
       };
 
       const result = getCurrentTest(state.tests);

--- a/src/modules/tests/test-status/__tests__/test-status.reducer.spec.ts
+++ b/src/modules/tests/test-status/__tests__/test-status.reducer.spec.ts
@@ -1,0 +1,14 @@
+import { initialState, testStatusReducer } from '../test-status.reducer';
+import { TestStatus } from '../test-status.model';
+import { TestStatusStarted } from '../test-status.actions';
+
+describe('test status reducer', () => {
+  it('should have the initial state of NotStarted', () => {
+    expect(initialState).toBe(TestStatus.NotStarted);
+  });
+
+  it('should move the test to started when receiving the TestStatusStarted action', () => {
+    const result = testStatusReducer(TestStatus.NotStarted, new TestStatusStarted());
+    expect(result).toBe(TestStatus.Started);
+  });
+});

--- a/src/modules/tests/test-status/__tests__/test-status.reducer.spec.ts
+++ b/src/modules/tests/test-status/__tests__/test-status.reducer.spec.ts
@@ -4,11 +4,11 @@ import { TestStatusStarted } from '../test-status.actions';
 
 describe('test status reducer', () => {
   it('should have the initial state of NotStarted', () => {
-    expect(initialState).toBe(TestStatus.NotStarted);
+    expect(initialState).toBe(TestStatus.Booked);
   });
 
   it('should move the test to started when receiving the TestStatusStarted action', () => {
-    const result = testStatusReducer(TestStatus.NotStarted, new TestStatusStarted());
+    const result = testStatusReducer(TestStatus.Booked, new TestStatusStarted());
     expect(result).toBe(TestStatus.Started);
   });
 });

--- a/src/modules/tests/test-status/test-status.actions.ts
+++ b/src/modules/tests/test-status/test-status.actions.ts
@@ -1,0 +1,10 @@
+import { Action } from '@ngrx/store';
+
+export const TEST_STATUS_STARTED = '[Test status] Started';
+
+export class TestStatusStarted implements Action {
+  readonly type = TEST_STATUS_STARTED;
+}
+
+export type Types =
+  | TestStatusStarted;

--- a/src/modules/tests/test-status/test-status.model.ts
+++ b/src/modules/tests/test-status/test-status.model.ts
@@ -1,5 +1,5 @@
 export enum TestStatus {
-  NotStarted = 'NotStarted',
+  Booked = 'Booked',
   Started = 'Started',
   Decided = 'Decided',
 }

--- a/src/modules/tests/test-status/test-status.model.ts
+++ b/src/modules/tests/test-status/test-status.model.ts
@@ -1,0 +1,5 @@
+export enum TestStatus {
+  NotStarted = 'NotStarted',
+  Started = 'Started',
+  Decided = 'Decided',
+}

--- a/src/modules/tests/test-status/test-status.reducer.ts
+++ b/src/modules/tests/test-status/test-status.reducer.ts
@@ -1,0 +1,19 @@
+import { TestStatus } from './test-status.model';
+import { createFeatureSelector } from '@ngrx/store';
+import * as testStatusActions from './test-status.actions';
+
+export const initialState = TestStatus.NotStarted;
+
+export function testStatusReducer(
+  state = initialState,
+  action: testStatusActions.Types,
+): TestStatus {
+  switch (action.type) {
+    case testStatusActions.TEST_STATUS_STARTED:
+      return TestStatus.Started;
+    default:
+      return state;
+  }
+}
+
+export const getCandidate = createFeatureSelector<TestStatus>('testStatus');

--- a/src/modules/tests/test-status/test-status.reducer.ts
+++ b/src/modules/tests/test-status/test-status.reducer.ts
@@ -6,7 +6,7 @@ export const initialState = TestStatus.NotStarted;
 
 export function testStatusReducer(
   state = initialState,
-  action: testStatusActions.Types,
+  action,
 ): TestStatus {
   switch (action.type) {
     case testStatusActions.TEST_STATUS_STARTED:

--- a/src/modules/tests/test-status/test-status.reducer.ts
+++ b/src/modules/tests/test-status/test-status.reducer.ts
@@ -2,7 +2,7 @@ import { TestStatus } from './test-status.model';
 import { createFeatureSelector } from '@ngrx/store';
 import * as testStatusActions from './test-status.actions';
 
-export const initialState = TestStatus.NotStarted;
+export const initialState = TestStatus.Booked;
 
 export function testStatusReducer(
   state = initialState,

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -13,6 +13,7 @@ import { eyesightTestResultReducer } from './eyesight-test-result/eyesight-test-
 import { postTestDeclarationsReducer } from './post-test-declarations/post-test-declarations.reducer';
 import { vehicleChecksReducer } from './vehicle-checks/vehicle-checks.reducer';
 import { testStatusReducer } from './test-status/test-status.reducer';
+import { TestStatus } from './test-status/test-status.model';
 
 export interface CurrentTest {
   slotId: string;
@@ -21,11 +22,13 @@ export interface CurrentTest {
 export interface TestsModel {
   currentTest: CurrentTest;
   startedTests: { [slotId: string]: StandardCarTestCATBSchema };
+  testLifecycles: { [slotId: string]: TestStatus };
 }
 
 const initialState: TestsModel = {
   currentTest: { slotId: null },
   startedTests: {},
+  testLifecycles: {},
 };
 
 /**
@@ -54,7 +57,6 @@ export const testsReducer = (
         // slotId to the relevant sub-reducer
         ...combineReducers(
           {
-            testStatus: testStatusReducer,
             preTestDeclarations: preTestDeclarationsReducer,
             candidate: candidateReducer,
             testData: testDataReducer,
@@ -73,6 +75,10 @@ export const testsReducer = (
     },
     currentTest: {
       slotId,
+    },
+    testLifecycles: {
+      ...state.testLifecycles,
+      [slotId]: testStatusReducer(state.testLifecycles[slotId], action),
     },
   };
 };

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -12,6 +12,7 @@ import { passCompletionReducer } from './pass-completion/pass-completion.reducer
 import { eyesightTestResultReducer } from './eyesight-test-result/eyesight-test-result.reducer';
 import { postTestDeclarationsReducer } from './post-test-declarations/post-test-declarations.reducer';
 import { vehicleChecksReducer } from './vehicle-checks/vehicle-checks.reducer';
+import { testStatusReducer } from './test-status/test-status.reducer';
 
 export interface CurrentTest {
   slotId: string;
@@ -53,6 +54,7 @@ export const testsReducer = (
         // slotId to the relevant sub-reducer
         ...combineReducers(
           {
+            testStatus: testStatusReducer,
             preTestDeclarations: preTestDeclarationsReducer,
             candidate: candidateReducer,
             testData: testDataReducer,

--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -36,6 +36,7 @@ describe('DebriefPage', () => {
             currentTest: {
               slotId: '123',
             },
+            testLifecycles: {},
             startedTests: {
               123: {
                 vehicleDetails: {},

--- a/src/pages/test-report/__tests__/test-report.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.spec.ts
@@ -64,6 +64,7 @@ describe('TestReportPage', () => {
             currentTest: {
               slotId: '123',
             },
+            testLifecycles: {},
             startedTests: {
               123: {
                 testData: initialState,

--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
@@ -68,6 +68,7 @@ describe('WaitingRoomToCarPage', () => {
             currentTest: {
               slotId: '123',
             },
+            testLifecycles: {},
             startedTests: {
               123: {
                 vehicleDetails: {},

--- a/src/pages/waiting-room/__tests__/waiting-room.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.spec.ts
@@ -54,6 +54,7 @@ describe('WaitingRoomPage', () => {
           currentTest: {
             slotId: '123',
           },
+          testLifecycles: {},
           startedTests: {
             123: {
               candidate: mockCandidate,

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -24,6 +24,7 @@ import { DeviceProvider } from '../../providers/device/device';
 import { getCurrentTest } from '../../modules/tests/tests.selector';
 import { DeviceAuthenticationProvider } from '../../providers/device-authentication/device-authentication';
 import { getTests } from '../../modules/tests/tests.reducer';
+import { TestStatusStarted } from '../../modules/tests/test-status/test-status.actions';
 
 interface WaitingRoomPageState {
   insuranceDeclarationAccepted$: Observable<boolean>;
@@ -143,6 +144,7 @@ export class WaitingRoomPage extends BasePageComponent {
     if (this.form.valid) {
       this.deviceAuthenticationProvider.triggerLockScreen()
       .then(() => {
+        this.store$.dispatch(new TestStatusStarted());
         this.navCtrl.push('WaitingRoomToCarPage');
       })
       .catch((err) => {


### PR DESCRIPTION
## Description and relevant Jira numbers
* Add a new key in the store under `tests` to store `testLifecycles`
* Keep this state tracking distinct from captured test data model (`startedTests`) to ensure it's not submitted to the backend
* Ensure that tests from from `NotStarted` to `Started` when Waiting Room form is submitted

**State tree**
```
tests: {
    currentTest: {
      slotId: '1005'
    },
    startedTests: {
      '1005': {
          ...
      }
    },
    testLifecycles: {
      '1005': 'Started'
    }
}
```

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
