### PR TITLE
MES-2156: Extract debrief witnessed presentational component to handle form repopulation (MES-1129)

### DIFF
--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -47,7 +47,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1001,
-        "start": "2019-04-23T08:10:00+01:00"
+        "start": "2019-04-24T08:10:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -95,7 +95,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1003,
-        "start": "2019-04-23T10:14:00+01:00"
+        "start": "2019-04-24T10:14:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -144,7 +144,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1004,
-        "start": "2019-04-23T11:11:00+01:00"
+        "start": "2019-04-24T11:11:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -195,7 +195,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1005,
-        "start": "2019-04-23T12:38:00+01:00"
+        "start": "2019-04-24T12:38:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -248,7 +248,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1006,
-        "start": "2019-04-23T13:35:00+01:00"
+        "start": "2019-04-24T13:35:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -293,7 +293,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1007,
-        "start": "2019-04-24T14:32:00+01:00"
+        "start": "2019-04-25T14:32:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,

--- a/src/modules/tests/test-summary/test-summary.selector.ts
+++ b/src/modules/tests/test-summary/test-summary.selector.ts
@@ -15,6 +15,3 @@ export const getSatNavUsed = (testSummary: TestSummary): boolean => testSummary.
 export const getTrafficSignsUsed = (testSummary: TestSummary): boolean =>
   testSummary.independentDriving === 'Traffic signs';
 export const isDebriefWitnessed = (testSummary: TestSummary): boolean => testSummary.debriefWitnessed;
