### PR TITLE
MES-2154: Extract independent driving presentational component to handle form repopulation (MES-1129)

### DIFF
--- a/src/modules/tests/test-summary/test-summary.selector.ts
+++ b/src/modules/tests/test-summary/test-summary.selector.ts
@@ -1,4 +1,4 @@
-import { TestSummary, WeatherConditions, Identification } from '@dvsa/mes-test-schema/categories/B';
+import { TestSummary, WeatherConditions, Identification, IndependentDriving } from '@dvsa/mes-test-schema/categories/B';
 
 export const getRouteNumber = (ts: TestSummary): number => ts.routeNumber;
 export const getCandidateDescription = (ts: TestSummary): string => ts.candidateDescription;
@@ -9,3 +9,4 @@ export const getSatNavUsed = (ts: TestSummary): boolean => ts.independentDriving
 export const getTrafficSignsUsed = (ts: TestSummary): boolean => ts.independentDriving === 'Traffic signs';
 export const isDebriefWitnessed = (ts: TestSummary): boolean => ts.debriefWitnessed;
 export const getWeatherConditions = (ts: TestSummary): WeatherConditions[] => ts.weatherConditions;
+export const getIndependentDriving = (ts: TestSummary): IndependentDriving => ts.independentDriving;

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -24,7 +24,6 @@ import {
 } from '../../../modules/tests/vehicle-checks/vehicle-checks.actions';
 import { PersistTests } from '../../../modules/tests/tests.actions';
 import {
-  IndependentDrivingTypeChanged,
   WeatherConditionsChanged,
 } from '../../../modules/tests/test-summary/test-summary.actions';
 import { WeatherConditions } from '@dvsa/mes-test-schema/categories/B';
@@ -39,6 +38,7 @@ import { WeatherConditionsComponent } from '../components/weather-conditions/wea
 import { D255Component } from '../components/d255/d255';
 import { AdditionalInformationComponent } from '../components/additional-information/additional-information';
 import { IdentificationComponent } from '../components/identification/identification';
