### PR TITLE
MES-2110: Clear test persistence when logging out on dev config (MES-2036)

### DIFF
--- a/src/environment/models/environment.model.ts
+++ b/src/environment/models/environment.model.ts
@@ -3,6 +3,7 @@ export interface EnvironmentFile {
   configUrl: string;
   daysToCacheJournalData: number;
   daysToCacheLogs: number;
+  logoutClearsTestPersistence?: boolean;
   authentication: {
     context: string;
     resourceUrl: string;

--- a/src/providers/app-config/__mocks__/app-config.mock.ts
+++ b/src/providers/app-config/__mocks__/app-config.mock.ts
@@ -18,6 +18,7 @@ export class AppConfigProviderMock {
       googleAnalyticsId: localEnvironmentMock.googleAnalyticsId,
       daysToCacheJournalData: localEnvironmentMock.daysToCacheJournalData,
       daysToCacheLogs: localEnvironmentMock.daysToCacheLogs,
+      logoutClearsTestPersistence:  localEnvironmentMock.logoutClearsTestPersistence,
       authentication: {
         clientId: localEnvironmentMock.authentication.clientId,
         context: localEnvironmentMock.authentication.context,

--- a/src/providers/app-config/__mocks__/app-config.mock.ts
+++ b/src/providers/app-config/__mocks__/app-config.mock.ts
@@ -18,7 +18,7 @@ export class AppConfigProviderMock {
       googleAnalyticsId: localEnvironmentMock.googleAnalyticsId,
       daysToCacheJournalData: localEnvironmentMock.daysToCacheJournalData,
       daysToCacheLogs: localEnvironmentMock.daysToCacheLogs,
-      logoutClearsTestPersistence:  localEnvironmentMock.logoutClearsTestPersistence,
+      logoutClearsTestPersistence: localEnvironmentMock.logoutClearsTestPersistence,
       authentication: {
         clientId: localEnvironmentMock.authentication.clientId,
         context: localEnvironmentMock.authentication.context,

--- a/src/providers/app-config/app-config.model.ts
+++ b/src/providers/app-config/app-config.model.ts
@@ -3,6 +3,7 @@ export type AppConfig = {
   googleAnalyticsId: string,
   daysToCacheJournalData: number,
   daysToCacheLogs: number,
+  logoutClearsTestPersistence?: boolean;
   authentication: {
     context: string,
     resourceUrl: string,

--- a/src/providers/app-config/app-config.ts
+++ b/src/providers/app-config/app-config.ts
@@ -71,6 +71,7 @@ export class AppConfigProvider {
       configUrl: data.configUrl,
       daysToCacheJournalData: data.daysToCacheJournalData,
       daysToCacheLogs: data.daysToCacheLogs,
+      logoutClearsTestPersistence: data.logoutClearsTestPersistence,
       authentication: {
         context: data.authentication.context,
         redirectUrl: data.authentication.redirectUrl,

--- a/src/providers/authentication/authentication.ts
+++ b/src/providers/authentication/authentication.ts
@@ -6,6 +6,7 @@ import jwtDecode from 'jwt-decode';
 import { AuthenticationError } from './authentication.constants';
 import { MsAdalError } from './authentication.models';
 import { NetworkStateProvider, ConnectionStatus } from '../network-state/network-state';
+import { TestPersistenceProvider } from '../test-persistence/test-persistence';
 
 @Injectable()
 export class AuthenticationProvider {
@@ -21,7 +22,9 @@ export class AuthenticationProvider {
     private msAdal: MSAdal,
     private inAppBrowser: InAppBrowser,
     private networkState: NetworkStateProvider,
-    private appConfig: AppConfigProvider) {
+    private appConfig: AppConfigProvider,
+    private testPersistenceProvider: TestPersistenceProvider,
+  ) {
   }
 
   public initialiseAuthentication = ():void => {
@@ -95,6 +98,10 @@ export class AuthenticationProvider {
     browser.on('loadstop').subscribe(() => {
       browser.close();
     });
+
+    if (this.appConfig.getAppConfig().logoutClearsTestPersistence) {
+      this.testPersistenceProvider.clearPersistedTests();
+    }
   }
 
   aquireTokenSilently = async (): Promise<AuthenticationResult> => {

--- a/src/providers/data-store/__mocks__/data-store.mock.ts
+++ b/src/providers/data-store/__mocks__/data-store.mock.ts
@@ -2,4 +2,5 @@ export class DataStoreProviderMock {
   setItem = jasmine.createSpy('setItem').and.returnValue(Promise.resolve('set'));
   getItem = jasmine.createSpy('getItem').and.returnValue(Promise.resolve('get'));
   setSecureContainer = jasmine.createSpy('setSecureContainer').and.returnValue(Promise.resolve());
+  removeItem = jasmine.createSpy('removeItem');
 }

--- a/src/providers/test-persistence/__mocks__/test-persistence.mock.ts
+++ b/src/providers/test-persistence/__mocks__/test-persistence.mock.ts
@@ -1,3 +1,4 @@
 export class TestPersistenceProviderMock {
   persistAllTests = jasmine.createSpy('persistAllTests');
+  clearPersistedTests = jasmine.createSpy('clearPersistedTests');
 }

--- a/src/providers/test-persistence/__tests__/test-persistence.spec.ts
+++ b/src/providers/test-persistence/__tests__/test-persistence.spec.ts
@@ -39,4 +39,12 @@ describe('TestPersistenceProvider', () => {
       expect(JSON.parse(dataStoreProvider.setItem.calls.first().args[1])).toEqual(testState);
     });
   });
+
+  describe('clearPersistedTests', () => {
+    it('should remove item on the data stores test key', async () => {
+      await testPersistenceProvider.clearPersistedTests();
+
+      expect(dataStoreProvider.removeItem).toHaveBeenCalledWith('TESTS');
+    });
+  });
 });

--- a/src/providers/test-persistence/test-persistence.ts
+++ b/src/providers/test-persistence/test-persistence.ts
@@ -24,8 +24,8 @@ export class TestPersistenceProvider {
     ).toPromise();
   }
 
-  clearPersistedTests(): Promise<void> {
-    return Promise.resolve();
+  async clearPersistedTests(): Promise<void> {
+    await this.dataStoreProvider.removeItem(this.testKeychainKey);
   }
 
 }

--- a/src/providers/test-persistence/test-persistence.ts
+++ b/src/providers/test-persistence/test-persistence.ts
@@ -24,4 +24,8 @@ export class TestPersistenceProvider {
     ).toPromise();
   }
 
+  clearPersistedTests(): Promise<void> {
+    return Promise.resolve();
+  }
+
 }


### PR DESCRIPTION
## Description and relevant Jira numbers
* Given that we only have one test that can be started in the dev test data, once we implement restoration of persisted test state and the test has been completed, the only way to re-run the test is to clear the persistent store
* Add a feature flag for clearing the persisted tests on logout
* To run a test again, set `logoutClearsTestPersistence` to true, logout and kill the app

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
