### PR TITLE
Fix display of driving faults on debrief page

### DIFF
--- a/src/pages/debrief/debrief.html
+++ b/src/pages/debrief/debrief.html
@@ -99,12 +99,13 @@
           <ion-col col-32></ion-col>
           <ion-col col-2>
             <div class="counter-icon">
-              <driving-faults-badge class="counter driving-faults" [count]="drivingFault.count"></driving-faults-badge>
+              <driving-faults-badge class="counter driving-faults" [count]="drivingFault.faultCount">
+              </driving-faults-badge>
             </div>
           </ion-col>
           <ion-col col-3></ion-col>
           <ion-col>
-            <div class="counter-label">{{drivingFault.name}}</div>
+            <div class="counter-label">{{drivingFault.competencyDisplayName}}</div>
           </ion-col>
         </ion-row>
       </ion-grid>


### PR DESCRIPTION
Fixes bug introduced in #344 where Debrief template wasn't updated to match the new fault/comment model.