### PR TITLE
MES-2245: Office comment alignment + other fixes

### DIFF
--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -62,4 +62,16 @@ describe('testsReducer', () => {
     expect(result.testLifecycles['123']).toBe(TestStatus.Started);
     expect(result.testLifecycles['456']).toBe(TestStatus.Decided);
   });
+
+  it('should assign the slot ID as the current test when a test is activated', () => {
+    const state: TestsModel = {
+      currentTest: { slotId: '123' },
+      startedTests: {},
+      testLifecycles: {},
+    };
+
+    const result = testsReducer(state, new journalActions.ActivateTest(456));
+
+    expect(result.currentTest.slotId).toBe('456');
+  });
 });

--- a/src/pages/office/components/fault-comment-card/__tests__/fault-comment-card.spec.ts
+++ b/src/pages/office/components/fault-comment-card/__tests__/fault-comment-card.spec.ts
@@ -7,7 +7,7 @@ import { By } from '@angular/platform-browser';
 import { AppModule } from '../../../../../app/app.module';
 import { FormGroup } from '@angular/forms';
 
-fdescribe('FaultCommentCardComponent', () => {
+describe('FaultCommentCardComponent', () => {
   let fixture: ComponentFixture<FaultCommentCardComponent>;
   let component: FaultCommentCardComponent;
 

--- a/src/pages/office/components/fault-comment-card/__tests__/fault-comment-card.spec.ts
+++ b/src/pages/office/components/fault-comment-card/__tests__/fault-comment-card.spec.ts
@@ -1,0 +1,61 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { FaultCommentCardComponent } from '../fault-comment-card';
+import { FaultCommentComponent } from '../../fault-comment/fault-comment';
+import { MockComponent } from 'ng-mocks';
+import { IonicModule } from 'ionic-angular';
+import { By } from '@angular/platform-browser';
+import { AppModule } from '../../../../../app/app.module';
+import { FormGroup } from '@angular/forms';
+
+fdescribe('FaultCommentCardComponent', () => {
+  let fixture: ComponentFixture<FaultCommentCardComponent>;
+  let component: FaultCommentCardComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        FaultCommentCardComponent,
+        MockComponent(FaultCommentComponent),
+      ],
+      imports: [
+        IonicModule,
+        AppModule,
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(FaultCommentCardComponent);
+        component = fixture.componentInstance;
+        component.formGroup = new FormGroup({});
+      });
+  }));
+
+  describe('DOM', () => {
+    it('should display the provided header', () => {
+      component.shouldRender = true;
+      component.header = 'header';
+      fixture.detectChanges();
+
+      const header = fixture.debugElement.query(By.css('h4')).nativeElement;
+      expect(header.innerHTML).toBe('header');
+    });
+
+    it('should pass the faultComment and type to the fault-comment component', () => {
+      component.shouldRender = true;
+      component.faultComments = [
+        { comment: 'c1', competencyIdentifier: 'id1', competencyDisplayName: 'display1' },
+        { comment: 'c2', competencyIdentifier: 'id2', competencyDisplayName: 'display2' },
+      ];
+      component.faultType = 'drivingFault';
+      fixture.detectChanges();
+
+      const commentLabels = fixture.debugElement.queryAll(By.css('fault-comment'));
+      expect(commentLabels.length).toBe(2);
+      expect(commentLabels[0].componentInstance.faultType).toBe('drivingFault');
+      expect(commentLabels[1].componentInstance.faultType).toBe('drivingFault');
+      expect(commentLabels[0].componentInstance.faultComment).toBe(component.faultComments[0]);
+      expect(commentLabels[1].componentInstance.faultComment).toBe(component.faultComments[1]);
+    });
+  });
+
+});

--- a/src/pages/office/components/fault-comment-card/fault-comment-card.scss
+++ b/src/pages/office/components/fault-comment-card/fault-comment-card.scss
@@ -1,0 +1,5 @@
+fault-comment-card {
+  fault-comment {
+    width: 100%;
+  }
+}

