### PR TITLE
Mes 2125 disable unselected manoeuvres

### DIFF
--- a/src/modules/tests/test_data/__tests__/test-data.reducer.spec.ts
+++ b/src/modules/tests/test_data/__tests__/test-data.reducer.spec.ts
@@ -136,7 +136,9 @@ describe('TestDataReducer reducer', () => {
         ...initialState,
         manoeuvres: {
           selectedReverseParkCarpark: true,
-          outcomeForwardParkControl: 'DF',
+          selectedControlledStop: true,
+          outcomeForwardParkControl: 'S',
+          outcomeControlledStop: 'DF',
         },
       };
       const result = testDataReducer(
@@ -144,8 +146,9 @@ describe('TestDataReducer reducer', () => {
         new RecordManoeuvresSelection(ManoeuvreTypes.selectedReverseParkRoad),
       );
       expect(result.manoeuvres[ManoeuvreTypes.selectedReverseParkRoad]).toEqual(true);
-      expect(result.manoeuvres.selectedReverseParkCarpark).toBeUndefined();
-      expect(result.manoeuvres.outcomeForwardParkControl).toBe('DF');
+      expect(result.manoeuvres.outcomeForwardParkControl).toBeUndefined();
+      expect(result.manoeuvres.selectedControlledStop).toBe(true);
+      expect(result.manoeuvres.outcomeControlledStop).toBe('DF');
     });
     describe('ADD_MANOEUVRE_DRIVING_FAULT', () => {
       it('should add a "DF" outcome to the selected manoeuvre', () => {

--- a/src/modules/tests/test_data/__tests__/test-data.reducer.spec.ts
+++ b/src/modules/tests/test_data/__tests__/test-data.reducer.spec.ts
@@ -130,7 +130,7 @@ describe('TestDataReducer reducer', () => {
       expect(result.manoeuvres[ManoeuvreTypes.selectedReverseParkRoad]).toEqual(true);
       expect(result.manoeuvres.selectedReverseParkCarpark).toBeUndefined();
       expect(result.manoeuvres.selectedControlledStop).toBeTruthy();
-      expect(result.manoeuvres.outcomeControlledStop).toBe('S');
+      expect(result.manoeuvres.outcomeControlledStop).toBe('DF');
     });
     it('should keep any outcome data from other manoeuvres when changing selected manoeuvre', () => {
       const state: TestData = {

--- a/src/modules/tests/test_data/__tests__/test-data.reducer.spec.ts
+++ b/src/modules/tests/test_data/__tests__/test-data.reducer.spec.ts
@@ -119,7 +119,8 @@ describe('TestDataReducer reducer', () => {
         manoeuvres: {
           selectedReverseParkCarpark: true,
           selectedControlledStop: true,
-          outcomeControlledStop: 'S',
+          outcomeForwardParkControl: 'S',
+          outcomeControlledStop: 'DF',
         },
       };
       const result = testDataReducer(
@@ -146,7 +147,7 @@ describe('TestDataReducer reducer', () => {
         new RecordManoeuvresSelection(ManoeuvreTypes.selectedReverseParkRoad),
       );
       expect(result.manoeuvres[ManoeuvreTypes.selectedReverseParkRoad]).toEqual(true);
-      expect(result.manoeuvres.outcomeForwardParkControl).toBeUndefined();
+      expect(result.manoeuvres.outcomeForwardParkControl).toEqual('S');
       expect(result.manoeuvres.selectedControlledStop).toBe(true);
       expect(result.manoeuvres.outcomeControlledStop).toBe('DF');
     });

--- a/src/modules/tests/test_data/test-data.reducer.ts
+++ b/src/modules/tests/test_data/test-data.reducer.ts
@@ -1,8 +1,6 @@
-import { TestData, Manoeuvres } from '@dvsa/mes-test-schema/categories/B';
+import { TestData } from '@dvsa/mes-test-schema/categories/B';
 import * as testDataActions from './test-data.actions';
 import { createFeatureSelector } from '@ngrx/store';
-import { ManoeuvreTypes } from '../../../pages/test-report/components/manoeuvres-popover/manoeuvres-popover.constants';
-import { pickBy, startsWith } from 'lodash';
 import { Competencies, ManoeuvreCompetencies } from './test-data.constants';
 import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 
@@ -24,7 +22,11 @@ export function testDataReducer(
     case testDataActions.RECORD_MANOEUVRES_SELECTION:
       return {
         ...state,
-        manoeuvres: preserveOutcomesAndGenerateNewManoeuvresState(state.manoeuvres, action.manoeuvre),
+        manoeuvres: {
+          selectedControlledStop: state.manoeuvres.selectedControlledStop,
+          outcomeControlledStop: state.manoeuvres.outcomeControlledStop,
+          [action.manoeuvre]: true,
+        },
       };
     case testDataActions.ADD_MANOEUVRE_DRIVING_FAULT:
       return {
@@ -177,24 +179,5 @@ export function testDataReducer(
       return state;
   }
 }
-/**
- * @param  {Manoeuvres} currentState
- * @param  {ManoeuvreTypes} manoeuvre
- * @returns Manoeuvres
- * Generate the manoeuvres slice of state when recording a new manoeuvre
- * Needs a separate function due to the need to preserve the outcomes of other manoeuvres
- */
-const preserveOutcomesAndGenerateNewManoeuvresState = (
-  currentState: Manoeuvres,
-  manoeuvre: ManoeuvreTypes,
-): Manoeuvres => {
-  const savedOutcomes = pickBy(currentState, (value, key) => startsWith(key, 'outcome'));
-  const { selectedControlledStop } = currentState;
-  return {
-    ...savedOutcomes,
-    selectedControlledStop,
-    [manoeuvre]: true,
-  };
-};
 
 export const getTestData = createFeatureSelector<TestData>('testData');

--- a/src/modules/tests/test_data/test-data.reducer.ts
+++ b/src/modules/tests/test_data/test-data.reducer.ts
@@ -1,7 +1,9 @@
-import { TestData } from '@dvsa/mes-test-schema/categories/B';
+import { TestData, Manoeuvres } from '@dvsa/mes-test-schema/categories/B';
 import * as testDataActions from './test-data.actions';
 import { createFeatureSelector } from '@ngrx/store';
 import { Competencies, ManoeuvreCompetencies } from './test-data.constants';
+import { ManoeuvreTypes } from '../../../pages/test-report/components/manoeuvres-popover/manoeuvres-popover.constants';
+import { pickBy, startsWith } from 'lodash';
 import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 
 export const initialState: TestData = {
@@ -22,11 +24,7 @@ export function testDataReducer(
     case testDataActions.RECORD_MANOEUVRES_SELECTION:
       return {
         ...state,
-        manoeuvres: {
-          selectedControlledStop: state.manoeuvres.selectedControlledStop,
-          outcomeControlledStop: state.manoeuvres.outcomeControlledStop,
-          [action.manoeuvre]: true,
-        },
+        manoeuvres: preserveOutcomesAndGenerateNewManoeuvresState(state.manoeuvres, action.manoeuvre),
       };
     case testDataActions.ADD_MANOEUVRE_DRIVING_FAULT:
       return {
@@ -179,5 +177,24 @@ export function testDataReducer(
       return state;
   }
 }
+/**
+ * @param  {Manoeuvres} currentState
+ * @param  {ManoeuvreTypes} manoeuvre
+ * @returns Manoeuvres
+ * Generate the manoeuvres slice of state when recording a new manoeuvre
+ * Needs a separate function due to the need to preserve the outcomes of controlled stop
+ */
+const preserveOutcomesAndGenerateNewManoeuvresState = (
+  currentState: Manoeuvres,
+  manoeuvre: ManoeuvreTypes,
+): Manoeuvres => {
+  const savedOutcomes = pickBy(currentState, (value, key) => startsWith(key, 'outcome'));
+  const { selectedControlledStop } = currentState;
+  return {
+    ...savedOutcomes,
+    selectedControlledStop,
+    [manoeuvre]: true,
+  };
+};
 
 export const getTestData = createFeatureSelector<TestData>('testData');

--- a/src/pages/test-report/components/manoeuvres-popover/__tests__/manoeuvres-popover.spec.ts
+++ b/src/pages/test-report/components/manoeuvres-popover/__tests__/manoeuvres-popover.spec.ts
@@ -18,7 +18,7 @@ import { testsReducer } from '../../../../../modules/tests/tests.reducer';
 import { StartTest } from '../../../../journal/journal.actions';
 import { ManoeuvreCompetencies } from '../../../../../modules/tests/test_data/test-data.constants';
 
-fdescribe('ManoeuvresPopoverComponent', () => {
+describe('ManoeuvresPopoverComponent', () => {
   let fixture: ComponentFixture<ManoeuvresPopoverComponent>;
   let component: ManoeuvresPopoverComponent;
   let store$: Store<StoreModel>;

--- a/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.html
+++ b/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="{
-  manoeuvre: manoeuvres$ | async
+  manoeuvres: manoeuvres$ | async
 } as asyncData">
   <ion-grid class="popover-content">
     <ion-row>
@@ -8,7 +8,7 @@
           <ion-col>
             <input type="radio" name="manoeuvres" 
             [attr.disabled]="(shouldManoeuvreDisable('reverseRight') | async) ? 'disabled' : null"
-            [checked]="asyncData.manoeuvre.selectedReverseRight" 
+            [checked]="asyncData.manoeuvres.selectedReverseRight" 
             (click)="recordManoeuvreSelection(manoeuvreTypes.selectedReverseRight)" 
             id="manoeuvres-reverse-right-radio" class="gds-radio-button">
             <label for="manoeuvres-reverse-right-radio" class="radio-label">Reverse/ Right</label>
@@ -18,7 +18,7 @@
           <ion-col>
             <input type="radio" name="manoeuvres" 
             [attr.disabled]="(shouldManoeuvreDisable('reverseParkRoad') | async) ? 'disabled' : null"
-            [checked]="asyncData.manoeuvre.selectedReverseParkRoad" 
+            [checked]="asyncData.manoeuvres.selectedReverseParkRoad" 
             (click)="recordManoeuvreSelection(manoeuvreTypes.selectedReverseParkRoad)" 
             id="manoeuvres-reverse-park-road-radio" class="gds-radio-button">
             <label for="manoeuvres-reverse-park-road-radio" class="radio-label">Reverse Park (Road)</label>
@@ -29,7 +29,7 @@
           <ion-col>
             <input type="radio" name="manoeuvres" 
             [attr.disabled]="(shouldManoeuvreDisable('reverseParkCarpark') | async) ? 'disabled' : null"
-            [checked]="asyncData.manoeuvre.selectedReverseParkCarpark" 
+            [checked]="asyncData.manoeuvres.selectedReverseParkCarpark" 
             (click)="recordManoeuvreSelection(manoeuvreTypes.selectedReverseParkCarpark)" 
             id="manoeuvres-reverse-park-carpark-radio" class="gds-radio-button">
             <label for="manoeuvres-reverse-park-carpark-radio" class="radio-label">Reverse Park (Car park)</label>
@@ -39,14 +39,14 @@
           <ion-col>
             <input type="radio" name="manoeuvres" 
             [attr.disabled]="(shouldManoeuvreDisable('forwardPark') | async) ? 'disabled' : null"
-            [checked]="asyncData.manoeuvre.selectedForwardPark" 
+            [checked]="asyncData.manoeuvres.selectedForwardPark" 
             (click)="recordManoeuvreSelection(manoeuvreTypes.selectedForwardPark)" 
             id="manoeuvres-forward-park-radio" class="gds-radio-button">
             <label for="manoeuvres-forward-park-radio" class="radio-label">Forward Park</label>
           </ion-col>
         </ion-row>
       </ion-col>
-      <ion-col class="manoeuvre-competencies-container" col-8 *ngIf="asyncData.manoeuvre.selectedReverseRight">
+      <ion-col class="manoeuvre-competencies-container" col-8 *ngIf="asyncData.manoeuvres.selectedReverseRight">
         <manoeuvre-competency 
           [competency]="competencies.outcomeReverseRightControl"
           [attr.id]="competencies.outcomeReverseRightControl"
@@ -57,7 +57,7 @@
           [competency]="competencies.outcomeReverseRightObservation"
           ></manoeuvre-competency>
       </ion-col>
-      <ion-col class="manoeuvre-competencies-container" col-8 *ngIf="asyncData.manoeuvre.selectedForwardPark">
+      <ion-col class="manoeuvre-competencies-container" col-8 *ngIf="asyncData.manoeuvres.selectedForwardPark">
         <manoeuvre-competency 
           [competency]="competencies.outcomeForwardParkControl"
           [attr.id]="competencies.outcomeForwardParkControl"
@@ -68,7 +68,7 @@
           [attr.id]="competencies.outcomeForwardParkObservation"
         ></manoeuvre-competency>
       </ion-col>
-        <ion-col class="manoeuvre-competencies-container" col-8 *ngIf="asyncData.manoeuvre.selectedReverseParkCarpark">
+        <ion-col class="manoeuvre-competencies-container" col-8 *ngIf="asyncData.manoeuvres.selectedReverseParkCarpark">
           <manoeuvre-competency 
             [competency]="competencies.outcomeReverseParkCarparkControl"
             [attr.id]="competencies.outcomeReverseParkCarparkControl"
@@ -79,7 +79,7 @@
             [competency]="competencies.outcomeReverseParkCarparkObservation"
           ></manoeuvre-competency>
         </ion-col>
-      <ion-col class="manoeuvre-competencies-container" col-8 *ngIf="asyncData.manoeuvre.selectedReverseParkRoad">
+      <ion-col class="manoeuvre-competencies-container" col-8 *ngIf="asyncData.manoeuvres.selectedReverseParkRoad">
         <manoeuvre-competency 
           [competency]="competencies.outcomeReverseParkRoadControl"
           [attr.id]="competencies.outcomeReverseParkRoadControl"

--- a/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.html
+++ b/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.html
@@ -7,6 +7,7 @@
         <ion-row>
           <ion-col>
             <input type="radio" name="manoeuvres" 
+            [attr.disabled]="(shouldManoeuvreDisable('reverseRight') | async) ? 'disabled' : null"
             [checked]="asyncData.manoeuvre.selectedReverseRight" 
             (click)="recordManoeuvreSelection(manoeuvreTypes.selectedReverseRight)" 
             id="manoeuvres-reverse-right-radio" class="gds-radio-button">
@@ -16,6 +17,7 @@
         <ion-row>
           <ion-col>
             <input type="radio" name="manoeuvres" 
+            [attr.disabled]="(shouldManoeuvreDisable('reverseParkRoad') | async) ? 'disabled' : null"
             [checked]="asyncData.manoeuvre.selectedReverseParkRoad" 
             (click)="recordManoeuvreSelection(manoeuvreTypes.selectedReverseParkRoad)" 
             id="manoeuvres-reverse-park-road-radio" class="gds-radio-button">
@@ -26,6 +28,7 @@
         <ion-row>
           <ion-col>
             <input type="radio" name="manoeuvres" 
+            [attr.disabled]="(shouldManoeuvreDisable('reverseParkCarpark') | async) ? 'disabled' : null"
             [checked]="asyncData.manoeuvre.selectedReverseParkCarpark" 
             (click)="recordManoeuvreSelection(manoeuvreTypes.selectedReverseParkCarpark)" 
             id="manoeuvres-reverse-park-carpark-radio" class="gds-radio-button">
@@ -35,6 +38,7 @@
         <ion-row>
           <ion-col>
             <input type="radio" name="manoeuvres" 
+            [attr.disabled]="(shouldManoeuvreDisable('forwardPark') | async) ? 'disabled' : null"
             [checked]="asyncData.manoeuvre.selectedForwardPark" 
             (click)="recordManoeuvreSelection(manoeuvreTypes.selectedForwardPark)" 
             id="manoeuvres-forward-park-radio" class="gds-radio-button">

--- a/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.scss
+++ b/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.scss
@@ -24,6 +24,12 @@
       background-color: black;
       box-shadow: inset 0 0 0 6px white;
     }
+    &:disabled + label {
+      color: map-get($colors-gds, "gds-grey-2");
+    }
+    &:disabled + label:before {
+      border-color: map-get($colors-gds, "gds-grey-2");
+    }
   }
   .popover-content {
     margin-left: 68px;

--- a/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.ts
+++ b/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.ts
@@ -60,7 +60,13 @@ export class ManoeuvresPopoverComponent {
   recordManoeuvreSelection(manoeuvre: ManoeuvreTypes): void {
     this.store$.dispatch(new RecordManoeuvresSelection(manoeuvre));
   }
-
+  /**
+   * @param  {string} manoeuvre
+   * @returns Observable<boolean>
+   * Called by the manoeuvre input elements in manoeuvres-popover.html
+   * Tells the input whether it needs to be disabled based on whether
+   * or not another manoeuvre has a fault recorded
+   */
   shouldManoeuvreDisable(manoeuvre: string): Observable<boolean> {
     return this.manoeuvresWithFaults$.pipe(
       map((manoeuvresWithFaults: ManoeuvresDisabledState) => {
@@ -69,7 +75,12 @@ export class ManoeuvresPopoverComponent {
       }),
     );
   }
-
+  /**
+   * @param  {ManoeuvrePrefix} manoeuvrePrefix
+   * @param  {Manoeuvres} manoeuvres
+   * @returns boolean
+   * Looks up the manoeuvre 'outcome' keys and returns true if they exist
+   */
   manoeuvreHasFaults(manoeuvrePrefix: ManoeuvrePrefix, manoeuvres: Manoeuvres): boolean {
     return !isEmpty(pickBy(manoeuvres, (value, key) => startsWith(key, manoeuvrePrefix)));
   }

--- a/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.ts
+++ b/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.ts
@@ -13,7 +13,7 @@ import { ManoeuvreCompetencies } from '../../../../modules/tests/test_data/test-
 import { map } from 'rxjs/operators';
 import { startsWith, pickBy, isEmpty, some } from 'lodash';
 
-enum ManoeuvrePrefixes {
+export enum ManoeuvrePrefixes {
   reverseRight = 'outcomeReverseRight',
   reverseParkRoad = 'outcomeReverseParkRoad',
   reverseParkCarpark = 'outcomeReverseParkCarpark',
@@ -48,7 +48,7 @@ export class ManoeuvresPopoverComponent {
       select(getManoeuvres),
     );
     this.manoeuvresWithFaults$ = this.manoeuvres$.pipe(
-      map(manoeuvres => ({
+      map((manoeuvres: Manoeuvres) => ({
         reverseRight: this.manoeuvreHasFaults(ManoeuvrePrefixes.reverseRight, manoeuvres),
         reverseParkRoad: this.manoeuvreHasFaults(ManoeuvrePrefixes.reverseParkRoad, manoeuvres),
         reverseParkCarpark: this.manoeuvreHasFaults(ManoeuvrePrefixes.reverseParkCarpark, manoeuvres),
@@ -67,7 +67,7 @@ export class ManoeuvresPopoverComponent {
    * Tells the input whether it needs to be disabled based on whether
    * or not another manoeuvre has a fault recorded
    */
-  shouldManoeuvreDisable(manoeuvre: string): Observable<boolean> {
+  shouldManoeuvreDisable(manoeuvre: ManoeuvrePrefixes): Observable<boolean> {
     return this.manoeuvresWithFaults$.pipe(
       map((manoeuvresWithFaults: ManoeuvresFaultState) => {
         const { [manoeuvre]: manoeuvreToOmit, ...otherManoeuvres } = manoeuvresWithFaults;

--- a/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.ts
+++ b/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.ts
@@ -81,7 +81,7 @@ export class ManoeuvresPopoverComponent {
    * @returns boolean
    * Looks up the manoeuvre 'outcome' keys and returns true if they exist
    */
-  manoeuvreHasFaults(manoeuvrePrefixes: ManoeuvrePrefixes, manoeuvres: Manoeuvres): boolean {
-    return !isEmpty(pickBy(manoeuvres, (value, key) => startsWith(key, manoeuvrePrefixes)));
+  manoeuvreHasFaults(manoeuvrePrefix: ManoeuvrePrefixes, manoeuvres: Manoeuvres): boolean {
+    return !isEmpty(pickBy(manoeuvres, (value, key) => startsWith(key, manoeuvrePrefix)));
   }
 }

--- a/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.ts
+++ b/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.ts
@@ -13,14 +13,14 @@ import { ManoeuvreCompetencies } from '../../../../modules/tests/test_data/test-
 import { map } from 'rxjs/operators';
 import { startsWith, pickBy, isEmpty, some } from 'lodash';
 
-enum ManoeuvrePrefix {
+enum ManoeuvrePrefixes {
   reverseRight = 'outcomeReverseRight',
   reverseParkRoad = 'outcomeReverseParkRoad',
   reverseParkCarpark = 'outcomeReverseParkCarpark',
   forwardPark = 'outcomeForwardPark',
 }
 
-interface ManoeuvresDisabledState {
+interface ManoeuvresFaultState {
   reverseRight: boolean;
   reverseParkRoad: boolean;
   reverseParkCarpark: boolean;
@@ -36,7 +36,7 @@ export class ManoeuvresPopoverComponent {
   public manoeuvreTypes = ManoeuvreTypes;
   manoeuvres$: Observable<Manoeuvres>;
   competencies = ManoeuvreCompetencies;
-  manoeuvresWithFaults$: Observable<ManoeuvresDisabledState>;
+  manoeuvresWithFaults$: Observable<ManoeuvresFaultState>;
 
   constructor(private store$: Store<StoreModel>) { }
 
@@ -49,10 +49,10 @@ export class ManoeuvresPopoverComponent {
     );
     this.manoeuvresWithFaults$ = this.manoeuvres$.pipe(
       map(manoeuvres => ({
-        reverseRight: this.manoeuvreHasFaults(ManoeuvrePrefix.reverseRight, manoeuvres),
-        reverseParkRoad: this.manoeuvreHasFaults(ManoeuvrePrefix.reverseParkRoad, manoeuvres),
-        reverseParkCarpark: this.manoeuvreHasFaults(ManoeuvrePrefix.reverseParkCarpark, manoeuvres),
-        forwardPark: this.manoeuvreHasFaults(ManoeuvrePrefix.forwardPark, manoeuvres),
+        reverseRight: this.manoeuvreHasFaults(ManoeuvrePrefixes.reverseRight, manoeuvres),
+        reverseParkRoad: this.manoeuvreHasFaults(ManoeuvrePrefixes.reverseParkRoad, manoeuvres),
+        reverseParkCarpark: this.manoeuvreHasFaults(ManoeuvrePrefixes.reverseParkCarpark, manoeuvres),
+        forwardPark: this.manoeuvreHasFaults(ManoeuvrePrefixes.forwardPark, manoeuvres),
       })),
     );
   }
@@ -69,19 +69,19 @@ export class ManoeuvresPopoverComponent {
    */
   shouldManoeuvreDisable(manoeuvre: string): Observable<boolean> {
     return this.manoeuvresWithFaults$.pipe(
-      map((manoeuvresWithFaults: ManoeuvresDisabledState) => {
+      map((manoeuvresWithFaults: ManoeuvresFaultState) => {
         const { [manoeuvre]: manoeuvreToOmit, ...otherManoeuvres } = manoeuvresWithFaults;
         return some(otherManoeuvres, (value: boolean) => value);
       }),
     );
   }
   /**
-   * @param  {ManoeuvrePrefix} manoeuvrePrefix
+   * @param  {ManoeuvrePrefixes} manoeuvrePrefixes
    * @param  {Manoeuvres} manoeuvres
    * @returns boolean
    * Looks up the manoeuvre 'outcome' keys and returns true if they exist
    */
-  manoeuvreHasFaults(manoeuvrePrefix: ManoeuvrePrefix, manoeuvres: Manoeuvres): boolean {
-    return !isEmpty(pickBy(manoeuvres, (value, key) => startsWith(key, manoeuvrePrefix)));
+  manoeuvreHasFaults(manoeuvrePrefixes: ManoeuvrePrefixes, manoeuvres: Manoeuvres): boolean {
+    return !isEmpty(pickBy(manoeuvres, (value, key) => startsWith(key, manoeuvrePrefixes)));
   }
 }

--- a/test-config/karma.conf.js
+++ b/test-config/karma.conf.js
@@ -58,6 +58,9 @@ module.exports = function(config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    specReporter: {
+      suppressSkipped: true,
+    },
     browsers: ['ChromeHeadless'],
     singleRun: true,
 


### PR DESCRIPTION
## Description and relevant Jira numbers
Ensures that faults can only be added to one manoeuvre by implementing the following disabling logic:
- When a fault is added to a given manoeuvre, we disable the remaining manoeuvres (greyed out and unresponsive).
- Only when all faults have been removed from the given manoeuvre will the remaining manoeuvres be re-enabled.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [x] Tested by QA
- [x] PO's approval

**Screenshot**:
![IMG_4C841DAC0013-1](https://user-images.githubusercontent.com/33695049/56372522-15149e80-61f7-11e9-9417-5012175bd4e4.jpeg)

