### PR TITLE
MES-2048 - show eta on office page

### DIFF
--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -47,7 +47,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1001,
-        "start": "2019-04-11T08:10:00+01:00"
+        "start": "2019-04-12T08:10:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -95,7 +95,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1003,
-        "start": "2019-04-11T10:14:00+01:00"
+        "start": "2019-04-12T10:14:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -144,7 +144,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1004,
-        "start": "2019-04-11T11:11:00+01:00"
+        "start": "2019-04-12T11:11:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -195,7 +195,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1005,
-        "start": "2019-04-11T12:38:00+01:00"
+        "start": "2019-04-12T12:38:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -248,7 +248,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1006,
-        "start": "2019-04-11T13:35:00+01:00"
+        "start": "2019-04-12T13:35:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -293,7 +293,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1007,
-        "start": "2019-04-12T14:32:00+01:00"
+        "start": "2019-04-13T14:32:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -94,6 +94,16 @@ describe('OfficePage', () => {
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css('#eco'))).toBeDefined();
     });
+    it('should display eta fault details if there are any', () => {
+      store$.dispatch(new ToggleVerbalEta());
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#etaFaults'))).toBeDefined();
+    });
+    it('should display eco fault details if there are any', () => {
+      store$.dispatch(new TogglePlanningEco());
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#ecoFaults'))).toBeDefined();
+    });
   });
 
   describe('popToRoot', () => {

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -8,16 +8,48 @@ import { AuthenticationProvider } from '../../../providers/authentication/authen
 import { AuthenticationProviderMock } from '../../../providers/authentication/__mocks__/authentication.mock';
 import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
+import { Store, StoreModule } from '@ngrx/store';
+import { StoreModel } from '../../../shared/models/store.model';
+import { ToggleVerbalEta, TogglePlanningEco } from '../../../modules/tests/test_data/test-data.actions';
+import { By } from '@angular/platform-browser';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficePage>;
   let component: OfficePage;
   let navCtrl: NavController;
+  let store$: Store<StoreModel>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [OfficePage],
-      imports: [IonicModule, AppModule],
+      imports: [IonicModule, AppModule,
+        StoreModule.forRoot({
+          tests: () => ({
+            currentTest: {
+              slotId: '123',
+            },
+            testLifecycles: {},
+            startedTests: {
+              123: {
+                vehicleDetails: {},
+                accompaniment: {},
+                candidate: {
+                  candidateName: 'Joe Bloggs',
+                },
+                testData: {
+                  dangerousFaults: {},
+                  drivingFaults: {},
+                  manoeuvres: {},
+                  seriousFaults: {},
+                  testRequirements: {},
+                  ETA: {},
+                  eco: {},
+                },
+              },
+            },
+          }),
+        }),
+      ],
       providers: [
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
         { provide: NavParams, useFactory: () => NavParamsMock.instance() },
@@ -32,6 +64,7 @@ describe('OfficePage', () => {
         fixture = TestBed.createComponent(OfficePage);
         component = fixture.componentInstance;
         navCtrl = TestBed.get(NavController);
+        store$ = TestBed.get(Store);
       });
   }));
 
@@ -39,6 +72,27 @@ describe('OfficePage', () => {
     // Unit tests for the components TypeScript class
     it('should create', () => {
       expect(component).toBeDefined();
+    });
+  });
+
+  describe('DOM', () => {
+    it('should hide ETA faults container if there are none', () => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#ETA'))).toBeNull();
+    });
+    it('should display ETA faults container if there are any', () => {
+      store$.dispatch(new ToggleVerbalEta());
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#ETA'))).toBeDefined();
+    });
+    it('should hide eco faults container if there are none', () => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#eco'))).toBeNull();
+    });
+    it('should display eco faults container if there are any', () => {
+      store$.dispatch(new TogglePlanningEco());
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#eco'))).toBeDefined();
     });
   });
 

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -19,4 +19,36 @@
         <button ion-button navPush="TerminateTestPage">Terminate Test</button>
       </ion-card-content>
     </ion-card>
