### PR TITLE
MES-2701 - Moves unlocking of device from exit of TestReportPage to BackToOfficePage

### DIFF
--- a/src/pages/back-to-office/__tests__/back-to-office.spec.ts
+++ b/src/pages/back-to-office/__tests__/back-to-office.spec.ts
@@ -11,12 +11,21 @@ import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/dat
 import { StoreModule, Store } from '@ngrx/store';
 import { StoreModel } from '../../../shared/models/store.model';
 import { TestStatusDecided } from '../../../modules/tests/test-status/test-status.actions';
+import { ScreenOrientation } from '@ionic-native/screen-orientation';
+import { Insomnia } from '@ionic-native/insomnia';
+import { DeviceProvider } from '../../../providers/device/device';
+import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
+import { InsomniaMock } from '../../../shared/mocks/insomnia.mock';
+import { ScreenOrientationMock } from '../../../shared/mocks/screen-orientation.mock';
 
 describe('BackToOfficePage', () => {
   let fixture: ComponentFixture<BackToOfficePage>;
   let component: BackToOfficePage;
   let navCtrl: NavController;
   let store$: Store<StoreModel>;
+  let screenOrientation: ScreenOrientation;
+  let insomnia: Insomnia;
+  let deviceProvider: DeviceProvider;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -33,6 +42,9 @@ describe('BackToOfficePage', () => {
         { provide: Platform, useFactory: () => PlatformMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
+        { provide: ScreenOrientation, useClass: ScreenOrientationMock },
+        { provide: Insomnia, useClass: InsomniaMock },
+        { provide: DeviceProvider, useClass: DeviceProviderMock },
       ],
     })
       .compileComponents()
@@ -40,6 +52,9 @@ describe('BackToOfficePage', () => {
         fixture = TestBed.createComponent(BackToOfficePage);
         component = fixture.componentInstance;
         navCtrl = TestBed.get(NavController);
+        screenOrientation = TestBed.get(ScreenOrientation);
+        insomnia = TestBed.get(Insomnia);
+        deviceProvider = TestBed.get(DeviceProvider);
         store$ = TestBed.get(Store);
         spyOn(store$, 'dispatch');
       });
@@ -53,6 +68,9 @@ describe('BackToOfficePage', () => {
     describe('ionViewDidEnter', () => {
       it('should dispatch a TestStatusDecided action', () => {
         component.ionViewDidEnter();
+        expect(deviceProvider.disableSingleAppMode).toHaveBeenCalled();
+        expect(screenOrientation.unlock).toHaveBeenCalled();
+        expect(insomnia.allowSleepAgain).toHaveBeenCalled();
         expect(store$.dispatch).toHaveBeenCalledWith(new TestStatusDecided());
       });
     });

--- a/src/pages/back-to-office/back-to-office.ts
+++ b/src/pages/back-to-office/back-to-office.ts
@@ -6,6 +6,9 @@ import { Store } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { BackToOfficeViewDidEnter } from './back-to-office.actions';
 import { TestStatusDecided } from '../../modules/tests/test-status/test-status.actions';
+import { DeviceProvider } from '../../providers/device/device';
+import { ScreenOrientation } from '@ionic-native/screen-orientation';
+import { Insomnia } from '@ionic-native/insomnia';
 
 @IonicPage()
 @Component({
@@ -16,15 +19,23 @@ export class BackToOfficePage extends BasePageComponent {
 
   constructor(
     private store$: Store<StoreModel>,
+    private deviceProvider: DeviceProvider,
     public navCtrl: NavController,
     public navParams: NavParams,
     public platform: Platform,
     public authenticationProvider: AuthenticationProvider,
+    public screenOrientation: ScreenOrientation,
+    public insomnia: Insomnia,
   ) {
     super(platform, navCtrl, authenticationProvider);
   }
 
   ionViewDidEnter(): void {
+    if (super.isIos()) {
+      this.deviceProvider.disableSingleAppMode();
+      this.screenOrientation.unlock();
+      this.insomnia.allowSleepAgain();
+    }
     this.store$.dispatch(new TestStatusDecided());
     this.store$.dispatch(new BackToOfficeViewDidEnter());
   }

--- a/src/pages/test-report/__tests__/test-report.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.spec.ts
@@ -10,13 +10,7 @@ import { AppModule } from '../../../app/app.module';
 import { TestReportPage } from '../test-report';
 import { AuthenticationProvider } from '../../../providers/authentication/authentication';
 import { AuthenticationProviderMock } from '../../../providers/authentication/__mocks__/authentication.mock';
-import { ScreenOrientation } from '@ionic-native/screen-orientation';
-import { ScreenOrientationMock } from '../../../shared/mocks/screen-orientation.mock';
-import { Insomnia } from '@ionic-native/insomnia';
-import { InsomniaMock } from '../../../shared/mocks/insomnia.mock';
 import { CompetencyComponent } from '../components/competency/competency';
-import { DeviceProvider } from '../../../providers/device/device';
-import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
 import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
 import { DrivingFaultSummaryComponent } from '../components/driving-fault-summary/driving-fault-summary';
@@ -33,9 +27,6 @@ import { ControlledStopComponent } from '../components/controlled-stop/controlle
 describe('TestReportPage', () => {
   let fixture: ComponentFixture<TestReportPage>;
   let component: TestReportPage;
-  let screenOrientation: ScreenOrientation;
-  let insomnia: Insomnia;
-  let deviceProvider: DeviceProvider;
 
   const mockCandidate = {
     driverNumber: '123',
@@ -82,9 +73,6 @@ describe('TestReportPage', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
         { provide: Platform, useFactory: () => PlatformMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: ScreenOrientation, useClass: ScreenOrientationMock },
-        { provide: Insomnia, useClass: InsomniaMock },
-        { provide: DeviceProvider, useClass: DeviceProviderMock },
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
       ],
     })
@@ -92,32 +80,12 @@ describe('TestReportPage', () => {
       .then(() => {
         fixture = TestBed.createComponent(TestReportPage);
         component = fixture.componentInstance;
-        screenOrientation = TestBed.get(ScreenOrientation);
-        insomnia = TestBed.get(Insomnia);
-        deviceProvider = TestBed.get(DeviceProvider);
       });
   }));
 
   describe('Class', () => {
     it('should create', () => {
       expect(component).toBeDefined();
-    });
-
-    describe('ionViewDidLeave', () => {
-      it('should unlock the screen orientation', () => {
-        component.ionViewDidLeave();
-        expect(screenOrientation.unlock).toHaveBeenCalled();
-      });
-
-      it('should allow the device to sleep', () => {
-        component.ionViewDidLeave();
-        expect(insomnia.allowSleepAgain).toHaveBeenCalled();
-      });
-
-      it('should disable singleAppMode', () => {
-        component.ionViewDidLeave();
-        expect(deviceProvider.disableSingleAppMode).toHaveBeenCalled();
-      });
     });
   });
 

--- a/src/pages/test-report/test-report.ts
+++ b/src/pages/test-report/test-report.ts
@@ -1,7 +1,5 @@
 import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams, Platform } from 'ionic-angular';
-import { ScreenOrientation } from '@ionic-native/screen-orientation';
-import { Insomnia } from '@ionic-native/insomnia';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 import { merge } from 'rxjs/observable/merge';
@@ -10,7 +8,6 @@ import { Subscription } from 'rxjs/Subscription';
 
 import { BasePageComponent } from '../../shared/classes/base-page';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
-import { DeviceProvider } from '../../providers/device/device';
 import { StoreModel } from '../../shared/models/store.model';
 import { getUntitledCandidateName } from '../../modules/tests/candidate/candidate.selector';
 import { getCandidate } from '../../modules/tests/candidate/candidate.reducer';
@@ -51,13 +48,10 @@ export class TestReportPage extends BasePageComponent {
 
   constructor(
     private store$: Store<StoreModel>,
-    private deviceProvider: DeviceProvider,
     public navCtrl: NavController,
     public navParams: NavParams,
     public platform: Platform,
     public authenticationProvider: AuthenticationProvider,
-    public screenOrientation: ScreenOrientation,
-    public insomnia: Insomnia,
   ) {
     super(platform, navCtrl, authenticationProvider);
     this.displayOverlay = false;
@@ -123,13 +117,6 @@ export class TestReportPage extends BasePageComponent {
     this.displayOverlay = !this.displayOverlay;
   }
 
-  ionViewDidLeave(): void {
-    if (super.isIos()) {
-      this.deviceProvider.disableSingleAppMode();
-      this.screenOrientation.unlock();
-      this.insomnia.allowSleepAgain();
-    }
-  }
   ngOnDestroy(): void {
     if (this.subscription) {
       this.subscription.unsubscribe();


### PR DESCRIPTION
## Description and relevant Jira numbers
Link to story - https://jira.i-env.net/browse/MES-2071
After a discussion with Steve Holmes and Graham OBrien we'll be moving the "turning off" of ASAM, screen orientation lock and insomnia from the exiting "TestReportPage" to entering of the "BackToOfficePage".

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [x] PO's approval
