### PR TITLE
Reinstate remove fault on tap gesture

### DIFF
--- a/src/pages/test-report/components/competency/__tests__/competency.spec.ts
+++ b/src/pages/test-report/components/competency/__tests__/competency.spec.ts
@@ -70,13 +70,24 @@ describe('CompetencyComponent', () => {
     });
 
     describe('addDrivingFault', () => {
-      it('should dispatch an ADD_DRIVING_FAULT action for press and hold', () => {
+      it('should dispatch an ADD_DRIVING_FAULT action for press', () => {
+        component.competency = Competencies.controlsSteering;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault(true);
+
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new AddDrivingFault({
+          competency: component.competency,
+          newFaultCount: 1,
+        }));
+      });
+      it('should not dispatch an ADD_DRIVING_FAULT action for tap', () => {
         component.competency = Competencies.controlsSteering;
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault();
 
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new AddDrivingFault({
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
           competency: component.competency,
           newFaultCount: 1,
         }));
@@ -395,7 +406,7 @@ describe('CompetencyComponent', () => {
         component.isDangerousMode = true;
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
-        component.addFault();
+        component.addOrRemoveFault();
 
         expect(storeDispatchSpy).toHaveBeenCalledWith(new AddDangerousFault(component.competency));
         expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleDangerousFaultMode());
@@ -406,7 +417,7 @@ describe('CompetencyComponent', () => {
         component.isSeriousMode = true;
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
-        component.addFault();
+        component.addOrRemoveFault();
 
         expect(storeDispatchSpy).toHaveBeenCalledWith(new AddSeriousFault(component.competency));
         expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleSeriousFaultMode());
@@ -466,7 +477,7 @@ describe('CompetencyComponent', () => {
     });
 
     it('should add the ripple effect animation css class', () => {
-      component.onPress();
+      component.addOrRemoveFault(true);
       fixture.detectChanges();
       const button = fixture.debugElement.query(By.css('.competency-button'));
 
@@ -475,7 +486,7 @@ describe('CompetencyComponent', () => {
     });
 
     it('should remove the ripple effect animation css class within the required time frame', (done) => {
-      component.onPress();
+      component.addOrRemoveFault(true);
       fixture.detectChanges();
       const button = fixture.debugElement.query(By.css('.competency-button'));
       setTimeout(

--- a/src/pages/test-report/components/competency/competency.html
+++ b/src/pages/test-report/components/competency/competency.html
@@ -1,5 +1,6 @@
 <div class="competency-button"
-  (press)="onPress()"
+  (tap)="addOrRemoveFault()"
+  (press)="addOrRemoveFault(true)"
   (touchstart)="onTouchStart()"
   (touchend)="onTouchEnd()"
   [ngClass]="{

--- a/src/pages/test-report/components/competency/competency.ts
+++ b/src/pages/test-report/components/competency/competency.ts
@@ -131,15 +131,18 @@ export class CompetencyComponent {
 
   getLabel = (): string => competencyLabels[this.competency];
 
-  addOrRemoveFault = (): void => {
+  addOrRemoveFault = (wasPress: boolean = false): void => {
+    if (wasPress) {
+      this.applyRippleEffect();
+    }
     if (this.isRemoveFaultMode) {
       this.removeFault();
     } else {
-      this.addFault();
+      this.addFault(wasPress);
     }
   }
 
-  addFault = (): void => {
+  addFault = (wasPress: boolean): void => {
     if (this.hasDangerousFault) {
       return;
     }
@@ -160,10 +163,12 @@ export class CompetencyComponent {
       return;
     }
 
-    this.store$.dispatch(new AddDrivingFault({
-      competency: this.competency,
-      newFaultCount: this.faultCount ? this.faultCount + 1 : 1,
-    }));
+    if (wasPress) {
+      this.store$.dispatch(new AddDrivingFault({
+        competency: this.competency,
+        newFaultCount: this.faultCount ? this.faultCount + 1 : 1,
+      }));
+    }
   }
 
   removeFault = (): void => {
@@ -210,11 +215,6 @@ export class CompetencyComponent {
   removeRippleEffect = (): any => {
     this.rippleState = false;
     clearTimeout(this.rippleTimeout);
-  }
-
-  onPress(): void {
-    this.applyRippleEffect();
-    this.addOrRemoveFault();
   }
 
   onTouchStart():void {


### PR DESCRIPTION
## Description and relevant Jira numbers

Quick PR to reinstate the ability to remove faults by tapping, not just by long pressing (removed in MES-2073)

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
