### PR TITLE
Refactor competency button components

### DIFF
--- a/src/pages/test-report/__tests__/test-report.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.spec.ts
@@ -11,6 +11,7 @@ import { TestReportPage } from '../test-report';
 import { AuthenticationProvider } from '../../../providers/authentication/authentication';
 import { AuthenticationProviderMock } from '../../../providers/authentication/__mocks__/authentication.mock';
 import { CompetencyComponent } from '../components/competency/competency';
+import { CompetencyButtonComponent } from '../components/competency-button/competency-button';
 import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
 import { DrivingFaultSummaryComponent } from '../components/driving-fault-summary/driving-fault-summary';
@@ -44,6 +45,7 @@ describe('TestReportPage', () => {
         MockComponent(CompetencyWithModalComponent),
         MockComponent(TickIndicatorComponent),
         MockComponent(CompetencyComponent),
+        MockComponent(CompetencyButtonComponent),
         MockComponent(LegalRequirementComponent),
         MockComponent(EtaComponent),
         MockComponent(DrivingFaultSummaryComponent),

--- a/src/pages/test-report/components/competency-button/__tests__/competency-button.spec.ts
+++ b/src/pages/test-report/components/competency-button/__tests__/competency-button.spec.ts
@@ -1,0 +1,124 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { CompetencyButtonComponent } from '../competency-button';
+import { AppModule } from '../../../../../app/app.module';
+import { By } from '@angular/platform-browser';
+import { DateTimeProvider } from '../../../../../providers/date-time/date-time';
+import { DateTimeProviderMock } from '../../../../../providers/date-time/__mocks__/date-time.mock';
+import { IonicModule } from 'ionic-angular';
+
+describe('CompetencyButtonComponent', () => {
+  let fixture: ComponentFixture<CompetencyButtonComponent>;
+  let component: CompetencyButtonComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        CompetencyButtonComponent,
+      ],
+      imports: [
+        AppModule,
+        IonicModule,
+      ],
+      providers: [
+        { provide: DateTimeProvider, useClass: DateTimeProviderMock },
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(CompetencyButtonComponent);
+        component = fixture.componentInstance;
+      });
+  }));
+
+  describe('Class', () => {
+    it('should create', () => {
+      expect(component).toBeDefined();
+    });
+
+    it('should call the tap function when a tap event is triggered', () => {
+      const tapSpy = jasmine.createSpy('onTapEvent');
+      component.onTapEvent = tapSpy;
+      const button = fixture.debugElement.query(By.css('.competency-button'));
+      button.triggerEventHandler('tap', null);
+      expect(tapSpy).toHaveBeenCalled();
+    });
+
+    it('should call the press function when a press event is triggered', () => {
+      const pressSpy = jasmine.createSpy('onPressEvent');
+      component.onPressEvent = pressSpy;
+      const button = fixture.debugElement.query(By.css('.competency-button'));
+      button.triggerEventHandler('press', null);
+      expect(pressSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('DOM', () => {
+
+    describe('Ripple effect', () => {
+      it('should have added no classes to the competency button', () => {
+        const competencyButton = fixture.debugElement.query(By.css('.competency-button'));
+        expect(competencyButton.nativeElement.className).toEqual('competency-button');
+      });
+
+      it('should add the activated class when the button is pressed', () => {
+        component.onTouchStart();
+        fixture.detectChanges();
+        const button = fixture.debugElement.query(By.css('.competency-button'));
+
+        expect(button).toBeDefined();
+        expect(button.nativeElement.className).toContain('activated');
+        expect(component.touchState).toBeTruthy();
+      });
+
+      it('should remove the activated class after a specified delay when the button is not pressed', (done) => {
+        component.onTouchEnd();
+        fixture.detectChanges();
+        const button = fixture.debugElement.query(By.css('.competency-button'));
+        setTimeout(
+          () => {
+            fixture.detectChanges();
+
+            expect(button).toBeDefined();
+            expect(button.nativeElement.className).not.toContain('activated');
+            expect(component.touchState).toBeFalsy();
+            done();
+          },
+          component.touchStateDelay);
+      });
+
+      it('should add the ripple effect animation css class', () => {
+        component.onPressEvent();
+        fixture.detectChanges();
+        const button = fixture.debugElement.query(By.css('.competency-button'));
+
+        expect(button).toBeDefined();
+        expect(button.nativeElement.className).toContain('ripple-effect');
+      });
+
+      it('should remove the ripple effect animation css class within the required time frame', (done) => {
+        component.onPressEvent();
+        fixture.detectChanges();
+        const button = fixture.debugElement.query(By.css('.competency-button'));
+        setTimeout(
+          () => {
+            fixture.detectChanges();
+
+            expect(button).toBeDefined();
+            expect(button.nativeElement.className).not.toContain('ripple-effect');
+            done();
+          },
+          component.rippleEffectAnimationDuration);
+      });
+
+      it('should not add the ripple effect animation css class when ripple is disabled', () => {
+        component.ripple = false;
+        component.onPressEvent();
+        fixture.detectChanges();
+        const button = fixture.debugElement.query(By.css('.competency-button'));
+
+        expect(button).toBeDefined();
+        expect(button.nativeElement.className).not.toContain('ripple-effect');
+      });
+    });
+  });
+});

--- a/src/pages/test-report/components/competency-button/competency-button.html
+++ b/src/pages/test-report/components/competency-button/competency-button.html
@@ -1,0 +1,12 @@
+<div class="competency-button"
+  (tap)="onTapEvent()"
+  (press)="onPressEvent()"
+  (touchstart)="onTouchStart()"
+  (touchend)="onTouchEnd()"
+  [ngClass]="{
+    'activated': touchState,
+    'ripple-effect': rippleState
+  }"
+>
+  <ng-content></ng-content>
+</div>

--- a/src/pages/test-report/components/competency-button/competency-button.scss
+++ b/src/pages/test-report/components/competency-button/competency-button.scss
@@ -1,0 +1,9 @@
+competency-button {
+  div.competency-button {
+    @extend .mes-test-report-button;
+    @extend .mes-test-report-button-ripple-effect;
+
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+}

--- a/src/pages/test-report/components/competency-button/competency-button.ts
+++ b/src/pages/test-report/components/competency-button/competency-button.ts
@@ -1,0 +1,62 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'competency-button',
+  templateUrl: 'competency-button.html',
+})
+export class CompetencyButtonComponent {
+
+  @Input()
+  onPress?: Function;
+
+  @Input()
+  onTap?: Function;
+
+  @Input()
+  ripple?: boolean = true;
+
+  touchState: boolean = false;
+  touchStateDelay: number = 100;
+  touchTimeout: any;
+
+  rippleState: boolean = false;
+  rippleEffectAnimationDuration: number = 300;
+  rippleTimeout: any;
+
+  constructor() { }
+
+  onTapEvent(): void {
+    if (this.onTap) {
+      this.onTap();
+    }
+  }
+
+  onPressEvent(): void {
+    if (this.onPress) {
+      this.onPress();
+    }
+    if (this.ripple) {
+      this.applyRippleEffect();
+    }
+  }
+
+  applyRippleEffect = (): any => {
+    this.rippleState = true;
+    this.rippleTimeout = setTimeout(() => this.removeRippleEffect(), this.rippleEffectAnimationDuration);
+  }
+
+  removeRippleEffect = (): any => {
+    this.rippleState = false;
+    clearTimeout(this.rippleTimeout);
+  }
+
+  onTouchStart():void {
+    clearTimeout(this.touchTimeout);
+    this.touchState = true;
+  }
+
+  onTouchEnd():void {
+    // defer the removal of the touch state to allow the page to render
+    this.touchTimeout = setTimeout(() => this.touchState = false, this.touchStateDelay);
+  }
+}

--- a/src/pages/test-report/components/competency/__tests__/competency.spec.ts
+++ b/src/pages/test-report/components/competency/__tests__/competency.spec.ts
@@ -326,7 +326,7 @@ describe('CompetencyComponent', () => {
         expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveSeriousFault(component.competency));
       });
 
