### PR TITLE
Fix driving fault counts not showing in the Office page

### DIFF
--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -37,6 +37,7 @@ import { AdditionalInformationComponent } from '../components/additional-informa
 import { IdentificationComponent } from '../components/identification/identification';
 import { IndependentDrivingComponent } from '../components/independent-driving/independent-driving';
 import { FaultCommentCardComponent } from '../components/fault-comment-card/fault-comment-card';
+import { CommentedCompetency, MultiFaultAssignableCompetency } from '../../../shared/models/fault-marking.model';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficePage>;
@@ -218,6 +219,47 @@ describe('OfficePage', () => {
         component.pageState.displayDrivingFaultComments$ = of(false);
         fixture.detectChanges();
         expect(drivingFaultCommentCard.shouldRender).toBeFalsy();
+      });
+    });
+
+    describe('driving fault overview', () => {
+      const drivingFaults: (CommentedCompetency & MultiFaultAssignableCompetency)[] = [
+        {
+          competencyIdentifier: 'signalsTimed',
+          competencyDisplayName: 'Signals - Timed',
+          faultCount: 3,
+          comment: 'dummy',
+        },
+        {
+          competencyIdentifier: 'useOfSpeed',
+          competencyDisplayName: 'Use of speed',
+          faultCount: 1,
+          comment: 'dummy',
+        },
+      ];
+      it('should display a driving faults badge with the count for each type of driving fault on the test', () => {
+        fixture.detectChanges();
+        component.pageState.drivingFaults$ = of(drivingFaults);
+        component.pageState.drivingFaultCount$ = of(4);
+        component.pageState.displayDrivingFaultComments$ = of(false);
+        fixture.detectChanges();
+
+        const drivingFaultBadges = fixture.debugElement.queryAll(By.css('driving-faults-badge'));
+        expect(drivingFaultBadges.length).toBe(2);
+        expect(drivingFaultBadges[0].componentInstance.count).toBe(3);
+        expect(drivingFaultBadges[1].componentInstance.count).toBe(1);
+      });
+      it('should render the display name for each driving fault', () => {
+        fixture.detectChanges();
+        component.pageState.drivingFaults$ = of(drivingFaults);
+        component.pageState.drivingFaultCount$ = of(4);
+        component.pageState.displayDrivingFaultComments$ = of(false);
+        fixture.detectChanges();
+
+        const faultLabels = fixture.debugElement.queryAll(By.css('.fault-label'));
+        expect(faultLabels.length).toBe(2);
+        expect(faultLabels[0].nativeElement.innerHTML).toBe('Signals - Timed');
+        expect(faultLabels[1].nativeElement.innerHTML).toBe('Use of speed');
       });
     });
   });

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -133,11 +133,12 @@
           *ngFor="let drivingFault of (pageState.drivingFaults$ | async)">
           <ion-col class="component-label" align-self-center col-1>
             <div class="counter-icon">
-              <driving-faults-badge class="counter driving-faults" [count]="drivingFault.count"></driving-faults-badge>
+              <driving-faults-badge class="counter driving-faults" [count]="drivingFault.faultCount">
+              </driving-faults-badge>
             </div>
           </ion-col>
           <ion-col class="component-label" col-58 align-self-center>
-            <label class="fault-label">{{drivingFault.name}}</label>
+            <label class="fault-label">{{drivingFault.competencyDisplayName}}</label>
           </ion-col>
         </ion-row>
       </ion-card-content>


### PR DESCRIPTION
## Description and relevant Jira numbers
* Fixes references to the comment model that weren't updated in the Office template as part of #344
* Similar fix to #347

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
