### PR TITLE
MES-2055: Set the activity code to 3 on eyesight failure

### DIFF
--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -47,7 +47,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1001,
-        "start": "2019-05-03T08:10:00+01:00"
+        "start": "2019-05-08T08:10:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -95,7 +95,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1003,
-        "start": "2019-05-03T10:14:00+01:00"
+        "start": "2019-05-08T10:14:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -144,7 +144,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1004,
-        "start": "2019-05-03T11:11:00+01:00"
+        "start": "2019-05-08T11:11:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -195,7 +195,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1005,
-        "start": "2019-05-03T12:38:00+01:00"
+        "start": "2019-05-08T12:38:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -248,7 +248,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1006,
-        "start": "2019-05-03T13:35:00+01:00"
+        "start": "2019-05-08T13:35:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -293,7 +293,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1007,
-        "start": "2019-05-04T14:32:00+01:00"
+        "start": "2019-05-09T14:32:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,

--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
@@ -231,15 +231,9 @@ describe('WaitingRoomToCarPage', () => {
       });
     });
   });
-  describe('onSubmit', () => {
+  describe('ionViewWillLeave', () => {
     it('should dispatch the PersistTests action', () => {
-      const form = component.form;
-      form.get('eyesightCtrl').setValue(true);
-      form.get('tellMeQuestionOutcomeCtrl').setValue(true);
-      form.get('tellMeQuestionCtrl').setValue(true);
-      form.get('registrationNumberCtrl').setValue(true);
-      form.get('transmissionRadioGroupCtrl').setValue(true);
-      component.onSubmit();
+      component.ionViewWillLeave();
       expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
     });
   });

--- a/src/pages/waiting-room-to-car/components/eyesight-failure-confirmation/__tests__/eyesight-failure-confirmation.spec.ts
+++ b/src/pages/waiting-room-to-car/components/eyesight-failure-confirmation/__tests__/eyesight-failure-confirmation.spec.ts
@@ -3,11 +3,16 @@ import { TestBed, ComponentFixture, async } from '@angular/core/testing';
 import { IonicModule, Config, NavController } from 'ionic-angular';
 import { By } from '@angular/platform-browser';
 import { ConfigMock, NavControllerMock } from 'ionic-mocks';
+import { StoreModule, Store } from '@ngrx/store';
+import { testsReducer } from '../../../../../modules/tests/tests.reducer';
+import { StoreModel } from '../../../../../shared/models/store.model';
+import { SetActivityCode } from '../../../../../modules/tests/tests.actions';
 
 describe('eyesight failure confirmation component', () => {
   let fixture: ComponentFixture<EyesightFailureConfirmationComponent>;
   let component: EyesightFailureConfirmationComponent;
   let navController: NavController;
+  let store$: Store<StoreModel>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -16,6 +21,9 @@ describe('eyesight failure confirmation component', () => {
       ],
       imports: [
         IonicModule,
+        StoreModule.forRoot({
+          tests: testsReducer,
+        }),
       ],
       providers: [
         { provide: Config, useFactory: () => ConfigMock.instance() },
@@ -27,6 +35,8 @@ describe('eyesight failure confirmation component', () => {
         fixture = TestBed.createComponent(EyesightFailureConfirmationComponent);
         component = fixture.componentInstance;
         navController = TestBed.get(NavController);
+        store$ = TestBed.get(Store);
+        spyOn(store$, 'dispatch');
       });
   }));
 
@@ -43,6 +53,15 @@ describe('eyesight failure confirmation component', () => {
       confirmButton.triggerEventHandler('click', null);
       const { calls } = navController.push as jasmine.Spy;
       expect(calls.argsFor(0)[0]).toBe('DebriefPage');
+    });
+  });
+
+  describe('Class', () => {
+    describe('onContinue', () => {
+      it('should dispatch an action to set the activity code to an eyesight failure', () => {
+        component.onContinue();
+        expect(store$.dispatch).toHaveBeenCalledWith(new SetActivityCode('3'));
+      });
     });
   });
 });

--- a/src/pages/waiting-room-to-car/components/eyesight-failure-confirmation/eyesight-failure-confirmation.ts
+++ b/src/pages/waiting-room-to-car/components/eyesight-failure-confirmation/eyesight-failure-confirmation.ts
@@ -1,12 +1,18 @@
 import { Component, Input } from '@angular/core';
 import { NavController } from 'ionic-angular';
+import { Store } from '@ngrx/store';
+import { StoreModel } from '../../../../shared/models/store.model';
+import { SetActivityCode } from '../../../../modules/tests/tests.actions';
 
 @Component({
   selector: 'eyesight-failure-confirmation',
   templateUrl: 'eyesight-failure-confirmation.html',
 })
 export class EyesightFailureConfirmationComponent {
-  constructor(public navController: NavController) { }
+  constructor(
+    public navController: NavController,
+    private store$: Store<StoreModel>,
+  ) { }
 
   @Input()
   cancelFn: Function;
@@ -17,5 +23,6 @@ export class EyesightFailureConfirmationComponent {
 
   onContinue(): void {
     this.navController.push('DebriefPage', { outcome: 'fail' });
+    this.store$.dispatch(new SetActivityCode('3'));
   }
 }

--- a/src/pages/waiting-room-to-car/components/eyesight-failure-confirmation/eyesight-failure-confirmation.ts
+++ b/src/pages/waiting-room-to-car/components/eyesight-failure-confirmation/eyesight-failure-confirmation.ts
@@ -22,7 +22,7 @@ export class EyesightFailureConfirmationComponent {
   }
 
   onContinue(): void {
-    this.navController.push('DebriefPage', { outcome: 'fail' });
+    this.navController.push('DebriefPage');
     this.store$.dispatch(new SetActivityCode('3'));
   }
 }

--- a/src/pages/waiting-room-to-car/components/eyesight-failure-confirmation/eyesight-failure-confirmation.ts
+++ b/src/pages/waiting-room-to-car/components/eyesight-failure-confirmation/eyesight-failure-confirmation.ts
@@ -3,6 +3,7 @@ import { NavController } from 'ionic-angular';
 import { Store } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
 import { SetActivityCode } from '../../../../modules/tests/tests.actions';
+import { ActivityCodes } from '../../../../shared/models/activity-codes';
 
 @Component({
   selector: 'eyesight-failure-confirmation',
@@ -23,6 +24,6 @@ export class EyesightFailureConfirmationComponent {
 
   onContinue(): void {
     this.navController.push('DebriefPage');
-    this.store$.dispatch(new SetActivityCode('3'));
+    this.store$.dispatch(new SetActivityCode(ActivityCodes.FAIL_EYESIGHT));
   }
 }

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.ts
@@ -213,6 +213,10 @@ export class WaitingRoomToCarPage extends BasePageComponent {
     this.store$.dispatch(new WaitingRoomToCarViewDidEnter());
   }
 
+  ionViewWillLeave(): void {
+    this.store$.dispatch(new PersistTests());
+  }
+
   schoolCarToggled(): void {
     this.store$.dispatch(new SchoolCarToggled());
   }
@@ -261,7 +265,6 @@ export class WaitingRoomToCarPage extends BasePageComponent {
   onSubmit() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
-      this.store$.dispatch(new PersistTests());
       this.navCtrl.push('TestReportPage');
     }
   }


### PR DESCRIPTION
## Description and relevant Jira numbers
* Assign the relevant activity code to the test when an eyesight failure is confirmed
* Remove the existing mechanism of indicating a failure to the debrief page with nav params
* Move WRTC persistence to navigation as opposed to form submit to persist on eyesight failure

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