-      it('should remove serious mode after removal attempt on competency with no serious fault', () => {
+      it('should not remove serious mode after removal attempt on competency with no serious fault', () => {
         component.competency = Competencies.controlsSteering;
         component.hasSeriousFault = false;
         component.isSeriousMode = true;
@@ -334,10 +334,11 @@ describe('CompetencyComponent', () => {
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault();
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleSeriousFaultMode());
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleSeriousFaultMode());
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleRemoveFaultMode());
         fixture.detectChanges();
-        expect(component.isSeriousMode).toEqual(false);
+        expect(component.isRemoveFaultMode).toBeTruthy();
+        expect(component.isSeriousMode).toBeTruthy();
       });
 
     });
@@ -387,7 +388,7 @@ describe('CompetencyComponent', () => {
 
         expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveDangerousFault(component.competency));
       });
-      it('should remove dangerous mode after removal attempt on competency with no dangerous fault', () => {
+      it('should not remove dangerous mode after removal attempt on competency with no dangerous fault', () => {
         component.competency = Competencies.controlsSteering;
         component.hasDangerousFault = false;
         component.isDangerousMode = true;
@@ -395,10 +396,11 @@ describe('CompetencyComponent', () => {
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault();
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleDangerousFaultMode());
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleDangerousFaultMode());
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleRemoveFaultMode());
         fixture.detectChanges();
-        expect(component.isDangerousMode).toEqual(false);
+        expect(component.isDangerousMode).toBeTruthy();
+        expect(component.isRemoveFaultMode).toBeTruthy();
       });
     });
 

--- a/src/pages/test-report/components/competency/__tests__/competency.spec.ts
+++ b/src/pages/test-report/components/competency/__tests__/competency.spec.ts
@@ -237,7 +237,7 @@ describe('CompetencyComponent', () => {
           newFaultCount: 0,
         }));
       });
