### PR TITLE
MES-2127 - Remove Attribute from Store when no fault exists

### DIFF
--- a/src/modules/tests/test_data/__tests__/test-data.reducer.spec.ts
+++ b/src/modules/tests/test_data/__tests__/test-data.reducer.spec.ts
@@ -11,7 +11,7 @@ import {
   ToggleETA,
   AddManoeuvreDrivingFault,
 } from '../test-data.actions';
-import { Competencies, LegalRequirements, ExaminerActions } from '../test-data.constants';
+import { Competencies, LegalRequirements, ExaminerActions, ManoeuvreCompetencies } from '../test-data.constants';
 import { TestData } from '@dvsa/mes-test-schema/categories/B';
 import {
   ManoeuvreTypes,
@@ -135,7 +135,7 @@ describe('TestDataReducer reducer', () => {
         // Act
         const result = testDataReducer(
           initialState,
-          new AddManoeuvreDrivingFault(Competencies.outcomeReverseParkRoadControl),
+          new AddManoeuvreDrivingFault(ManoeuvreCompetencies.outcomeReverseParkRoadControl),
         );
         // Assert
         expect(result.manoeuvres.outcomeReverseParkRoadControl).toEqual('DF');

--- a/src/modules/tests/test_data/__tests__/test-data.reducer.spec.ts
+++ b/src/modules/tests/test_data/__tests__/test-data.reducer.spec.ts
@@ -10,6 +10,9 @@ import {
   ToggleLegalRequirement,
   ToggleETA,
   AddManoeuvreDrivingFault,
+  RemoveDrivingFault,
+  RemoveSeriousFault,
+  RemoveDangerousFault,
 } from '../test-data.actions';
 import { Competencies, LegalRequirements, ExaminerActions, ManoeuvreCompetencies } from '../test-data.constants';
 import { TestData } from '@dvsa/mes-test-schema/categories/B';
@@ -370,4 +373,65 @@ describe('TestDataReducer reducer', () => {
       expect(result.ETA.physical).toBeFalsy();
     });
   });
+
+  describe(('REMOVE_DRIVING_FAULT'), () => {
+    it('should remove a fault if the fault count is higher then 0', () => {
+      const state: TestData = {
+        drivingFaults: {
+          awarenessPlanning: 2,
+        },
+      };
+
+      const result = testDataReducer(state, new RemoveDrivingFault({
+        competency: Competencies.awarenessPlanning,
+        newFaultCount: 1,
+      }));
+
+      expect(result.drivingFaults.awarenessPlanning).toBe(1);
+    });
+
+    it('should remove the competency from the state if the fault count is 0', () => {
+      const state: TestData = {
+        drivingFaults: {
+          awarenessPlanning: 1,
+        },
+      };
+
+      const result = testDataReducer(state, new RemoveDrivingFault({
+        competency: Competencies.awarenessPlanning,
+        newFaultCount: 0,
+      }));
+
+      expect(result.drivingFaults.awarenessPlanning).toBeUndefined();
+    });
+  });
+
+  describe(('REMOVE_SERIOUS_FAULT'), () => {
+    it('should remove the competency from the state when a fault is removed', () => {
+      const state: TestData = {
+        seriousFaults: {
+          controlsGears: true,
+        },
+      };
+
+      const result = testDataReducer(state, new RemoveSeriousFault(Competencies.controlsGears));
+
+      expect(result.seriousFaults.controlsGears).toBeUndefined();
+    });
+  });
+
+  describe(('REMOVE_DANGEROUS_FAULT'), () => {
+    it('should remove the competency from the state when a fault is removed', () => {
+      const state: TestData = {
+        dangerousFaults: {
+          controlsGears: true,
+        },
+      };
+
+      const result = testDataReducer(state, new RemoveDangerousFault(Competencies.controlsGears));
+
+      expect(result.dangerousFaults.controlsGears).toBeUndefined();
+    });
+  });
+
 });

--- a/src/modules/tests/test_data/test-data.actions.ts
+++ b/src/modules/tests/test_data/test-data.actions.ts
@@ -3,7 +3,7 @@ import {
 } from './../../../pages/test-report/components/manoeuvres-popover/manoeuvres-popover.constants';
 import { Action } from '@ngrx/store';
 import { FaultPayload } from './test-data.models';
-import { Competencies, LegalRequirements, ExaminerActions } from './test-data.constants';
+import { Competencies, LegalRequirements, ExaminerActions, ManoeuvreCompetencies } from './test-data.constants';
 
 export const RECORD_MANOEUVRES_SELECTION = '[Manoeuvres] Record Manoeuvres Selection';
 export const ADD_MANOEUVRE_DRIVING_FAULT = '[Manoeuvres] Add Manoeuvre Driving Fault';
@@ -27,7 +27,7 @@ export class RecordManoeuvresSelection implements Action {
 }
 
 export class AddManoeuvreDrivingFault implements Action {
-  constructor(public payload: Competencies) { }
+  constructor(public payload: ManoeuvreCompetencies) { }
   readonly type = ADD_MANOEUVRE_DRIVING_FAULT;
 }
 

