### PR TITLE
MES-2076: Show a finalise test button on slots where the test is decided (MES-2028)

### DIFF
--- a/src/modules/tests/__tests__/tests.selector.spec.ts
+++ b/src/modules/tests/__tests__/tests.selector.spec.ts
@@ -1,8 +1,10 @@
-import { getCurrentTest } from '../tests.selector';
+import { getCurrentTest, getTestStatus } from '../tests.selector';
 import { JournalModel } from '../../../pages/journal/journal.model';
 import { AppInfoModel } from '../../app-info/app-info.model';
 import { LogsModel } from '../../logs/logs.model';
 import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
+import { TestsModel } from '../tests.reducer';
+import { TestStatus } from '../test-status/test-status.model';
 
 describe('testsSelector', () => {
   describe('getCurrentTest', () => {
@@ -33,6 +35,20 @@ describe('testsSelector', () => {
       const result = getCurrentTest(state.tests);
 
       expect(result).toBe(currentTest);
+    });
+  });
+
+  describe('getTestStatus', () => {
+    it('should retrieve the status of the test with the given slotId', () => {
+      const testState: TestsModel = {
+        currentTest: { slotId: '0' },
+        startedTests: {},
+        testLifecycles: { 12345: TestStatus.Decided },
+      };
+
+      const result = getTestStatus(testState, 12345);
+
+      expect(result).toBe(TestStatus.Decided);
     });
   });
 });

