### PR TITLE
MES-2160: Extract D255 presentational component to handle form repopulation (MES-1129)

### DIFF
--- a/src/modules/tests/test-summary/test-summary.selector.ts
+++ b/src/modules/tests/test-summary/test-summary.selector.ts
@@ -7,10 +7,7 @@ export const isIdentificationLicense = (testSummary: TestSummary): boolean =>
   testSummary.identification === 'Licence';
 export const isIdentificationPassport = (testSummary: TestSummary): boolean =>
   testSummary.identification === 'Passport';
-export const isD255Yes = (testSummary: TestSummary): boolean => testSummary.D255;
-export const isD255No = (testSummary: TestSummary): boolean => {
-  return (testSummary.D255 !== null && !testSummary.D255) || false;
-};
+export const getD255 = (testSummary: TestSummary): boolean => testSummary.D255;
 export const getSatNavUsed = (testSummary: TestSummary): boolean => testSummary.independentDriving === 'Sat nav';
 export const getTrafficSignsUsed = (testSummary: TestSummary): boolean =>
   testSummary.independentDriving === 'Traffic signs';

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -21,8 +21,6 @@ import { PersistTests } from '../../../modules/tests/tests.actions';
 import {
   IndependentDrivingTypeChanged,
   IdentificationUsedChanged,
-  D255Yes,
-  D255No,
   WeatherConditionsChanged,
 } from '../../../modules/tests/test-summary/test-summary.actions';
 import { WeatherConditions } from '@dvsa/mes-test-schema/categories/B';
@@ -34,6 +32,7 @@ import { CandidateDescriptionComponent } from '../components/candidate-descripti
 import { DebriefWitnessedComponent } from '../components/debrief-witnessed/debrief-witnessed';
 import { ShowMeQuestionComponent } from '../show-me-question/show-me-question';
 import { WeatherConditionsComponent } from '../components/weather-conditions/weather-conditions';