--- a/src/modules/tests/test_data/test-data.constants.ts
+++ b/src/modules/tests/test_data/test-data.constants.ts
@@ -38,6 +38,9 @@ export enum Competencies {
   pedestrianCrossings = 'pedestrianCrossings',
   positionNormalStops = 'positionNormalStops',
   awarenessPlanning = 'awarenessPlanning',
+}
+
+export enum ManoeuvreCompetencies {
   outcomeReverseLeftControl = 'outcomeReverseLeftControl',
   outcomeReverseLeftObservation = 'outcomeReverseLeftObservation',
   outcomeReverseRightControl = 'outcomeReverseRightControl',

--- a/src/modules/tests/test_data/test-data.reducer.ts
+++ b/src/modules/tests/test_data/test-data.reducer.ts
@@ -3,6 +3,7 @@ import * as testDataActions from './test-data.actions';
 import { createFeatureSelector } from '@ngrx/store';
 import { ManoeuvreTypes } from '../../../pages/test-report/components/manoeuvres-popover/manoeuvres-popover.constants';
 import { pickBy, startsWith } from 'lodash';
+import { Competencies } from './test-data.constants';
 
 export const initialState: TestData = {
   dangerousFaults: {},
@@ -57,6 +58,13 @@ export function testDataReducer(
         },
       };
     case testDataActions.REMOVE_DRIVING_FAULT:
+      if (action.payload.newFaultCount === 0) {
+        const { [action.payload.competency] : removedDrivingFault, ...updatedDrivingFaults } = state.drivingFaults;
+        return {
+          ...state,
+          drivingFaults: updatedDrivingFaults,
+        };
+      }
       return {
         ...state,
         drivingFaults: {
@@ -65,22 +73,20 @@ export function testDataReducer(
         },
       };
     case testDataActions.REMOVE_SERIOUS_FAULT:
+      const seriousCompetency = action.payload as Competencies;
+      const { [seriousCompetency]: removedSeriousFault, ...updatedSeriousFaults } = state.seriousFaults;
       return {
         ...state,
-        seriousFaults: {
-          ...state.seriousFaults,
-          [action.payload]: false,
-        },
+        seriousFaults: updatedSeriousFaults,
       };
-    case testDataActions.REMOVE_DANGEROUS_FAULT:
+    case testDataActions.REMOVE_DANGEROUS_FAULT :
+      const dangerousCompetency = action.payload as Competencies;
+      const { [dangerousCompetency]: removedDangerousFault, ...updatedDangerousFaults } = state.dangerousFaults;
       return {
         ...state,
-        dangerousFaults: {
-          ...state.dangerousFaults,
-          [action.payload]: false,
-        },
+        dangerousFaults: updatedDangerousFaults,
       };
-    case testDataActions.TOGGLE_LEGAL_REQUIREMENT:
+    case testDataActions.TOGGLE_LEGAL_REQUIREMENT :
       return {
         ...state,
         testRequirements: {
@@ -88,7 +94,7 @@ export function testDataReducer(
           [action.payload]: !state.testRequirements[action.payload],
         },
       };
-    case testDataActions.TOGGLE_ETA:
+    case testDataActions.TOGGLE_ETA :
       return {
         ...state,
         ETA: {
@@ -96,7 +102,7 @@ export function testDataReducer(
           [action.payload]: !state.ETA[action.payload],
         },
       };
-    case testDataActions.TOGGLE_CONTROL_ECO:
+    case testDataActions.TOGGLE_CONTROL_ECO :
       return {
         ...state,
         eco: {
@@ -104,7 +110,7 @@ export function testDataReducer(
           adviceGivenControl: !state.eco.adviceGivenControl,
         },
       };
-    case testDataActions.TOGGLE_PLANNING_ECO:
+    case testDataActions.TOGGLE_PLANNING_ECO :
       return {
         ...state,
         eco: {
@@ -112,7 +118,7 @@ export function testDataReducer(
           adviceGivenPlanning: !state.eco.adviceGivenPlanning,
         },
       };
-    case testDataActions.TOGGLE_CONTROLLED_STOP:
+    case testDataActions.TOGGLE_CONTROLLED_STOP :
       return {
         ...state,
         manoeuvres: {

--- a/src/pages/test-report/components/competency/__tests__/competency.spec.ts
+++ b/src/pages/test-report/components/competency/__tests__/competency.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { CompetencyComponent } from '../competency';
 import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
-import { Competencies } from '../../../../../modules/tests/test_data/test-data.constants';
+import { Competencies, ManoeuvreCompetencies } from '../../../../../modules/tests/test_data/test-data.constants';
 import { StoreModule, Store } from '@ngrx/store';
 import { StoreModel } from '../../../../../shared/models/store.model';
 import {

--- a/src/pages/test-report/components/competency/__tests__/competency.spec.ts
+++ b/src/pages/test-report/components/competency/__tests__/competency.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { CompetencyComponent } from '../competency';
 import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
-import { Competencies, ManoeuvreCompetencies } from '../../../../../modules/tests/test_data/test-data.constants';
+import { Competencies } from '../../../../../modules/tests/test_data/test-data.constants';
 import { StoreModule, Store } from '@ngrx/store';
 import { StoreModel } from '../../../../../shared/models/store.model';
 import {

--- a/src/pages/test-report/components/competency/competency.ts
+++ b/src/pages/test-report/components/competency/competency.ts
@@ -26,6 +26,7 @@ import {
 import { getTestReportState } from '../../test-report.reducer';
 import { isRemoveFaultMode, isSeriousMode, isDangerousMode } from '../../test-report.selector';
 import { ToggleRemoveFaultMode, ToggleSeriousFaultMode, ToggleDangerousFaultMode } from '../../test-report.actions';
+import { Competencies } from '../../../../modules/tests/test_data/test-data.constants';
 
 interface CompetencyState {
   isRemoveFaultMode$: Observable<boolean>;
@@ -43,7 +44,7 @@ interface CompetencyState {
 export class CompetencyComponent {
 
   @Input()
-  competency: any;
+  competency: Competencies;
 
   touchStateDelay: number = 100;
 

--- a/src/pages/test-report/components/competency/competency.ts
+++ b/src/pages/test-report/components/competency/competency.ts
@@ -14,7 +14,6 @@ import {
   RemoveSeriousFault,
   RemoveDangerousFault,
 } from '../../../../modules/tests/test_data/test-data.actions';
-import { Competencies } from '../../../../modules/tests/test_data/test-data.constants';
 import { competencyLabels } from './competency.constants';
 import { getCurrentTest } from '../../../../modules/tests/tests.selector';
 import { getTestData } from '../../../../modules/tests/test_data/test-data.reducer';
@@ -44,7 +43,7 @@ interface CompetencyState {
 export class CompetencyComponent {
 
   @Input()
-  competency: Competencies;
+  competency: any;
 
   touchStateDelay: number = 100;
 

--- a/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
+++ b/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
@@ -13,20 +13,10 @@ import { SeriousFaultBadgeComponent } from '../../../../../components/serious-fa
 import { DangerousFaultBadgeComponent } from '../../../../../components/dangerous-fault-badge/dangerous-fault-badge';
 import { StartTest } from '../../../../journal/journal.actions';
 import {
-  ToggleSeriousFaultMode,
-  ToggleDangerousFaultMode,
-  ToggleRemoveFaultMode,
-} from '../../../test-report.actions';
-import {
-  AddDrivingFault,
-  AddSeriousFault,
-  AddDangerousFault,
-  RemoveDrivingFault,
-  RemoveDangerousFault,
-  RemoveSeriousFault,
-  ToggleControlledStop,
   ControlledStopComplete,
+  AddManoeuvreDrivingFault,
 } from '../../../../../modules/tests/test_data/test-data.actions';
+import { ManoeuvreCompetencies } from '../../../../../modules/tests/test_data/test-data.constants';
 
 describe('ControlledStopComponent', () => {
   let fixture: ComponentFixture<ControlledStopComponent>;
@@ -62,86 +52,73 @@ describe('ControlledStopComponent', () => {
       expect(component).toBeDefined();
     });
 
-    describe('addDrivingFault', () => {
-      it('should dispatch an ADD_DRIVING_FAULT action for press', () => {
+    describe('addManoeuvreDrivingFault', () => {
+      it('should dispatch an ADD_MANOEUVRE_DRIVING_FAULT action for press', () => {
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault(true);
 
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new AddDrivingFault({
-          competency: component.competency,
-          newFaultCount: 1,
-        }));
+        expect(storeDispatchSpy).toHaveBeenCalledWith(
+          new AddManoeuvreDrivingFault(ManoeuvreCompetencies.outcomeControlledStop));
+
         expect(storeDispatchSpy).toHaveBeenCalledWith(new ControlledStopComplete());
       });
-      it('should not dispatch an ADD_DRIVING_FAULT action for tap', () => {
+      it('should not dispatch an ADD_MANOEUVRE_DRIVING_FAULT action for tap', () => {
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault();
 
-        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
-          competency: component.competency,
-          newFaultCount: 1,
-        }));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(
+          new AddManoeuvreDrivingFault(ManoeuvreCompetencies.outcomeControlledStop));
       });
-      it('should not dispatch an ADD_DRIVING_FAULT action if there is already a driving fault', () => {
+      it('should not dispatch an ADD_MANOEUVRE_DRIVING_FAULT action if there is already a driving fault', () => {
         component.faultCount = 1;
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault(true);
 
-        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
-          competency: component.competency,
-          newFaultCount: 1,
-        }));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(
+          new AddManoeuvreDrivingFault(ManoeuvreCompetencies.outcomeControlledStop));
       });
-      it('should not dispatch an ADD_DRIVING_FAULT action if there is a serious fault', () => {
+      it('should not dispatch an ADD_MANOEUVRE_DRIVING_FAULT action if there is a serious fault', () => {
         component.hasSeriousFault = true;
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault();
 
-        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
-          competency: component.competency,
-          newFaultCount: 1,
-        }));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(
+          new AddManoeuvreDrivingFault(ManoeuvreCompetencies.outcomeControlledStop));
       });
-      it('should not dispatch an ADD_DRIVING_FAULT action if serious mode is active', () => {
+      it('should not dispatch an ADD_MANOEUVRE_DRIVING_FAULT action if serious mode is active', () => {
         component.isSeriousMode = true;
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault();
 
-        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
-          competency: component.competency,
-          newFaultCount: 1,
-        }));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(
+          new AddManoeuvreDrivingFault(ManoeuvreCompetencies.outcomeControlledStop));
       });
-      it('should not dispatch an ADD_DRIVING_FAULT action if there is a dangerous fault', () => {
+      it('should not dispatch an ADD_MANOEUVRE_DRIVING_FAULT action if there is a dangerous fault', () => {
         component.hasDangerousFault = true;
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault();
 
-        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
-          competency: component.competency,
-          newFaultCount: 1,
-        }));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(
+          new AddManoeuvreDrivingFault(ManoeuvreCompetencies.outcomeControlledStop));
       });
-      it('should not dispatch an ADD_DRIVING_FAULT action if dangerous mode is active', () => {
+      it('should not dispatch an ADD_MANOEUVRE_DRIVING_FAULT action if dangerous mode is active', () => {
         component.isDangerousMode = true;
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault();
 
-        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new AddDrivingFault({
-          competency: component.competency,
-          newFaultCount: 1,
-        }));
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(
+          new AddManoeuvreDrivingFault(ManoeuvreCompetencies.outcomeControlledStop));
       });
     });
 
-    describe('addDangerousFault', () => {
+    /* describe('addDangerousFault', () => {
       it('should dispatch a ADD_DANGEROUS_FAULT action if dangerous mode is active on press', () => {
         component.isDangerousMode = true;
 
@@ -303,119 +280,119 @@ describe('ControlledStopComponent', () => {
           newFaultCount: 1,
         }));
       });
+  });
+
+  describe('removeSeriousFault', () => {
+    it('should not dispatch a REMOVE_SERIOUS_FAULT when not in remove mode', () => {
+      component.hasSeriousFault = true;
+      component.isSeriousMode = true;
+      component.isRemoveFaultMode = false;
+
+      const storeDispatchSpy = spyOn(store$, 'dispatch');
+      component.addOrRemoveFault();
+
+      expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
+    });
+    it('should dispatch a REMOVE_SERIOUS_FAULT for press and hold', () => {
+      component.hasSeriousFault = true;
+      component.isSeriousMode = true;
+      component.isRemoveFaultMode = true;
+
+      const storeDispatchSpy = spyOn(store$, 'dispatch');
+      component.addOrRemoveFault();
+
+      expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
+    });
+    it('should dispatch a REMOVE_SERIOUS_FAULT for press', () => {
+      component.hasSeriousFault = true;
+      component.isSeriousMode = true;
+      component.isRemoveFaultMode = true;
+
+      const storeDispatchSpy = spyOn(store$, 'dispatch');
+      component.addOrRemoveFault();
+
+      expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
+    });
+    it('should not dispatch a REMOVE_SERIOUS_FAULT when is dangerous mode', () => {
+      component.hasSeriousFault = true;
+      component.isDangerousMode = true;
+      component.isRemoveFaultMode = true;
+
+      const storeDispatchSpy = spyOn(store$, 'dispatch');
+      component.addOrRemoveFault();
+
+      expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
     });
 
-    describe('removeSeriousFault', () => {
-      it('should not dispatch a REMOVE_SERIOUS_FAULT when not in remove mode', () => {
-        component.hasSeriousFault = true;
-        component.isSeriousMode = true;
-        component.isRemoveFaultMode = false;
+    it('should remove serious mode after removal attempt on competency with no serious fault', () => {
+      component.hasSeriousFault = false;
+      component.isSeriousMode = true;
+      component.isRemoveFaultMode = true;
 
-        const storeDispatchSpy = spyOn(store$, 'dispatch');
-        component.addOrRemoveFault();
-
-        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
-      });
-      it('should dispatch a REMOVE_SERIOUS_FAULT for press and hold', () => {
-        component.hasSeriousFault = true;
-        component.isSeriousMode = true;
-        component.isRemoveFaultMode = true;
-
-        const storeDispatchSpy = spyOn(store$, 'dispatch');
-        component.addOrRemoveFault();
-
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
-      });
-      it('should dispatch a REMOVE_SERIOUS_FAULT for press', () => {
-        component.hasSeriousFault = true;
-        component.isSeriousMode = true;
-        component.isRemoveFaultMode = true;
-
-        const storeDispatchSpy = spyOn(store$, 'dispatch');
-        component.addOrRemoveFault();
-
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
-      });
-      it('should not dispatch a REMOVE_SERIOUS_FAULT when is dangerous mode', () => {
-        component.hasSeriousFault = true;
-        component.isDangerousMode = true;
-        component.isRemoveFaultMode = true;
-
-        const storeDispatchSpy = spyOn(store$, 'dispatch');
-        component.addOrRemoveFault();
-
-        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
-      });
-
-      it('should remove serious mode after removal attempt on competency with no serious fault', () => {
-        component.hasSeriousFault = false;
-        component.isSeriousMode = true;
-        component.isRemoveFaultMode = true;
-
-        const storeDispatchSpy = spyOn(store$, 'dispatch');
-        component.addOrRemoveFault();
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleSeriousFaultMode());
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
-        fixture.detectChanges();
-        expect(component.isSeriousMode).toEqual(false);
-      });
-
+      const storeDispatchSpy = spyOn(store$, 'dispatch');
+      component.addOrRemoveFault();
+      expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleSeriousFaultMode());
+      expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
+      fixture.detectChanges();
+      expect(component.isSeriousMode).toEqual(false);
     });
 
-    describe('removeDangerousFault', () => {
-      it('should not dispatch a REMOVE_DANGEROUS_FAULT when not in remove mode', () => {
-        component.hasDangerousFault = true;
-        component.isDangerousMode = true;
-        component.isRemoveFaultMode = false;
+  });
 
-        const storeDispatchSpy = spyOn(store$, 'dispatch');
-        component.addOrRemoveFault();
+  describe('removeDangerousFault', () => {
+    it('should not dispatch a REMOVE_DANGEROUS_FAULT when not in remove mode', () => {
+      component.hasDangerousFault = true;
+      component.isDangerousMode = true;
+      component.isRemoveFaultMode = false;
 
-        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
-      });
-      it('should dispatch a REMOVE_DANGEROUS_FAULT for press and hold', () => {
-        component.hasDangerousFault = true;
-        component.isDangerousMode = true;
-        component.isRemoveFaultMode = true;
+      const storeDispatchSpy = spyOn(store$, 'dispatch');
+      component.addOrRemoveFault();
 
-        const storeDispatchSpy = spyOn(store$, 'dispatch');
-        component.addOrRemoveFault();
-
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
-      });
-      it('should dispatch a REMOVE_DANGEROUS_FAULT for press', () => {
-        component.hasDangerousFault = true;
-        component.isDangerousMode = true;
-        component.isRemoveFaultMode = true;
-
-        const storeDispatchSpy = spyOn(store$, 'dispatch');
-        component.addOrRemoveFault();
-
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
-      });
-      it('should not dispatch a REMOVE_DANGEROUS_FAULT when is serious mode', () => {
-        component.hasDangerousFault = true;
-        component.isSeriousMode = true;
-        component.isRemoveFaultMode = true;
-
-        const storeDispatchSpy = spyOn(store$, 'dispatch');
-        component.addOrRemoveFault();
-
-        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
-      });
-      it('should remove dangerous mode after removal attempt on competency with no dangerous fault', () => {
-        component.hasDangerousFault = false;
-        component.isDangerousMode = true;
-        component.isRemoveFaultMode = true;
-
-        const storeDispatchSpy = spyOn(store$, 'dispatch');
-        component.addOrRemoveFault();
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleDangerousFaultMode());
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
-        fixture.detectChanges();
-        expect(component.isDangerousMode).toEqual(false);
-      });
+      expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
     });
+    it('should dispatch a REMOVE_DANGEROUS_FAULT for press and hold', () => {
+      component.hasDangerousFault = true;
+      component.isDangerousMode = true;
+      component.isRemoveFaultMode = true;
+
+      const storeDispatchSpy = spyOn(store$, 'dispatch');
+      component.addOrRemoveFault();
+
+      expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
+    });
+    it('should dispatch a REMOVE_DANGEROUS_FAULT for press', () => {
+      component.hasDangerousFault = true;
+      component.isDangerousMode = true;
+      component.isRemoveFaultMode = true;
+
+      const storeDispatchSpy = spyOn(store$, 'dispatch');
+      component.addOrRemoveFault();
+
+      expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
+    });
+    it('should not dispatch a REMOVE_DANGEROUS_FAULT when is serious mode', () => {
+      component.hasDangerousFault = true;
+      component.isSeriousMode = true;
+      component.isRemoveFaultMode = true;
+
+      const storeDispatchSpy = spyOn(store$, 'dispatch');
+      component.addOrRemoveFault();
+
+      expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
+    });
+    it('should remove dangerous mode after removal attempt on competency with no dangerous fault', () => {
+      component.hasDangerousFault = false;
+      component.isDangerousMode = true;
+      component.isRemoveFaultMode = true;
+
+      const storeDispatchSpy = spyOn(store$, 'dispatch');
+      component.addOrRemoveFault();
+      expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleDangerousFaultMode());
+      expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
+      fixture.detectChanges();
+      expect(component.isDangerousMode).toEqual(false);
+    });
+  });
 
     describe('toggleControlledStop', () => {
       it('should dispatch a TOGGLE_CONTROLLED_STOP action when there are no faults', () => {
@@ -448,7 +425,7 @@ describe('ControlledStopComponent', () => {
 
         expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleControlledStop());
       });
-    });
+    }); */
   });
 
   describe('DOM', () => {

--- a/src/pages/test-report/components/controlled-stop/controlled-stop.ts
+++ b/src/pages/test-report/components/controlled-stop/controlled-stop.ts
@@ -11,24 +11,25 @@ import { getCurrentTest } from '../../../../modules/tests/tests.selector';
 import { getTestData } from '../../../../modules/tests/test_data/test-data.reducer';
 import {
   hasControlledStopBeenCompleted,
-  getDrivingFaultCount,
-  hasSeriousFault,
-  hasDangerousFault,
+ // getDrivingFaultCount,
+  // hasSeriousFault,
+  // hasDangerousFault,
 } from '../../../../modules/tests/test_data/test-data.selector';
 import {
   ToggleControlledStop,
-  AddDrivingFault,
-  AddSeriousFault,
-  AddDangerousFault,
-  RemoveDrivingFault,
-  RemoveSeriousFault,
-  RemoveDangerousFault,
+  // AddDrivingFault,
+  // AddSeriousFault,
+  // AddDangerousFault,
+  // RemoveDrivingFault,
+  // RemoveSeriousFault,
+  // RemoveDangerousFault,
   ControlledStopComplete,
+  AddManoeuvreDrivingFault,
 } from '../../../../modules/tests/test_data/test-data.actions';
 import { getTestReportState } from '../../test-report.reducer';
 import { isRemoveFaultMode, isSeriousMode, isDangerousMode } from '../../test-report.selector';
 import { ToggleRemoveFaultMode, ToggleSeriousFaultMode, ToggleDangerousFaultMode } from '../../test-report.actions';
-import { Competencies } from '../../../../modules/tests/test_data/test-data.constants';
+import { ManoeuvreCompetencies } from '../../../../modules/tests/test_data/test-data.constants';
 
 interface ControlledStopComponentState {
   isRemoveFaultMode$: Observable<boolean>;
@@ -36,9 +37,9 @@ interface ControlledStopComponentState {
   isDangerousMode$: Observable<boolean>;
 
   selectedControlledStop$: Observable<boolean>;
-  drivingFaultCount$: Observable<number>;
-  hasSeriousFault$: Observable<boolean>;
-  hasDangerousFault$: Observable<boolean>;
+  // drivingFaultCount$: Observable<number>;
+  // hasSeriousFault$: Observable<boolean>;
+  // hasDangerousFault$: Observable<boolean>;
 }
 
 @Component({
@@ -47,7 +48,7 @@ interface ControlledStopComponentState {
 })
 export class ControlledStopComponent implements OnInit {
 
-  competency: Competencies = Competencies.outcomeControlledStop;
+  competency: ManoeuvreCompetencies = ManoeuvreCompetencies.outcomeControlledStop;
 
   componentState: ControlledStopComponentState;
   subscription: Subscription;
@@ -98,35 +99,37 @@ export class ControlledStopComponent implements OnInit {
         select(getTestData),
         select(hasControlledStopBeenCompleted),
       ),
-      drivingFaultCount$: currentTest$.pipe(
-        select(getTestData),
-        select(testData => getDrivingFaultCount(testData, this.competency))),
-      hasSeriousFault$: currentTest$.pipe(
-        select(getTestData),
-        select(testData => hasSeriousFault(testData, this.competency))),
-      hasDangerousFault$: currentTest$.pipe(
-        select(getTestData),
-        select(testData => hasDangerousFault(testData, this.competency)),
-      ),
+      // TODO - This needs to use the get fault actions for Manoeuvres
+
+      // drivingFaultCount$: currentTest$.pipe(
+        // select(getTestData),
+        // select(testData => getDrivingFaultCount(testData, this.competency))),
+      // hasSeriousFault$: currentTest$.pipe(
+        // select(getTestData),
+        // select(testData => hasSeriousFault(testData, this.competency))),
+      // hasDangerousFault$: currentTest$.pipe(
+        // select(getTestData),
+        // select(testData => hasDangerousFault(testData, this.competency)),
+      // ),
     };
 
     const {
-      drivingFaultCount$,
+     // drivingFaultCount$,
       isRemoveFaultMode$,
       isSeriousMode$,
-      hasSeriousFault$,
+      // hasSeriousFault$,
       isDangerousMode$,
-      hasDangerousFault$,
+      // hasDangerousFault$,
       selectedControlledStop$,
     } = this.componentState;
 
     const merged$ = merge(
-      drivingFaultCount$.pipe(map(count => this.faultCount = count)),
+      // drivingFaultCount$.pipe(map(count => this.faultCount = count)),
       isRemoveFaultMode$.pipe(map(toggle => this.isRemoveFaultMode = toggle)),
       isSeriousMode$.pipe(map(toggle => this.isSeriousMode = toggle)),
-      hasSeriousFault$.pipe(map(toggle => this.hasSeriousFault = toggle)),
+      // hasSeriousFault$.pipe(map(toggle => this.hasSeriousFault = toggle)),
       isDangerousMode$.pipe(map(toggle => this.isDangerousMode = toggle)),
-      hasDangerousFault$.pipe(map(toggle => this.hasDangerousFault = toggle)),
+      // hasDangerousFault$.pipe(map(toggle => this.hasDangerousFault = toggle)),
       selectedControlledStop$.pipe(map(toggle => this.controlledStopCompleted = toggle)),
     );
 
@@ -166,24 +169,23 @@ export class ControlledStopComponent implements OnInit {
 
     if (this.isDangerousMode) {
       this.store$.dispatch(new ControlledStopComplete());
-      this.store$.dispatch(new AddDangerousFault(this.competency));
+      // TODO - Refactor to use Add Manoeuvres Dangerous Faults
+      // this.store$.dispatch(new AddDangerousFault(this.competency));
       this.store$.dispatch(new ToggleDangerousFaultMode());
       return;
     }
 
     if (this.isSeriousMode) {
       this.store$.dispatch(new ControlledStopComplete());
-      this.store$.dispatch(new AddSeriousFault(this.competency));
+      // TODO - Refactor to use Add Manoeuvres Serious Fault
+      // this.store$.dispatch(new AddSeriousFault(this.competency));
       this.store$.dispatch(new ToggleSeriousFaultMode());
       return;
     }
 
     if (wasPress) {
       this.store$.dispatch(new ControlledStopComplete());
-      this.store$.dispatch(new AddDrivingFault({
-        competency: this.competency,
-        newFaultCount: this.faultCount ? this.faultCount + 1 : 1,
-      }));
+      this.store$.dispatch(new AddManoeuvreDrivingFault(ManoeuvreCompetencies.outcomeControlledStop));
     }
   }
 
@@ -194,23 +196,26 @@ export class ControlledStopComponent implements OnInit {
     }
 
     if (this.hasDangerousFault && this.isDangerousMode && this.isRemoveFaultMode) {
-      this.store$.dispatch(new RemoveDangerousFault(this.competency));
+      // TODO - Refactor to use Remove Maneourves Fault Action
+      // this.store$.dispatch(new RemoveDangerousFault(this.competency));
       this.store$.dispatch(new ToggleDangerousFaultMode());
       this.store$.dispatch(new ToggleRemoveFaultMode());
       return;
     }
 
     if (this.hasSeriousFault && this.isSeriousMode && this.isRemoveFaultMode) {
-      this.store$.dispatch(new RemoveSeriousFault(this.competency));
+      // TODO - Refactor to use Remove Maneourves Fault Action
+      // this.store$.dispatch(new RemoveSeriousFault(this.competency));
       this.store$.dispatch(new ToggleSeriousFaultMode());
       this.store$.dispatch(new ToggleRemoveFaultMode());
       return;
     }
     if (!this.isSeriousMode && !this.isDangerousMode && this.isRemoveFaultMode) {
-      this.store$.dispatch(new RemoveDrivingFault({
-        competency: this.competency,
-        newFaultCount: this.faultCount ? this.faultCount - 1 : 0,
-      }));
+      // TODO - Refactor to use Remove Maneourves Fault Action
+      // this.store$.dispatch(new RemoveDrivingFault({
+        // competency: this.competency,
+        // newFaultCount: this.faultCount ? this.faultCount - 1 : 0,
+      // }));
     }
 
     this.store$.dispatch(new ToggleRemoveFaultMode());

--- a/src/pages/test-report/components/manoeuvre-competency/__tests__/manoeuvre-competency.spec.ts
+++ b/src/pages/test-report/components/manoeuvre-competency/__tests__/manoeuvre-competency.spec.ts
@@ -1,14 +1,10 @@
-import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { AppModule } from '../../../../../app/app.module';
-import { StoreModule, Store } from '@ngrx/store';
 import { StoreModel } from '../../../../../shared/models/store.model';
-import { MockComponent } from 'ng-mocks';
-import { Competencies } from '../../../../../modules/tests/test_data/test-data.constants';
+import { ManoeuvreCompetencies } from '../../../../../modules/tests/test_data/test-data.constants';
 import { DrivingFaultsBadgeComponent } from '../../../../../components/driving-faults-badge/driving-faults-badge';
 import { DateTimeProvider } from '../../../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../../../providers/date-time/__mocks__/date-time.mock';
 import { SeriousFaultBadgeComponent } from '../../../../../components/serious-fault-badge/serious-fault-badge';
-import { IonicModule } from 'ionic-angular';
 import { DangerousFaultBadgeComponent } from '../../../../../components/dangerous-fault-badge/dangerous-fault-badge';
 import { testsReducer } from '../../../../../modules/tests/tests.reducer';
 import { testReportReducer } from '../../../test-report.reducer';
@@ -16,6 +12,10 @@ import { StartTest } from '../../../../journal/journal.actions';
 import { ManoeuvreCompetencyComponent } from '../manoeuvre-competency';
 import { AddManoeuvreDrivingFault } from '../../../../../modules/tests/test_data/test-data.actions';
 import { By } from '@angular/platform-browser';
+import { IonicModule } from 'ionic-angular';
+import { MockComponent } from 'ng-mocks';
+import { StoreModule, Store } from '@ngrx/store';
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 
 describe('ManoeuvreCompetencyComponent', () => {
   let fixture: ComponentFixture<ManoeuvreCompetencyComponent>;
@@ -51,7 +51,7 @@ describe('ManoeuvreCompetencyComponent', () => {
 
   describe('Manoeuvre competency', () => {
     it('should get the competency label from the correct object', () => {
-      component.competency = Competencies.outcomeReverseRightControl;
+      component.competency = ManoeuvreCompetencies.outcomeReverseRightControl;
       fixture.detectChanges();
       const result = component.getLabel();
       const expected = 'Control';
@@ -60,7 +60,7 @@ describe('ManoeuvreCompetencyComponent', () => {
 
     describe('AddManoeuvreDrivingFault', () => {
       it('should dispatch the correct action when the competency is a manoeuvre', () => {
-        component.competency = Competencies.outcomeReverseRightControl;
+        component.competency = ManoeuvreCompetencies.outcomeReverseRightControl;
         fixture.detectChanges();
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault(true);
@@ -71,7 +71,7 @@ describe('ManoeuvreCompetencyComponent', () => {
 
     describe('DOM', () => {
       it('should display the correct driving fault badge with a count of 1', () => {
-        component.competency = Competencies.outcomeReverseRightControl;
+        component.competency = ManoeuvreCompetencies.outcomeReverseRightControl;
         component.manoeuvreCompetencyOutcome = 'DF';
         const result = component.hasDrivingFault();
         fixture.detectChanges();

--- a/src/pages/test-report/components/manoeuvre-competency/manoeuvre-competency.ts
+++ b/src/pages/test-report/components/manoeuvre-competency/manoeuvre-competency.ts
@@ -1,12 +1,7 @@
-import { Component, Input } from '@angular/core';
-import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
-import { Subscription } from 'rxjs/Subscription';
-import { merge } from 'rxjs/observable/merge';
-import { map } from 'rxjs/operators';
 import { StoreModel } from '../../../../shared/models/store.model';
 import { AddManoeuvreDrivingFault } from '../../../../modules/tests/test_data/test-data.actions';
-import { Competencies } from '../../../../modules/tests/test_data/test-data.constants';
+import { ManoeuvreCompetencies } from '../../../../modules/tests/test_data/test-data.constants';
 import { getCurrentTest } from '../../../../modules/tests/tests.selector';
 import { getTestData } from '../../../../modules/tests/test_data/test-data.reducer';
 import { getTests } from '../../../../modules/tests/tests.reducer';
@@ -14,8 +9,13 @@ import { getManoeuvres } from '../../../../modules/tests/test_data/test-data.sel
 import { getTestReportState } from '../../test-report.reducer';
 import { isRemoveFaultMode  } from '../../test-report.selector';
 import { manoeuvreCompetencyLabels } from './manoeuvre-competency.constants';
-import { ManoeuvreOutcome } from '@dvsa/mes-test-schema/categories/B';
 import { CompetencyOutcome } from '../../../../shared/models/competency-outcome';
+import { Component, Input } from '@angular/core';
+import { Store, select } from '@ngrx/store';
+import { Subscription } from 'rxjs/Subscription';
+import { merge } from 'rxjs/observable/merge';
+import { map } from 'rxjs/operators';
+import { ManoeuvreOutcome } from '@dvsa/mes-test-schema/categories/B';
 
 interface ManoeuvreCompetencyComponentState {
   isRemoveFaultMode$: Observable<boolean>;
@@ -29,7 +29,7 @@ interface ManoeuvreCompetencyComponentState {
 export class ManoeuvreCompetencyComponent {
 
   @Input()
-  competency: Competencies;
+  competency: ManoeuvreCompetencies;
 
   touchStateDelay: number = 100;
 


### PR DESCRIPTION
## Description and relevant Jira numbers

This PR:
- Extracts the manoeuvre competencies from Competencies enum to ManoeuvreComptencies enum
- Removes the attribute from the drivingFault, seriousFault or dangerousFault array when it is 0 or false
- Commented out a load of code which incorrectly implements Controlled Stop

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
