### PR TITLE
MES-2250 update terminate modal to use shared styles

### DIFF
--- a/src/components/end-test-link/end-test-link.scss
+++ b/src/components/end-test-link/end-test-link.scss
@@ -1,3 +1,6 @@
 .end-test-link-button {
   background: transparent;
+  &.activated {
+    background: transparent
+  }
 }

--- a/src/components/end-test-link/end-test-link.ts
+++ b/src/components/end-test-link/end-test-link.ts
@@ -17,7 +17,7 @@ export class EndTestLinkComponent {
     this.terminateTestModal = this.modalController.create('TerminateTestModal', {
       onCancel: this.onCancel,
       onTerminate: this.onTerminate,
-    });
+    }, { cssClass: 'mes-modal-alert text-zoom-regular' });
     this.terminateTestModal.present();
   }
 

--- a/src/components/terminate-test-modal/terminate-test-modal.html
+++ b/src/components/terminate-test-modal/terminate-test-modal.html
@@ -1,20 +1,20 @@
-<ion-card id="terminate-test-modal-card">
+<ion-card id="terminate-test-modal-card" class="modal-alert">
   <ion-row>
-    <ion-col class="center-icon">
-      <ion-icon class="terminate-icon" ios="ios-alert"></ion-icon>
+    <ion-col class="center-icon" no-padding>
+      <ion-icon class="terminate-icon" ios="md-alert"></ion-icon>
     </ion-col>
   </ion-row>
   <ion-row justify-content-center>
-    <ion-col class="terminate-test-text" col-50>
-      <span class="terminate-test-text">You're about to terminate the test</span>
+    <ion-col no-padding>
+      <h2 class="modal-alert-header">You're about to<br/>terminate the test</h2>
     </ion-col>
   </ion-row>
   <ion-row>
-    <ion-col class="column-border-top column-border-right">
-      <button ion-button class="terminate-button" (click)="terminationWrapper()">Terminate test</button>
+    <ion-col class="column-border-top column-border-right" no-padding>
+      <button ion-button clear class="terminate-button" (click)="terminationWrapper()">Terminate test</button>
     </ion-col>
-    <ion-col class="column-border-top">
-      <button ion-button class="return-button" (click)="onCancel()">Return to test</button>
+    <ion-col class="column-border-top" no-padding>
+      <button ion-button clear class="return-button" (click)="onCancel()">Return to test</button>
     </ion-col>
   </ion-row>
 </ion-card>

--- a/src/components/terminate-test-modal/terminate-test-modal.scss
+++ b/src/components/terminate-test-modal/terminate-test-modal.scss
@@ -1,7 +1,8 @@
 terminate-test-modal {
-  #terminate-test-modal-card {
-    background: map-get($colors-gds, gds-grey-4);
-    border-radius: 14px;
+  @extend .modal-alert-wrapper;
+
+  .modal-alert {
+    width: 400px;
   }
 
   .center-icon {
@@ -9,48 +10,20 @@ terminate-test-modal {
   }
 
   .terminate-icon {
-    padding: 20px 0;
+    margin: 40px 0px 16px;
     font-size: 96px;
   }
 
-  .terminate-test-text {
-    font-size: 28px;
-    font-weight: bold;
-    letter-spacing: 0.27px;
-    line-height: 40px;
-    text-align: center;
-    margin-bottom: 25px;
+  .modal-alert-header {
+    margin: 0 0 36px;
   }
 
   .terminate-button {
-    width: 100%;
-    font-size: 23px;
-    font-weight: 500;
-    background: transparent;
-    color: crimson;
-    &:active {
-      background: inherit;
-    }
+    color: map-get($colors-gds, gds-red);
   }
 
   .return-button {
-    width: 100%;
-    font-size: 23px;
-    font-weight: 500;
-    background: transparent;
-    color: black;
-    &:active {
-      background: inherit;
-    }
+    color: map-get($colors-gds, gds-black);
   }
 
-  .column-border-top {
-    border-top: 1px solid lightgrey;
-    padding-top: 2px;
-  }
-
-  .column-border-right {
-    border-right: 1px solid lightgrey;
-    padding-top: 2px;
-  }
 }


### PR DESCRIPTION
## Description and relevant Jira numbers
- Update the terminate test (before test started) modal so that it reuses the shared modal styles created in MES-2170

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

![Screenshot 2019-05-02 at 17 30 17](https://user-images.githubusercontent.com/8069071/57091224-95abc280-6d00-11e9-89e8-634db4b06f93.png)