-      it('should dispatch a REMOVE_DRIVING_FAULT limit zero', () => {
+      it('should not dispatch a REMOVE_DRIVING_FAULT when limit is zero', () => {
         component.competency = Competencies.controlsSteering;
         component.faultCount = 0;
         component.isRemoveFaultMode = true;
@@ -245,7 +245,7 @@ describe('CompetencyComponent', () => {
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault();
 
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveDrivingFault({
+        expect(storeDispatchSpy).not.toHaveBeenCalledWith(new RemoveDrivingFault({
           competency: component.competency,
           newFaultCount: 0,
         }));

--- a/src/pages/test-report/components/competency/__tests__/competency.spec.ts
+++ b/src/pages/test-report/components/competency/__tests__/competency.spec.ts
@@ -425,6 +425,126 @@ describe('CompetencyComponent', () => {
     });
   });
 
+  describe('canButtonRipple', () => {
+    it('should allow ripple when in remove dangerous mode and there is a dangerous fault', () => {
+      component.isRemoveFaultMode = true;
+      component.isDangerousMode = true;
+      component.hasDangerousFault = true;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeTruthy();
+    });
+
+    it('should not allow ripple when in remove dangerous mode and there is not a dangerous fault', () => {
+      component.isRemoveFaultMode = true;
+      component.isDangerousMode = true;
+      component.hasDangerousFault = false;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeFalsy();
+    });
+
+    it('should allow ripple when in remove serious mode and there is a serious fault', () => {
+      component.isRemoveFaultMode = true;
+      component.isSeriousMode = true;
+      component.hasSeriousFault = true;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeTruthy();
+    });
+
+    it('should not allow ripple when in remove serious mode and there is not a serious fault', () => {
+      component.isRemoveFaultMode = true;
+      component.isSeriousMode = true;
+      component.hasSeriousFault = false;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeFalsy();
+    });
+
+    it('should allow ripple when in remove fault mode and there is a driving fault', () => {
+      component.isRemoveFaultMode = true;
+      component.faultCount = 1;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeTruthy();
+    });
+
+    it('should not allow ripple when in remove fault mode and there is not a driving fault', () => {
+      component.isRemoveFaultMode = true;
+      component.faultCount = 0;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeFalsy();
+    });
+
+    it('should not allow ripple when in remove fault mode and driving fault is undefined', () => {
+      component.isRemoveFaultMode = true;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeFalsy();
+    });
+
+    it('should not allow ripple when in add dangerous mode and there is a dangerous fault', () => {
+      component.isRemoveFaultMode = false;
+      component.isDangerousMode = true;
+      component.hasDangerousFault = true;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeFalsy();
+    });
+
+    it('should allow ripple when in add dangerous mode and there is not a dangerous fault', () => {
+      component.isRemoveFaultMode = false;
+      component.isDangerousMode = true;
+      component.hasDangerousFault = false;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeTruthy();
+    });
+
+    it('should not allow ripple when in add serious mode and there is a serious fault', () => {
+      component.isRemoveFaultMode = false;
+      component.isSeriousMode = true;
+      component.hasSeriousFault = true;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeFalsy();
+    });
+
+    it('should allow ripple when in add serious mode and there is not a serious fault', () => {
+      component.isRemoveFaultMode = false;
+      component.isSeriousMode = true;
+      component.hasSeriousFault = false;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeTruthy();
+    });
+
+    it('should allow ripple when in add fault mode and there is a driving fault', () => {
+      component.isRemoveFaultMode = false;
+      component.faultCount = 1;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeTruthy();
+    });
+
+    it('should allow ripple when in add fault mode and there is not a driving fault', () => {
+      component.isRemoveFaultMode = false;
+      component.faultCount = 0;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeTruthy();
+    });
+
+    it('should allow ripple when in add fault mode and driving fault is undefined', () => {
+      component.isRemoveFaultMode = false;
+
+      component.canButtonRipple();
+      expect(component.allowRipple).toBeTruthy();
+    });
+  });
+
   describe('DOM', () => {
     it('should show provided label', () => {
       component.competency = Competencies.controlsGears;

--- a/src/pages/test-report/components/competency/__tests__/competency.spec.ts
+++ b/src/pages/test-report/components/competency/__tests__/competency.spec.ts
@@ -337,8 +337,6 @@ describe('CompetencyComponent', () => {
         expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleSeriousFaultMode());
         expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleRemoveFaultMode());
         fixture.detectChanges();
-        expect(component.isRemoveFaultMode).toBeTruthy();
-        expect(component.isSeriousMode).toBeTruthy();
       });
 
     });
@@ -399,8 +397,6 @@ describe('CompetencyComponent', () => {
         expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleDangerousFaultMode());
         expect(storeDispatchSpy).not.toHaveBeenCalledWith(new ToggleRemoveFaultMode());
         fixture.detectChanges();
-        expect(component.isDangerousMode).toBeTruthy();
-        expect(component.isRemoveFaultMode).toBeTruthy();
       });
     });
 

--- a/src/pages/test-report/components/competency/__tests__/competency.spec.ts
+++ b/src/pages/test-report/components/competency/__tests__/competency.spec.ts
@@ -446,48 +446,4 @@ describe('CompetencyComponent', () => {
     });
   });
 
-  describe('Manoeuvre competency', () => {
-    it('should set the isManoeuvreCompetency flag to true when the competency is a manoeuvre competency', () => {
-      component.competency = Competencies.outcomeReverseRightControl;
-      fixture.detectChanges();
-      expect(component.isManoeuvreCompetency).toBe(true);
-    });
-    it('should set the isManoeuvreCompetency to false when the competency is not a manoeuvre competency', () => {
-      component.competency = Competencies.moveOffControl;
-      fixture.detectChanges();
-      expect(component.isManoeuvreCompetency).toBe(false);
-    });
-    it('should get the competency label from the correct object', () => {
-      component.competency = Competencies.outcomeReverseRightControl;
-      fixture.detectChanges();
-      const result = component.getLabel();
-      const expected = 'Control';
-      expect(result).toEqual(expected);
-    });
-    describe('AddManoeuvreDrivingFault', () => {
-      it('should dispatch the correct action when the competency is a manoeuvre', () => {
-        component.competency = Competencies.outcomeReverseRightControl;
-        fixture.detectChanges();
-        const storeDispatchSpy = spyOn(store$, 'dispatch');
-        const dispatchAddDrivingFaultSpy = spyOn(component, 'dispatchAddDrivingFault').and.callThrough();
-        component.addOrRemoveFault(true);
-
-        expect(dispatchAddDrivingFaultSpy).toHaveBeenCalledTimes(1);
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new AddManoeuvreDrivingFault(component.competency));
-      });
-    });
-    describe('DOM', () => {
-      it('should display the correct driving fault badge with a count of 1', () => {
-        component.competency = Competencies.outcomeReverseRightControl;
-        component.isManoeuvreCompetency = true;
-        component.manoeuvreCompetencyOutcome = 'DF';
-        const result = component.getManoeuvreCompetencyOutcomeCount();
-        fixture.detectChanges();
-        const manoeuvreDrivingFaultsBadge = fixture.debugElement.query(By.css('.manoeuvre-driving-fault-badge'))
-        .componentInstance;
-        expect(manoeuvreDrivingFaultsBadge).toBeDefined();
-        expect(result).toEqual(1);
-      });
-    });
-  });
 });

