### PR TITLE
MES-2154: Extract candidate description capture into presentational component handling form repopulation (MES-1129)

### DIFF
--- a/src/pages/journal/components/test-outcome/test-outcome.html
+++ b/src/pages/journal/components/test-outcome/test-outcome.html
@@ -2,25 +2,30 @@
   <ion-grid no-padding>
     <ion-row align-items-right>
       <ion-col *ngIf="showOutcome()">
-        <span class="outcome"><h4>{{outcome}}</h4></span>
+        <span class="outcome">
+          <h4>{{outcome}}</h4>
+        </span>
       </ion-col>
       <ion-col *ngIf="showStartTestButton()">
         <span>
-          <button
-            class="mes-primary-button"
-            ion-button
-            (click)="startTest()"
-            [disabled]="!canStartTest"
-          >
+          <button class="mes-primary-button" ion-button (click)="startTest()" [disabled]="!canStartTest">
             <h3>Start test</h3>
           </button>
         </span>
       </ion-col>
       <ion-col *ngIf="showSubmitTestButton()">
-        <span><button class="mes-secondary-button" ion-button navPush="OfficePage"><h3>Submit</h3></button></span>
+        <span>
+          <button class="mes-secondary-button" ion-button>
+            <h3>Submit</h3>
+          </button>
+        </span>
       </ion-col>
       <ion-col *ngIf="needsWriteUp()">
-        <span><button class="mes-secondary-button mes-warning-button" ion-button><h3 class="write-up-label">Write-up</h3></button></span>
+        <span>
+          <button class="mes-secondary-button mes-warning-button" ion-button navPush="OfficePage">
+            <h3 class="write-up-label">Write-up</h3>
+          </button>
+        </span>
       </ion-col>
     </ion-row>
   </ion-grid>

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -32,6 +32,7 @@ import { of } from 'rxjs/observable/of';
 import { OfficeComponentsModule } from '../components/office.components.module';
 import { MockComponent } from 'ng-mocks';
 import { RouteNumberComponent } from '../components/route-number/route-number';
