### PR TITLE
Mes-2029 - Remove faults manoeuvre

### DIFF
--- a/src/modules/tests/test_data/test-data.actions.ts
+++ b/src/modules/tests/test_data/test-data.actions.ts
@@ -58,7 +58,7 @@ export class AddManoeuvreDangerousFault implements Action {
 }
 
 export class RemoveManoeuvreFault implements Action {
-  constructor(public payload: ManoeuvreCompetencies) { }
+  constructor(public payload: ManoeuvrePayload) { }
   readonly type = REMOVE_MANOEUVRE_FAULT;
 }
 export class ControlledStopAddDrivingFault implements Action {

--- a/src/modules/tests/test_data/test-data.reducer.ts
+++ b/src/modules/tests/test_data/test-data.reducer.ts
@@ -63,6 +63,17 @@ export function testDataReducer(
           },
         },
       };
+    case testDataActions.REMOVE_MANOEUVRE_FAULT:
+      const {
+        [action.payload.competency]: competencyToOmit, ...stateToPreserve
+      } = state.manoeuvres[action.payload.manoeuvre];
+      return {
+        ...state,
+        manoeuvres: {
+          ...state.manoeuvres,
+          [action.payload.manoeuvre]: stateToPreserve,
+        },
+      };
     case testDataActions.ADD_DRIVING_FAULT:
       return {
         ...state,

--- a/src/pages/test-report/components/manoeuvre-competency/__tests__/manoeuvre-competency.spec.ts
+++ b/src/pages/test-report/components/manoeuvre-competency/__tests__/manoeuvre-competency.spec.ts
@@ -14,6 +14,7 @@ import {
   AddManoeuvreDrivingFault,
   AddManoeuvreDangerousFault,
   AddManoeuvreSeriousFault,
+  RemoveManoeuvreFault,
 } from '../../../../../modules/tests/test_data/test-data.actions';
 import { By } from '@angular/platform-browser';
 import { IonicModule } from 'ionic-angular';
@@ -21,7 +22,7 @@ import { MockComponent } from 'ng-mocks';
 import { StoreModule, Store } from '@ngrx/store';
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { CompetencyOutcome } from '../../../../../shared/models/competency-outcome';
-import { ToggleDangerousFaultMode, ToggleSeriousFaultMode } from '../../../test-report.actions';
+import { ToggleDangerousFaultMode, ToggleSeriousFaultMode, ToggleRemoveFaultMode } from '../../../test-report.actions';
 
 describe('ManoeuvreCompetencyComponent', () => {
   let fixture: ComponentFixture<ManoeuvreCompetencyComponent>;
@@ -197,6 +198,95 @@ describe('ManoeuvreCompetencyComponent', () => {
           manoeuvre: component.manoeuvre,
           competency: component.competency,
         }));
+      });
+    });
+
+    describe('Remove faults', () => {
+      describe('dispatched the actions competency outcome is undefined', () => {
+        beforeEach(() => {
+          fixture.detectChanges();
+          component.manoeuvre = ManoeuvreTypes.reverseRight;
+          component.competency = ManoeuvreCompetencies.controlFault;
+          component.isRemoveFaultMode = true;
+          component.manoeuvreCompetencyOutcome = undefined;
+        });
+        it('should only toggle remove fault when remove fault mode is true', () => {
+          fixture.detectChanges();
+          const storeDispatchSpy = spyOn(store$, 'dispatch');
+          component.addOrRemoveFault();
+          expect(storeDispatchSpy).toHaveBeenCalledTimes(1);
+          expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
+        });
+        it('should only toggle remove and serious fault when remove and serious fault modes are true', () => {
+          component.isSeriousMode = true;
+          fixture.detectChanges();
+          const storeDispatchSpy = spyOn(store$, 'dispatch');
+          component.addOrRemoveFault();
+          expect(storeDispatchSpy).toHaveBeenCalledTimes(2);
+          expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
+          expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleSeriousFaultMode());
+        });
+        it('should only toggle remove and serious fault when remove and serious fault modes are true', () => {
+          component.isDangerousMode = true;
+          fixture.detectChanges();
+          const storeDispatchSpy = spyOn(store$, 'dispatch');
+          component.addOrRemoveFault();
+          expect(storeDispatchSpy).toHaveBeenCalledTimes(2);
+          expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
+          expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleDangerousFaultMode());
+        });
+      });
+      it('should remove a dangerous fault and toggle dangerous mode when dangerous mode is true', () => {
+        fixture.detectChanges();
+        component.manoeuvre = ManoeuvreTypes.reverseRight;
+        component.competency = ManoeuvreCompetencies.controlFault;
+        component.isRemoveFaultMode = true;
+        component.isDangerousMode = true;
+        component.manoeuvreCompetencyOutcome = CompetencyOutcome.D;
+        fixture.detectChanges();
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+        expect(storeDispatchSpy).toHaveBeenCalledTimes(3);
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveManoeuvreFault({
+          competency: component.competency,
+          manoeuvre: component.manoeuvre,
+        }));
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleDangerousFaultMode());
+      });
+      it('should remove a serious fault and toggle serious mode when serious mode is true', () => {
+        fixture.detectChanges();
+        component.manoeuvre = ManoeuvreTypes.reverseRight;
+        component.competency = ManoeuvreCompetencies.controlFault;
+        component.isRemoveFaultMode = true;
+        component.isSeriousMode = true;
+        component.manoeuvreCompetencyOutcome = CompetencyOutcome.S;
+        fixture.detectChanges();
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+        expect(storeDispatchSpy).toHaveBeenCalledTimes(3);
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveManoeuvreFault({
+          competency: component.competency,
+          manoeuvre: component.manoeuvre,
+        }));
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleSeriousFaultMode());
+      });
+      it('should remove a driving fault and toggle remove mode', () => {
+        fixture.detectChanges();
+        component.manoeuvre = ManoeuvreTypes.reverseRight;
+        component.competency = ManoeuvreCompetencies.controlFault;
+        component.isRemoveFaultMode = true;
+        component.manoeuvreCompetencyOutcome = CompetencyOutcome.DF;
+        fixture.detectChanges();
+        const storeDispatchSpy = spyOn(store$, 'dispatch');
+        component.addOrRemoveFault();
+        expect(storeDispatchSpy).toHaveBeenCalledTimes(2);
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new RemoveManoeuvreFault({
+          competency: component.competency,
+          manoeuvre: component.manoeuvre,
+        }));
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
       });
     });
   });

