### PR TITLE
Allow switching between different writeups

### DIFF
--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -95,7 +95,7 @@ export function testsReducer(
 }
 
 const deriveSlotId = (state: TestsModel, action: Action): string | null => {
-  if (action instanceof journalActions.StartTest) {
+  if (action instanceof journalActions.StartTest || action instanceof journalActions.ActivateTest) {
     return `${action.slotId}`;
   }
   return (state.currentTest && state.currentTest.slotId) ? state.currentTest.slotId : null;

--- a/src/pages/journal/components/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/pages/journal/components/test-outcome/__tests__/test-outcome.spec.ts
@@ -2,18 +2,19 @@ import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { IonicModule, NavController } from 'ionic-angular';
 import { TestOutcomeComponent } from '../test-outcome';
 import { StoreModel } from '../../../../../shared/models/store.model';
-import { Store , StoreModule } from '@ngrx/store';
+import { Store, StoreModule } from '@ngrx/store';
 import { By } from '@angular/platform-browser';
 import { NavControllerMock } from 'ionic-mocks';
 import { AnalyticsProviderMock } from '../../../../../providers/analytics/__mocks__/analytics.mock';
 import { AnalyticsProvider } from '../../../../../providers/analytics/analytics';
-import { StartTest } from '../../../journal.actions';
+import { StartTest, ActivateTest } from '../../../journal.actions';
 import { TestStatus } from '../../../../../modules/tests/test-status/test-status.model';
 
 describe('Test Outcome', () => {
   let fixture: ComponentFixture<TestOutcomeComponent>;
   let component: TestOutcomeComponent;
   let store$: Store<StoreModel>;
+  let navController: NavController;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -31,6 +32,7 @@ describe('Test Outcome', () => {
       .then(() => {
         fixture = TestBed.createComponent(TestOutcomeComponent);
         component = fixture.componentInstance;
+        navController = TestBed.get(NavController);
       });
     store$ = TestBed.get(Store);
     spyOn(store$, 'dispatch');
@@ -49,6 +51,28 @@ describe('Test Outcome', () => {
         component.startTest();
 
         expect(store$.dispatch).toHaveBeenCalledWith(new StartTest(component.slotId));
+      });
+    });
+
+    describe('writeUpTest', () => {
+      it('should dispatch an ActivateTest action and navigate to the Office page', () => {
+        component.slotId = 123;
+        component.writeUpTest();
+
+        expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotId));
+        const { calls } = navController.push as jasmine.Spy;
+        expect(calls.argsFor(0)[0]).toBe('OfficePage');
+      });
+    });
+
+    describe('resumeTest', () => {
+      it('should dispatch an ActivateTest action and navigate to the Office page', () => {
+        component.slotId = 123;
+        component.resumeTest();
+
+        expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotId));
+        const { calls } = navController.push as jasmine.Spy;
+        expect(calls.argsFor(0)[0]).toBe('WaitingRoomPage');
       });
     });
   });
@@ -92,7 +116,7 @@ describe('Test Outcome', () => {
         component.outcome = '1234';
         fixture.detectChanges();
         const outcome = fixture.debugElement.queryAll(By.css('.outcome'));
-        expect(outcome.length) .toBe(1);
+        expect(outcome.length).toBe(1);
       });
 
       it('should not show activity code when an outcome is not provided', () => {
@@ -101,7 +125,45 @@ describe('Test Outcome', () => {
         const outcome = fixture.debugElement.queryAll(By.css('.outcome'));
         expect(outcome.length).toBe(0);
       });
+    });
 
+    describe('start a test', () => {
+      it('should call the startTest method when `Start test` is clicked', () => {
+        component.testStatus = TestStatus.Booked;
+        fixture.detectChanges();
+        spyOn(component, 'startTest');
+
+        const startButton = fixture.debugElement.query(By.css('.mes-primary-button'));
+        startButton.triggerEventHandler('click', null);
+
+        expect(component.startTest).toHaveBeenCalled();
+      });
+    });
+
+    describe('write up a test', () => {
+      it('should call the writeUpTest method when `Write-up` is clicked', () => {
+        component.testStatus = TestStatus.Decided;
+        fixture.detectChanges();
+        spyOn(component, 'writeUpTest');
+
+        const writeUpButton = fixture.debugElement.query(By.css('.mes-secondary-button'));
+        writeUpButton.triggerEventHandler('click', null);
+
+        expect(component.writeUpTest).toHaveBeenCalled();
+      });
+    });
+
+    describe('resume a test', () => {
+      it('should call the resumeTest method when `Resume` is clicked', () => {
+        component.testStatus = TestStatus.Started;
+        fixture.detectChanges();
+        spyOn(component, 'resumeTest');
+
+        const resumeButton = fixture.debugElement.query(By.css('.mes-secondary-button'));
+        resumeButton.triggerEventHandler('click', null);
+
+        expect(component.resumeTest).toHaveBeenCalled();
+      });
     });
 
   });

--- a/src/pages/journal/components/test-outcome/test-outcome.html
+++ b/src/pages/journal/components/test-outcome/test-outcome.html
@@ -22,14 +22,14 @@
       </ion-col>
       <ion-col *ngIf="needsWriteUp()">
         <span>
-          <button class="mes-secondary-button mes-warning-button" ion-button navPush="OfficePage">
+          <button class="mes-secondary-button mes-warning-button" ion-button (click)="writeUpTest()">
             <h3 class="write-up-label">Write-up</h3>
           </button>
         </span>
       </ion-col>
       <ion-col *ngIf="showResumeTestButton()">
         <span>
