### PR TITLE
MES-1849 mark faults against controlled stop

### DIFF
--- a/src/modules/tests/test_data/test-data.actions.ts
+++ b/src/modules/tests/test_data/test-data.actions.ts
@@ -18,6 +18,8 @@ export const TOGGLE_ETA = '[Eta] Toggle Eta';
 export const TOGGLE_CONTROL_ECO = '[Eco] Toggle Control Eco';
 export const TOGGLE_PLANNING_ECO = '[Eco] Toggle Planning Eco';
 export const TOGGLE_CONTROLLED_STOP = '[ControlledStop] Toggle Controlled Stop';
+export const CONTROLLED_STOP_COMPLETE = '[ControlledStop] Controlled Stop Complete';
+export const CONTROLLED_STOP_PENDING = '[ControlledStop] Controlled Stop Pending';
 
 export class RecordManoeuvresSelection implements Action {
   constructor(public manoeuvre: ManoeuvreTypes) { }
@@ -75,6 +77,12 @@ export class TogglePlanningEco implements Action {
 export class ToggleControlledStop implements Action {
   readonly type = TOGGLE_CONTROLLED_STOP;
 }
+export class ControlledStopComplete implements Action {
+  readonly type = CONTROLLED_STOP_COMPLETE;
+}
+export class ControlledStopPending implements Action {
+  readonly type = CONTROLLED_STOP_PENDING;
+}
 
 export type Types =
   | RecordManoeuvresSelection
@@ -89,4 +97,6 @@ export type Types =
   | ToggleETA
   | ToggleControlEco
   | TogglePlanningEco
-  | ToggleControlledStop;
+  | ToggleControlledStop
+  | ControlledStopComplete
+  | ControlledStopPending;

--- a/src/modules/tests/test_data/test-data.reducer.ts
+++ b/src/modules/tests/test_data/test-data.reducer.ts
@@ -120,7 +120,22 @@ export function testDataReducer(
           selectedControlledStop: !state.manoeuvres.selectedControlledStop,
         },
       };
-
+    case testDataActions.CONTROLLED_STOP_COMPLETE:
+      return {
+        ...state,
+        manoeuvres: {
+          ...state.manoeuvres,
+          selectedControlledStop: true,
+        },
+      };
+    case testDataActions.CONTROLLED_STOP_PENDING:
+      return {
+        ...state,
+        manoeuvres: {
+          ...state.manoeuvres,
+          selectedControlledStop: false,
+        },
+      };
     default:
       return state;
   }

--- a/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
+++ b/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
@@ -1,11 +1,32 @@
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { ControlledStopComponent } from '../controlled-stop';
 import { IonicModule } from 'ionic-angular';
 import { StoreModule, Store } from '@ngrx/store';
 import { testsReducer } from '../../../../../modules/tests/tests.reducer';
+import { testReportReducer } from '../../../test-report.reducer';
 import { StoreModel } from '../../../../../shared/models/store.model';
 import { MockComponent } from 'ng-mocks';
 import { TickIndicatorComponent } from '../../tick-indicator/tick-indicator';
+import { DrivingFaultsBadgeComponent } from '../../../../../components/driving-faults-badge/driving-faults-badge';
+import { SeriousFaultBadgeComponent } from '../../../../../components/serious-fault-badge/serious-fault-badge';
+import { DangerousFaultBadgeComponent } from '../../../../../components/dangerous-fault-badge/dangerous-fault-badge';
+import { StartTest } from '../../../../journal/journal.actions';
+import {
+  ToggleSeriousFaultMode,
+  ToggleDangerousFaultMode,
+  ToggleRemoveFaultMode,
+} from '../../../test-report.actions';
+import {
+  AddDrivingFault,
+  AddSeriousFault,
+  AddDangerousFault,
+  RemoveDrivingFault,
+  RemoveDangerousFault,
+  RemoveSeriousFault,
+  ToggleControlledStop,
+  ControlledStopComplete,
+} from '../../../../../modules/tests/test_data/test-data.actions';
 
 describe('ControlledStopComponent', () => {
   let fixture: ComponentFixture<ControlledStopComponent>;
@@ -17,10 +38,13 @@ describe('ControlledStopComponent', () => {
       declarations: [
         ControlledStopComponent,
         MockComponent(TickIndicatorComponent),
+        MockComponent(DrivingFaultsBadgeComponent),
+        MockComponent(SeriousFaultBadgeComponent),
+        MockComponent(DangerousFaultBadgeComponent),
       ],
       imports: [
         IonicModule,
-        StoreModule.forRoot({ tests: testsReducer }),
+        StoreModule.forRoot({ tests: testsReducer, testReport : testReportReducer }),
       ],
     })
       .compileComponents()
@@ -28,7 +52,8 @@ describe('ControlledStopComponent', () => {
         fixture = TestBed.createComponent(ControlledStopComponent);
         component = fixture.componentInstance;
         store$ = TestBed.get(Store);
-        spyOn(store$, 'dispatch');
+        // spyOn(store$, 'dispatch');
+        store$.dispatch(new StartTest(103));
       });
   }));
 