+
+    <ion-card id="ETA" *ngIf="(pageState.etaFaults$ | async)">
+        <ion-card-content>
+          <ion-grid>
+            <ion-row align-items-start class="mes-data">
+              <ion-col col-3></ion-col>
+              <ion-col col-34>
+                <h4 class="fault-heading">ETA</h4>
+              </ion-col>
+              <ion-col align-self-start>
+                <div id="etaFaults">{{pageState.etaFaults$ | async}}</div>
+              </ion-col>
+            </ion-row>
+          </ion-grid>
+        </ion-card-content>
+      </ion-card>
+
+      <ion-card id="eco" *ngIf="(pageState.ecoFaults$ | async)">
+          <ion-card-content>
+            <ion-grid>
+              <ion-row align-items-start class="mes-data">
+                <ion-col col-3></ion-col>
+                <ion-col col-34>
+                  <h4 class="fault-heading">ECO</h4>
+                </ion-col>
+                <ion-col align-self-start>
+                  <div id="ecoFaults">{{pageState.ecoFaults$ | async}}</div>
+                </ion-col>
+              </ion-row>
+            </ion-grid>
+          </ion-card-content>
+        </ion-card>
   </ion-content>

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -24,7 +24,6 @@
         <ion-card-content>
           <ion-grid>
             <ion-row align-items-start class="mes-data">
-              <ion-col col-3></ion-col>
               <ion-col col-34>
                 <h4 class="fault-heading">ETA</h4>
               </ion-col>
@@ -40,7 +39,6 @@
           <ion-card-content>
             <ion-grid>
               <ion-row align-items-start class="mes-data">
-                <ion-col col-3></ion-col>
                 <ion-col col-34>
                   <h4 class="fault-heading">ECO</h4>
                 </ion-col>

--- a/src/pages/office/office.scss
+++ b/src/pages/office/office.scss
@@ -1,2 +1,5 @@
 page-office {
+    .fault-heading{
+        padding-left: 20px;
+    }
 }

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -2,9 +2,19 @@ import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams, Platform } from 'ionic-angular';
 import { BasePageComponent } from '../../shared/classes/base-page';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
-import { Store } from '@ngrx/store';
+import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { OfficeViewDidEnter } from './office.actions';
+import { Observable } from 'rxjs/Observable';
+import { getCurrentTest } from '../../modules/tests/tests.selector';
+import { getTests } from '../../modules/tests/tests.reducer';
+import { getETA, getETAFaultText, getEco, getEcoFaultText } from '../../modules/tests/test_data/test-data.selector';
+import { getTestData } from '../../modules/tests/test_data/test-data.reducer';
+
+interface OfficePageState {
+  etaFaults$: Observable<string>;
+  ecoFaults$: Observable<string>;
+}
 
 @IonicPage()
 @Component({
@@ -12,6 +22,7 @@ import { OfficeViewDidEnter } from './office.actions';
   templateUrl: 'office.html',
 })
 export class OfficePage extends BasePageComponent {
+  pageState: OfficePageState;
 
   constructor(
     private store$: Store<StoreModel>,
@@ -21,10 +32,31 @@ export class OfficePage extends BasePageComponent {
     public authenticationProvider: AuthenticationProvider,
   ) {
     super(platform, navCtrl, authenticationProvider);
+
   }
 
   ionViewDidEnter(): void {
     this.store$.dispatch(new OfficeViewDidEnter());
+  }
+
+  ngOnInit(): void {
+
+    this.pageState = {
+      etaFaults$: this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getTestData),
+        select(getETA),
+        select(getETAFaultText),
+      ),
+      ecoFaults$: this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getTestData),
+        select(getEco),
+        select(getEcoFaultText),
+      ),
+    };
   }
 
   popToRoot() {


### PR DESCRIPTION
## Description and relevant Jira numbers

Added ETA fault display to office page, 
https://jira.i-env.net/browse/MES-2048
Also added ECO faults display (MES-2049) while waiting on initial office form creation,
https://jira.i-env.net/browse/MES-2049

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
<img width="418" alt="Screen Shot 2019-04-11 at 16 47 46" src="https://user-images.githubusercontent.com/47523567/55971539-97421780-5c79-11e9-90fb-0095366e471d.png">