-export const isDebriefUnwitnessed = (testSummary: TestSummary): boolean => {
-  return (testSummary.debriefWitnessed != null && !testSummary.debriefWitnessed) || false;
-};

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -20,8 +20,6 @@ import {
 import { PersistTests } from '../../../modules/tests/tests.actions';
 import {
   IndependentDrivingTypeChanged,
-  DebriefWitnessed,
-  DebriefUnwitnessed,
   IdentificationUsedChanged,
   D255Yes,
   D255No,
@@ -33,6 +31,7 @@ import { OfficeComponentsModule } from '../components/office.components.module';
 import { MockComponent } from 'ng-mocks';
 import { RouteNumberComponent } from '../components/route-number/route-number';
 import { CandidateDescriptionComponent } from '../components/candidate-description/candidate-description';
+import { DebriefWitnessedComponent } from '../components/debrief-witnessed/debrief-witnessed';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficePage>;
@@ -46,6 +45,7 @@ describe('OfficePage', () => {
         OfficePage,
         MockComponent(RouteNumberComponent),
         MockComponent(CandidateDescriptionComponent),
+        MockComponent(DebriefWitnessedComponent),
       ],
       imports: [IonicModule, AppModule, ComponentsModule, OfficeComponentsModule,
         StoreModule.forRoot({
@@ -178,21 +178,6 @@ describe('OfficePage', () => {
 
         expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
         expect(navCtrl.popToRoot).toHaveBeenCalled();
-      });
-    });
-
-    describe('changing debrief witnessed', () => {
-      it('should dispatch a change to debrief witnessed action when Yes is clicked', () => {
-        const witnessedRadio = fixture.debugElement.query(By.css('#debrief-witnessed-yes'));
-        witnessedRadio.triggerEventHandler('click', null);
-        fixture.detectChanges();
-        expect(store$.dispatch).toHaveBeenCalledWith(new DebriefWitnessed());
-      });
-      it('should dispatch a change to debrief unwitnessed when No is clicked', () => {
-        const unwitnessedRadio = fixture.debugElement.query(By.css('#debrief-witnessed-no'));
-        unwitnessedRadio.triggerEventHandler('click', null);
-        fixture.detectChanges();
-        expect(store$.dispatch).toHaveBeenCalledWith(new DebriefUnwitnessed());
       });
     });
 

--- a/src/pages/office/components/debrief-witnessed/debrief-witnessed.html
+++ b/src/pages/office/components/debrief-witnessed/debrief-witnessed.html
@@ -1,0 +1,29 @@
+<ion-row class="mes-validated-row mes-row-separator" id="debrief-card" [formGroup]="formGroup">
+  <div class="validation-bar" [class.ng-invalid]="invalid">
+  </div>
+  <ion-col class="component-label" col-32 align-self-center>
+    <label>Debrief witnessed?</label>
+  </ion-col>
+  <ion-col align-self-center>
+    <ion-row class="spacing-row"></ion-row>
+    <ion-row>
+      <ion-col col-32>
+        <input type="radio" formControlName="debriefWitnessed" id="debrief-witnessed-yes" name="debriefWitnessed"
+          formControlName="debriefWitnessed" class="gds-radio-button" [class.ng-invalid]="invalid" value="Yes"
+          [checked]="debriefWitnessed === true" (change)="debriefWitnessedChanged($event.target.value)">
+        <label for="debrief-witnessed-yes" class="radio-label">Yes</label>
+      </ion-col>
+      <ion-col col-32>
+        <input type="radio" formControlName="debriefWitnessed" id="debrief-witnessed-no" name="debriefWitnessed"
+          formControlName="debriefWitnessed" class="gds-radio-button" [class.ng-invalid]="invalid" value="No"
+          [checked]="debriefWitnessed === false" (change)="debriefWitnessedChanged($event.target.value)">
+        <label for="debrief-witnessed-no" class="radio-label">No</label>
+      </ion-col>
+    </ion-row>
+    <ion-row class="validation-message-row" align-items-center>
+      <div class="validation-text" [class.ng-invalid]="invalid">
+        Was the debrief witnessed?
+      </div>
+    </ion-row>
+  </ion-col>
+</ion-row>

--- a/src/pages/office/components/debrief-witnessed/debrief-witnessed.ts
+++ b/src/pages/office/components/debrief-witnessed/debrief-witnessed.ts
@@ -1,0 +1,41 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'debrief-witnessed',
+  templateUrl: 'debrief-witnessed.html',
+})
+export class DebriefWitnessedComponent implements OnChanges {
+
+  @Input()
+  debriefWitnessed: boolean;
+
+  @Input()
+  formGroup: FormGroup;
+
+  @Output()
+  debriefWitnessedChange = new EventEmitter<boolean>();
+
+  private formControl: FormControl;
+
+  ngOnChanges(): void {
+    if (!this.formControl) {
+      this.formControl = new FormControl(null, [Validators.required]);
+      this.formGroup.addControl('debriefWitnessed', this.formControl);
+    }
+    if (this.debriefWitnessed !== null) {
+      this.formControl.patchValue(this.debriefWitnessed ? 'Yes' : 'No');
+    }
+  }
+
+  debriefWitnessedChanged(debriefWitnessedFormValue: string): void {
+    if (this.formControl.valid) {
+      this.debriefWitnessedChange.emit(debriefWitnessedFormValue === 'Yes' ? true : false);
+    }
+  }
+
+  get invalid(): boolean {
+    return !this.formControl.valid && this.formControl.dirty;
+  }
+
+}

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -71,37 +71,8 @@
           <candidate-description [formGroup]="form" [candidateDescription]="pageState.candidateDescription$ | async"
             (candidateDescriptionChange)="candidateDescriptionChanged($event)"></candidate-description>
 
-          <ion-row class="mes-validated-row mes-row-separator" id="debrief-card">
-            <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('debriefWitnessedCtrl')">
-            </div>
-            <ion-col class="component-label" col-32 align-self-center>
-              <label>Debrief witnessed?</label>
-            </ion-col>
-            <ion-col align-self-center>
-              <ion-row class="spacing-row"></ion-row>
-              <ion-row>
-                <ion-col col-32>
-                  <input type="radio" formControlName="debriefWitnessedCtrl" name="debriefWitnessedCtrl"
-                    id="debrief-witnessed-yes" class="gds-radio-button"
-                    [class.ng-invalid]="isCtrlDirtyAndInvalid('debriefWitnessedCtrl')" (click)="debriefWitnessed()"
-                    [checked]="pageState.debriefWitnessedYesRadioChecked$ | async" value='Yes'>
-                  <label for="debrief-witnessed-yes" class="radio-label">Yes</label>
-                </ion-col>
-                <ion-col col-32>
-                  <input type="radio" formControlName="debriefWitnessedCtrl" name="debriefWitnessedCtrl"
-                    id="debrief-witnessed-no" class="gds-radio-button"
-                    [class.ng-invalid]="isCtrlDirtyAndInvalid('debriefWitnessedCtrl')" (click)="debriefUnwitnessed()"
-                    [checked]="pageState.debriefWitnessedNoRadioChecked$ | async" value='No'>
-                  <label for="debrief-witnessed-no" class="radio-label">No</label>
-                </ion-col>
-              </ion-row>
-              <ion-row class="validation-message-row" align-items-center>
-                <div class="validation-text" [class.ng-invalid]="isCtrlDirtyAndInvalid('debriefWitnessedCtrl')">
-                  Was the debrief witnessed?
-                </div>
-              </ion-row>
-            </ion-col>
-          </ion-row>
+          <debrief-witnessed [formGroup]="form" [debriefWitnessed]="pageState.debriefWitnessed$ | async"
+            (debriefWitnessedChange)="debriefWitnessedChanged($event)"></debrief-witnessed>
 
           <ion-row class="mes-validated-row mes-row-separator" id="identification-card">
             <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('identificationCtrl')">

--- a/src/pages/office/office.module.ts
+++ b/src/pages/office/office.module.ts
@@ -8,11 +8,13 @@ import { ComponentsModule } from '../../components/components.module';
 import { OfficeComponentsModule } from './components/office.components.module';
 import { RouteNumberComponent } from './components/route-number/route-number';
 import { CandidateDescriptionComponent } from './components/candidate-description/candidate-description';
+import { DebriefWitnessedComponent } from './components/debrief-witnessed/debrief-witnessed';
 @NgModule({
   declarations: [
     OfficePage,
     RouteNumberComponent,
     CandidateDescriptionComponent,
+    DebriefWitnessedComponent,
   ],
   imports: [
     IonicPageModule.forChild(OfficePage),

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -24,7 +24,6 @@ import {
   getSatNavUsed,
   getTrafficSignsUsed,
   isDebriefWitnessed,
-  isDebriefUnwitnessed,
 } from '../../modules/tests/test-summary/test-summary.selector';
 import { getTestSummary } from '../../modules/tests/test-summary/test-summary.reducer';
 import { fromEvent } from 'rxjs/Observable/fromEvent';
@@ -79,8 +78,7 @@ interface OfficePageState {
   candidateName$: Observable<string>;
   candidateDriverNumber$: Observable<string>;
   routeNumber$: Observable<number>;
-  debriefWitnessedYesRadioChecked$: Observable<boolean>;
-  debriefWitnessedNoRadioChecked$: Observable<boolean>;
+  debriefWitnessed$: Observable<boolean>;
   identificationLicenseRadioChecked$: Observable<boolean>;
   identificationPassportRadioChecked$: Observable<boolean>;
   independentDrivingSatNavRadioChecked$: Observable<boolean>;
@@ -189,13 +187,9 @@ export class OfficePage extends BasePageComponent {
         select(getTestSummary),
         select(getTrafficSignsUsed),
       ),
-      debriefWitnessedYesRadioChecked$: currentTest$.pipe(
+      debriefWitnessed$: currentTest$.pipe(
         select(getTestSummary),
         select(isDebriefWitnessed),
-      ),
-      debriefWitnessedNoRadioChecked$: currentTest$.pipe(
-        select(getTestSummary),
-        select(isDebriefUnwitnessed),
       ),
       identificationLicenseRadioChecked$: currentTest$.pipe(
         select(getTestSummary),
@@ -259,6 +253,7 @@ export class OfficePage extends BasePageComponent {
     this.storeSubscription = merge(
       this.pageState.routeNumber$,
       this.pageState.candidateDescription$,
+      this.pageState.debriefWitnessed$,
     ).subscribe();
 
     this.drivingFaultSubscription = this.pageState.displayDrivingFaultComments$.subscribe((display) => {
@@ -334,7 +329,6 @@ export class OfficePage extends BasePageComponent {
   getFormValidation(): { [key: string]: FormControl } {
     return {
       candidateDescriptionCtrl: new FormControl('', [Validators.required]),
-      debriefWitnessedCtrl: new FormControl('', [Validators.required]),
       identificationCtrl: new FormControl('', [Validators.required]),
       independentDrivingCtrl: new FormControl('', [Validators.required]),
       d255Ctrl: new FormControl('', [Validators.required]),
@@ -389,6 +383,10 @@ export class OfficePage extends BasePageComponent {
 
   candidateDescriptionChanged(candidateDescription: string) {
     this.store$.dispatch(new CandidateDescriptionChanged(candidateDescription));
+  }
+
+  debriefWitnessedChanged(debriefWitnessed: boolean) {
+    this.store$.dispatch(debriefWitnessed ? new DebriefWitnessed() : new DebriefUnwitnessed());
   }
 
   private createToast = (errorMessage: string) => {


### PR DESCRIPTION
## Description and relevant Jira numbers
* Extract debrief witnessed capture into a dedicated presentational component
* Have `DebriefWitnessed` handle it's form validation and repopulation of the form value
* Emit an event back to the Office page when the debrief witnessed status changes to update the store

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