--- a/src/modules/tests/__tests__/tests.selector.spec.ts
+++ b/src/modules/tests/__tests__/tests.selector.spec.ts
@@ -41,7 +41,7 @@ describe('testsSelector', () => {
   describe('getTestStatus', () => {
     it('should retrieve the status of the test with the given slotId', () => {
       const testState: TestsModel = {
-        currentTest: { slotId: '0' },
+        currentTest: { slotId: null },
         startedTests: {},
         testLifecycles: { 12345: TestStatus.Decided },
       };
@@ -49,6 +49,18 @@ describe('testsSelector', () => {
       const result = getTestStatus(testState, 12345);
 
       expect(result).toBe(TestStatus.Decided);
+    });
+
+    it('should default to booked if the test with the given slot ID does not have a status yet', () => {
+      const testState: TestsModel = {
+        currentTest: { slotId: null },
+        startedTests: {},
+        testLifecycles: {},
+      };
+
+      const result = getTestStatus(testState, 12345);
+
+      expect(result).toBe(TestStatus.Booked);
     });
   });
 });

--- a/src/modules/tests/tests.selector.ts
+++ b/src/modules/tests/tests.selector.ts
@@ -1,8 +1,9 @@
 import { TestsModel } from './tests.reducer';
+import { TestStatus } from './test-status/test-status.model';
 
 export const getCurrentTest = (tests: TestsModel) => {
   const currentTestSlotId = tests.currentTest.slotId;
   return tests.startedTests[currentTestSlotId];
 };
 
-export const getTestStatus = (tests: TestsModel, slotId: number) => tests.testLifecycles[slotId];
+export const getTestStatus = (tests: TestsModel, slotId: number) => tests.testLifecycles[slotId] || TestStatus.Booked;

--- a/src/modules/tests/tests.selector.ts
+++ b/src/modules/tests/tests.selector.ts
@@ -4,3 +4,5 @@ export const getCurrentTest = (tests: TestsModel) => {
   const currentTestSlotId = tests.currentTest.slotId;
   return tests.startedTests[currentTestSlotId];
 };
+
+export const getTestStatus = (tests: TestsModel, slotId: number) => tests.testLifecycles[slotId];

--- a/src/pages/journal/components/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/pages/journal/components/test-outcome/__tests__/test-outcome.spec.ts
@@ -8,6 +8,7 @@ import { NavControllerMock } from 'ionic-mocks';
 import { AnalyticsProviderMock } from '../../../../../providers/analytics/__mocks__/analytics.mock';
 import { AnalyticsProvider } from '../../../../../providers/analytics/analytics';
 import { StartTest } from '../../../journal.actions';
+import { TestStatus } from '../../../../../modules/tests/test-status/test-status.model';
 
 describe('Test Outcome', () => {
   let fixture: ComponentFixture<TestOutcomeComponent>;
@@ -55,24 +56,15 @@ describe('Test Outcome', () => {
   describe('DOM', () => {
 
     describe('show start test button', () => {
-      it('should show the start test button when there is no outcome and user can not submit test', () => {
-        component.canSubmitTest = false;
-        component.outcome = undefined;
+      it('should show the start test button when the test status is Booked', () => {
+        component.testStatus = TestStatus.Booked;
         fixture.detectChanges();
         const startButton = fixture.debugElement.queryAll(By.css('.mes-primary-button'));
         expect(startButton.length).toBe(1);
       });
 
-      it('should not show the start test button when the test has an outcome', () => {
-        component.outcome = '12345';
-        component.canSubmitTest = false;
-        fixture.detectChanges();
-        const startButton = fixture.debugElement.queryAll(By.css('.mes-primary-button'));
-        expect(startButton.length).toBe(0);
-      });
-      it('should not show start test button when the user can submit the test', () => {
-        component.outcome = undefined;
-        component.canSubmitTest = true;
+      it('should not show the start test button when the test has a status other than booked', () => {
+        component.testStatus = TestStatus.Started;
         fixture.detectChanges();
         const startButton = fixture.debugElement.queryAll(By.css('.mes-primary-button'));
         expect(startButton.length).toBe(0);

--- a/src/pages/journal/components/test-outcome/test-outcome.html
+++ b/src/pages/journal/components/test-outcome/test-outcome.html
@@ -19,6 +19,9 @@
       <ion-col *ngIf="showSubmitTestButton()">
         <span><button class="mes-secondary-button" ion-button><h3>Submit</h3></button></span>
       </ion-col>
+      <ion-col *ngIf="needsFinalisation()">
+        <span><button class="mes-secondary-button needs-finalisation" ion-button><h3>Finalise</h3></button></span>
+      </ion-col>
     </ion-row>
   </ion-grid>
 </div>

--- a/src/pages/journal/components/test-outcome/test-outcome.html
+++ b/src/pages/journal/components/test-outcome/test-outcome.html
@@ -19,8 +19,8 @@
       <ion-col *ngIf="showSubmitTestButton()">
         <span><button class="mes-secondary-button" ion-button><h3>Submit</h3></button></span>
       </ion-col>
-      <ion-col *ngIf="needsFinalisation()">
-        <span><button class="mes-secondary-button needs-finalisation" ion-button><h3>Finalise</h3></button></span>
+      <ion-col *ngIf="needsWriteUp()">
+        <span><button class="mes-secondary-button mes-warning-button" ion-button><h3 class="write-up-label">Write-up</h3></button></span>
       </ion-col>
     </ion-row>
   </ion-grid>

--- a/src/pages/journal/components/test-outcome/test-outcome.scss
+++ b/src/pages/journal/components/test-outcome/test-outcome.scss
@@ -2,7 +2,7 @@ test-outcome {
   .button-ios {
     margin: 0;
   }
-  .needs-finalisation {
-    background: black;
+  .write-up-label {
+    color: inherit;
   }
 }

--- a/src/pages/journal/components/test-outcome/test-outcome.scss
+++ b/src/pages/journal/components/test-outcome/test-outcome.scss
@@ -2,4 +2,7 @@ test-outcome {
   .button-ios {
     margin: 0;
   }
+  .needs-finalisation {
+    background: black;
+  }
 }

--- a/src/pages/journal/components/test-outcome/test-outcome.ts
+++ b/src/pages/journal/components/test-outcome/test-outcome.ts
@@ -3,6 +3,7 @@ import { NavController } from 'ionic-angular';
 import { Store } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
 import { StartTest } from '../../journal.actions';
+import { TestStatus } from '../../../../modules/tests/test-status/test-status.model';
 
 @Component({
   selector: 'test-outcome',
@@ -15,6 +16,9 @@ export class TestOutcomeComponent {
 
   @Input()
   canStartTest: boolean;
+
+  @Input()
+  testStatus: TestStatus;
 
   canSubmitTest: boolean = false;
   outcome: string;
@@ -29,7 +33,7 @@ export class TestOutcomeComponent {
   }
 
   showStartTestButton(): boolean {
-    return (this.outcome === undefined || this.outcome == null) && !this.canSubmitTest;
+    return (this.outcome === undefined || this.outcome == null) && !this.canSubmitTest && !this.needsFinalisation();
   }
 
   showSubmitTestButton(): boolean {
@@ -39,5 +43,9 @@ export class TestOutcomeComponent {
   startTest() {
     this.store$.dispatch(new StartTest(this.slotId));
     this.navController.push('WaitingRoomPage');
+  }
+
+  needsFinalisation(): boolean {
+    return this.testStatus === TestStatus.Decided;
   }
 }

--- a/src/pages/journal/components/test-outcome/test-outcome.ts
+++ b/src/pages/journal/components/test-outcome/test-outcome.ts
@@ -33,7 +33,7 @@ export class TestOutcomeComponent {
   }
 
   showStartTestButton(): boolean {
-    return (this.outcome === undefined || this.outcome == null) && !this.canSubmitTest && !this.needsFinalisation();
+    return this.testStatus === TestStatus.Booked;
   }
 
   showSubmitTestButton(): boolean {

--- a/src/pages/journal/components/test-outcome/test-outcome.ts
+++ b/src/pages/journal/components/test-outcome/test-outcome.ts
@@ -45,7 +45,7 @@ export class TestOutcomeComponent {
     this.navController.push('WaitingRoomPage');
   }
 
-  needsFinalisation(): boolean {
+  needsWriteUp(): boolean {
     return this.testStatus === TestStatus.Decided;
   }
 }

--- a/src/pages/journal/components/test-slot/__tests__/test-slot.spec.ts
+++ b/src/pages/journal/components/test-slot/__tests__/test-slot.spec.ts
@@ -20,6 +20,9 @@ import { AppConfigProviderMock } from '../../../../../providers/app-config/__moc
 import { DateTime, Duration } from '../../../../../shared/helpers/date-time';
 import { DateTimeProvider } from '../../../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../../../providers/date-time/__mocks__/date-time.mock';
+import { StoreModule } from '@ngrx/store';
+import { testsReducer } from '../../../../../modules/tests/tests.reducer';
+import { TestStatus } from '../../../../../modules/tests/test-status/test-status.model';
 
 describe('TestSlotComponent', () => {
   let fixture: ComponentFixture<TestSlotComponent>;
@@ -96,7 +99,12 @@ describe('TestSlotComponent', () => {
         MockComponent(VehicleDetailsComponent),
         MockComponent(CandidateLinkComponent),
       ],
-      imports: [IonicModule],
+      imports: [
+        IonicModule,
+        StoreModule.forRoot({
+          tests: testsReducer,
+        }),
+      ],
       providers: [
         { provide: Config, useFactory: () => ConfigMock.instance() },
         { provide: ScreenOrientation, useClass: ScreenOrientationMock },
@@ -257,23 +265,25 @@ describe('TestSlotComponent', () => {
         expect(subByDirective.isPortrait).toBeFalsy();
       });
 
-      it('should pass something to sub-component test-category  input', () => {
+      it('should pass something to sub-component test-category input', () => {
         fixture.detectChanges();
         const subByDirective = fixture.debugElement.query(
           By.directive(MockComponent(TestCategoryComponent))).componentInstance;
         expect(subByDirective.category).toBe('B');
       });
 
-      it('should pass something to sub-component test-outcome  input', () => {
+      it('should pass something to sub-component test-outcome input', () => {
+        component.slotStatus = TestStatus.Booked;
         fixture.detectChanges();
         const subByDirective = fixture.debugElement.query(
           By.directive(MockComponent(TestOutcomeComponent))).componentInstance;
 
         expect(subByDirective.slotId).toEqual(mockSlot.slotDetail.slotId);
         expect(subByDirective.canStartTest).toEqual(true);
+        expect(subByDirective.testStatus).toBe(TestStatus.Booked);
       });
 
-      it('should pass something to sub-component vehicle-details  input', () => {
+      it('should pass something to sub-component vehicle-details input', () => {
         fixture.detectChanges();
         const subByDirective = fixture.debugElement.query(
           By.directive(MockComponent(VehicleDetailsComponent))).componentInstance;
@@ -286,7 +296,7 @@ describe('TestSlotComponent', () => {
         expect(subByDirective.showVehicleDetails).toBeFalsy();
       });
 
-      it('should pass something to sub-component language  input', () => {
+      it('should pass something to sub-component language input', () => {
         fixture.detectChanges();
         const subByDirective = fixture.debugElement.query(
           By.directive(MockComponent(LanguageComponent))).componentInstance;

--- a/src/pages/journal/components/test-slot/__tests__/test-slot.spec.ts
+++ b/src/pages/journal/components/test-slot/__tests__/test-slot.spec.ts
@@ -280,7 +280,7 @@ describe('TestSlotComponent', () => {
 
       it('should pass something to sub-component test-outcome input', () => {
         fixture.detectChanges();
-        component.slotStatus$ = of(TestStatus.Booked);
+        component.componentState = { testStatus$: of(TestStatus.Booked) };
         fixture.detectChanges();
         const subByDirective = fixture.debugElement.query(
           By.directive(MockComponent(TestOutcomeComponent))).componentInstance;

--- a/src/pages/journal/components/test-slot/test-slot.html
+++ b/src/pages/journal/components/test-slot/test-slot.html
@@ -52,7 +52,7 @@
           </ion-grid>
         </ion-col>
         <ion-col class="test-outcome-col" no-padding padding-right>
-          <test-outcome [slotId]="slot.slotDetail.slotId" [canStartTest]="canStartTest()" [testStatus]="slotStatus"></test-outcome>
+          <test-outcome [slotId]="slot.slotDetail.slotId" [canStartTest]="canStartTest()" [testStatus]="slotStatus$ | async"></test-outcome>
         </ion-col>
       </ion-row>
       <ion-row class="slot-footer"

--- a/src/pages/journal/components/test-slot/test-slot.html
+++ b/src/pages/journal/components/test-slot/test-slot.html
@@ -52,7 +52,7 @@
           </ion-grid>
         </ion-col>
         <ion-col class="test-outcome-col" no-padding padding-right>
-          <test-outcome [slotId]="slot.slotDetail.slotId" [canStartTest]="canStartTest()"></test-outcome>
+          <test-outcome [slotId]="slot.slotDetail.slotId" [canStartTest]="canStartTest()" [testStatus]="slotStatus"></test-outcome>
         </ion-col>
       </ion-row>
       <ion-row class="slot-footer"

--- a/src/pages/journal/components/test-slot/test-slot.html
+++ b/src/pages/journal/components/test-slot/test-slot.html
@@ -52,7 +52,7 @@
           </ion-grid>
         </ion-col>
         <ion-col class="test-outcome-col" no-padding padding-right>
-          <test-outcome [slotId]="slot.slotDetail.slotId" [canStartTest]="canStartTest()" [testStatus]="slotStatus$ | async"></test-outcome>
+          <test-outcome [slotId]="slot.slotDetail.slotId" [canStartTest]="canStartTest()" [testStatus]="componentState.testStatus$ | async"></test-outcome>
         </ion-col>
       </ion-row>
       <ion-row class="slot-footer"

--- a/src/pages/journal/components/test-slot/test-slot.ts
+++ b/src/pages/journal/components/test-slot/test-slot.ts
@@ -8,6 +8,8 @@ import { AppConfigProvider } from '../../../../providers/app-config/app-config';
 import { DateTime } from '../../../../shared/helpers/date-time';
 import { DateTimeProvider } from '../../../../providers/date-time/date-time';
 import { TestStatus } from '../../../../modules/tests/test-status/test-status.model';
+import { Store } from '@ngrx/store';
+import { StoreModel } from '../../../../shared/models/store.model';
 
 @Component({
   selector: 'test-slot',
@@ -30,6 +32,7 @@ export class TestSlotComponent implements SlotComponent {
     public screenOrientation: ScreenOrientation,
     public appConfig: AppConfigProvider,
     public dateTimeProvider: DateTimeProvider,
+    public store$: Store<StoreModel>,
   ) {}
 
   isIndicatorNeededForSlot(): boolean {

--- a/src/pages/journal/components/test-slot/test-slot.ts
+++ b/src/pages/journal/components/test-slot/test-slot.ts
@@ -13,6 +13,11 @@ import { StoreModel } from '../../../../shared/models/store.model';
 import { Observable } from 'rxjs/Observable';
 import { getTests } from '../../../../modules/tests/tests.reducer';
 import { Subscription } from 'rxjs/Subscription';
+import { merge } from 'rxjs/observable/merge';
+
+interface TestSlotComponentState {
+  testStatus$: Observable<TestStatus>;
+}
 
 @Component({
   selector: 'test-slot',
@@ -28,7 +33,7 @@ export class TestSlotComponent implements SlotComponent, OnInit, OnDestroy {
   @Input()
   showLocation: boolean;
 
-  slotStatus$: Observable<TestStatus>;
+  componentState: TestSlotComponentState;
 
   subscription: Subscription;
 
@@ -41,12 +46,16 @@ export class TestSlotComponent implements SlotComponent, OnInit, OnDestroy {
 
   ngOnInit(): void {
     const { slotId } = this.slot.slotDetail;
-    this.slotStatus$ = this.store$.pipe(
-      select(getTests),
-      select(t => t.testLifecycles[slotId]),
-    );
+    this.componentState = {
+      testStatus$: this.store$.pipe(
+        select(getTests),
+        select(t => t.testLifecycles[slotId]),
+      ),
+    };
 
-    this.subscription = this.slotStatus$.subscribe();
+    const { testStatus$ } = this.componentState;
+
+    this.subscription = merge(testStatus$).subscribe();
   }
 
   ngOnDestroy(): void {

--- a/src/pages/journal/components/test-slot/test-slot.ts
+++ b/src/pages/journal/components/test-slot/test-slot.ts
@@ -14,6 +14,7 @@ import { Observable } from 'rxjs/Observable';
 import { getTests } from '../../../../modules/tests/tests.reducer';
 import { Subscription } from 'rxjs/Subscription';
 import { merge } from 'rxjs/observable/merge';
+import { getTestStatus } from '../../../../modules/tests/tests.selector';
 
 interface TestSlotComponentState {
   testStatus$: Observable<TestStatus>;
@@ -49,7 +50,7 @@ export class TestSlotComponent implements SlotComponent, OnInit, OnDestroy {
     this.componentState = {
       testStatus$: this.store$.pipe(
         select(getTests),
-        select(t => t.testLifecycles[slotId]),
+        select(tests => getTestStatus(tests, slotId)),
       ),
     };
 

--- a/src/pages/journal/components/test-slot/test-slot.ts
+++ b/src/pages/journal/components/test-slot/test-slot.ts
@@ -7,6 +7,7 @@ import { TestCategory } from '../../../../shared/models/test-category';
 import { AppConfigProvider } from '../../../../providers/app-config/app-config';
 import { DateTime } from '../../../../shared/helpers/date-time';
 import { DateTimeProvider } from '../../../../providers/date-time/date-time';
+import { TestStatus } from '../../../../modules/tests/test-status/test-status.model';
 
 @Component({
   selector: 'test-slot',
@@ -21,6 +22,9 @@ export class TestSlotComponent implements SlotComponent {
 
   @Input()
   showLocation: boolean;
+
+  @Input()
+  slotStatus: TestStatus;
 
   constructor(
     public screenOrientation: ScreenOrientation,

--- a/src/pages/journal/journal.ts
+++ b/src/pages/journal/journal.ts
@@ -6,7 +6,7 @@ import {
 import { select, Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
-import { map } from 'rxjs/operators';
+import { map, withLatestFrom } from 'rxjs/operators';
 
 import { BasePageComponent } from '../../shared/classes/base-page';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
@@ -26,6 +26,9 @@ import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import { getAppInfoState } from '../../modules/app-info/app-info.reducer';
 import { getVersionNumber } from '../../modules/app-info/app-info.selector';
 import { DateTimeProvider } from '../../providers/date-time/date-time';
+import { TestStatus } from '../../modules/tests/test-status/test-status.model';
+import { getTests } from '../../modules/tests/tests.reducer';
+import { TestSlotComponent } from './components/test-slot/test-slot';
 
 interface JournalPageState {
   selectedDate$: Observable<string>;
@@ -34,6 +37,7 @@ interface JournalPageState {
   isLoading$: Observable<boolean>;
   lastRefreshedTime$: Observable<string>;
   appVersion$: Observable<string>;
+  testStatuses$: Observable<{[slotId: string]: TestStatus}>;
 }
 
 @IonicPage()
@@ -104,13 +108,20 @@ export class JournalPage extends BasePageComponent implements OnInit, OnDestroy 
         select(getAppInfoState),
         map(getVersionNumber),
       ),
+      testStatuses$: this.store$.pipe(
+        select(getTests),
+        select(t => t.testLifecycles),
+      ),
     };
 
-    const { selectedDate$, slots$, error$, isLoading$ } = this.pageState;
+    const { selectedDate$, slots$, error$, isLoading$, testStatuses$ } = this.pageState;
     // Merge observables into one
     const merged$ = merge(
       selectedDate$.pipe(map(this.setSelectedDate)),
-      slots$.pipe(map(this.createSlots)),
+      slots$.pipe(
+        withLatestFrom(testStatuses$),
+        map(([slots, statuses]) => this.createSlots(slots, statuses)),
+      ),
       // Run any transformations necessary here
       error$.pipe(map(this.showError)),
       isLoading$.pipe(map(this.handleLoadingUI)),
@@ -172,7 +183,7 @@ export class JournalPage extends BasePageComponent implements OnInit, OnDestroy 
     this.toast.present();
   }
 
-  private createSlots = (emission: any) => {
+  private createSlots = (emission: any, slotStatuses: { [slotId: string]: TestStatus }) => {
     if (!Array.isArray(emission)) return;
 
     // Clear any dynamically created slots before adding the latest
@@ -185,10 +196,15 @@ export class JournalPage extends BasePageComponent implements OnInit, OnDestroy 
     for (const slot of slots) {
       const factory = this.resolver.resolveComponentFactory(slot.component);
       const componentRef = this.slotContainer.createComponent(factory);
+      const { slotId } = slot.slotData.slotDetail;
       (<SlotComponent>componentRef.instance).slot = slot.slotData;
       (<SlotComponent>componentRef.instance).hasSlotChanged = slot.hasSlotChanged;
       (<SlotComponent>componentRef.instance).showLocation = (slot.slotData.testCentre.centreName !== lastLocation);
       lastLocation = slot.slotData.testCentre.centreName;
+      if (componentRef.instance instanceof TestSlotComponent) {
+        const slotStatus = slotStatuses[slotId] || null;
+        (<TestSlotComponent>componentRef.instance).slotStatus = slotStatus;
+      }
     }
   }
 

--- a/src/pages/journal/journal.ts
+++ b/src/pages/journal/journal.ts
@@ -28,7 +28,6 @@ import { getVersionNumber } from '../../modules/app-info/app-info.selector';
 import { DateTimeProvider } from '../../providers/date-time/date-time';
 import { TestStatus } from '../../modules/tests/test-status/test-status.model';
 import { getTests } from '../../modules/tests/tests.reducer';
-import { TestSlotComponent } from './components/test-slot/test-slot';
 
 interface JournalPageState {
   selectedDate$: Observable<string>;
@@ -196,15 +195,10 @@ export class JournalPage extends BasePageComponent implements OnInit, OnDestroy 
     for (const slot of slots) {
       const factory = this.resolver.resolveComponentFactory(slot.component);
       const componentRef = this.slotContainer.createComponent(factory);
-      const { slotId } = slot.slotData.slotDetail;
       (<SlotComponent>componentRef.instance).slot = slot.slotData;
       (<SlotComponent>componentRef.instance).hasSlotChanged = slot.hasSlotChanged;
       (<SlotComponent>componentRef.instance).showLocation = (slot.slotData.testCentre.centreName !== lastLocation);
       lastLocation = slot.slotData.testCentre.centreName;
-      if (componentRef.instance instanceof TestSlotComponent) {
-        const slotStatus = slotStatuses[slotId] || null;
-        (<TestSlotComponent>componentRef.instance).slotStatus = slotStatus;
-      }
     }
   }
 

--- a/src/providers/slot/slot.ts
+++ b/src/providers/slot/slot.ts
@@ -16,7 +16,8 @@ export class SlotProvider {
   constructor(
     private store$: Store<StoreModel>,
     public appConfigProvider: AppConfigProvider,
-    private dateTimeProvider: DateTimeProvider) {}
+    private dateTimeProvider: DateTimeProvider,
+  ) {}
 
   detectSlotChanges(slots: {[k: string]: SlotItem[]}, newJournal: ExaminerWorkSchedule): SlotItem[] {
     const newSlots = flatten([

--- a/src/theme/sass-partials/_buttons.scss
+++ b/src/theme/sass-partials/_buttons.scss
@@ -51,6 +51,12 @@
   }
 }
 
+.mes-warning-button {
+  background: map-get($colors-gds, gds-yellow);
+  color: map-get($colors-gds, gds-black);
+  box-shadow: 0px 2px 0px 0px rgba(0, 0, 0, 0.5);
+}
+
 .bar-button-ios {
   height: 44px;
   padding: 10px 8px;


### PR DESCRIPTION
## Description and relevant Jira numbers
* Select the state of the test into TestSlotComponent component state
* Refactor predicate for showing start test button to use test status
![image](https://user-images.githubusercontent.com/41190821/55891793-17e71200-5bad-11e9-8d4f-038da39cacbf.png)

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [x] PO's approval
