### PR TITLE
MES-1102 fixes: Add missing weather condition validation indicators and fix select reflow

### DIFF
--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -208,7 +208,7 @@
             </ion-col>
           </ion-row>
 
-          <ion-row class="mes-validated-row mes-row-separator" id="weather-conditions-card">
+          <ion-row class="mes-validated-row mes-row-separator" id="weather-conditions-card" nowrap>
             <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('weatherConditionsCtrl')"></div>
             <ion-col class="component-label" col-32 align-self-center>
               <label>Weather conditions</label>
@@ -216,17 +216,15 @@
             <ion-col align-self-center>
               <ion-row class="spacing-row"></ion-row>
               <ion-row>
-                <ion-col>
-                  <ion-select id="weather-selector" value="weather" multiple="true" okText="Submit" cancelText="Cancel"
-                    placeholder="Select weather conditions" formControlName="weatherConditionsCtrl"
-                    [class.ng-invalid]="isCtrlDirtyAndInvalid('weatherConditionsCtrl')"
-                    (ionChange)="weatherConditionsChanged($event)">
-                    <ion-option [value]="weatherCondition.weatherConditionDescription"
-                      *ngFor="let weatherCondition of weatherConditions">
-                      {{weatherCondition.weatherConditionNumber}} - {{weatherCondition.weatherConditionDescription}}
-                    </ion-option>
-                  </ion-select>
-                </ion-col>
+                <ion-select value="weather" multiple="true" okText="Submit" cancelText="Cancel"
+                  placeholder="Select weather conditions" formControlName="weatherConditionsCtrl"
+                  [class.ng-invalid]="isCtrlDirtyAndInvalid('weatherConditionsCtrl')"
+                  (ionChange)="weatherConditionsChanged($event)">
+                  <ion-option [value]="weatherCondition.weatherConditionDescription"
+                    *ngFor="let weatherCondition of weatherConditions">
+                    {{weatherCondition.weatherConditionNumber}} - {{weatherCondition.weatherConditionDescription}}
+                  </ion-option>
+                </ion-select>
               </ion-row>
               <ion-row class="validation-message-row" align-items-center>
                 <div class="validation-text" [class.ng-invalid]="isCtrlDirtyAndInvalid('weatherConditionsCtrl')">

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -228,7 +228,11 @@
                   </ion-select>
                 </ion-col>
               </ion-row>
-              <ion-row class="spacing-row"></ion-row>
+              <ion-row class="validation-message-row" align-items-center>
+                <div class="validation-text" [class.ng-invalid]="isCtrlDirtyAndInvalid('weatherConditionsCtrl')">
+                  Select weather conditions
+                </div>
+              </ion-row>
             </ion-col>
           </ion-row>
 

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -68,7 +68,7 @@
                     [checked]="pageState.independentDrivingSatNavRadioChecked$ | async" value='Sat nav'>
                   <label for="independent-driving-satnav" class="radio-label">Sat Nav</label>
                 </ion-col>
-                <ion-col col-32>
+                <ion-col>
                   <input type="radio" formControlName="independentDrivingCtrl" name="independentDrivingCtrl"
                     id="independent-driving-trafficsigns" class="gds-radio-button"
                     [class.ng-invalid]="isCtrlDirtyAndInvalid('independentDrivingCtrl')" (click)="trafficSignsUsed()"

--- a/src/pages/office/office.scss
+++ b/src/pages/office/office.scss
@@ -2,7 +2,7 @@ page-office {
     ion-content {
         
         ion-select{
-          width:452px;
+          width: 452px;
         }
         .mes-full-width-card {
           height: 120px;
@@ -50,9 +50,6 @@ page-office {
         min-height: 44px;
         padding-top: 1px
       }
-    }
-    #weather-selector {
-      width: 85%;
     }
     .fault-heading {
       padding-left: 20px;

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -309,11 +309,12 @@ export class OfficePage extends BasePageComponent {
       independentDrivingCtrl: new FormControl('', [Validators.required]),
       d255Ctrl: new FormControl('', [Validators.required]),
       weatherConditionsCtrl: new FormControl([], [Validators.required]),
-      showMeQuestionCtrl: new FormControl('', [Validators.required]),
+      showMeQuestionCtrl: new FormControl([], [Validators.required]),
     };
   }
+
   isCtrlDirtyAndInvalid(controlName: string): boolean {
-    return !this.form.value[controlName] && this.form.get(controlName).dirty;
+    return this.form.controls[controlName].invalid && this.form.get(controlName).dirty;
   }
 
   debriefWitnessed(): void {


### PR DESCRIPTION
## Description and relevant Jira numbers
* Previously, there was no text indicator on the validation, it now says "Select weather conditions".
* Previously, the validation indicator at the very beginning of the row wasn't showing.
* When selecting a lot of weather conditions, the row reflowed. This doesn't happen anymore.

![image](https://user-images.githubusercontent.com/41190821/56280895-21b7ca80-6103-11e9-9b04-47963c744dae.png)

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [x] Tested by QA
- [ ] PO's approval