@@ -36,9 +61,495 @@ describe('ControlledStopComponent', () => {
     it('should compile', () => {
       expect(component).toBeDefined();
     });
+
+    describe('addDrivingFault', () => {
+      it('should dispatch an ADD_DRIVING_FAULT action for press', () => {
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault(true);
+
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new AddDrivingFault({
+          competency: component.competency,
+          newFaultCount: 1,
+        }));
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ControlledStopComplete());
+      });
+      it('should not dispatch an ADD_DRIVING_FAULT action for tap', () => {
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
+          competency: component.competency,
+          newFaultCount: 1,
+        }));
+      });
+      it('should not dispatch an ADD_DRIVING_FAULT action if there is already a driving fault', () => {
+        component.faultCount = 1;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault(true);
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
+          competency: component.competency,
+          newFaultCount: 1,
+        }));
+      });
+      it('should not dispatch an ADD_DRIVING_FAULT action if there is a serious fault', () => {
+        component.hasSeriousFault = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
+          competency: component.competency,
+          newFaultCount: 1,
+        }));
+      });
+      it('should not dispatch an ADD_DRIVING_FAULT action if serious mode is active', () => {
+        component.isSeriousMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
+          competency: component.competency,
+          newFaultCount: 1,
+        }));
+      });
+      it('should not dispatch an ADD_DRIVING_FAULT action if there is a dangerous fault', () => {
+        component.hasDangerousFault = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
+          competency: component.competency,
+          newFaultCount: 1,
+        }));
+      });
+      it('should not dispatch an ADD_DRIVING_FAULT action if dangerous mode is active', () => {
+        component.isDangerousMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
+          competency: component.competency,
+          newFaultCount: 1,
+        }));
+      });
+    });
+
+    describe('addDangerousFault', () => {
+      it('should dispatch a ADD_DANGEROUS_FAULT action if dangerous mode is active on press', () => {
+        component.isDangerousMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new AddDangerousFault(component.competency));
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleDangerousFaultMode());
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ControlledStopComplete());
+      });
+      it('should dispatch a ADD_DANGEROUS_FAULT action if dangerous mode is active on press and hold', () => {
+        component.isDangerousMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new AddDangerousFault(component.competency));
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleDangerousFaultMode());
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ControlledStopComplete());
+      });
+      it('should not dispatch a ADD_DANGEROUS_FAULT action if there is a dangerous fault', () => {
+        component.hasDangerousFault = true;
+        component.isDangerousMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDangerousFault(component.competency));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleDangerousFaultMode());
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ControlledStopComplete());
+      });
+      it('should not dispatch a ADD_DANGEROUS_FAULT action if there is a serious fault', () => {
+        component.hasSeriousFault = true;
+        component.isDangerousMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDangerousFault(component.competency));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleDangerousFaultMode());
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ControlledStopComplete());
+      });
+      it('should not dispatch a ADD_DANGEROUS_FAULT action if there is a driving fault', () => {
+        component.faultCount = 1;
+        component.isDangerousMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDangerousFault(component.competency));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleDangerousFaultMode());
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ControlledStopComplete());
+      });
+    });
+
+    describe('addSeriousFault', () => {
+      it('should dispatch an ADD_SERIOUS_FAULT action if serious mode is active', () => {
+        component.isSeriousMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new AddSeriousFault(component.competency));
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleSeriousFaultMode());
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ControlledStopComplete());
+      });
+      it('should not dispatch a ADD_SERIOUS_FAULT action if there is a serious fault', () => {
+        component.hasSeriousFault = true;
+        component.isSeriousMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddSeriousFault(component.competency));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleSeriousFaultMode());
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ControlledStopComplete());
+      });
+      it('should not dispatch a ADD_SERIOUS_FAULT action if dangerous mode is active', () => { //
+        component.isDangerousMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddSeriousFault(component.competency));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleSeriousFaultMode());
+      });
+      it('should not dispatch a ADD_SERIOUS_FAULT action if there is a dangerous fault', () => {
+        component.hasDangerousFault = true;
+        component.isSeriousMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddSeriousFault(component.competency));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleSeriousFaultMode());
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ControlledStopComplete());
+      });
+      it('should not dispatch a ADD_SERIOUS_FAULT action if there is a driving fault', () => {
+        component.faultCount = 1;
+        component.isSeriousMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddSeriousFault(component.competency));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleSeriousFaultMode());
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ControlledStopComplete());
+      });
+    });
+
+    describe('removeDrivingFault', () => {
+      it('should dispatch a REMOVE_DRIVING_FAULT', () => {
+        component.faultCount = 1;
+        component.isRemoveFaultMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveDrivingFault({
+          competency: component.competency,
+          newFaultCount: 0,
+        }));
+      });
+      it('should dispatch a REMOVE_DRIVING_FAULT limit zero', () => {
+        component.faultCount = 0;
+        component.isRemoveFaultMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveDrivingFault({
+          competency: component.competency,
+          newFaultCount: 0,
+        }));
+      });
+      it('should NOT remove driving fault when serious mode is active', () => {
+        component.faultCount = 1;
+        component.isSeriousMode = true;
+        component.isRemoveFaultMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveDrivingFault({
+          competency: component.competency,
+          newFaultCount: 1,
+        }));
+      });
+      it('should NOT remove driving fault when dangerous mode is active', () => {
+        component.faultCount = 1;
+        component.isDangerousMode = true;
+        component.isRemoveFaultMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveDrivingFault({
+          competency: component.competency,
+          newFaultCount: 1,
+        }));
+      });
+    });
+
+    describe('removeSeriousFault', () => {
+      it('should not dispatch a REMOVE_SERIOUS_FAULT when not in remove mode', () => {
+        component.hasSeriousFault = true;
+        component.isSeriousMode = true;
+        component.isRemoveFaultMode = false;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
+      });
+      it('should dispatch a REMOVE_SERIOUS_FAULT for press and hold', () => {
+        component.hasSeriousFault = true;
+        component.isSeriousMode = true;
+        component.isRemoveFaultMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
+      });
+      it('should dispatch a REMOVE_SERIOUS_FAULT for press', () => {
+        component.hasSeriousFault = true;
+        component.isSeriousMode = true;
+        component.isRemoveFaultMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
+      });
+      it('should not dispatch a REMOVE_SERIOUS_FAULT when is dangerous mode', () => {
+        component.hasSeriousFault = true;
+        component.isDangerousMode = true;
+        component.isRemoveFaultMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
+      });
+
+      it('should remove serious mode after removal attempt on competency with no serious fault', () => {
+        component.hasSeriousFault = false;
+        component.isSeriousMode = true;
+        component.isRemoveFaultMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleSeriousFaultMode());
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
+        fixture.detectChanges();
+        expect(component.isSeriousMode).toEqual(false);
+      });
+
+    });
+
+    describe('removeDangerousFault', () => {
+      it('should not dispatch a REMOVE_DANGEROUS_FAULT when not in remove mode', () => {
+        component.hasDangerousFault = true;
+        component.isDangerousMode = true;
+        component.isRemoveFaultMode = false;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
+      });
+      it('should dispatch a REMOVE_DANGEROUS_FAULT for press and hold', () => {
+        component.hasDangerousFault = true;
+        component.isDangerousMode = true;
+        component.isRemoveFaultMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
+      });
+      it('should dispatch a REMOVE_DANGEROUS_FAULT for press', () => {
+        component.hasDangerousFault = true;
+        component.isDangerousMode = true;
+        component.isRemoveFaultMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
+      });
+      it('should not dispatch a REMOVE_DANGEROUS_FAULT when is serious mode', () => {
+        component.hasDangerousFault = true;
+        component.isSeriousMode = true;
+        component.isRemoveFaultMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
+      });
+      it('should remove dangerous mode after removal attempt on competency with no dangerous fault', () => {
+        component.hasDangerousFault = false;
+        component.isDangerousMode = true;
+        component.isRemoveFaultMode = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleDangerousFaultMode());
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
+        fixture.detectChanges();
+        expect(component.isDangerousMode).toEqual(false);
+      });
+    });
+
+    describe('toggleControlledStop', () => {
+      it('should dispatch a TOGGLE_CONTROLLED_STOP action when there are no faults', () => {
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.toggleControlledStop();
+
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleControlledStop());
+      });
+      it('should not dispatch a TOGGLE_CONTROLLED_STOP action when there is a driving fault', () => {
+        component.faultCount = 1;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.toggleControlledStop();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleControlledStop());
+      });
+      it('should not dispatch a TOGGLE_CONTROLLED_STOP action when there is a serious fault', () => {
+        component.hasSeriousFault = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.toggleControlledStop();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleControlledStop());
+      });
+      it('should not dispatch a TOGGLE_CONTROLLED_STOP action when there is a dangerous fault', () => {
+        component.hasDangerousFault = true;
+
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.toggleControlledStop();
+
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleControlledStop());
+      });
+    });
   });
 
   describe('DOM', () => {
+    it('should pass the number of driving faults to the driving faults badge component', () => {
+      fixture.detectChanges();
+      const drivingFaultsBadge = fixture.debugElement.query(By.css('.driving-faults'))
+        .componentInstance as DrivingFaultsBadgeComponent;
+      component.faultCount = 1;
 
+      fixture.detectChanges();
+      expect(drivingFaultsBadge.count).toBe(1);
+    });
+  });
+
+  describe('Competency button effects', () => {
+    it('should have added no classes to the competency button', () => {
+      const competencyButton = fixture.debugElement.query(By.css('.competency-button'));
+      expect(competencyButton.nativeElement.className).toEqual('competency-button');
+    });
+
+    it('should add the activated class when the button is pressed', () => {
+      component.onTouchStart('competency');
+      fixture.detectChanges();
+      const button = fixture.debugElement.query(By.css('.competency-button'));
+
+      expect(button).toBeDefined();
+      expect(button.nativeElement.className).toContain('activated');
+      expect(component.touchState).toBeTruthy();
+    });
+
+    it('should remove the activated class after a specified delay when the button is not pressed', (done) => {
+      component.onTouchEnd('competency');
+      fixture.detectChanges();
+      const button = fixture.debugElement.query(By.css('.competency-button'));
+      setTimeout(
+        () => {
+          fixture.detectChanges();
+
+          expect(button).toBeDefined();
+          expect(button.nativeElement.className).not.toContain('activated');
+          expect(component.touchState).toBeFalsy();
+          done();
+        },
+        component.touchStateDelay);
+    });
+
+    it('should add the ripple effect animation css class', () => {
+      component.addOrRemoveFault(true);
+      fixture.detectChanges();
+      const button = fixture.debugElement.query(By.css('.competency-button'));
+
+      expect(button).toBeDefined();
+      expect(button.nativeElement.className).toContain('ripple-effect');
+    });
+
+    it('should remove the ripple effect animation css class within the required time frame', (done) => {
+      component.addOrRemoveFault(true);
+      fixture.detectChanges();
+      const button = fixture.debugElement.query(By.css('.competency-button'));
+      setTimeout(
+        () => {
+          fixture.detectChanges();
+
+          expect(button).toBeDefined();
+          expect(button.nativeElement.className).not.toContain('ripple-effect');
+          done();
+        },
+        component.rippleEffectAnimationDuration);
+    });
+  });
+
+  describe('Tick button effects', () => {
+    it('should have added no classes to the tick button', () => {
+      const tickButton = fixture.debugElement.query(By.css('.tick-button'));
+      expect(tickButton.nativeElement.className).toEqual('tick-button');
+    });
+
+    it('should add the activated class when the button is pressed', () => {
+      component.onTouchStart('tick');
+      fixture.detectChanges();
+      const button = fixture.debugElement.query(By.css('.tick-button'));
+
+      expect(button).toBeDefined();
+      expect(button.nativeElement.className).toContain('activated');
+      expect(component.touchStateTick).toBeTruthy();
+    });
+
+    it('should remove the activated class after a specified delay when the button is not pressed', (done) => {
+      component.onTouchEnd('tick');
+      fixture.detectChanges();
+      const button = fixture.debugElement.query(By.css('.tick-button'));
+      setTimeout(
+        () => {
+          fixture.detectChanges();
+
+          expect(button).toBeDefined();
+          expect(button.nativeElement.className).not.toContain('activated');
+          expect(component.touchStateTick).toBeFalsy();
+          done();
+        },
+        component.touchStateDelay);
+    });
   });
 });