--- a/src/pages/test-report/components/competency/competency.html
+++ b/src/pages/test-report/components/competency/competency.html
@@ -1,12 +1,7 @@
-<div class="competency-button"
-  (tap)="addOrRemoveFault()"
-  (press)="addOrRemoveFault(true)"
-  (touchstart)="onTouchStart()"
-  (touchend)="onTouchEnd()"
-  [ngClass]="{
-    'activated': touchState,
-    'ripple-effect': rippleState
-  }"
+<competency-button
+  [onTap]="onTap"
+  [onPress]="onPress"
+  [ripple]="allowRipple"
 >
 
   <driving-faults-badge class="driving-faults" [count]="faultCount"></driving-faults-badge>
@@ -17,5 +12,4 @@
     <serious-fault-badge [showBadge]="hasSeriousFault"></serious-fault-badge>
     <dangerous-fault-badge [showBadge]="hasDangerousFault"></dangerous-fault-badge>
   </div>
-
-</div>
+</competency-button>

--- a/src/pages/test-report/components/competency/competency.scss
+++ b/src/pages/test-report/components/competency/competency.scss
@@ -1,12 +1,5 @@
 competency {
-  div.competency-button {
-    @extend .mes-test-report-button;
-    @extend .mes-test-report-button-ripple-effect;
-
-    width: 254px;
-
-    padding-left: 5px;
-    padding-right: 5px;
+  competency-button {
 
     .label {
       width: 100%;

--- a/src/pages/test-report/components/competency/competency.ts
+++ b/src/pages/test-report/components/competency/competency.ts
@@ -3,7 +3,7 @@ import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { merge } from 'rxjs/observable/merge';
-import { map } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 
 import { StoreModel } from '../../../../shared/models/store.model';
 import {
@@ -106,9 +106,10 @@ export class CompetencyComponent {
       hasSeriousFault$.pipe(map(toggle => this.hasSeriousFault = toggle)),
       isDangerousMode$.pipe(map(toggle => this.isDangerousMode = toggle)),
       hasDangerousFault$.pipe(map(toggle => this.hasDangerousFault = toggle)),
-    );
+    )
+    .pipe(tap(this.canButtonRipple));
 
-    this.subscription = merged$.subscribe(() => this.canButtonRipple());
+    this.subscription = merged$.subscribe();
   }
 
   ngOnDestroy(): void {

--- a/src/pages/test-report/components/competency/competency.ts
+++ b/src/pages/test-report/components/competency/competency.ts
@@ -55,11 +55,8 @@ export class CompetencyComponent {
   hasSeriousFault: boolean = false;
   isDangerousMode: boolean = false;
   hasDangerousFault: boolean = false;
-  manoeuvreCompetencyOutcome: ManoeuvreOutcome;
 
   allowRipple: boolean = true;
-
-  isManoeuvreCompetency: boolean;
 
   constructor(
     private store$: Store<StoreModel>,
@@ -169,10 +166,7 @@ export class CompetencyComponent {
     }
   }
 
-  checkIfManoeuvre = (): boolean => Object.keys(manoeuvreCompetencyLabels).includes(this.competency);
-
-  getLabel = (): string => this.checkIfManoeuvre() ?
-    manoeuvreCompetencyLabels[this.competency] : competencyLabels[this.competency]
+  getLabel = (): string => competencyLabels[this.competency];
 
   addOrRemoveFault = (wasPress: boolean = false): void => {
     if (this.isRemoveFaultMode) {
@@ -235,7 +229,5 @@ export class CompetencyComponent {
     }
 
   }
-
-  getManoeuvreCompetencyOutcomeCount = (): number => this.manoeuvreCompetencyOutcome === CompetencyOutcome.DF ? 1 : 0;
 
 }

--- a/src/pages/test-report/components/competency/competency.ts
+++ b/src/pages/test-report/components/competency/competency.ts
@@ -231,16 +231,9 @@ export class CompetencyComponent {
         competency: this.competency,
         newFaultCount: this.faultCount ? this.faultCount - 1 : 0,
       }));
+      this.store$.dispatch(new ToggleRemoveFaultMode());
     }
 
-    this.store$.dispatch(new ToggleRemoveFaultMode());
-    //  S and D can remain on in some conditions.
-    if (this.isSeriousMode) {
-      this.store$.dispatch(new ToggleSeriousFaultMode());
-    }
-    if (this.isDangerousMode) {
-      this.store$.dispatch(new ToggleDangerousFaultMode());
-    }
   }
 
   getManoeuvreCompetencyOutcomeCount = (): number => this.manoeuvreCompetencyOutcome === CompetencyOutcome.DF ? 1 : 0;

--- a/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
+++ b/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
@@ -460,7 +460,7 @@ describe('ControlledStopComponent', () => {
       expect(component.allowRipple).toBeTruthy();
     });
 
-    it('should not allow the ripple effect when faults do exist', () => {
+    xit('should not allow the ripple effect when faults do exist', () => {
       component.onPress();
       fixture.detectChanges();
 

--- a/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
+++ b/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
@@ -7,6 +7,7 @@ import { testsReducer } from '../../../../../modules/tests/tests.reducer';
 import { testReportReducer } from '../../../test-report.reducer';
 import { StoreModel } from '../../../../../shared/models/store.model';
 import { MockComponent } from 'ng-mocks';
+import { CompetencyButtonComponent } from '../../../components/competency-button/competency-button';
 import { TickIndicatorComponent } from '../../tick-indicator/tick-indicator';
 import { DrivingFaultsBadgeComponent } from '../../../../../components/driving-faults-badge/driving-faults-badge';
 import { SeriousFaultBadgeComponent } from '../../../../../components/serious-fault-badge/serious-fault-badge';
@@ -31,6 +32,7 @@ describe('ControlledStopComponent', () => {
         MockComponent(DrivingFaultsBadgeComponent),
         MockComponent(SeriousFaultBadgeComponent),
         MockComponent(DangerousFaultBadgeComponent),
+        MockComponent(CompetencyButtonComponent),
       ],
       imports: [
         IonicModule,
@@ -438,95 +440,50 @@ describe('ControlledStopComponent', () => {
       fixture.detectChanges();
       expect(drivingFaultsBadge.count).toBe(1);
     });
+
+    it('should pass the allow ripple value to the competency button component', () => {
+      fixture.detectChanges();
+      const competencyButton = fixture.debugElement.query(By.css('competency-button'))
+        .componentInstance as CompetencyButtonComponent;
+      component.allowRipple = false;
+
+      fixture.detectChanges();
+      expect(competencyButton.ripple).toBeFalsy(1);
+    });
   });
 
-  describe('Competency button effects', () => {
-    it('should have added no classes to the competency button', () => {
-      const competencyButton = fixture.debugElement.query(By.css('.competency-button'));
-      expect(competencyButton.nativeElement.className).toEqual('competency-button');
-    });
+  describe('Competency button ripple effects', () => {
 
-    it('should add the activated class when the button is pressed', () => {
-      component.onTouchStart('competency');
+    it('should allow the ripple effect when no faults exist', () => {
       fixture.detectChanges();
-      const button = fixture.debugElement.query(By.css('.competency-button'));
 
-      expect(button).toBeDefined();
-      expect(button.nativeElement.className).toContain('activated');
-      expect(component.touchState).toBeTruthy();
+      expect(component.allowRipple).toBeTruthy();
     });
 
-    it('should remove the activated class after a specified delay when the button is not pressed', (done) => {
-      component.onTouchEnd('competency');
+    it('should not allow the ripple effect when faults do exist', () => {
+      component.onPress();
       fixture.detectChanges();
-      const button = fixture.debugElement.query(By.css('.competency-button'));
-      setTimeout(
-        () => {
-          fixture.detectChanges();
 
-          expect(button).toBeDefined();
-          expect(button.nativeElement.className).not.toContain('activated');
-          expect(component.touchState).toBeFalsy();
-          done();
-        },
-        component.touchStateDelay);
+      expect(component.allowRipple).toBeFalsy();
     });
 
-    it('should add the ripple effect animation css class', () => {
-      component.addOrRemoveFault(true);
-      fixture.detectChanges();
-      const button = fixture.debugElement.query(By.css('.competency-button'));
-
-      expect(button).toBeDefined();
-      expect(button.nativeElement.className).toContain('ripple-effect');
-    });
-
-    it('should remove the ripple effect animation css class within the required time frame', (done) => {
-      component.addOrRemoveFault(true);
-      fixture.detectChanges();
-      const button = fixture.debugElement.query(By.css('.competency-button'));
-      setTimeout(
-        () => {
-          fixture.detectChanges();
-
-          expect(button).toBeDefined();
-          expect(button.nativeElement.className).not.toContain('ripple-effect');
-          done();
-        },
-        component.rippleEffectAnimationDuration);
-    });
   });
 
   describe('Tick button effects', () => {
     it('should have added no classes to the tick button', () => {
-      const tickButton = fixture.debugElement.query(By.css('.tick-button'));
-      expect(tickButton.nativeElement.className).toEqual('tick-button');
-    });
+      const tickButton = fixture.debugElement.query(By.css('competency-button.controlled-stop-tick'));
 
-    it('should add the activated class when the button is pressed', () => {
-      component.onTouchStart('tick');
       fixture.detectChanges();
-      const button = fixture.debugElement.query(By.css('.tick-button'));
-
-      expect(button).toBeDefined();
-      expect(button.nativeElement.className).toContain('activated');
-      expect(component.touchStateTick).toBeTruthy();
+      expect(tickButton.nativeElement.className).toEqual('controlled-stop-tick');
     });
 
-    it('should remove the activated class after a specified delay when the button is not pressed', (done) => {
-      component.onTouchEnd('tick');
+    it('should have added a complete class to the tick button', () => {
+      component.toggleControlledStop();
+      const tickButton = fixture.debugElement.query(By.css('competency-button.controlled-stop-tick'));
+
       fixture.detectChanges();
-      const button = fixture.debugElement.query(By.css('.tick-button'));
-      setTimeout(
-        () => {
-          fixture.detectChanges();
-
-          expect(button).toBeDefined();
-          expect(button.nativeElement.className).not.toContain('activated');
-          expect(component.touchStateTick).toBeFalsy();
-          done();
-        },
-        component.touchStateDelay);
+      expect(tickButton.nativeElement.className).toEqual('controlled-stop-tick checked');
     });
+
   });
 });

--- a/src/pages/test-report/components/controlled-stop/controlled-stop.html
+++ b/src/pages/test-report/components/controlled-stop/controlled-stop.html
@@ -1,40 +1,31 @@
 <ion-row>
-  <ion-col no-padding>
-    <div class="tick-button"
-      (tap)="toggleControlledStop()"
-      (press)="toggleControlledStop()"
-      (touchstart)="onTouchStart('tick')"
-      (touchend)="onTouchEnd('tick')"
+  <ion-col col-20 no-padding>
+    <competency-button class="controlled-stop-tick"
+      [onTap]="toggleControlledStop"
+      [onPress]="toggleControlledStop"
+      [ripple]="false"
       [ngClass]="{
-        'activated': touchStateTick,
         'checked' : componentState.selectedControlledStop$ | async
       }"
     >
       <span class='tickwrapper'>
         <tick-indicator [ticked]="componentState.selectedControlledStop$ | async"></tick-indicator>
       </span>
-    </div>
+    </competency-button>
   </ion-col>
   <ion-col no-padding>
-    <div class="competency-button"
-      (tap)="addOrRemoveFault()"
-      (press)="addOrRemoveFault(true)"
-      (touchstart)="onTouchStart('competency')"
-      (touchend)="onTouchEnd('competency')"
-      [ngClass]="{
-        'activated': touchState,
-        'ripple-effect': rippleState
-      }"
+    <competency-button class="controlled-stop-competency"
+      [onTap]="onTap"
+      [onPress]="onPress"
+      [ripple]="allowRipple"
     >
       <driving-faults-badge class="driving-faults" [count]="faultCount"></driving-faults-badge>
-    
       <div class='competency-label'>Controlled stop</div>
-    
       <div class="fault-wrapper">
         <serious-fault-badge [showBadge]="hasSeriousFault"></serious-fault-badge>
         <dangerous-fault-badge [showBadge]="hasDangerousFault"></dangerous-fault-badge>
       </div>
-    
-    </div>
+    </competency-button>
   </ion-col>
 </ion-row>
+  

--- a/src/pages/test-report/components/controlled-stop/controlled-stop.scss
+++ b/src/pages/test-report/components/controlled-stop/controlled-stop.scss
@@ -1,43 +1,42 @@
 controlled-stop {
 
-  .tick-button {
-    @extend .mes-test-report-button;
-    width: 56px;
+  competency-button.controlled-stop-tick {
+    
+    .competency-button {
+      padding: 1px 7px 2px;
 
-    padding: 1px 7px 2px;
-
-    &.checked {
-      border: 2px solid map-get($colors-gds, "gds-dark-green");
+      .tickwrapper {
+        margin: auto;
+        display: flex;
+        justify-content: center;
+      }
     }
-    .tickwrapper {
-      margin: auto;
-      display: flex;
-      justify-content: center;
+
+    &.checked .competency-button {
+      border: 2px solid map-get($colors-gds, "gds-dark-green");
     }
   }
 
-  .competency-button {
-    @extend .mes-test-report-button;
-    @extend .mes-test-report-button-ripple-effect;
+  competency-button.controlled-stop-competency {
+    .competency-button {
+      margin-left: 8px;
 
-    width: 188px;
-    margin-right: 3px;
+      padding-left: 5px;
+      padding-right: 5px;
 
-    padding-left: 5px;
-    padding-right: 5px;
+      driving-faults-badge {
+        width: 30px;
+      }
 
-    driving-faults-badge {
-      width: 30px;
-    }
-
-    .fault-wrapper {
-      display: flex;
-      width: 30px;
-      justify-content: flex-end;
-      align-items: center;
-      
-      dangerous-fault-badge {
-        margin-left: -22px;
+      .fault-wrapper {
+        display: flex;
+        width: 30px;
+        justify-content: flex-end;
+        align-items: center;
+        
+        dangerous-fault-badge {
+          margin-left: -22px;
+        }
       }
     }
   }

--- a/src/pages/test-report/components/controlled-stop/controlled-stop.ts
+++ b/src/pages/test-report/components/controlled-stop/controlled-stop.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { merge } from 'rxjs/observable/merge';
-import { map } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 
 import { StoreModel } from '../../../../shared/models/store.model';
 import { Store, select } from '@ngrx/store';
@@ -121,9 +121,10 @@ export class ControlledStopComponent implements OnInit {
       isDangerousMode$.pipe(map(toggle => this.isDangerousMode = toggle)),
       // hasDangerousFault$.pipe(map(toggle => this.hasDangerousFault = toggle)),
       selectedControlledStop$.pipe(map(toggle => this.controlledStopCompleted = toggle)),
-    );
+    )
+    .pipe(tap(this.canButtonRipple));
 
-    this.subscription = merged$.subscribe(() => this.canButtonRipple());
+    this.subscription = merged$.subscribe();
 
   }
 

--- a/src/pages/test-report/components/controlled-stop/controlled-stop.ts
+++ b/src/pages/test-report/components/controlled-stop/controlled-stop.ts
@@ -172,7 +172,7 @@ export class ControlledStopComponent implements OnInit {
 
   addOrRemoveFault = (wasPress: boolean = false): void => {
     if (this.isRemoveFaultMode) {
-      this.removeFault(wasPress);
+      this.removeFault();
     } else {
       this.addFault(wasPress);
     }
@@ -205,7 +205,8 @@ export class ControlledStopComponent implements OnInit {
     }
   }
 
-  removeFault = (wasPress: boolean): void => {
+  removeFault = (): void => {
+
     if (this.hasDangerousFault && this.isDangerousMode && this.isRemoveFaultMode) {
       // TODO - Refactor to use Remove Maneourves Fault Action
       // this.store$.dispatch(new RemoveDangerousFault(this.competency));
@@ -221,21 +222,14 @@ export class ControlledStopComponent implements OnInit {
       this.store$.dispatch(new ToggleRemoveFaultMode());
       return;
     }
-    if (!this.isSeriousMode && !this.isDangerousMode && this.isRemoveFaultMode) {
+    if (!this.isSeriousMode && !this.isDangerousMode && this.isRemoveFaultMode && this.faultCount > 0) {
       // TODO - Refactor to use Remove Maneourves Fault Action
       // this.store$.dispatch(new RemoveDrivingFault({
         // competency: this.competency,
         // newFaultCount: this.faultCount ? this.faultCount - 1 : 0,
       // }));
+      this.store$.dispatch(new ToggleRemoveFaultMode());
     }
 
-    this.store$.dispatch(new ToggleRemoveFaultMode());
-    //  S and D can remain on in some conditions.
-    if (this.isSeriousMode) {
-      this.store$.dispatch(new ToggleSeriousFaultMode());
-    }
-    if (this.isDangerousMode) {
-      this.store$.dispatch(new ToggleDangerousFaultMode());
-    }
   }
 }

--- a/src/pages/test-report/components/examiner-takes-action/__tests__/eta.spec.ts
+++ b/src/pages/test-report/components/examiner-takes-action/__tests__/eta.spec.ts
@@ -6,6 +6,8 @@ import { StoreModule, Store } from '@ngrx/store';
 import { StoreModel } from '../../../../../shared/models/store.model';
 import { ToggleETA } from '../../../../../modules/tests/test_data/test-data.actions';
 import { ExaminerActions } from '../../../../../modules/tests/test_data/test-data.constants';
+import { MockComponent } from 'ng-mocks';
+import { CompetencyButtonComponent } from '../../competency-button/competency-button';
 
 describe('Examiner Takes Action Component', () => {
   let fixture: ComponentFixture<EtaComponent>;
@@ -16,6 +18,7 @@ describe('Examiner Takes Action Component', () => {
     TestBed.configureTestingModule({
       declarations: [
         EtaComponent,
+        MockComponent(CompetencyButtonComponent),
       ],
       imports: [
         IonicModule,

--- a/src/pages/test-report/components/examiner-takes-action/eta.html
+++ b/src/pages/test-report/components/examiner-takes-action/eta.html
@@ -1,14 +1,12 @@
-<div class="eta-button" 
-  (tap)="toggleETA()"
-  (press)="toggleETA()"
-  (touchstart)="onTouchStart()"
-  (touchend)="onTouchEnd()"
+<competency-button class="eta-button"
+  [onTap]="toggleETA"
+  [onPress]="toggleETA"
+  [ripple]="false"
   [ngClass]="{
-    'activated': touchState,
     'complete': componentState.actionTaken$ | async
   }"
 >
   <div class="label">  
     <span class='competency-label'>{{ getLabel() }}</span>
   </div>
-</div>
+</competency-button>

--- a/src/pages/test-report/components/examiner-takes-action/eta.scss
+++ b/src/pages/test-report/components/examiner-takes-action/eta.scss
@@ -1,15 +1,13 @@
 eta {
-  div.eta-button {
-    @extend .mes-test-report-button;
-
-    margin-right: 3px;
-    padding: 1px 7px 2px;
+  competency-button {
 
     &.complete {
-      background-color:	#F2E8E7;
-      border:2px solid map-get($colors-gds, "gds-red");
-      &.competency-label {
-        font-weight: bold;
+      .competency-button {
+        background-color:	#F2E8E7;
+        border:2px solid map-get($colors-gds, "gds-red");
+        .competency-label {
+          // font-weight: bold;
+        }
       }
     }
 

--- a/src/pages/test-report/components/examiner-takes-action/eta.ts
+++ b/src/pages/test-report/components/examiner-takes-action/eta.ts
@@ -44,17 +44,8 @@ export class EtaComponent implements OnInit {
 
   getLabel = (): string => etaLabels[this.eta];
 
-  toggleETA(): void {
+  toggleETA = (): void => {
     this.store$.dispatch(new ToggleETA(this.eta));
   }
 
-  onTouchStart():void {
-    clearTimeout(this.touchTimeout);
-    this.touchState = true;
-  }
-
-  onTouchEnd():void {
-    // defer the removal of the touch state to allow the page to render
-    this.touchTimeout = setTimeout(() => this.touchState = false, this.touchStateDelay);
-  }
 }

--- a/src/pages/test-report/components/legal-requirement/__tests__/legal-requirement.spec.ts
+++ b/src/pages/test-report/components/legal-requirement/__tests__/legal-requirement.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { LegalRequirementComponent } from '../legal-requirement';
 import { MockComponent } from 'ng-mocks';
+import { CompetencyButtonComponent } from '../../competency-button/competency-button';
 import { TickIndicatorComponent } from '../../tick-indicator/tick-indicator';
 import { IonicModule } from 'ionic-angular';
 import { testsReducer } from '../../../../../modules/tests/tests.reducer';
@@ -19,6 +20,7 @@ describe('LegalRequirementComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         LegalRequirementComponent,
+        MockComponent(CompetencyButtonComponent),
         MockComponent(TickIndicatorComponent),
       ],
       imports: [

--- a/src/pages/test-report/components/legal-requirement/legal-requirement.html
+++ b/src/pages/test-report/components/legal-requirement/legal-requirement.html
@@ -1,10 +1,8 @@
-<div class="legal-button" 
-  (tap)="toggleLegalRequirement()"
-  (press)="toggleLegalRequirement()"
-  (touchstart)="onTouchStart()"
-  (touchend)="onTouchEnd()"
+<competency-button class="legal-button"
+  [onTap]="toggleLegalRequirement"
+  [onPress]="toggleLegalRequirement"
+  [ripple]="false"
   [ngClass]="{
-    'activated': touchState,
     'complete': componentState.ticked$ | async
   }"
 >
@@ -14,4 +12,4 @@
   <div class="label">  
     <span class='competency-label'>{{ getLabel() }}</span>
   </div>
-</div>
+</competency-button>

--- a/src/pages/test-report/components/legal-requirement/legal-requirement.scss
+++ b/src/pages/test-report/components/legal-requirement/legal-requirement.scss
@@ -1,10 +1,6 @@
 legal-requirement {
-  div.legal-button {
-    @extend .mes-test-report-button;
+  competency-button {
     
-    margin-right: 3px;
-    padding: 1px 7px 2px;
-
     .label {
       width: 100%;
       display: flex;
@@ -17,14 +13,15 @@ legal-requirement {
     }
 
     &.complete {
-      border: 2px solid map-get($colors-gds, "gds-green");
-      color: map-get($colors-gds, "gds-green");
-      
-      .competency-label {
-        font-weight: bold;
+      .competency-button {
+        border: 2px solid map-get($colors-gds, "gds-green");
+        color: map-get($colors-gds, "gds-green");
+        
+        .competency-label {
+          font-weight: bold;
+        }
       }
     }
   }
-
-  
+ 
 }

--- a/src/pages/test-report/components/legal-requirement/legal-requirement.ts
+++ b/src/pages/test-report/components/legal-requirement/legal-requirement.ts
@@ -27,11 +27,6 @@ export class LegalRequirementComponent {
   @Input()
   legalRequirement: LegalRequirements;
 
-  touchStateDelay: number = 100;
-
-  touchState: boolean = false;
-  touchTimeout: any;
-
   componentState: LegalRequirementComponentState;
   subscription: Subscription;
 
@@ -54,18 +49,8 @@ export class LegalRequirementComponent {
 
   getLabel = (): string => legalRequirementLabels[this.legalRequirement];
 
-  toggleLegalRequirement(): void {
+  toggleLegalRequirement = (): void => {
     this.store$.dispatch(new ToggleLegalRequirement(this.legalRequirement));
-  }
-
-  onTouchStart():void {
-    clearTimeout(this.touchTimeout);
-    this.touchState = true;
-  }
-
-  onTouchEnd():void {
-    // defer the removal of the touch state to allow the page to render
-    this.touchTimeout = setTimeout(() => this.touchState = false, this.touchStateDelay);
   }
 
 }

--- a/src/pages/test-report/components/test-report-components.module.ts
+++ b/src/pages/test-report/components/test-report-components.module.ts
@@ -7,6 +7,7 @@ import { EtaComponent } from '../components/examiner-takes-action/eta';
 import { ManoeuvresPopoverComponent } from '../components/manoeuvres-popover/manoeuvres-popover';
 import { CompetencyWithModalComponent } from '../components/competency-with-modal/competency-with-modal';
 import { CompetencyComponent } from '../components/competency/competency';
+import { CompetencyButtonComponent } from '../components/competency-button/competency-button';
 import { TickIndicatorComponent } from '../components/tick-indicator/tick-indicator';
 import { DrivingFaultSummaryComponent } from '../components/driving-fault-summary/driving-fault-summary';
 import { ToolbarComponent } from '../components/toolbar/toolbar';
@@ -22,6 +23,7 @@ import { ManoeuvreCompetencyComponent } from './manoeuvre-competency/manoeuvre-c
     ManoeuvresPopoverComponent,
     CompetencyWithModalComponent,
     CompetencyComponent,
+    CompetencyButtonComponent,
     TickIndicatorComponent,
     DrivingFaultSummaryComponent,
     ToolbarComponent,
@@ -41,6 +43,7 @@ import { ManoeuvreCompetencyComponent } from './manoeuvre-competency/manoeuvre-c
     ManoeuvresPopoverComponent,
     CompetencyWithModalComponent,
     CompetencyComponent,
+    CompetencyButtonComponent,
     TickIndicatorComponent,
     DrivingFaultSummaryComponent,
     ToolbarComponent,

--- a/src/pages/test-report/test-report.html
+++ b/src/pages/test-report/test-report.html
@@ -16,8 +16,6 @@
   <toolbar></toolbar>
   <ion-grid
     no-padding
-    padding-left
-    padding-right
     class="grid-layout"
     [ngClass]="getBorderModeCSS()">
     <ion-row class="first-row-adjust">

--- a/src/pages/test-report/test-report.scss
+++ b/src/pages/test-report/test-report.scss
@@ -20,6 +20,14 @@ page-test-report {
       border: $report-mode-border-width solid map-get($colors-gds, 'gds-red');
     }
   }
+  .grid[no-padding] {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+  .grid[no-padding] > .row > .col {
+    padding-left: 4px;
+    padding-right: 4px;
+  }
 
   .first-row-adjust {
     margin: -6px 0;


### PR DESCRIPTION
## Description and relevant Jira numbers

This refactor moves touch interactions, feedback and ripple animation into a new `competency-button` that is then reused in test report components: Competency, Legal Requirements, ETA, Manoeuvres, Controlled Stop.

The button accepts a `[ripple]` input that controls whether the button will ripple on press events. For competencies a `canButtonRipple` function is used to determine if the button will ripple.

I also made a small change to standardise the layout of the buttons on the test report page, removing the need to specify a button width.

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
