### PR TITLE
MES-2156: Extract identification presentational component to handle form repopulation (MES-1129)

### DIFF
--- a/src/modules/tests/test-summary/test-summary.actions.ts
+++ b/src/modules/tests/test-summary/test-summary.actions.ts
@@ -1,5 +1,5 @@
 import { Action } from '@ngrx/store';
-import { WeatherConditions } from '@dvsa/mes-test-schema/categories/B';
+import { WeatherConditions, Identification } from '@dvsa/mes-test-schema/categories/B';
 
 export const CANDIDATE_DESCRIPTION_CHANGED = '[Test Summary] Candidate description changed';
 export const ADDITIONAL_INFORMATION_CHANGED = '[Test Summary] Additional Information changed';
@@ -14,16 +14,16 @@ export const WEATHER_CONDITIONS_CHANGED = '[Test Summary] Weather conditions cha
 
 export class AdditionalInformationChanged implements Action {
   readonly type = ADDITIONAL_INFORMATION_CHANGED;
-  constructor(public additionalInformation: string) {}
+  constructor(public additionalInformation: string) { }
 }
 export class CandidateDescriptionChanged implements Action {
   readonly type = CANDIDATE_DESCRIPTION_CHANGED;
-  constructor(public description: string) {}
+  constructor(public description: string) { }
 }
 
 export class RouteNumberChanged implements Action {
   readonly type = ROUTE_NUMBER_CHANGED;
-  constructor(public routeNumber: number) {}
+  constructor(public routeNumber: number) { }
 }
 
 export class DebriefWitnessed implements Action {
@@ -36,12 +36,12 @@ export class DebriefUnwitnessed implements Action {
 
 export class IdentificationUsedChanged implements Action {
   readonly type = IDENTIFICATION_USED_CHANGED;
-  constructor(public identification: any) {}
+  constructor(public identification: Identification) { }
 }
 
 export class IndependentDrivingTypeChanged implements Action {
   readonly type = INDEPENDENT_DRIVING_TYPE_CHANGED;
-  constructor(public drivingType: any) {}
+  constructor(public drivingType: any) { }
 }
 
 export class D255Yes implements Action {
@@ -53,7 +53,7 @@ export class D255No implements Action {
 
 export class WeatherConditionsChanged implements Action {
   readonly type = WEATHER_CONDITIONS_CHANGED;
-  constructor(public weatherConditions: WeatherConditions[]) {}
+  constructor(public weatherConditions: WeatherConditions[]) { }
 }
 
 export type Types =

--- a/src/modules/tests/test-summary/test-summary.selector.ts
+++ b/src/modules/tests/test-summary/test-summary.selector.ts
@@ -1,15 +1,11 @@
-import { TestSummary, WeatherConditions } from '@dvsa/mes-test-schema/categories/B';
+import { TestSummary, WeatherConditions, Identification } from '@dvsa/mes-test-schema/categories/B';
 
-export const getRouteNumber = (testSummary: TestSummary): number => testSummary.routeNumber;
-export const getCandidateDescription = (testSummary: TestSummary): string => testSummary.candidateDescription;
-export const getAdditionalInformation = (testSummary: TestSummary): string => testSummary.additionalInformation;
-export const isIdentificationLicense = (testSummary: TestSummary): boolean =>
-  testSummary.identification === 'Licence';
-export const isIdentificationPassport = (testSummary: TestSummary): boolean =>
-  testSummary.identification === 'Passport';
-export const getD255 = (testSummary: TestSummary): boolean => testSummary.D255;
-export const getSatNavUsed = (testSummary: TestSummary): boolean => testSummary.independentDriving === 'Sat nav';
-export const getTrafficSignsUsed = (testSummary: TestSummary): boolean =>
-  testSummary.independentDriving === 'Traffic signs';
-export const isDebriefWitnessed = (testSummary: TestSummary): boolean => testSummary.debriefWitnessed;
-export const getWeatherConditions = (testSummary: TestSummary): WeatherConditions[] => testSummary.weatherConditions;
+export const getRouteNumber = (ts: TestSummary): number => ts.routeNumber;
+export const getCandidateDescription = (ts: TestSummary): string => ts.candidateDescription;
+export const getAdditionalInformation = (ts: TestSummary): string => ts.additionalInformation;
+export const getD255 = (ts: TestSummary): boolean => ts.D255;
+export const getIdentification = (ts: TestSummary): Identification => ts.identification;
+export const getSatNavUsed = (ts: TestSummary): boolean => ts.independentDriving === 'Sat nav';
+export const getTrafficSignsUsed = (ts: TestSummary): boolean => ts.independentDriving === 'Traffic signs';
+export const isDebriefWitnessed = (ts: TestSummary): boolean => ts.debriefWitnessed;
+export const getWeatherConditions = (ts: TestSummary): WeatherConditions[] => ts.weatherConditions;

--- a/src/pages/debrief/debrief.selector.ts
+++ b/src/pages/debrief/debrief.selector.ts
@@ -2,7 +2,7 @@ import { forOwn } from 'lodash';
 import { SeriousFaults, DrivingFaults, DangerousFaults, TestData } from '@dvsa/mes-test-schema/categories/B';
 import { competencyLabels } from '../test-report/components/competency/competency.constants';
 import { FaultCount, fullCompetencyLabels, SeriousFaultsContainer }
- from '../../shared/constants/competencies/catb-competencies';
+  from '../../shared/constants/competencies/catb-competencies';
 
 export const getSeriousOrDangerousFaults = (faults: SeriousFaults | DangerousFaults): string[] => {
   const faultsEncountered: string[] = [];
@@ -16,7 +16,7 @@ export const getSeriousOrDangerousFaults = (faults: SeriousFaults | DangerousFau
 };
 
 export const getDrivingFaults = (faults: DrivingFaults): FaultCount[] => {
-  const faultsEncountered : FaultCount[] = [];
+  const faultsEncountered: FaultCount[] = [];
   forOwn(faults, (value: number, key) => {
     if (value > 0 && !key.endsWith('Comments')) {
       const label = key as keyof typeof competencyLabels;
@@ -26,8 +26,8 @@ export const getDrivingFaults = (faults: DrivingFaults): FaultCount[] => {
   return faultsEncountered.sort((a, b) => b.count - a.count);
 };
 
-export const displayDrivingFaultComments = (data: TestData) : boolean => {
-  const seriousFaults =  getSeriousOrDangerousFaults(data.seriousFaults);
+export const displayDrivingFaultComments = (data: TestData): boolean => {
+  const seriousFaults = getSeriousOrDangerousFaults(data.seriousFaults);
   const dangerousFaults = getSeriousOrDangerousFaults(data.dangerousFaults);
   let drivingFaultCount: number = 0;
 
@@ -85,6 +85,6 @@ export const getSeriousFaults = (faults: SeriousFaults): SeriousFaultsContainer[
 
 export const getDrivingFaultComment = (
   faults: DrivingFaults | DangerousFaults | SeriousFaults, competency: string,
-  ): string => {
+): string => {
   return faults[competency] || '';
 };

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -25,7 +25,6 @@ import {
 import { PersistTests } from '../../../modules/tests/tests.actions';
 import {
   IndependentDrivingTypeChanged,
-  IdentificationUsedChanged,
   WeatherConditionsChanged,
 } from '../../../modules/tests/test-summary/test-summary.actions';
 import { WeatherConditions } from '@dvsa/mes-test-schema/categories/B';
@@ -39,6 +38,7 @@ import { ShowMeQuestionComponent } from '../components/show-me-question/show-me-
 import { WeatherConditionsComponent } from '../components/weather-conditions/weather-conditions';
 import { D255Component } from '../components/d255/d255';
 import { AdditionalInformationComponent } from '../components/additional-information/additional-information';
+import { IdentificationComponent } from '../components/identification/identification';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficePage>;
@@ -53,6 +53,7 @@ describe('OfficePage', () => {
         MockComponent(RouteNumberComponent),
         MockComponent(CandidateDescriptionComponent),
         MockComponent(DebriefWitnessedComponent),
+        MockComponent(IdentificationComponent),
         MockComponent(ShowMeQuestionComponent),
         MockComponent(WeatherConditionsComponent),
         MockComponent(D255Component),
@@ -212,21 +213,6 @@ describe('OfficePage', () => {
         trafficSignsRadio.triggerEventHandler('click', null);
         fixture.detectChanges();
         expect(store$.dispatch).toHaveBeenCalledWith(new IndependentDrivingTypeChanged('Traffic signs'));
-      });
-    });
-
-    describe('changing identification', () => {
-      it('should dispatch a change to identification action when Licence is clicked', () => {
-        const licenceRadio = fixture.debugElement.query(By.css('#identification-license'));
-        licenceRadio.triggerEventHandler('click', null);
-        fixture.detectChanges();
-        expect(store$.dispatch).toHaveBeenCalledWith(new IdentificationUsedChanged('Licence'));
-      });
-      it('should dispatch a change to identification action when Passport is clicked', () => {
-        const passportRadio = fixture.debugElement.query(By.css('#identification-passport'));
-        passportRadio.triggerEventHandler('click', null);
-        fixture.detectChanges();
-        expect(store$.dispatch).toHaveBeenCalledWith(new IdentificationUsedChanged('Passport'));
       });
     });
 

--- a/src/pages/office/components/identification/identification.html
+++ b/src/pages/office/components/identification/identification.html
@@ -1,0 +1,26 @@
+<ion-row class="mes-validated-row mes-row-separator" id="identification-card" [formGroup]="formGroup">
+  <div class="validation-bar"></div>
+  <ion-col class="component-label" col-32 align-self-center>
+    <label>Identification</label>
+  </ion-col>
+  <ion-col align-self-center>
+    <ion-row class="spacing-row"></ion-row>
+    <ion-row>
+      <ion-col col-32>
+        <input type="radio" id="identification-license" class="gds-radio-button" name="identification"
+          formControlName="identification" value="Licence" [checked]="identification === 'Licence'"
+          (change)="identificationChanged($event.target.value)">
+        <label for="identification-license" class="radio-label">Licence</label>
+      </ion-col>
+      <ion-col col-32>
+        <input type="radio" id="identification-passport" class="gds-radio-button" name="identification"
+          formControlName="identification" [class.ng-invalid]="invalid" value="Passport"
+          [checked]="identification === 'Passport'" (change)="identificationChanged($event.target.value)">
+        <label for="identification-passport" class="radio-label">Passport</label>
+      </ion-col>
+    </ion-row>
+    <ion-row class="validation-message-row" align-items-center>
+      <div class="validation-text"></div>
+    </ion-row>
+  </ion-col>
+</ion-row>

--- a/src/pages/office/components/identification/identification.ts
+++ b/src/pages/office/components/identification/identification.ts
@@ -1,0 +1,37 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+
+import { Identification } from '@dvsa/mes-test-schema/categories/B';
+
+@Component({
+  selector: 'identification',
+  templateUrl: 'identification.html',
+})
+export class IdentificationComponent implements OnChanges {
+
+  @Input()
+  identification: Identification;
+
+  @Input()
+  formGroup: FormGroup;
+
+  @Output()
+  identificationChange = new EventEmitter<Identification>();
+
+  private formControl: FormControl;
+
+  ngOnChanges(): void {
+    if (!this.formControl) {
+      this.formControl = new FormControl('Licence', [Validators.required]);
+      this.formGroup.addControl('identification', this.formControl);
+    }
+    this.formControl.patchValue(this.identification);
+  }
+
+  identificationChanged(identification: Identification): void {
+    if (this.formControl.valid) {
+      this.identificationChange.emit(identification);
+    }
+  }
+
+}

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -74,37 +74,10 @@
           <debrief-witnessed [formGroup]="form" [debriefWitnessed]="pageState.debriefWitnessed$ | async"
             (debriefWitnessedChange)="debriefWitnessedChanged($event)"></debrief-witnessed>
 
-          <ion-row class="mes-validated-row mes-row-separator" id="identification-card">
-            <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('identificationCtrl')">
-            </div>
-            <ion-col class="component-label" col-32 align-self-center>
-              <label>Identification</label>
-            </ion-col>
-            <ion-col align-self-center>
-              <ion-row class="spacing-row"></ion-row>
-              <ion-row>
-                <ion-col col-32>
-                  <input type="radio" formControlName="identificationCtrl" name="identificationCtrl"
-                    id="identification-license" class="gds-radio-button"
-                    [class.ng-invalid]="isCtrlDirtyAndInvalid('identificationCtrl')" (click)="identificationLicence()"
-                    [checked]="pageState.identificationLicenseRadioChecked$ | async" value='Licence'>
-                  <label for="identification-license" class="radio-label">Licence</label>
-                </ion-col>
-                <ion-col col-32>
-                  <input type="radio" formControlName="identificationCtrl" name="identificationCtrl"
-                    id="identification-passport" class="gds-radio-button"
-                    [class.ng-invalid]="isCtrlDirtyAndInvalid('identificationCtrl')" (click)="identificationPassport()"
-                    [checked]="pageState.identificationPassportRadioChecked$ | async" value='Passport'>
-                  <label for="identification-passport" class="radio-label">Passport</label>
-                </ion-col>
-              </ion-row>
-              <ion-row class="validation-message-row" align-items-center>
-                <div class="validation-text" [class.ng-invalid]="isCtrlDirtyAndInvalid('identificationCtrl')">
-                  Select the proof of identity
-                </div>
-              </ion-row>
-            </ion-col>
-          </ion-row>
+          <identification [formGroup]="form" [identification]="pageState.identification$ | async"
+            (identificationChange)="identificationChanged($event)">
+          </identification>
+
           <ion-row class="mes-validated-row mes-row-separator" id="tell-me-question-card">
             <div class="validation-bar"></div>
             <ion-col class="component-label" col-32 align-self-center>

--- a/src/pages/office/office.module.ts
+++ b/src/pages/office/office.module.ts
@@ -9,6 +9,7 @@ import { OfficeComponentsModule } from './components/office.components.module';
 import { RouteNumberComponent } from './components/route-number/route-number';
 import { CandidateDescriptionComponent } from './components/candidate-description/candidate-description';
 import { DebriefWitnessedComponent } from './components/debrief-witnessed/debrief-witnessed';
+import { IdentificationComponent } from './components/identification/identification';
 import { ShowMeQuestionComponent } from './components/show-me-question/show-me-question';
 import { WeatherConditionsComponent } from './components/weather-conditions/weather-conditions';
 import { D255Component } from './components/d255/d255';
@@ -20,6 +21,7 @@ import { AdditionalInformationComponent } from './components/additional-informat
     RouteNumberComponent,
     CandidateDescriptionComponent,
     DebriefWitnessedComponent,
+    IdentificationComponent,
     ShowMeQuestionComponent,
     WeatherConditionsComponent,
     D255Component,

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -15,14 +15,13 @@ import { getTests } from '../../modules/tests/tests.reducer';
 import {
   getRouteNumber,
   getCandidateDescription,
-  isIdentificationLicense,
-  isIdentificationPassport,
   getD255,
   getAdditionalInformation,
   getSatNavUsed,
   getTrafficSignsUsed,
   isDebriefWitnessed,
   getWeatherConditions,
+  getIdentification,
 } from '../../modules/tests/test-summary/test-summary.selector';
 import { getTestSummary } from '../../modules/tests/test-summary/test-summary.reducer';
 import { fromEvent } from 'rxjs/Observable/fromEvent';
@@ -67,7 +66,7 @@ import {
 import { FaultCount, SeriousFaultsContainer } from '../../shared/constants/competencies/catb-competencies';
 import { WeatherConditionSelection } from '../../providers/weather-conditions/weather-conditions.model';
 import { WeatherConditionProvider } from '../../providers/weather-conditions/weather-condition';
-import { WeatherConditions } from '@dvsa/mes-test-schema/categories/B';
+import { WeatherConditions, Identification } from '@dvsa/mes-test-schema/categories/B';
 import { merge } from 'rxjs/observable/merge';
 
 interface OfficePageState {
@@ -79,8 +78,7 @@ interface OfficePageState {
   candidateDriverNumber$: Observable<string>;
   routeNumber$: Observable<number>;
   debriefWitnessed$: Observable<boolean>;
-  identificationLicenseRadioChecked$: Observable<boolean>;
-  identificationPassportRadioChecked$: Observable<boolean>;
+  identification$: Observable<Identification>;
   independentDrivingSatNavRadioChecked$: Observable<boolean>;
   independentDrivingTrafficSignsRadioChecked$: Observable<boolean>;
   d255$: Observable<boolean>;
@@ -193,13 +191,9 @@ export class OfficePage extends BasePageComponent {
         select(getTestSummary),
         select(isDebriefWitnessed),
       ),
-      identificationLicenseRadioChecked$: currentTest$.pipe(
+      identification$: currentTest$.pipe(
         select(getTestSummary),
-        select(isIdentificationLicense),
-      ),
-      identificationPassportRadioChecked$: currentTest$.pipe(
-        select(getTestSummary),
-        select(isIdentificationPassport),
+        select(getIdentification),
       ),
       d255$: currentTest$.pipe(
         select(getTestSummary),
@@ -264,6 +258,7 @@ export class OfficePage extends BasePageComponent {
       this.pageState.weatherConditions$,
       this.pageState.d255$,
       this.pageState.additionalInformation$,
+      this.pageState.identification$,
     ).subscribe();
 
     this.drivingFaultSubscription = this.pageState.displayDrivingFaultComments$.subscribe((display) => {
@@ -337,7 +332,6 @@ export class OfficePage extends BasePageComponent {
   getFormValidation(): { [key: string]: FormControl } {
     return {
       candidateDescriptionCtrl: new FormControl('', [Validators.required]),
-      identificationCtrl: new FormControl('', [Validators.required]),
       independentDrivingCtrl: new FormControl('', [Validators.required]),
     };
   }
@@ -354,12 +348,8 @@ export class OfficePage extends BasePageComponent {
     this.store$.dispatch(new DebriefUnwitnessed());
   }
 
-  identificationLicence(): void {
-    this.store$.dispatch(new IdentificationUsedChanged('Licence'));
-  }
-
-  identificationPassport(): void {
-    this.store$.dispatch(new IdentificationUsedChanged('Passport'));
+  identificationChanged(identification: Identification): void {
+    this.store$.dispatch(new IdentificationUsedChanged(identification));
   }
 
   satNavUsed(): void {


### PR DESCRIPTION
## Description and relevant Jira numbers
* **FYI Depends on https://github.com/dvsa/mes-api-definitions/pull/18 and requires a test schema dependency update once merged** ✅ 
* Extract identification capture into a dedicated presentational component
* Have `IdentificationComponent` handle it's form validation and repopulation of the form value
* Emit an event back to the Office page when identification changes to update the store

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
