### PR TITLE
MES-2131 persist manoeuvre faults to summary screen

### DIFF
--- a/src/modules/tests/test_data/test-data.selector.ts
+++ b/src/modules/tests/test_data/test-data.selector.ts
@@ -15,7 +15,7 @@ export const getDrivingFaultSummaryCount = (data: TestData): number => {
   const drivingFaultSumOfSimpleCompetencies =
     Object.values(drivingFaults).reduce((acc, numberOfFaults) => acc + numberOfFaults, 0);
 
-  const controlledStopHasDrivingFault = (controlledStop.fault === CompetencyOutcome.DF) ? 1 : 0;
+  const controlledStopHasDrivingFault = (controlledStop && controlledStop.fault === CompetencyOutcome.DF) ? 1 : 0;
 
   const result =
     drivingFaultSumOfSimpleCompetencies +

--- a/src/pages/debrief/__tests__/debrief.selector.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.selector.spec.ts
@@ -1,10 +1,21 @@
-import { SeriousFaults, DangerousFaults, DrivingFaults, TestData } from '@dvsa/mes-test-schema/categories/B';
-import { getSeriousOrDangerousFaults, getDrivingFaults, displayDrivingFaultComments } from '../debrief.selector';
+import { SeriousFaults,
+  DangerousFaults,
+  DrivingFaults,
+  TestData,
+  Manoeuvres,
+} from '@dvsa/mes-test-schema/categories/B';
+import { getSeriousOrDangerousFaults,
+  getDrivingFaults,
+  displayDrivingFaultComments,
+  getManoeuvreFaults,
+} from '../debrief.selector';
+import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 
 describe('debriefSelector', () => {
   const dangerousFaults: DangerousFaults = {};
   const seriousFaults: SeriousFaults = {};
   const drivingFaults: DrivingFaults = {};
+  const manoeuvres: Manoeuvres = {};
 
   describe('getSeriousOrDangerousFaults', () => {
     it('should return an empty array if there are no serious faults', () => {
@@ -139,6 +150,53 @@ describe('debriefSelector', () => {
 
     });
 
+  });
+
+  describe('getManoeuvreFaults', () => {
+    it('should return an empty array if there are no manoeuvre driving faults', () => {
+      const result = getManoeuvreFaults(manoeuvres, CompetencyOutcome.DF);
+      expect(result.length).toBe(0);
+    });
+
+    it('should return an array length matching the number of manoeuvre driving faults', () => {
+      manoeuvres.reverseRight = {
+        selected: true,
+        controlFault: 'DF',
+        observationFault: 'DF',
+      };
+      const result = getManoeuvreFaults(manoeuvres, CompetencyOutcome.DF);
+      expect(result.length).toBe(2);
+    });
+
+    it('should return an array length matching the number of manoeuvre serious faults', () => {
+      manoeuvres.reverseRight = {
+        selected: true,
+        controlFault: 'S',
+        observationFault: 'DF',
+      };
+      const result = getManoeuvreFaults(manoeuvres, CompetencyOutcome.S);
+      expect(result.length).toBe(1);
+    });
+
+    it('should return an array length matching the number of manoeuvre dangerous faults', () => {
+      manoeuvres.reverseRight = {
+        selected: true,
+        controlFault: 'DF',
+        observationFault: 'D',
+      };
+      const result = getManoeuvreFaults(manoeuvres, CompetencyOutcome.D);
+      expect(result.length).toBe(1);
+    });
+
+    it('should return an array with a correctly formatted fault object ', () => {
+      manoeuvres.reverseRight = {
+        selected: true,
+        controlFault: 'DF',
+      };
+      const result = getManoeuvreFaults(manoeuvres, CompetencyOutcome.DF);
+      expect(result[0].name).toBe('Reverse right - Control');
+      expect(result[0].count).toBe(1);
+    });
   });
 
 });

--- a/src/pages/test-report/components/manoeuvre-competency/manoeuvre-competency.constants.ts
+++ b/src/pages/test-report/components/manoeuvre-competency/manoeuvre-competency.constants.ts
@@ -6,3 +6,10 @@ export const manoeuvreCompetencyLabels: ManoeuvreCompetencyLabel = {
   controlFault: 'Control',
   observationFault: 'Observation',
 };
+
+export enum manoeuvreTypeLabels {
+  reverseRight = 'Reverse right',
+  reverseParkRoad = 'Reverse park (road)',
+  reverseParkCarpark = 'Reverse park (car park)',
+  forwardPark = 'Forward park',
+}

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     "quotemark": [true, "single"],
     "indent": [true, "spaces", 2],
     "max-line-length": [true, 120],
+    "align": [true, "parameters", "statements", "members"],
     "rxjs-add": { "severity": "error" },
     "rxjs-no-operator": { "severity": "error" },
     "rxjs-no-patched": { "severity": "error" },

--- a/tslint.json
+++ b/tslint.json
@@ -5,7 +5,7 @@
     "quotemark": [true, "single"],
     "indent": [true, "spaces", 2],
     "max-line-length": [true, 120],
-    "align": [true, "parameters", "statements", "members"],
+    "align": [true, "parameters", "statements"],
     "rxjs-add": { "severity": "error" },
     "rxjs-no-operator": { "severity": "error" },
     "rxjs-no-patched": { "severity": "error" },


### PR DESCRIPTION
## Description and relevant Jira numbers
- Include the manoeuvre faults in the counts on the summary screen
- Show the manoeuvre fault descriptions in the relevant sections
- **Update linting rule so arguments don't need to be aligned**

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

![Screenshot 2019-04-25 at 15 05 33](https://user-images.githubusercontent.com/8069071/56744291-1baf9280-6770-11e9-9eae-4f8b0dee158f.png)