-          <button class="mes-secondary-button mes-warning-button" ion-button navPush="WaitingRoomPage">
+          <button class="mes-secondary-button mes-warning-button" ion-button (click)="resumeTest()">
             <h3 class="write-up-label">Resume</h3>
           </button>
         </span>

--- a/src/pages/journal/components/test-outcome/test-outcome.ts
+++ b/src/pages/journal/components/test-outcome/test-outcome.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 import { NavController } from 'ionic-angular';
 import { Store } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
-import { StartTest } from '../../journal.actions';
+import { StartTest, ActivateTest } from '../../journal.actions';
 import { TestStatus } from '../../../../modules/tests/test-status/test-status.model';
 
 @Component({
@@ -26,7 +26,7 @@ export class TestOutcomeComponent {
   constructor(
     private store$: Store<StoreModel>,
     public navController: NavController,
-  ) {}
+  ) { }
 
   showOutcome(): boolean {
     return this.outcome !== undefined || this.outcome != null;
@@ -43,6 +43,16 @@ export class TestOutcomeComponent {
   startTest() {
     console.log(`starting test ${this.slotId}`);
     this.store$.dispatch(new StartTest(this.slotId));
+    this.navController.push('WaitingRoomPage');
+  }
+
+  writeUpTest() {
+    this.store$.dispatch(new ActivateTest(this.slotId));
+    this.navController.push('OfficePage');
+  }
+
+  resumeTest() {
+    this.store$.dispatch(new ActivateTest(this.slotId));
     this.navController.push('WaitingRoomPage');
   }
 

--- a/src/pages/journal/journal.actions.ts
+++ b/src/pages/journal/journal.actions.ts
@@ -20,6 +20,7 @@ export const SELECT_NEXT_DAY = '[JournalPage] Select Next Day';
 export const SET_SELECTED_DAY = '[JournalEffects] Set Selected Day';
 
 export const START_TEST = '[TestOutcomeComponent] Start Test';
+// Differs from START_TEST in that it won't trigger the journal -> test state copy effect
 export const ACTIVATE_TEST = '[TestOutcomeComponent] Activate Test';
 
 // Analytic actions

--- a/src/pages/journal/journal.actions.ts
+++ b/src/pages/journal/journal.actions.ts
@@ -20,6 +20,7 @@ export const SELECT_NEXT_DAY = '[JournalPage] Select Next Day';
 export const SET_SELECTED_DAY = '[JournalEffects] Set Selected Day';
 
 export const START_TEST = '[TestOutcomeComponent] Start Test';
+export const ACTIVATE_TEST = '[TestOutcomeComponent] Activate Test';
 
 // Analytic actions
 
@@ -41,20 +42,20 @@ export class LoadJournalSuccess implements Action {
 
   // TODO: declare payload with the correct type when we have a slot type in place
   constructor(
-    public payload: {[k: string]: SlotItem[]},
+    public payload: { [k: string]: SlotItem[] },
     public onlineOffline: ConnectionStatus,
     public unAuthenticatedMode: boolean,
-    public lastRefreshed: Date) {}
+    public lastRefreshed: Date) { }
 }
 
 export class LoadJournalFailure implements Action {
   readonly type = LOAD_JOURNAL_FAILURE;
-  constructor(public payload: MesError) {}
+  constructor(public payload: MesError) { }
 }
 
 export class LoadJournalSilentFailure implements Action {
   readonly type = LOAD_JOURNAL_SILENT_FAILURE;
-  constructor(public payload: MesError) {}
+  constructor(public payload: MesError) { }
 }
 
 export class UnloadJournal implements Action {
@@ -67,7 +68,7 @@ export class UnsetError implements Action {
 
 export class ClearChangedSlot implements Action {
   readonly type = CLEAR_CHANGED_SLOT;
-  constructor(public slotId: number) {}
+  constructor(public slotId: number) { }
 }
 
 export class SelectPreviousDay implements Action {
@@ -80,7 +81,7 @@ export class SelectNextDay implements Action {
 
 export class SetSelectedDate implements Action {
   readonly type = SET_SELECTED_DAY;
-  constructor(public payload: string) {}
+  constructor(public payload: string) { }
 }
 
 export class SetupPolling implements Action {
@@ -97,22 +98,27 @@ export class JournalViewDidEnter implements Action {
 
 export class JournalNavigateDay implements Action {
   readonly type = JOURNAL_NAVIGATE_DAY;
-  constructor(public day: string) {}
+  constructor(public day: string) { }
 }
 
 export class JournalRefreshError implements Action {
   readonly type = JOURNAL_REFRESH_ERROR;
-  constructor(public errorDescription: string, public errorMessage: string) {}
+  constructor(public errorDescription: string, public errorMessage: string) { }
 }
 
 export class JournalRefresh implements Action {
   readonly type = JOURNAL_REFRESH;
-  constructor(public mode: string) {}
+  constructor(public mode: string) { }
 }
 
 export class StartTest implements Action {
   readonly type = START_TEST;
-  constructor(public slotId: number) {}
+  constructor(public slotId: number) { }
+}
+
+export class ActivateTest implements Action {
+  readonly type = ACTIVATE_TEST;
+  constructor(public slotId: number) { }
 }
 
 export type JournalActionTypes =
@@ -132,4 +138,5 @@ export type JournalActionTypes =
   | JournalNavigateDay
   | JournalRefreshError
   | JournalRefresh
-  | StartTest;
+  | StartTest
+  | ActivateTest;


### PR DESCRIPTION
## Description and relevant Jira numbers
* Currently, clicking "Write-up" views the Office form for the latest started test
* Ensure that re-nav from Journal to Office assigns the resumed test slot ID into `/tests/currentTest`

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