+import { IndependentDrivingComponent } from '../components/independent-driving/independent-driving';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficePage>;
@@ -58,6 +58,7 @@ describe('OfficePage', () => {
         MockComponent(WeatherConditionsComponent),
         MockComponent(D255Component),
         MockComponent(AdditionalInformationComponent),
+        MockComponent(IndependentDrivingComponent),
       ],
       imports: [IonicModule, AppModule, ComponentsModule, OfficeComponentsModule,
         StoreModule.forRoot({
@@ -198,21 +199,6 @@ describe('OfficePage', () => {
 
         expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
         expect(navCtrl.popToRoot).toHaveBeenCalled();
-      });
-    });
-
-    describe('changing independent driving', () => {
-      it('should dispatch a change to independent driving action when Yes is clicked', () => {
-        const satNavRadio = fixture.debugElement.query(By.css('#independent-driving-satnav'));
-        satNavRadio.triggerEventHandler('click', null);
-        fixture.detectChanges();
-        expect(store$.dispatch).toHaveBeenCalledWith(new IndependentDrivingTypeChanged('Sat nav'));
-      });
-      it('should dispatch a change to independent driving action when Traffic signs is clicked', () => {
-        const trafficSignsRadio = fixture.debugElement.query(By.css('#independent-driving-trafficsigns'));
-        trafficSignsRadio.triggerEventHandler('click', null);
-        fixture.detectChanges();
-        expect(store$.dispatch).toHaveBeenCalledWith(new IndependentDrivingTypeChanged('Traffic signs'));
       });
     });
 

--- a/src/pages/office/components/independent-driving/independent-driving.html
+++ b/src/pages/office/components/independent-driving/independent-driving.html
@@ -1,0 +1,30 @@
+<ion-row class="mes-validated-row mes-row-separator" id="independent-driving-card" [formGroup]="formGroup">
+  <div class="validation-bar" [class.ng-invalid]="invalid">
+  </div>
+  <ion-col class="component-label" col-32 align-self-center>
+    <label>Independent driving</label>
+  </ion-col>
+  <ion-col align-self-center>
+    <ion-row class="spacing-row"></ion-row>
+    <ion-row>
+      <ion-col col-32>
+        <input type="radio" id="independent-driving-satnav" class="gds-radio-button"
+          formControlName="independentDriving" name="independentDriving" value='Sat nav' [class.ng-invalid]="invalid"
+          [checked]="independentDriving === 'Sat nav'" (change)="independentDrivingChanged($event.target.value)">
+        <label for="independent-driving-satnav" class="radio-label">Sat Nav</label>
+      </ion-col>
+      <ion-col>
+        <input type="radio" id="independent-driving-trafficsigns" class="gds-radio-button"
+          formControlName="independentDriving" name="independentDriving" value='Traffic signs'
+          [class.ng-invalid]="invalid" [checked]="independentDriving === 'Traffic signs'"
+          (change)="independentDrivingChanged($event.target.value)">
+        <label for="independent-driving-trafficsigns" class="radio-label">Traffic signs</label>
+      </ion-col>
+    </ion-row>
+    <ion-row class="validation-message-row" align-items-center>
+      <div class="validation-text" [class.ng-invalid]="invalid">
+        Select the method of independent driving
+      </div>
+    </ion-row>
+  </ion-col>
+</ion-row>

--- a/src/pages/office/components/independent-driving/independent-driving.ts
+++ b/src/pages/office/components/independent-driving/independent-driving.ts
@@ -1,0 +1,40 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { IndependentDriving } from '@dvsa/mes-test-schema/categories/B';
+
+@Component({
+  selector: 'independent-driving',
+  templateUrl: 'independent-driving.html',
+})
+export class IndependentDrivingComponent implements OnChanges {
+
+  @Input()
+  independentDriving: IndependentDriving;
+
+  @Input()
+  formGroup: FormGroup;
+
+  @Output()
+  independentDrivingChange = new EventEmitter<IndependentDriving>();
+
+  private formControl: FormControl;
+
+  ngOnChanges(): void {
+    if (!this.formControl) {
+      this.formControl = new FormControl(null, [Validators.required]);
+      this.formGroup.addControl('independentDriving', this.formControl);
+    }
+    this.formControl.patchValue(this.independentDriving);
+  }
+
+  independentDrivingChanged(independentDriving: IndependentDriving): void {
+    if (this.formControl.valid) {
+      this.independentDrivingChange.emit(independentDriving);
+    }
+  }
+
+  get invalid(): boolean {
+    return !this.formControl.valid && this.formControl.dirty;
+  }
+
+}

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -36,37 +36,8 @@
             [formGroup]="form">
           </route-number>
 
-          <ion-row class="mes-validated-row mes-row-separator" id="independent-driving-card">
-            <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('independentDrivingCtrl')">
-            </div>
-            <ion-col class="component-label" col-32 align-self-center>
-              <label>Independent driving</label>
-            </ion-col>
-            <ion-col align-self-center>
-              <ion-row class="spacing-row"></ion-row>
-              <ion-row>
-                <ion-col col-32>
-                  <input type="radio" formControlName="independentDrivingCtrl" name="independentDrivingCtrl"
-                    id="independent-driving-satnav" class="gds-radio-button"
-                    [class.ng-invalid]="isCtrlDirtyAndInvalid('independentDrivingCtrl')" (click)="satNavUsed()"
-                    [checked]="pageState.independentDrivingSatNavRadioChecked$ | async" value='Sat nav'>
-                  <label for="independent-driving-satnav" class="radio-label">Sat Nav</label>
-                </ion-col>
-                <ion-col>
-                  <input type="radio" formControlName="independentDrivingCtrl" name="independentDrivingCtrl"
-                    id="independent-driving-trafficsigns" class="gds-radio-button"
-                    [class.ng-invalid]="isCtrlDirtyAndInvalid('independentDrivingCtrl')" (click)="trafficSignsUsed()"
-                    [checked]="pageState.independentDrivingTrafficSignsRadioChecked$ | async" value='Traffic signs'>
-                  <label for="independent-driving-trafficsigns" class="radio-label">Traffic signs</label>
-                </ion-col>
-              </ion-row>
-              <ion-row class="validation-message-row" align-items-center>
-                <div class="validation-text" [class.ng-invalid]="isCtrlDirtyAndInvalid('independentDrivingCtrl')">
-                  Select the method of independent driving
-                </div>
-              </ion-row>
-            </ion-col>
-          </ion-row>
+          <independent-driving [formGroup]="form" [independentDriving]="pageState.independentDriving$ | async"
+            (independentDrivingChange)="independentDrivingChanged($event)"></independent-driving>
 
           <candidate-description [formGroup]="form" [candidateDescription]="pageState.candidateDescription$ | async"
             (candidateDescriptionChange)="candidateDescriptionChanged($event)"></candidate-description>
@@ -261,7 +232,7 @@
       </ion-card-content>
     </ion-card>
 
-      <div [hidden]="!keyboard.isOpen()" class="keyboard-space"></div>
+    <div [hidden]="!keyboard.isOpen()" class="keyboard-space"></div>
   </form>
 </ion-content>
 <ion-footer>

--- a/src/pages/office/office.module.ts
+++ b/src/pages/office/office.module.ts
@@ -14,6 +14,7 @@ import { ShowMeQuestionComponent } from './components/show-me-question/show-me-q
 import { WeatherConditionsComponent } from './components/weather-conditions/weather-conditions';
 import { D255Component } from './components/d255/d255';
 import { AdditionalInformationComponent } from './components/additional-information/additional-information';
+import { IndependentDrivingComponent } from './components/independent-driving/independent-driving';
 
 @NgModule({
   declarations: [
@@ -26,6 +27,7 @@ import { AdditionalInformationComponent } from './components/additional-informat
     WeatherConditionsComponent,
     D255Component,
     AdditionalInformationComponent,
+    IndependentDrivingComponent,
   ],
   imports: [
     IonicPageModule.forChild(OfficePage),


### PR DESCRIPTION
## Description and relevant Jira numbers
* Extract independent driving capture into a dedicated presentational component
* Have `IndependentDrivingComponent` handle it's form validation and repopulation of the form value
* Emit an event back to the Office page when independent driving changes to update the store
* Remove unnecessary subscriptions as suggested by @szabolcs-keresztes.
* Remove last of `FormGroup` setup from the Office page component, it's all now handled by subcomponents.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
