### PR TITLE
MES-2153: Repopulate route number when returning to office write up (MES-1129)

### DIFF
--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -47,7 +47,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1001,
-        "start": "2019-04-18T08:10:00+01:00"
+        "start": "2019-04-23T08:10:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -95,7 +95,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1003,
-        "start": "2019-04-18T10:14:00+01:00"
+        "start": "2019-04-23T10:14:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -144,7 +144,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1004,
-        "start": "2019-04-19T11:11:00+01:00"
+        "start": "2019-04-23T11:11:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -195,7 +195,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1005,
-        "start": "2019-04-19T12:38:00+01:00"
+        "start": "2019-04-23T12:38:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -248,7 +248,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1006,
-        "start": "2019-04-19T13:35:00+01:00"
+        "start": "2019-04-23T13:35:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -293,7 +293,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1007,
-        "start": "2019-04-20T14:32:00+01:00"
+        "start": "2019-04-24T14:32:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,

--- a/src/pages/journal/components/test-outcome/test-outcome.html
+++ b/src/pages/journal/components/test-outcome/test-outcome.html
@@ -17,7 +17,7 @@
         </span>
       </ion-col>
       <ion-col *ngIf="showSubmitTestButton()">
-        <span><button class="mes-secondary-button" ion-button><h3>Submit</h3></button></span>
+        <span><button class="mes-secondary-button" ion-button navPush="OfficePage"><h3>Submit</h3></button></span>
       </ion-col>
       <ion-col *ngIf="needsWriteUp()">
         <span><button class="mes-secondary-button mes-warning-button" ion-button><h3 class="write-up-label">Write-up</h3></button></span>

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -30,6 +30,8 @@ import {
 import { WeatherConditions } from '@dvsa/mes-test-schema/categories/B';
 import { of } from 'rxjs/observable/of';
 import { OfficeComponentsModule } from '../components/office.components.module';
+import { MockComponent } from 'ng-mocks';
+import { RouteNumberComponent } from '../components/route-number/route-number';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficePage>;
@@ -39,7 +41,10 @@ describe('OfficePage', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [OfficePage],
+      declarations: [
+        OfficePage,
+        MockComponent(RouteNumberComponent),
+      ],
       imports: [IonicModule, AppModule, ComponentsModule, OfficeComponentsModule,
         StoreModule.forRoot({
           tests: () => ({

--- a/src/pages/office/components/route-number/route-number.html
+++ b/src/pages/office/components/route-number/route-number.html
@@ -1,0 +1,20 @@
+<ion-row class="mes-validated-row mes-row-separator" id="route-number-card" [formGroup]="formGroup">
+  <div class="validation-bar" [class.ng-invalid]="invalid"></div>
+  <ion-col class="component-label" col-32 align-self-center>
+    <label>Route number</label>
+  </ion-col>
+  <ion-col align-self-center>
+    <ion-row class="spacing-row"></ion-row>
+    <ion-row>
+      <ion-col col-32>
+        <input type="text" id="route" class="vehicle-reg-input mes-data" numberonly formControlName="routeNumber"
+          (change)="routeNumberChanged($event.target.value)">
+      </ion-col>
+    </ion-row>
+    <ion-row class="validation-message-row" align-items-center>
+      <div class="validation-text">
+        Enter the route number
+      </div>
+    </ion-row>
+  </ion-col>
+</ion-row>

--- a/src/pages/office/components/route-number/route-number.ts
+++ b/src/pages/office/components/route-number/route-number.ts
@@ -1,0 +1,39 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'route-number',
+  templateUrl: 'route-number.html',
+})
+export class RouteNumberComponent implements OnChanges {
+
+  @Input()
+  routeNumber: number;
+
+  @Input()
+  formGroup: FormGroup;
+
+  @Output()
+  routeNumberChange = new EventEmitter<number>();
+
+  private formControl: FormControl;
+
+  ngOnChanges(): void {
+    if (!this.formControl) {
+      this.formControl = new FormControl(null, [Validators.required]);
+      this.formGroup.addControl('routeNumber', this.formControl);
+    }
+    this.formControl.patchValue(this.routeNumber);
+  }
+
+  routeNumberChanged(routeNumber: string): void {
+    if (this.formControl.valid) {
+      this.routeNumberChange.emit(Number.parseInt(routeNumber, 10));
+    }
+  }
+
+  get invalid(): boolean {
+    return !this.formControl.valid && this.formControl.dirty;
+  }
+
+}

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -31,27 +31,10 @@
 
       <ion-card-content class="card-content-ios" no-bounce>
         <ion-grid class="grid">
-          <ion-row class="mes-validated-row mes-row-separator" id="route-number-card">
-            <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('routeNumberCtrl')"></div>
-            <ion-col class="component-label" col-32 align-self-center>
-              <label>Route number</label>
-            </ion-col>
-            <ion-col align-self-center>
-              <ion-row class="spacing-row"></ion-row>
-              <ion-row>
-                <ion-col col-32>
-                  <input #routeInput type="text" id="route" formControlName="routeNumberCtrl" class="mes-data"
-                    numberonly [class.ng-invalid]="isCtrlDirtyAndInvalid('routeNumberCtrl')"
-                    [value]="pageState.routeNumber$ | async">
-                </ion-col>
-              </ion-row>
-              <ion-row class="validation-message-row" align-items-center>
-                <div class="validation-text" [class.ng-invalid]="isCtrlDirtyAndInvalid('routeNumberCtrl')">
-                  Enter the route number
-                </div>
-              </ion-row>
-            </ion-col>
-          </ion-row>
+
+          <route-number [routeNumber]="pageState.routeNumber$ | async" (routeNumberChange)="routeNumberChanged($event)"
+            [formGroup]="form">
+          </route-number>
 
           <ion-row class="mes-validated-row mes-row-separator" id="independent-driving-card">
             <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('independentDrivingCtrl')">
@@ -364,8 +347,7 @@
             <ion-row>
               <driving-fault-comment [index]="$i" [competency]="drivingFault.propertyName"
                 [faultCount]="drivingFault.count" [faultName]="drivingFault.name"
-                [invalidIndicator]="isCtrlDirtyAndInvalid('drivingFaultCtrl' + $i)"
-                [parentForm]="form">
+                [invalidIndicator]="isCtrlDirtyAndInvalid('drivingFaultCtrl' + $i)" [parentForm]="form">
               </driving-fault-comment>
             </ion-row>
             <ion-row class="validation-message-row" align-items-center>

--- a/src/pages/office/office.module.ts
+++ b/src/pages/office/office.module.ts
@@ -6,9 +6,11 @@ import { OfficeAnalyticsEffects } from './office.analytics.effects';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import { ComponentsModule } from '../../components/components.module';
 import { OfficeComponentsModule } from './components/office.components.module';
+import { RouteNumberComponent } from './components/route-number/route-number';
 @NgModule({
   declarations: [
     OfficePage,
+    RouteNumberComponent,
   ],
   imports: [
     IonicPageModule.forChild(OfficePage),
@@ -20,4 +22,4 @@ import { OfficeComponentsModule } from './components/office.components.module';
     AnalyticsProvider,
   ],
 })
-export class OfficePageModule {}
+export class OfficePageModule { }

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -109,9 +109,6 @@ export class OfficePage extends BasePageComponent {
   toast: Toast;
   drivingFaultCtrl: String = 'drivingFaultCtrl';
 
-  @ViewChild('routeInput')
-  routeInput: ElementRef;
-
   @ViewChild('candidateDescriptionInput')
   candidateDescriptionInput: ElementRef;
 
@@ -268,7 +265,6 @@ export class OfficePage extends BasePageComponent {
 
     this.inputSubscriptions = [
       this.pageState.showMeQuestion$.subscribe(showMeQuestion => this.showMeQuestion = showMeQuestion),
-      this.inputChangeSubscriptionDispatchingAction(this.routeInput, RouteNumberChanged),
       this.inputChangeSubscriptionDispatchingAction(
         this.additionalInformationInput,
         AdditionalInformationChanged,
@@ -333,7 +329,6 @@ export class OfficePage extends BasePageComponent {
 
   getFormValidation(): { [key: string]: FormControl } {
     return {
-      routeNumberCtrl: new FormControl('', [Validators.required]),
       candidateDescriptionCtrl: new FormControl('', [Validators.required]),
       debriefWitnessedCtrl: new FormControl('', [Validators.required]),
       identificationCtrl: new FormControl('', [Validators.required]),
@@ -382,6 +377,10 @@ export class OfficePage extends BasePageComponent {
 
   weatherConditionsChanged(weatherConditions: WeatherConditions[]): void {
     this.store$.dispatch(new WeatherConditionsChanged(weatherConditions));
+  }
+
+  routeNumberChanged(routeNumber: number) {
+    this.store$.dispatch(new RouteNumberChanged(routeNumber));
   }
 
   private createToast = (errorMessage: string) => {


### PR DESCRIPTION
## Description and relevant Jira numbers
* Enable navigation back to Office page to finalise the write up
* Extract route number capture into a dedicated presentational component
* Have `RouteNumberComponent` handle it's form validation and repopulation of the form value
* Emit an event back to the Office page when the route number changes to update the store

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