+import { CandidateDescriptionComponent } from '../components/candidate-description/candidate-description';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficePage>;
@@ -44,6 +45,7 @@ describe('OfficePage', () => {
       declarations: [
         OfficePage,
         MockComponent(RouteNumberComponent),
+        MockComponent(CandidateDescriptionComponent),
       ],
       imports: [IonicModule, AppModule, ComponentsModule, OfficeComponentsModule,
         StoreModule.forRoot({

--- a/src/pages/office/components/candidate-description/candidate-description.html
+++ b/src/pages/office/components/candidate-description/candidate-description.html
@@ -1,0 +1,23 @@
+<ion-row class="mes-validated-row mes-row-separator" id="candidate-description-card" [formGroup]="formGroup">
+  <div class="validation-bar" [class.ng-invalid]="invalid">
+  </div>
+  <ion-col class="component-label" col-32 align-self-center>
+    <label>Physical description of the candidate</label>
+  </ion-col>
+  <ion-col align-self-center>
+    <ion-row class="spacing-row"></ion-row>
+    <ion-row>
+      <ion-col col-64>
+        <textarea id="physical-description" formControlName="candidateDescription" class="vehicle-reg-input mes-data"
+          [class.ng-invalid]="invalid" [value]="candidateDescription"
+          (change)="candidateDescriptionChanged($event.target.value)">
+        </textarea>
+      </ion-col>
+    </ion-row>
+    <ion-row class="validation-message-row" align-items-center>
+      <div class="validation-text" [class.ng-invalid]="invalid">
+        Describe the candidate
+      </div>
+    </ion-row>
+  </ion-col>
+</ion-row>

--- a/src/pages/office/components/candidate-description/candidate-description.ts
+++ b/src/pages/office/components/candidate-description/candidate-description.ts
@@ -1,0 +1,39 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'candidate-description',
+  templateUrl: 'candidate-description.html',
+})
+export class CandidateDescriptionComponent implements OnChanges {
+
+  @Input()
+  candidateDescription: string;
+
+  @Input()
+  formGroup: FormGroup;
+
+  @Output()
+  candidateDescriptionChange = new EventEmitter<string>();
+
+  private formControl: FormControl;
+
+  ngOnChanges(): void {
+    if (!this.formControl) {
+      this.formControl = new FormControl(null, [Validators.required]);
+      this.formGroup.addControl('candidateDescription', this.formControl);
+    }
+    this.formControl.patchValue(this.candidateDescription);
+  }
+
+  candidateDescriptionChanged(candidateDescription: string): void {
+    if (this.formControl.valid) {
+      this.candidateDescriptionChange.emit(candidateDescription);
+    }
+  }
+
+  get invalid(): boolean {
+    return !this.formControl.valid && this.formControl.dirty;
+  }
+
+}

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -67,30 +67,9 @@
               </ion-row>
             </ion-col>
           </ion-row>
-          <ion-row class="mes-validated-row mes-row-separator" id="candidate-description-card">
-            <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('candidateDescriptionCtrl')">
-            </div>
-            <ion-col class="component-label" col-32 align-self-center>
-              <label>Physical description of the candidate</label>
-            </ion-col>
-            <ion-col align-self-center>
-              <ion-row class="spacing-row"></ion-row>
-              <ion-row>
-                <ion-col col-64>
-                  <textarea #candidateDescriptionInput id="physical-description"
-                    formControlName="candidateDescriptionCtrl" class="mes-data"
-                    [class.ng-invalid]="isCtrlDirtyAndInvalid('candidateDescriptionCtrl')"
-                    [value]="pageState.candidateDescription$ | async">
-                          </textarea>
-                </ion-col>
-              </ion-row>
-              <ion-row class="validation-message-row" align-items-center>
-                <div class="validation-text" [class.ng-invalid]="isCtrlDirtyAndInvalid('candidateDescriptionCtrl')">
-                  Describe the candidate
-                </div>
-              </ion-row>
-            </ion-col>
-          </ion-row>
+
+          <candidate-description [formGroup]="form" [candidateDescription]="pageState.candidateDescription$ | async"
+            (candidateDescriptionChange)="candidateDescriptionChanged($event)"></candidate-description>
 
           <ion-row class="mes-validated-row mes-row-separator" id="debrief-card">
             <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('debriefWitnessedCtrl')">

--- a/src/pages/office/office.module.ts
+++ b/src/pages/office/office.module.ts
@@ -7,10 +7,12 @@ import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import { ComponentsModule } from '../../components/components.module';
 import { OfficeComponentsModule } from './components/office.components.module';
 import { RouteNumberComponent } from './components/route-number/route-number';
+import { CandidateDescriptionComponent } from './components/candidate-description/candidate-description';
 @NgModule({
   declarations: [
     OfficePage,
     RouteNumberComponent,
+    CandidateDescriptionComponent,
   ],
   imports: [
     IonicPageModule.forChild(OfficePage),

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -69,6 +69,7 @@ import { FaultCount } from '../../shared/constants/competencies/catb-competencie
 import { WeatherConditionSelection } from '../../providers/weather-conditions/weather-conditions.model';
 import { WeatherConditionProvider } from '../../providers/weather-conditions/weather-condition';
 import { WeatherConditions } from '@dvsa/mes-test-schema/categories/B';
+import { merge } from 'rxjs/observable/merge';
 
 interface OfficePageState {
   startTime$: Observable<string>;
@@ -109,9 +110,6 @@ export class OfficePage extends BasePageComponent {
   toast: Toast;
   drivingFaultCtrl: String = 'drivingFaultCtrl';
 
-  @ViewChild('candidateDescriptionInput')
-  candidateDescriptionInput: ElementRef;
-
   @ViewChild('additionalInformationInput')
   additionalInformationInput: ElementRef;
 
@@ -119,6 +117,7 @@ export class OfficePage extends BasePageComponent {
   dangerousFaultComment: QueryList<ElementRef>;
 
   inputSubscriptions: Subscription[] = [];
+  storeSubscription: Subscription;
   drivingFaultSubscription: Subscription;
 
   weatherConditions: WeatherConditionSelection[];
@@ -257,6 +256,11 @@ export class OfficePage extends BasePageComponent {
       ),
     };
 
+    this.storeSubscription = merge(
+      this.pageState.routeNumber$,
+      this.pageState.candidateDescription$,
+    ).subscribe();
+
     this.drivingFaultSubscription = this.pageState.displayDrivingFaultComments$.subscribe((display) => {
       if (display) {
         this.getDrivingFaultCtrls();
@@ -269,7 +273,6 @@ export class OfficePage extends BasePageComponent {
         this.additionalInformationInput,
         AdditionalInformationChanged,
       ),
-      this.inputChangeSubscriptionDispatchingAction(this.candidateDescriptionInput, CandidateDescriptionChanged),
     ];
 
   }
@@ -284,6 +287,7 @@ export class OfficePage extends BasePageComponent {
   ngOnDestroy(): void {
     this.inputSubscriptions.forEach(sub => sub.unsubscribe());
     this.drivingFaultSubscription.unsubscribe();
+    this.storeSubscription.unsubscribe();
   }
 
   popToRoot() {
@@ -381,6 +385,10 @@ export class OfficePage extends BasePageComponent {
 
   routeNumberChanged(routeNumber: number) {
     this.store$.dispatch(new RouteNumberChanged(routeNumber));
+  }
+
+  candidateDescriptionChanged(candidateDescription: string) {
+    this.store$.dispatch(new CandidateDescriptionChanged(candidateDescription));
   }
 
   private createToast = (errorMessage: string) => {


### PR DESCRIPTION
## Description and relevant Jira numbers
* Extract candidate description capture into a dedicated presentational component
* Have `CandidateDescriptionComponent` handle it's form validation and repopulation of the form value
* Emit an event back to the Office page when the candidate description changes to update the store

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