--- a/src/pages/test-report/components/controlled-stop/controlled-stop.html
+++ b/src/pages/test-report/components/controlled-stop/controlled-stop.html
@@ -28,7 +28,7 @@
     >
       <driving-faults-badge class="driving-faults" [count]="faultCount"></driving-faults-badge>
     
-      <div class='competency-label'>Controlled Stop</div>
+      <div class='competency-label'>Controlled stop</div>
     
       <div class="fault-wrapper">
         <serious-fault-badge [showBadge]="hasSeriousFault"></serious-fault-badge>

--- a/src/pages/test-report/components/controlled-stop/controlled-stop.html
+++ b/src/pages/test-report/components/controlled-stop/controlled-stop.html
@@ -1,23 +1,40 @@
 <ion-row>
   <ion-col no-padding>
-    <button
-      (click)="toggleControlledStop()"
-      class="mes-test-report-button  tick-button"
-      [ngClass]="{'checked' : componentState.selectedControlledStop$ | async}"
+    <div class="tick-button"
+      (tap)="toggleControlledStop()"
+      (press)="toggleControlledStop()"
+      (touchstart)="onTouchStart('tick')"
+      (touchend)="onTouchEnd('tick')"
+      [ngClass]="{
+        'activated': touchStateTick,
+        'checked' : componentState.selectedControlledStop$ | async
+      }"
     >
       <span class='tickwrapper'>
         <tick-indicator [ticked]="componentState.selectedControlledStop$ | async"></tick-indicator>
       </span>