--- a/src/pages/test-report/components/manoeuvres-popover/__tests__/manoeuvres-popover.spec.ts
+++ b/src/pages/test-report/components/manoeuvres-popover/__tests__/manoeuvres-popover.spec.ts
@@ -5,7 +5,7 @@ import { CompetencyComponent } from '../../competency/competency';
 import { ManoeuvresPopoverComponent } from '../manoeuvres-popover';
 import { AppModule } from '../../../../../app/app.module';
 import {
-  RecordManoeuvresSelection, AddManoeuvreDrivingFault,
+  RecordManoeuvresSelection, AddManoeuvreDrivingFault, AddManoeuvreSeriousFault, AddManoeuvreDangerousFault,
 } from '../../../../../modules/tests/test_data/test-data.actions';
 import { StoreModel } from '../../../../../shared/models/store.model';
 import { Store, StoreModule } from '@ngrx/store';
@@ -84,7 +84,7 @@ describe('ManoeuvresPopoverComponent', () => {
         expect(fixture.debugElement.query(By.css('#manoeuvres-reverse-right-radio'))
           .nativeElement.disabled).toBe(false);
       });
-      it('should disable other manoeuvres from being selected when a fault is added', () => {
+      it('should disable other manoeuvres from being selected when a driving fault is added', () => {
         store$.dispatch(new AddManoeuvreDrivingFault({
           manoeuvre: ManoeuvreTypes.reverseRight,
           competency: ManoeuvreCompetencies.controlFault,
@@ -98,6 +98,36 @@ describe('ManoeuvresPopoverComponent', () => {
           .nativeElement.disabled).toBe(true);
         expect(fixture.debugElement.query(By.css('#manoeuvres-reverse-right-radio'))
           .nativeElement.disabled).toBe(false);
+      });
+      it('should disable other manoeuvres from being selected when a serious fault is added', () => {
+        store$.dispatch(new AddManoeuvreSeriousFault({
+          manoeuvre: ManoeuvreTypes.reverseRight,
+          competency: ManoeuvreCompetencies.controlFault,
+        }));
+        fixture.detectChanges();
+        expect(fixture.debugElement.query(By.css('#manoeuvres-reverse-park-road-radio'))
+          .nativeElement.disabled).toBe(true);
+        expect(fixture.debugElement.query(By.css('#manoeuvres-reverse-park-carpark-radio'))
+          .nativeElement.disabled).toBe(true);
+        expect(fixture.debugElement.query(By.css('#manoeuvres-forward-park-radio'))
+          .nativeElement.disabled).toBe(true);
+        expect(fixture.debugElement.query(By.css('#manoeuvres-reverse-right-radio'))
+          .nativeElement.disabled).toBe(true);
+      });
+      it('should disable other manoeuvres from being selected when a dangerous fault is added', () => {
+        store$.dispatch(new AddManoeuvreDangerousFault({
+          manoeuvre: ManoeuvreTypes.reverseRight,
+          competency: ManoeuvreCompetencies.controlFault,
+        }));
+        fixture.detectChanges();
+        expect(fixture.debugElement.query(By.css('#manoeuvres-reverse-park-road-radio'))
+          .nativeElement.disabled).toBe(true);
+        expect(fixture.debugElement.query(By.css('#manoeuvres-reverse-park-carpark-radio'))
+          .nativeElement.disabled).toBe(true);
+        expect(fixture.debugElement.query(By.css('#manoeuvres-forward-park-radio'))
+          .nativeElement.disabled).toBe(true);
+        expect(fixture.debugElement.query(By.css('#manoeuvres-reverse-right-radio'))
+          .nativeElement.disabled).toBe(true);
       });
     });
   });

--- a/src/pages/test-report/components/manoeuvres-popover/__tests__/manoeuvres-popover.spec.ts
+++ b/src/pages/test-report/components/manoeuvres-popover/__tests__/manoeuvres-popover.spec.ts
@@ -112,7 +112,7 @@ describe('ManoeuvresPopoverComponent', () => {
         expect(fixture.debugElement.query(By.css('#manoeuvres-forward-park-radio'))
           .nativeElement.disabled).toBe(true);
         expect(fixture.debugElement.query(By.css('#manoeuvres-reverse-right-radio'))
-          .nativeElement.disabled).toBe(true);
+          .nativeElement.disabled).toBe(false);
       });
       it('should disable other manoeuvres from being selected when a dangerous fault is added', () => {
         store$.dispatch(new AddManoeuvreDangerousFault({
@@ -127,7 +127,7 @@ describe('ManoeuvresPopoverComponent', () => {
         expect(fixture.debugElement.query(By.css('#manoeuvres-forward-park-radio'))
           .nativeElement.disabled).toBe(true);
         expect(fixture.debugElement.query(By.css('#manoeuvres-reverse-right-radio'))
-          .nativeElement.disabled).toBe(true);
+          .nativeElement.disabled).toBe(false);
       });
     });
   });

--- a/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.ts
+++ b/src/pages/test-report/components/manoeuvres-popover/manoeuvres-popover.ts
@@ -11,7 +11,6 @@ import { RecordManoeuvresSelection } from '../../../../modules/tests/test_data/t
 import { ManoeuvreCompetencies, ManoeuvreTypes } from '../../../../modules/tests/test_data/test-data.constants';
 import { map } from 'rxjs/operators';
 import { some } from 'lodash';
-import { CompetencyOutcome } from '../../../../shared/models/competency-outcome';
 
 interface ManoeuvresFaultState {
   reverseRight: boolean;
@@ -71,8 +70,8 @@ export class ManoeuvresPopoverComponent {
 
   manoeuvreHasFaults = (manoeuvre): boolean => (
     manoeuvre &&
-    (manoeuvre.controlFault === CompetencyOutcome.DF ||
-    manoeuvre.observationFault === CompetencyOutcome.DF)
+    (manoeuvre.controlFault != null ||
+    manoeuvre.observationFault != null)
   )
 
   getId = (manoeuvre: ManoeuvreTypes, competency: ManoeuvreCompetencies) => `${manoeuvre}-${competency}`;


### PR DESCRIPTION
## Description and relevant Jira numbers
- Replicates the logic from `competency.ts` to handle removal of faults from manoeuvure competencies.
- Fixes a bug where the manoeuvres weren't being disabled if you added either Serious or Dangerous faults.
 
## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [x] PO's approval