--- a/src/pages/office/components/fault-comment/__tests__/fault-comment.spec.ts
+++ b/src/pages/office/components/fault-comment/__tests__/fault-comment.spec.ts
@@ -1,0 +1,67 @@
+
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { FaultCommentComponent } from '../fault-comment';
+import { IonicModule } from 'ionic-angular';
+import { AppModule } from '../../../../../app/app.module';
+import { By } from '@angular/platform-browser';
+import { MockComponent } from 'ng-mocks';
+import { DrivingFaultsBadgeComponent } from '../../../../../components/driving-faults-badge/driving-faults-badge';
+import { SeriousFaultBadgeComponent } from '../../../../../components/serious-fault-badge/serious-fault-badge';
+import { DangerousFaultBadgeComponent } from '../../../../../components/dangerous-fault-badge/dangerous-fault-badge';
+import { FormGroup } from '@angular/forms';
+
+describe('FaultCommentComponent', () => {
+  let fixture: ComponentFixture<FaultCommentComponent>;
+  let component: FaultCommentComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        FaultCommentComponent,
+        MockComponent(DrivingFaultsBadgeComponent),
+        MockComponent(SeriousFaultBadgeComponent),
+        MockComponent(DangerousFaultBadgeComponent),
+      ],
+      imports: [
+        IonicModule,
+        AppModule,
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(FaultCommentComponent);
+        component = fixture.componentInstance;
+        component.parentForm = new FormGroup({});
+      });
+  }));
+
+  describe('DOM', () => {
+    it('should display the fault competency display name', () => {
+      component.faultComment = { comment: 'comment', competencyDisplayName: 'display', competencyIdentifier: 'id' };
+      component.faultType = 'driving';
+      component.ngOnChanges();
+      fixture.detectChanges();
+
+      const displayName = fixture.debugElement.query(By.css('.fault-label')).nativeElement;
+
+      expect(displayName.innerHTML).toBe('display');
+    });
+
+    it('should pass the fault count down to the driving-fault-badge', () => {
+      component.faultComment = {
+        comment: 'comment',
+        competencyDisplayName: 'display',
+        competencyIdentifier: 'id',
+        faultCount: 3,
+      };
+      component.faultType = 'driving';
+      component.ngOnChanges();
+      fixture.detectChanges();
+
+      const drivingFaultBadge: DrivingFaultsBadgeComponent = fixture.debugElement
+        .query(By.css('driving-faults-badge')).componentInstance;
+      expect(drivingFaultBadge.count).toBe(3);
+    });
+  });
+
+});

--- a/src/pages/office/components/fault-comment/fault-comment.html
+++ b/src/pages/office/components/fault-comment/fault-comment.html
@@ -5,7 +5,7 @@
     <ion-col class="component-label" align-self-center col-1 [ngSwitch]="faultType">
       <dangerous-fault-badge [showBadge]="true" *ngSwitchCase="'dangerous'"></dangerous-fault-badge>
       <serious-fault-badge [showBadge]="true" *ngSwitchCase="'serious'"></serious-fault-badge>
-      <driving-faults-badge [count]="faultComment.drivingFaultCount" *ngSwitchCase="'driving'"></driving-faults-badge>
+      <driving-faults-badge [count]="faultComment.faultCount" *ngSwitchCase="'driving'"></driving-faults-badge>
     </ion-col>
     <ion-col class="component-label" col-29 align-self-center>
       <label class="fault-label">{{faultComment.competencyDisplayName}}</label>

--- a/src/pages/office/components/fault-comment/fault-comment.ts
+++ b/src/pages/office/components/fault-comment/fault-comment.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
-import { CommentedCompetency } from '../../../../shared/models/fault-marking.model';
+import { CommentedCompetency, MultiFaultAssignableCompetency } from '../../../../shared/models/fault-marking.model';
 
 @Component({
   selector: 'fault-comment',
@@ -12,7 +12,7 @@ export class FaultCommentComponent implements OnChanges {
   parentForm: FormGroup;
 
   @Input()
-  faultComment: CommentedCompetency;
+  faultComment: CommentedCompetency | (CommentedCompetency & MultiFaultAssignableCompetency);
 
   @Input()
   faultType: string;
@@ -32,7 +32,7 @@ export class FaultCommentComponent implements OnChanges {
 
   faultCommentChanged(newComment: string): void {
     const { comment, ...commentedCompetencyWithoutComment } = this.faultComment;
-    const commentedCompetency: CommentedCompetency = {
+    const commentedCompetency: CommentedCompetency | (CommentedCompetency & MultiFaultAssignableCompetency) = {
       comment: newComment,
       ...commentedCompetencyWithoutComment,
     };


### PR DESCRIPTION
## Description and relevant Jira numbers
* Fix issue with some fault comment text areas being severely misaligned
* Fix driving fault counts not displaying next to driving fault comment boxes
* Add a missing unit test from #362
* Unit tests around `FaultCommentComponent` and `FaultCommentCardComponent`

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
