### PR TITLE
MES-2158: Extract Show Me Question presentational component to handle form repopulation (MES-1129)

### DIFF
--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -32,6 +32,7 @@ import { MockComponent } from 'ng-mocks';
 import { RouteNumberComponent } from '../components/route-number/route-number';
 import { CandidateDescriptionComponent } from '../components/candidate-description/candidate-description';
 import { DebriefWitnessedComponent } from '../components/debrief-witnessed/debrief-witnessed';
+import { ShowMeQuestionComponent } from '../show-me-question/show-me-question';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficePage>;
@@ -46,6 +47,7 @@ describe('OfficePage', () => {
         MockComponent(RouteNumberComponent),
         MockComponent(CandidateDescriptionComponent),
         MockComponent(DebriefWitnessedComponent),
+        MockComponent(ShowMeQuestionComponent),
       ],
       imports: [IonicModule, AppModule, ComponentsModule, OfficeComponentsModule,
         StoreModule.forRoot({
@@ -126,10 +128,11 @@ describe('OfficePage', () => {
   });
 
   describe('DOM', () => {
-    it('should display the description for stored show me question code', () => {
+    it('should pass the selected show me question code to the show me subcomponent', () => {
       fixture.detectChanges();
-      const showMeElement: HTMLElement = fixture.debugElement.query(By.css('ion-select .select-text')).nativeElement;
-      expect(showMeElement.innerText).toEqual('S3 - Dipped headlights');
+      const showMeElement = fixture.debugElement.query(By.css('show-me-question'))
+        .componentInstance as ShowMeQuestionComponent;
+      expect(showMeElement.showMeQuestion.showMeQuestionCode).toEqual('S3');
     });
     it('should hide ETA faults container if there are none', () => {
       fixture.detectChanges();

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -119,29 +119,9 @@
             </ion-col>
           </ion-row>
 
-          <ion-row class="mes-validated-row mes-row-separator" id="show-me-question-card">
-            <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('showMeQuestionCtrl')"></div>
-            <ion-col class="component-label" col-32 align-self-center>
-              <label>Show me question</label>
-            </ion-col>
-            <ion-col align-self-center>
-              <ion-row class="spacing-row"></ion-row>
-              <ion-row>
-                <ion-select (ionChange)="showMeQuestionChanged($event)" placeholder="Select a question"
-                  id="show-me-selector" [(ngModel)]="showMeQuestion" okText="Submit" cancelText="Cancel"
-                  formControlName="showMeQuestionCtrl">
-                  <ion-option [value]="showMeQuestion" *ngFor="let showMeQuestion of showMeQuestions">
-                    {{showMeQuestion.showMeQuestionCode}} - {{showMeQuestion.showMeQuestionShortName}}
-                  </ion-option>
-                </ion-select>
-              </ion-row>
-              <ion-row class="validation-message-row" align-it ems-center>
-                <div class="validation-text" [class.ng-invalid]="isCtrlDirtyAndInvalid('showMeQuestionCtrl')">
-                  Select the show me question
-                </div>
-              </ion-row>
-            </ion-col>
-          </ion-row>
+          <show-me-question [formGroup]="form" [showMeQuestion]="pageState.showMeQuestion$ | async" [showMeQuestionOptions]="showMeQuestions"
+            (showMeQuestionChange)="showMeQuestionChanged($event)">
+          </show-me-question>
 
           <ion-row class="mes-validated-row mes-row-separator" id="weather-conditions-card">
             <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('weatherConditionsCtrl')"></div>

--- a/src/pages/office/office.module.ts
+++ b/src/pages/office/office.module.ts
@@ -9,12 +9,14 @@ import { OfficeComponentsModule } from './components/office.components.module';
 import { RouteNumberComponent } from './components/route-number/route-number';
 import { CandidateDescriptionComponent } from './components/candidate-description/candidate-description';
 import { DebriefWitnessedComponent } from './components/debrief-witnessed/debrief-witnessed';
+import { ShowMeQuestionComponent } from './show-me-question/show-me-question';
 @NgModule({
   declarations: [
     OfficePage,
     RouteNumberComponent,
     CandidateDescriptionComponent,
     DebriefWitnessedComponent,
+    ShowMeQuestionComponent,
   ],
   imports: [
     IonicPageModule.forChild(OfficePage),

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -120,7 +120,6 @@ export class OfficePage extends BasePageComponent {
 
   weatherConditions: WeatherConditionSelection[];
   showMeQuestions: ShowMeQuestion[];
-  showMeQuestion: ShowMeQuestion;
 
   constructor(
     private store$: Store<StoreModel>,
@@ -254,6 +253,7 @@ export class OfficePage extends BasePageComponent {
       this.pageState.routeNumber$,
       this.pageState.candidateDescription$,
       this.pageState.debriefWitnessed$,
+      this.pageState.showMeQuestion$,
     ).subscribe();
 
     this.drivingFaultSubscription = this.pageState.displayDrivingFaultComments$.subscribe((display) => {
@@ -263,7 +263,6 @@ export class OfficePage extends BasePageComponent {
     });
 
     this.inputSubscriptions = [
-      this.pageState.showMeQuestion$.subscribe(showMeQuestion => this.showMeQuestion = showMeQuestion),
       this.inputChangeSubscriptionDispatchingAction(
         this.additionalInformationInput,
         AdditionalInformationChanged,
@@ -322,8 +321,8 @@ export class OfficePage extends BasePageComponent {
     }
   }
 
-  showMeQuestionChanged(newShowMeQuestion): void {
-    this.store$.dispatch(new ShowMeQuestionSelected(newShowMeQuestion));
+  showMeQuestionChanged(showMeQuestion: ShowMeQuestion): void {
+    this.store$.dispatch(new ShowMeQuestionSelected(showMeQuestion));
   }
 
   getFormValidation(): { [key: string]: FormControl } {
@@ -333,7 +332,6 @@ export class OfficePage extends BasePageComponent {
       independentDrivingCtrl: new FormControl('', [Validators.required]),
       d255Ctrl: new FormControl('', [Validators.required]),
       weatherConditionsCtrl: new FormControl([], [Validators.required]),
-      showMeQuestionCtrl: new FormControl([], [Validators.required]),
     };
   }
 

--- a/src/pages/office/show-me-question/show-me-question.html
+++ b/src/pages/office/show-me-question/show-me-question.html
@@ -1,0 +1,22 @@
+<ion-row class="mes-validated-row mes-row-separator" id="show-me-question-card" [formGroup]="formGroup">
+  <div class="validation-bar" [class.ng-invalid]="invalid"></div>
+  <ion-col class="component-label" col-32 align-self-center>
+    <label>Show me question</label>
+  </ion-col>
+  <ion-col align-self-center>
+    <ion-row class="spacing-row"></ion-row>
+    <ion-row>
+      <ion-select id="show-me-selector" placeholder="Select a question" okText="Submit" cancelText="Cancel"
+        formControlName="showMeQuestion" (ionChange)="showMeQuestionChanged($event)">
+        <ion-option [value]="showMeQuestion" *ngFor="let showMeQuestion of showMeQuestionOptions">
+          {{showMeQuestion.showMeQuestionCode}} - {{showMeQuestion.showMeQuestionShortName}}
+        </ion-option>
+      </ion-select>
+    </ion-row>
+    <ion-row class="validation-message-row" align-items-center>
+      <div class="validation-text" [class.ng-invalid]="invalid">
+        Select the show me question
+      </div>
+    </ion-row>
+  </ion-col>
+</ion-row>

--- a/src/pages/office/show-me-question/show-me-question.ts
+++ b/src/pages/office/show-me-question/show-me-question.ts
@@ -1,0 +1,43 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { ShowMeQuestion } from '../../../providers/question/show-me-question.model';
+
+@Component({
+  selector: 'show-me-question',
+  templateUrl: 'show-me-question.html',
+})
+export class ShowMeQuestionComponent implements OnChanges {
+
+  @Input()
+  showMeQuestion: ShowMeQuestion;
+
+  @Input()
+  showMeQuestionOptions: ShowMeQuestion[];
+
+  @Input()
+  formGroup: FormGroup;
+
+  @Output()
+  showMeQuestionChange = new EventEmitter<ShowMeQuestion>();
+
+  private formControl: FormControl;
+
+  ngOnChanges(): void {
+    if (!this.formControl) {
+      this.formControl = new FormControl([], [Validators.required]);
+      this.formGroup.addControl('showMeQuestion', this.formControl);
+    }
+    this.formControl.patchValue(this.showMeQuestion);
+  }
+
+  showMeQuestionChanged(showMeQuestion: ShowMeQuestion): void {
+    if (this.formControl.valid) {
+      this.showMeQuestionChange.emit(showMeQuestion);
+    }
+  }
+
+  get invalid(): boolean {
+    return !this.formControl.valid && this.formControl.dirty;
+  }
+
+}


### PR DESCRIPTION
## Description and relevant Jira numbers
* Extract Show Me question capture into a dedicated presentational component
* Have `ShowMeQuestionComponent` handle it's form validation and repopulation of the form value
* Emit an event back to the Office page when identification changes to update the store

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