+import { D255Component } from '../components/d255/d255';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficePage>;
@@ -50,6 +49,7 @@ describe('OfficePage', () => {
         MockComponent(DebriefWitnessedComponent),
         MockComponent(ShowMeQuestionComponent),
         MockComponent(WeatherConditionsComponent),
+        MockComponent(D255Component),
       ],
       imports: [IonicModule, AppModule, ComponentsModule, OfficeComponentsModule,
         StoreModule.forRoot({
@@ -213,21 +213,6 @@ describe('OfficePage', () => {
         passportRadio.triggerEventHandler('click', null);
         fixture.detectChanges();
         expect(store$.dispatch).toHaveBeenCalledWith(new IdentificationUsedChanged('Passport'));
-      });
-    });
-
-    describe('changing D255', () => {
-      it('should dispatch a change to D255 action when Yes is clicked', () => {
-        const d255YesRadio = fixture.debugElement.query(By.css('#d255-yes'));
-        d255YesRadio.triggerEventHandler('click', null);
-        fixture.detectChanges();
-        expect(store$.dispatch).toHaveBeenCalledWith(new D255Yes());
-      });
-      it('should dispatch a change to D255 action when No is clicked', () => {
-        const d255NoRadio = fixture.debugElement.query(By.css('#d255-no'));
-        d255NoRadio.triggerEventHandler('click', null);
-        fixture.detectChanges();
-        expect(store$.dispatch).toHaveBeenCalledWith(new D255No());
       });
     });
 

--- a/src/pages/office/components/d255/d255.html
+++ b/src/pages/office/components/d255/d255.html
@@ -1,0 +1,27 @@
+<ion-row class="mes-validated-row mes-row-separator" id="d255-card" [formGroup]="formGroup">
+  <div class="validation-bar" [class.ng-invalid]="invalid">
+  </div>
+  <ion-col class="component-label" col-32 align-self-center>
+    <label>D255?</label>
+  </ion-col>
+  <ion-col align-self-center>
+    <ion-row class="spacing-row"></ion-row>
+    <ion-row>
+      <ion-col col-32>
+        <input type="radio" id="d255-yes" class="gds-radio-button" name="d255" formControlName="d255" value="Yes"
+          [class.ng-invalid]="invalid" [checked]="d255 === true" (change)="d255Changed($event.target.value)">
+        <label for="d255-yes" class="radio-label">Yes</label>
+      </ion-col>
+      <ion-col col-32>
+        <input type="radio" id="d255-no" class="gds-radio-button" name="d255" formControlName="d255" value="No"
+          [class.ng-invalid]="invalid" [checked]="d255 === false" (change)="d255Changed($event.target.value)">
+        <label for="d255-no" class="radio-label">No</label>
+      </ion-col>
+    </ion-row>
+    <ion-row class="validation-message-row" align-items-center>
+      <div class="validation-text" [class.ng-invalid]="invalid">
+        Select D255
+      </div>
+    </ion-row>
+  </ion-col>
+</ion-row>

--- a/src/pages/office/components/d255/d255.ts
+++ b/src/pages/office/components/d255/d255.ts
@@ -1,0 +1,41 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'd255',
+  templateUrl: 'd255.html',
+})
+export class D255Component implements OnChanges {
+
+  @Input()
+  d255: boolean;
+
+  @Input()
+  formGroup: FormGroup;
+
+  @Output()
+  d255Change = new EventEmitter<boolean>();
+
+  private formControl: FormControl;
+
+  ngOnChanges(): void {
+    if (!this.formControl) {
+      this.formControl = new FormControl(null, [Validators.required]);
+      this.formGroup.addControl('d255', this.formControl);
+    }
+    if (this.d255 !== null) {
+      this.formControl.patchValue(this.d255 ? 'Yes' : 'No');
+    }
+  }
+
+  d255Changed(d255FormValue: string): void {
+    if (this.formControl.valid) {
+      this.d255Change.emit(d255FormValue === 'Yes' ? true : false);
+    }
+  }
+
+  get invalid(): boolean {
+    return !this.formControl.valid && this.formControl.dirty;
+  }
+
+}

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -127,35 +127,7 @@
             [weatherConditionsOptions]="weatherConditions" (weatherConditionsChange)="weatherConditionsChanged($event)">
           </weather-conditions>
 
-          <ion-row class="mes-validated-row mes-row-separator" id="d255-card">
-            <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('d255Ctrl')">
-            </div>
-            <ion-col class="component-label" col-32 align-self-center>
-              <label>D255?</label>
-            </ion-col>
-            <ion-col align-self-center>
-              <ion-row class="spacing-row"></ion-row>
-              <ion-row>
-                <ion-col col-32>
-                  <input type="radio" formControlName="d255Ctrl" name="d255Ctrl" id="d255-yes" class="gds-radio-button"
-                    [class.ng-invalid]="isCtrlDirtyAndInvalid('d255Ctrl')" (click)="d255Yes()"
-                    [checked]="pageState.d255YesRadioChecked$ | async" value='Yes'>
-                  <label for="d255-yes" class="radio-label">Yes</label>
-                </ion-col>
-                <ion-col col-32>
-                  <input type="radio" formControlName="d255Ctrl" name="d255Ctrl" id="d255-no" class="gds-radio-button"
-                    [class.ng-invalid]="isCtrlDirtyAndInvalid('d255Ctrl')" (click)="d255No()"
-                    [checked]="pageState.d255NoRadioChecked$ | async" value='No'>
-                  <label for="d255-no" class="radio-label">No</label>
-                </ion-col>
-              </ion-row>
-              <ion-row class="validation-message-row" align-items-center>
-                <div class="validation-text" [class.ng-invalid]="isCtrlDirtyAndInvalid('d255Ctrl')">
-                  Select D255
-                </div>
-              </ion-row>
-            </ion-col>
-          </ion-row>
+          <d255 [d255]="pageState.d255$ | async" [formGroup]="form" (d255Change)="d255Changed($event)"></d255>
 
           <ion-row class="mes-component-row mes-row-separator" id="additional-information-card">
             <ion-col class="component-label" col-32 align-self-center>