-    </button>
+    </div>
   </ion-col>
   <ion-col no-padding>
-    <button
-      class="label-button mes-test-report-button"
-      [ngClass]="{'checked' : componentState.selectedControlledStop$ | async}"
+    <div class="competency-button"
+      (tap)="addOrRemoveFault()"
+      (press)="addOrRemoveFault(true)"
+      (touchstart)="onTouchStart('competency')"
+      (touchend)="onTouchEnd('competency')"
+      [ngClass]="{
+        'activated': touchState,
+        'ripple-effect': rippleState
+      }"
     >
-      <span class="label">
-        Controlled Stop
-      </span>
-    </button>
+      <driving-faults-badge class="driving-faults" [count]="faultCount"></driving-faults-badge>
+    
+      <div class='competency-label'>Controlled Stop</div>
+    
+      <div class="fault-wrapper">
+        <serious-fault-badge [showBadge]="hasSeriousFault"></serious-fault-badge>
+        <dangerous-fault-badge [showBadge]="hasDangerousFault"></dangerous-fault-badge>
+      </div>
+    
+    </div>
   </ion-col>
 </ion-row>

--- a/src/pages/test-report/components/controlled-stop/controlled-stop.scss
+++ b/src/pages/test-report/components/controlled-stop/controlled-stop.scss
@@ -1,22 +1,44 @@
 controlled-stop {
 
   .tick-button {
+    @extend .mes-test-report-button;
     width: 56px;
+
+    padding: 1px 7px 2px;
 
     &.checked {
       border: 2px solid map-get($colors-gds, "gds-dark-green");
     }
     .tickwrapper {
       margin: auto;
+      display: flex;
+      justify-content: center;
     }
   }
 
-  .label-button {
-    width: 192px;
-    color: rgb(11, 12, 12);
+  .competency-button {
+    @extend .mes-test-report-button;
+    @extend .mes-test-report-button-ripple-effect;
 
-    .label {
-      width: 100%;
+    width: 188px;
+    margin-right: 3px;
+
+    padding-left: 5px;
+    padding-right: 5px;
+
+    driving-faults-badge {
+      width: 30px;
+    }
+
+    .fault-wrapper {
+      display: flex;
+      width: 30px;
+      justify-content: flex-end;
+      align-items: center;
+      
+      dangerous-fault-badge {
+        margin-left: -22px;
+      }
     }
   }
 }

--- a/src/pages/test-report/components/controlled-stop/controlled-stop.ts
+++ b/src/pages/test-report/components/controlled-stop/controlled-stop.ts
@@ -1,15 +1,44 @@
 import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
+import { merge } from 'rxjs/observable/merge';
+import { map } from 'rxjs/operators';
+
 import { StoreModel } from '../../../../shared/models/store.model';
 import { Store, select } from '@ngrx/store';
 import { getTests } from '../../../../modules/tests/tests.reducer';
 import { getCurrentTest } from '../../../../modules/tests/tests.selector';
 import { getTestData } from '../../../../modules/tests/test_data/test-data.reducer';
-import { hasControlledStopBeenCompleted } from '../../../../modules/tests/test_data/test-data.selector';
-import { ToggleControlledStop } from '../../../../modules/tests/test_data/test-data.actions';
+import {
+  hasControlledStopBeenCompleted,
+  getDrivingFaultCount,
+  hasSeriousFault,
+  hasDangerousFault,
+} from '../../../../modules/tests/test_data/test-data.selector';
+import {
+  ToggleControlledStop,
+  AddDrivingFault,
+  AddSeriousFault,
+  AddDangerousFault,
+  RemoveDrivingFault,
+  RemoveSeriousFault,
+  RemoveDangerousFault,
+  ControlledStopComplete,
+} from '../../../../modules/tests/test_data/test-data.actions';
+import { getTestReportState } from '../../test-report.reducer';
+import { isRemoveFaultMode, isSeriousMode, isDangerousMode } from '../../test-report.selector';
+import { ToggleRemoveFaultMode, ToggleSeriousFaultMode, ToggleDangerousFaultMode } from '../../test-report.actions';
+import { Competencies } from '../../../../modules/tests/test_data/test-data.constants';
 
 interface ControlledStopComponentState {
+  isRemoveFaultMode$: Observable<boolean>;
+  isSeriousMode$: Observable<boolean>;
+  isDangerousMode$: Observable<boolean>;
+
   selectedControlledStop$: Observable<boolean>;
+  drivingFaultCount$: Observable<number>;
+  hasSeriousFault$: Observable<boolean>;
+  hasDangerousFault$: Observable<boolean>;
 }
 
 @Component({
@@ -18,23 +47,212 @@ interface ControlledStopComponentState {
 })
 export class ControlledStopComponent implements OnInit {
 
+  competency: Competencies = Competencies.outcomeControlledStop;
+
   componentState: ControlledStopComponentState;
+  subscription: Subscription;
+
+  touchStateDelay: number = 100;
+
+  touchStateTick: boolean = false;
+  touchState: boolean = false;
+  rippleState: boolean = false;
+
+  rippleTimeout: any;
+  touchTimeoutTick: any;
+  touchTimeout: any;
+
+  rippleEffectAnimationDuration: number = 300;
+
+  isRemoveFaultMode: boolean = false;
+
+  faultCount: number;
+
+  isSeriousMode: boolean = false;
+  hasSeriousFault: boolean = false;
+
+  isDangerousMode: boolean = false;
+  hasDangerousFault: boolean = false;
+
+  controlledStopCompleted: boolean = false;
 
   constructor(private store$: Store<StoreModel>) {}
 
   ngOnInit(): void {
+    const currentTest$ = this.store$.pipe(
+      select(getTests),
+      select(getCurrentTest),
+    );
+
     this.componentState = {
-      selectedControlledStop$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      isRemoveFaultMode$: this.store$.pipe(
+        select(getTestReportState),
+        select(isRemoveFaultMode)),
+      isSeriousMode$: this.store$.pipe(
+        select(getTestReportState),
+        select(isSeriousMode)),
+      isDangerousMode$: this.store$.pipe(
+        select(getTestReportState),
+        select(isDangerousMode)),
+      selectedControlledStop$: currentTest$.pipe(
         select(getTestData),
         select(hasControlledStopBeenCompleted),
       ),
+      drivingFaultCount$: currentTest$.pipe(
+        select(getTestData),
+        select(testData => getDrivingFaultCount(testData, this.competency))),
+      hasSeriousFault$: currentTest$.pipe(
+        select(getTestData),
+        select(testData => hasSeriousFault(testData, this.competency))),
+      hasDangerousFault$: currentTest$.pipe(
+        select(getTestData),
+        select(testData => hasDangerousFault(testData, this.competency)),
+      ),
     };
+
+    const {
+      drivingFaultCount$,
+      isRemoveFaultMode$,
+      isSeriousMode$,
+      hasSeriousFault$,
+      isDangerousMode$,
+      hasDangerousFault$,
+      selectedControlledStop$,
+    } = this.componentState;
+
+    const merged$ = merge(
+      drivingFaultCount$.pipe(map(count => this.faultCount = count)),
+      isRemoveFaultMode$.pipe(map(toggle => this.isRemoveFaultMode = toggle)),
+      isSeriousMode$.pipe(map(toggle => this.isSeriousMode = toggle)),
+      hasSeriousFault$.pipe(map(toggle => this.hasSeriousFault = toggle)),
+      isDangerousMode$.pipe(map(toggle => this.isDangerousMode = toggle)),
+      hasDangerousFault$.pipe(map(toggle => this.hasDangerousFault = toggle)),
+      selectedControlledStop$.pipe(map(toggle => this.controlledStopCompleted = toggle)),
+    );
+
+    this.subscription = merged$.subscribe();
+
+  }
+
+  ngOnDestroy(): void {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 
   toggleControlledStop = (): void => {
+    if (this.hasDangerousFault || this.hasSeriousFault || this.faultCount > 0) {
+      return;
+    }
     this.store$.dispatch(new ToggleControlledStop());
   }
 
+  addOrRemoveFault = (wasPress: boolean = false): void => {
+    if (this.isRemoveFaultMode) {
+      this.removeFault(wasPress);
+    } else {
+      this.addFault(wasPress);
+    }
+  }
+
+  addFault = (wasPress: boolean): void => {
+    if (this.hasDangerousFault || this.hasSeriousFault || this.faultCount > 0) {
+      return;
+    }
+
+    if (wasPress) {
+      this.applyRippleEffect();
+    }
+
+    if (this.isDangerousMode) {
+      this.store$.dispatch(new ControlledStopComplete());
+      this.store$.dispatch(new AddDangerousFault(this.competency));
+      this.store$.dispatch(new ToggleDangerousFaultMode());
+      return;
+    }
+
+    if (this.isSeriousMode) {
+      this.store$.dispatch(new ControlledStopComplete());
+      this.store$.dispatch(new AddSeriousFault(this.competency));
+      this.store$.dispatch(new ToggleSeriousFaultMode());
+      return;
+    }
+
+    if (wasPress) {
+      this.store$.dispatch(new ControlledStopComplete());
+      this.store$.dispatch(new AddDrivingFault({
+        competency: this.competency,
+        newFaultCount: this.faultCount ? this.faultCount + 1 : 1,
+      }));
+    }
+  }
+
+  removeFault = (wasPress: boolean): void => {
+
+    if (wasPress) {
+      this.applyRippleEffect();
+    }
+
+    if (this.hasDangerousFault && this.isDangerousMode && this.isRemoveFaultMode) {
+      this.store$.dispatch(new RemoveDangerousFault(this.competency));
+      this.store$.dispatch(new ToggleDangerousFaultMode());
+      this.store$.dispatch(new ToggleRemoveFaultMode());
+      return;
+    }
+
+    if (this.hasSeriousFault && this.isSeriousMode && this.isRemoveFaultMode) {
+      this.store$.dispatch(new RemoveSeriousFault(this.competency));
+      this.store$.dispatch(new ToggleSeriousFaultMode());
+      this.store$.dispatch(new ToggleRemoveFaultMode());
+      return;
+    }
+    if (!this.isSeriousMode && !this.isDangerousMode && this.isRemoveFaultMode) {
+      this.store$.dispatch(new RemoveDrivingFault({
+        competency: this.competency,
+        newFaultCount: this.faultCount ? this.faultCount - 1 : 0,
+      }));
+    }
+
+    this.store$.dispatch(new ToggleRemoveFaultMode());
+    //  S and D can remain on in some conditions.
+    if (this.isSeriousMode) {
+      this.store$.dispatch(new ToggleSeriousFaultMode());
+    }
+    if (this.isDangerousMode) {
+      this.store$.dispatch(new ToggleDangerousFaultMode());
+    }
+  }
+
+  /**
+   * Manages the addition and removal of the ripple effect animation css class
+   * @returns any
+   */
+  applyRippleEffect = (): any => {
+    this.rippleState = true;
+    this.rippleTimeout = setTimeout(() => this.removeRippleEffect(), this.rippleEffectAnimationDuration);
+  }
+
+  removeRippleEffect = (): any => {
+    this.rippleState = false;
+    clearTimeout(this.rippleTimeout);
+  }
+
+  onTouchStart(target: string):void {
+    if (target === 'tick') {
+      clearTimeout(this.touchTimeoutTick);
+      this.touchStateTick = true;
+    } else {
+      clearTimeout(this.touchTimeout);
+      this.touchState = true;
+    }
+  }
+
+  onTouchEnd(target: string):void {
+    // defer the removal of the touch state to allow the page to render
+    if (target === 'tick') {
+      this.touchTimeoutTick = setTimeout(() => this.touchStateTick = false, this.touchStateDelay);
+    } else {
+      this.touchTimeout = setTimeout(() => this.touchState = false, this.touchStateDelay);
+    }
+  }
 }

--- a/src/shared/constants/competencies/catb-competencies.ts
+++ b/src/shared/constants/competencies/catb-competencies.ts
@@ -39,6 +39,7 @@ export enum fullCompetencyLabels  {
     pedestrianCrossings  = 'Pedestrian crossings',
     positionNormalStops  = 'Position/normal stop',
     awarenessPlanning  = 'Awareness planning',
+    outcomeControlledStop = 'Controlled Stop',
   }
 
 export type FaultCount = { name: string, count: number };

--- a/src/shared/constants/competencies/catb-competencies.ts
+++ b/src/shared/constants/competencies/catb-competencies.ts
@@ -39,7 +39,7 @@ export enum fullCompetencyLabels  {
     pedestrianCrossings  = 'Pedestrian crossings',
     positionNormalStops  = 'Position/normal stop',
     awarenessPlanning  = 'Awareness planning',
-    outcomeControlledStop = 'Controlled Stop',
+    outcomeControlledStop = 'Controlled stop',
   }
 
 export type FaultCount = { name: string, count: number };


### PR DESCRIPTION
## Description and relevant Jira numbers

Allow faults to be recorded against the controlled stop and display them in the competency button.

This is a copy of the regular competency button but with customised logic and styling to ensure that only one type of fault can be recorded (either a driving fault, a serious fault or a dangerous fault) and displayed as a badge in the reduced width button.

The tick box is checked when a fault is recorded. It can only be unchecked if there are no faults.

The same div-as-button code, ripple effect and activated state are used, just like the regular competency component.

There's probably scope for a future refactor to move some of this code into a shared custom `mes-button` component.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

![Simulator Screen Shot - iPad Pro (10 5-inch) - 2019-04-16 at 15 02 40](https://user-images.githubusercontent.com/8069071/56216128-c7622f80-6058-11e9-832a-5a0cbc9a77c6.png)

![Simulator Screen Shot - iPad Pro (10 5-inch) - 2019-04-16 at 15 01 59](https://user-images.githubusercontent.com/8069071/56216154-d0eb9780-6058-11e9-969e-5090ab0866f7.png)

![Simulator Screen Shot - iPad Pro (10 5-inch) - 2019-04-16 at 15 02 21](https://user-images.githubusercontent.com/8069071/56216161-d5b04b80-6058-11e9-9eb0-3c44a14640ca.png)

![Simulator Screen Shot - iPad Pro (10 5-inch) - 2019-04-16 at 15 02 10](https://user-images.githubusercontent.com/8069071/56216170-d943d280-6058-11e9-9c0d-a19a8d3c97bd.png)

![Simulator Screen Shot - iPad Pro (10 5-inch) - 2019-04-16 at 15 32 12](https://user-images.githubusercontent.com/8069071/56218412-d9de6800-605c-11e9-9be9-968fcdf2d8f9.png)