--- a/src/pages/office/office.module.ts
+++ b/src/pages/office/office.module.ts
@@ -11,6 +11,7 @@ import { CandidateDescriptionComponent } from './components/candidate-descriptio
 import { DebriefWitnessedComponent } from './components/debrief-witnessed/debrief-witnessed';
 import { ShowMeQuestionComponent } from './show-me-question/show-me-question';
 import { WeatherConditionsComponent } from './components/weather-conditions/weather-conditions';
+import { D255Component } from './components/d255/d255';
 
 @NgModule({
   declarations: [
@@ -20,6 +21,7 @@ import { WeatherConditionsComponent } from './components/weather-conditions/weat
     DebriefWitnessedComponent,
     ShowMeQuestionComponent,
     WeatherConditionsComponent,
+    D255Component,
   ],
   imports: [
     IonicPageModule.forChild(OfficePage),

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -18,8 +18,7 @@ import {
   getCandidateDescription,
   isIdentificationLicense,
   isIdentificationPassport,
-  isD255Yes,
-  isD255No,
+  getD255,
   getAdditionalInformation,
   getSatNavUsed,
   getTrafficSignsUsed,
@@ -84,8 +83,7 @@ interface OfficePageState {
   identificationPassportRadioChecked$: Observable<boolean>;
   independentDrivingSatNavRadioChecked$: Observable<boolean>;
   independentDrivingTrafficSignsRadioChecked$: Observable<boolean>;
-  d255YesRadioChecked$: Observable<boolean>;
-  d255NoRadioChecked$: Observable<boolean>;
+  d255$: Observable<boolean>;
   candidateDescription$: Observable<string>;
   additionalInformation$: Observable<string>;
   showMeQuestion$: Observable<ShowMeQuestion>;
@@ -200,13 +198,9 @@ export class OfficePage extends BasePageComponent {
         select(getTestSummary),
         select(isIdentificationPassport),
       ),
-      d255YesRadioChecked$: currentTest$.pipe(
+      d255$: currentTest$.pipe(
         select(getTestSummary),
-        select(isD255Yes),
-      ),
-      d255NoRadioChecked$: currentTest$.pipe(
-        select(getTestSummary),
-        select(isD255No),
+        select(getD255),
       ),
       additionalInformation$: currentTest$.pipe(
         select(getTestSummary),
@@ -261,6 +255,7 @@ export class OfficePage extends BasePageComponent {
       this.pageState.debriefWitnessed$,
       this.pageState.showMeQuestion$,
       this.pageState.weatherConditions$,
+      this.pageState.d255$,
     ).subscribe();
 
     this.drivingFaultSubscription = this.pageState.displayDrivingFaultComments$.subscribe((display) => {
@@ -337,7 +332,6 @@ export class OfficePage extends BasePageComponent {
       candidateDescriptionCtrl: new FormControl('', [Validators.required]),
       identificationCtrl: new FormControl('', [Validators.required]),
       independentDrivingCtrl: new FormControl('', [Validators.required]),
-      d255Ctrl: new FormControl('', [Validators.required]),
     };
   }
 
@@ -369,12 +363,8 @@ export class OfficePage extends BasePageComponent {
     this.store$.dispatch(new IndependentDrivingTypeChanged('Traffic signs'));
   }
 
-  d255Yes(): void {
-    this.store$.dispatch(new D255Yes());
-  }
-
-  d255No(): void {
-    this.store$.dispatch(new D255No());
+  d255Changed(d255: boolean): void {
+    this.store$.dispatch(d255 ? new D255Yes() : new D255No());
   }
 
   weatherConditionsChanged(weatherConditions: WeatherConditions[]): void {


### PR DESCRIPTION
## Description and relevant Jira numbers
* Extract D255 capture into a dedicated presentational component
* Have `D255Component` handle it's form validation and repopulation of the form value
* Emit an event back to the Office page when D255 changes to update the store

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
