### PR TITLE
mes-2267: Adding basic communication page layout

### DIFF
--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -47,7 +47,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1001,
-        "start": "2019-05-08T08:10:00+01:00"
+        "start": "2019-05-09T08:10:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -95,7 +95,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1003,
-        "start": "2019-05-08T10:14:00+01:00"
+        "start": "2019-05-09T10:14:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -144,7 +144,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1004,
-        "start": "2019-05-08T11:11:00+01:00"
+        "start": "2019-05-09T11:11:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -195,7 +195,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1005,
-        "start": "2019-05-08T12:38:00+01:00"
+        "start": "2019-05-09T12:38:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -248,7 +248,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1006,
-        "start": "2019-05-08T13:35:00+01:00"
+        "start": "2019-05-09T13:35:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -293,7 +293,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1007,
-        "start": "2019-05-09T14:32:00+01:00"
+        "start": "2019-05-10T14:32:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,

--- a/src/components/candidate-section/candidate-section.html
+++ b/src/components/candidate-section/candidate-section.html
@@ -1,0 +1,11 @@
+<ion-row class="mes-full-width-card" id="candidate-section">
+  <ion-col>
+    <h2 id="candidate-name">{{ candidateName }}</h2>
+    <h3 id="candidate-driver-number">{{ candidateDriverNumber }}</h3>
+  </ion-col>
+  <ion-col col-auto>
+    <button (click)="proceed()" id="continue-button" class="mes-primary-button" float-right ion-button>
+      <h3>Continue</h3>
+    </button>
+  </ion-col>
+</ion-row>

--- a/src/components/candidate-section/candidate-section.scss
+++ b/src/components/candidate-section/candidate-section.scss
@@ -1,0 +1,11 @@
+candidate-section {
+  #candidate-section {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    #continue-button {
+      padding: 8px 24px;
+    }
+  }
+}

--- a/src/components/candidate-section/candidate-section.ts
+++ b/src/components/candidate-section/candidate-section.ts
@@ -1,0 +1,21 @@
+import { Component, Output, EventEmitter, Input } from '@angular/core';
+
+@Component({
+  selector: 'candidate-section',
+  templateUrl: 'candidate-section.html',
+})
+export class CandidateSectionComponent {
+
+  @Input()
+  candidateName: string;
+
+  @Input()
+  candidateDriverNumber: string;
+
+  @Output()
+  continueClickEvent = new EventEmitter<boolean>();
+
+  proceed(): void {
+    this.continueClickEvent.emit(true);
+  }
+}

--- a/src/components/components.module.ts
+++ b/src/components/components.module.ts
@@ -9,6 +9,7 @@ import { DangerousFaultBadgeComponent } from './dangerous-fault-badge/dangerous-
 import { IonicModule } from 'ionic-angular';
 import { EndTestLinkComponent } from './end-test-link/end-test-link';
 import { TerminateTestModalModule } from './terminate-test-modal/terminate-test-modal.module';
+import { CandidateSectionComponent } from './candidate-section/candidate-section';
 
 @NgModule({
   declarations: [
@@ -18,6 +19,7 @@ import { TerminateTestModalModule } from './terminate-test-modal/terminate-test-
     SeriousFaultBadgeComponent,
     DangerousFaultBadgeComponent,
     EndTestLinkComponent,
+    CandidateSectionComponent,
   ],
   imports: [
     SignaturePadModule,
@@ -32,6 +34,7 @@ import { TerminateTestModalModule } from './terminate-test-modal/terminate-test-
     SeriousFaultBadgeComponent,
     DangerousFaultBadgeComponent,
     EndTestLinkComponent,
+    CandidateSectionComponent,
   ],
 })
 export class ComponentsModule { }

--- a/src/pages/communication-page/__tests__/communication.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.spec.ts
@@ -1,0 +1,147 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { CommunicationPage } from '../communication';
+import { Store, StoreModule } from '@ngrx/store';
+import { StoreModel } from '../../../shared/models/store.model';
+import { DeviceProvider } from '../../../providers/device/device';
+import { DeviceAuthenticationProvider } from '../../../providers/device-authentication/device-authentication';
+import { Insomnia } from '@ionic-native/insomnia';
+import { AppModule } from '../../../app/app.module';
+import { IonicModule, NavController, NavParams, Config, Platform } from 'ionic-angular';
+import { ComponentsModule } from '../../../components/components.module';
+import { NavControllerMock, NavParamsMock, ConfigMock, PlatformMock } from 'ionic-mocks';
+import { AuthenticationProvider } from '../../../providers/authentication/authentication';
+import { AuthenticationProviderMock } from '../../../providers/authentication/__mocks__/authentication.mock';
+import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
+import { ScreenOrientation } from '@ionic-native/screen-orientation'; import {
+  initialState as preTestDeclarationInitialState,
+} from '../../../modules/tests/pre-test-declarations/pre-test-declarations.reducer';
+import {
+  DeviceAuthenticationProviderMock,
+} from '../../../providers/device-authentication/__mocks__/device-authentication.mock';
+import { DateTimeProvider } from '../../../providers/date-time/date-time';
+import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
+import { ScreenOrientationMock } from '../../../shared/mocks/screen-orientation.mock';
+import { InsomniaMock } from '../../../shared/mocks/insomnia.mock';
+
+describe('CommunicationPage', () => {
+  let fixture: ComponentFixture<CommunicationPage>;
+  let component: CommunicationPage;
+  let store$: Store<StoreModel>;
+  let deviceProvider: DeviceProvider;
+  let deviceAuthenticationProvider: DeviceAuthenticationProvider;
+  let screenOrientation: ScreenOrientation;
+  let insomnia: Insomnia;
+
+  const mockCandidate = {
+    driverNumber: '123',
+    candidateName: {
+      firstName: 'Joe',
+      lastName: 'Blogs',
+    },
+  };
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        CommunicationPage,
+      ],
+      imports: [
+        IonicModule,
+        AppModule,
+        ComponentsModule,
+        StoreModule.forFeature('tests', () => ({
+          currentTest: {
+            slotId: '123',
+          },
+          testLifecycles: {},
+          startedTests: {
+            123: {
+              candidate: mockCandidate,
+              preTestDeclarations: preTestDeclarationInitialState,
+              postTestDeclarations: {
+                healthDeclarationAccepted: false,
+                passCertificateNumberReceived: false,
+                postTestSignature: '',
+              },
+            },
+          },
+        })),
+      ],
+      providers: [
+        { provide: NavController, useFactory: () => NavControllerMock.instance() },
+        { provide: NavParams, useFactory: () => NavParamsMock.instance() },
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+        { provide: Platform, useFactory: () => PlatformMock.instance() },
+        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
+        { provide: DeviceProvider, useClass: DeviceProviderMock },
+        { provide: DeviceAuthenticationProvider, useClass: DeviceAuthenticationProviderMock },
+        { provide: DateTimeProvider, useClass: DateTimeProviderMock },
+        { provide: ScreenOrientation, useClass: ScreenOrientationMock },
+        { provide: Insomnia, useClass: InsomniaMock },
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(CommunicationPage);
+        component = fixture.componentInstance;
+      });
+
+    deviceProvider = TestBed.get(DeviceProvider);
+    screenOrientation = TestBed.get(ScreenOrientation);
+    insomnia = TestBed.get(Insomnia);
+    deviceAuthenticationProvider = TestBed.get(DeviceAuthenticationProvider);
+    store$ = TestBed.get(Store);
+    spyOn(store$, 'dispatch');
+  }));
+
+  describe('Class', () => {
+    it('should create', () => {
+      expect(component).toBeDefined();
+    });
+
+    describe('ionViewDidEnter', () => {
+      it('should enable single app mode if on ios', () => {
+        component.ionViewDidEnter();
+        expect(deviceProvider.enableSingleAppMode).toHaveBeenCalled();
+      });
+
+      it('should lock the screen orientation to Portrait Primary', () => {
+        component.ionViewDidEnter();
+        expect(screenOrientation.lock)
+          .toHaveBeenCalledWith(screenOrientation.ORIENTATIONS.PORTRAIT_PRIMARY);
+      });
+
+      it('should keep the device awake', () => {
+        component.ionViewDidEnter();
+        expect(insomnia.keepAwake).toHaveBeenCalled();
+      });
+
+    });
+  });
+
+  describe('ionViewDidEnter', () => {
+    it('should enable single app mode if on ios', () => {
+      component.ionViewDidEnter();
+      expect(deviceProvider.enableSingleAppMode).toHaveBeenCalled();
+    });
+
+    it('should lock the screen orientation to Portrait Primary', () => {
+      component.ionViewDidEnter();
+      expect(screenOrientation.lock)
+        .toHaveBeenCalledWith(screenOrientation.ORIENTATIONS.PORTRAIT_PRIMARY);
+    });
+
+    it('should keep the device awake', () => {
+      component.ionViewDidEnter();
+      expect(insomnia.keepAwake).toHaveBeenCalled();
+    });
+
+  });
+
+  describe('clickBack', () => {
+    it('should should trigger the lock screen', () => {
+      component.clickBack();
+      expect(deviceAuthenticationProvider.triggerLockScreen).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/pages/communication-page/communication.actions.ts
+++ b/src/pages/communication-page/communication.actions.ts
@@ -1,0 +1,10 @@
+import { Action } from '@ngrx/store';
+
+export const COMMUNICATION_VIEW_DID_ENTER = '[CommunicationPage] Communication page did enter';
+
+export class CommunicationViewDidEnter implements Action {
+  readonly type = COMMUNICATION_VIEW_DID_ENTER;
+}
+
+export type Types =
+  | CommunicationViewDidEnter;

--- a/src/pages/communication-page/communication.html
+++ b/src/pages/communication-page/communication.html
@@ -1,0 +1,20 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>Declaration - {{pageState.candidateUntitledName$ | async}}</ion-title>
+    <ion-buttons end>
+      <end-test-link></end-test-link>
+    </ion-buttons>
+  </ion-navbar>
+</ion-header>
+<ion-content no-bounce>
+  <lock-screen-indicator></lock-screen-indicator>
+  <form>
+    <candidate-section [candidateName]="pageState.candidateName$ | async"
+      [candidateDriverNumber]="pageState.candidateDriverNumber$ | async" (continueClickEvent)="onSubmit()">
+    </candidate-section>
+    <div class="mes-full-width-card-separator"></div>
+    <div class="mes-full-width-card" id="declaration-section">
+      <h3>Select how to receive the test results</h3>
+    </div>
+  </form>
+</ion-content>

--- a/src/pages/communication-page/communication.module.ts
+++ b/src/pages/communication-page/communication.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { ComponentsModule } from '../../components/components.module';
+import { AnalyticsProvider } from '../../providers/analytics/analytics';
+import { CommunicationPage } from './communication';
+
+@NgModule({
+  declarations: [
+    CommunicationPage,
+  ],
+  imports: [
+    IonicPageModule.forChild(CommunicationPage),
+    ComponentsModule,
+  ],
+  providers: [
+    AnalyticsProvider,
+  ],
+})
+export class CommunicationPageModule {}

--- a/src/pages/communication-page/communication.scss
+++ b/src/pages/communication-page/communication.scss
@@ -1,0 +1,5 @@
+communication {
+  ion-content>div {
+    background-color: map-get($colors, "mes-white");
+  }
+}

--- a/src/pages/communication-page/communication.ts
+++ b/src/pages/communication-page/communication.ts
@@ -1,0 +1,105 @@
+import { IonicPage, Navbar, Platform, NavController } from 'ionic-angular';
+import { Component, ViewChild } from '@angular/core';
+import { BasePageComponent } from '../../shared/classes/base-page';
+import { FormGroup } from '@angular/forms';
+import { AuthenticationProvider } from '../../providers/authentication/authentication';
+import { Observable } from 'rxjs/Observable';
+import { StoreModel } from '../../shared/models/store.model';
+import { Store, select } from '@ngrx/store';
+import { DeviceProvider } from '../../providers/device/device';
+import { ScreenOrientation } from '@ionic-native/screen-orientation';
+import { Insomnia } from '@ionic-native/insomnia';
+import { DeviceAuthenticationProvider } from '../../providers/device-authentication/device-authentication';
+import { getCurrentTest } from '../../modules/tests/tests.selector';
+import { getTests } from '../../modules/tests/tests.reducer';
+import { getCandidate } from '../../modules/tests/candidate/candidate.reducer';
+import {
+  getCandidateName,
+  getUntitledCandidateName,
+  getCandidateDriverNumber,
+  formatDriverNumber,
+} from '../../modules/tests/candidate/candidate.selector';
+import { CommunicationViewDidEnter } from './communication.actions';
+import { map } from 'rxjs/operators';
+
+interface CommunicationPageState {
+  candidateName$: Observable<string>;
+  candidateUntitledName$: Observable<string>;
+  candidateDriverNumber$: Observable<string>;
+}
+@IonicPage()
+@Component({
+  selector: 'communication',
+  templateUrl: 'communication.html',
+})
+export class CommunicationPage extends BasePageComponent {
+  @ViewChild(Navbar) navBar: Navbar;
+
+  form: FormGroup;
+
+  pageState: CommunicationPageState;
+
+  constructor(
+    private store$: Store<StoreModel>,
+    public navCtrl: NavController,
+    public platform: Platform,
+    public authenticationProvider: AuthenticationProvider,
+    private deviceProvider: DeviceProvider,
+    private deviceAuthenticationProvider: DeviceAuthenticationProvider,
+    private screenOrientation: ScreenOrientation,
+    private insomnia: Insomnia,
+  ) {
+    super(platform, navCtrl, authenticationProvider);
+  }
+
+  ionViewDidEnter(): void {
+    this.store$.dispatch(new CommunicationViewDidEnter());
+
+    if (super.isIos()) {
+      this.deviceProvider.enableSingleAppMode();
+      this.screenOrientation.lock(this.screenOrientation.ORIENTATIONS.PORTRAIT_PRIMARY);
+      this.insomnia.keepAwake();
+    }
+
+    this.navBar.backButtonClick = (e: UIEvent) => {
+      this.clickBack();
+    };
+  }
+
+  clickBack(): void {
+    this.deviceAuthenticationProvider.triggerLockScreen()
+      .then(() => {
+        this.navCtrl.pop();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }
+
+  ngOnInit(): void {
+    const currentTest$ = this.store$.pipe(
+      select(getTests),
+      select(getCurrentTest),
+    );
+
+    this.pageState = {
+      candidateName$: currentTest$.pipe(
+        select(getCandidate),
+        select(getCandidateName),
+      ),
+      candidateUntitledName$: currentTest$.pipe(
+        select(getCandidate),
+        select(getUntitledCandidateName),
+      ),
+      candidateDriverNumber$: currentTest$.pipe(
+        select(getCandidate),
+        select(getCandidateDriverNumber),
+        map(formatDriverNumber),
+      ),
+    };
+  }
+
+  onSubmit() {
+    this.navController.push('WaitingRoomPage');
+  }
+}

--- a/src/pages/journal/components/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/pages/journal/components/test-outcome/__tests__/test-outcome.spec.ts
@@ -72,7 +72,7 @@ describe('Test Outcome', () => {
 
         expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotId));
         const { calls } = navController.push as jasmine.Spy;
-        expect(calls.argsFor(0)[0]).toBe('WaitingRoomPage');
+        expect(calls.argsFor(0)[0]).toBe('CommunicationPage');
       });
     });
   });

--- a/src/pages/journal/components/test-outcome/test-outcome.ts
+++ b/src/pages/journal/components/test-outcome/test-outcome.ts
@@ -43,7 +43,7 @@ export class TestOutcomeComponent {
   startTest() {
     console.log(`starting test ${this.slotId}`);
     this.store$.dispatch(new StartTest(this.slotId));
-    this.navController.push('WaitingRoomPage');
+    this.navController.push('CommunicationPage');
   }
 
   writeUpTest() {
@@ -53,7 +53,7 @@ export class TestOutcomeComponent {
 
   resumeTest() {
     this.store$.dispatch(new ActivateTest(this.slotId));
-    this.navController.push('WaitingRoomPage');
+    this.navController.push('CommunicationPage');
   }
 
   needsWriteUp(): boolean {

--- a/src/pages/waiting-room/__tests__/waiting-room.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.spec.ts
@@ -37,10 +37,7 @@ describe('WaitingRoomPage', () => {
   let fixture: ComponentFixture<WaitingRoomPage>;
   let component: WaitingRoomPage;
   let store$: Store<StoreModel>;
-  let deviceProvider: DeviceProvider;
   let deviceAuthenticationProvider: DeviceAuthenticationProvider;
-  let screenOrientation: ScreenOrientation;
-  let insomnia: Insomnia;
 
   const mockCandidate = {
     driverNumber: '123',
@@ -95,10 +92,6 @@ describe('WaitingRoomPage', () => {
         fixture = TestBed.createComponent(WaitingRoomPage);
         component = fixture.componentInstance;
       });
-
-    deviceProvider = TestBed.get(DeviceProvider);
-    screenOrientation = TestBed.get(ScreenOrientation);
-    insomnia = TestBed.get(Insomnia);
     deviceAuthenticationProvider = TestBed.get(DeviceAuthenticationProvider);
     store$ = TestBed.get(Store);
     spyOn(store$, 'dispatch');
@@ -122,31 +115,12 @@ describe('WaitingRoomPage', () => {
         expect(store$.dispatch).toHaveBeenCalledWith(new ToggleInsuranceDeclaration());
       });
     });
-
-    describe('ionViewDidEnter', () => {
-      it('should enable single app mode if on ios', () => {
-        component.ionViewDidEnter();
-        expect(deviceProvider.enableSingleAppMode).toHaveBeenCalled();
-      });
-
-      it('should lock the screen orientation to Portrait Primary', () => {
-        component.ionViewDidEnter();
-        expect(screenOrientation.lock)
-          .toHaveBeenCalledWith(screenOrientation.ORIENTATIONS.PORTRAIT_PRIMARY);
-      });
-
-      it('should keep the device awake', () => {
-        component.ionViewDidEnter();
-        expect(insomnia.keepAwake).toHaveBeenCalled();
-      });
-
-    });
   });
 
   describe('clickBack', () => {
-    it('should should trigger the lock screen', () => {
+    it('should should not trigger the lock screen', () => {
       component.clickBack();
-      expect(deviceAuthenticationProvider.triggerLockScreen).toHaveBeenCalled();
+      expect(deviceAuthenticationProvider.triggerLockScreen).not.toHaveBeenCalled();
     });
 
     describe('Declaration Validation', () => {

--- a/src/pages/waiting-room/waiting-room.html
+++ b/src/pages/waiting-room/waiting-room.html
@@ -8,18 +8,10 @@
 </ion-header>
 <ion-content no-bounce>
   <lock-screen-indicator></lock-screen-indicator>
-  <form [formGroup]="form" (ngSubmit)="onSubmit()">
-    <ion-row class="mes-full-width-card" id="candidate-section">
-      <ion-col>
-        <h2 id="candidate-name">{{pageState.candidateName$ | async}}</h2>
-        <h3 id="candidate-driver-number">{{pageState.candidateDriverNumber$ | async}}</h3>
-      </ion-col>
-      <ion-col col-auto>
-        <button type="submit" id="continue-button" class="mes-primary-button" float-right ion-button>
-          <h3>Continue</h3>
-        </button>
-      </ion-col>
-    </ion-row>
+  <form [formGroup]="form">
+    <candidate-section [candidateName]="pageState.candidateName$ | async"
+      [candidateDriverNumber]="pageState.candidateDriverNumber$ | async" (continueClickEvent)="onSubmit()">
+    </candidate-section>
     <div class="mes-full-width-card-separator"></div>
     <div class="mes-full-width-card" id="declaration-section">
       <ion-row>

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -20,13 +20,10 @@ import {
   getCandidateName, getCandidateDriverNumber, formatDriverNumber, getUntitledCandidateName,
 } from '../../modules/tests/candidate/candidate.selector';
 import { map } from 'rxjs/operators';
-import { DeviceProvider } from '../../providers/device/device';
 import { getCurrentTest } from '../../modules/tests/tests.selector';
 import { DeviceAuthenticationProvider } from '../../providers/device-authentication/device-authentication';
 import { getTests } from '../../modules/tests/tests.reducer';
 import { TestStatusStarted } from '../../modules/tests/test-status/test-status.actions';
-import { Insomnia } from '@ionic-native/insomnia';
-import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { PersistTests } from '../../modules/tests/tests.actions';
 
 interface WaitingRoomPageState {
@@ -59,10 +56,7 @@ export class WaitingRoomPage extends BasePageComponent {
     public navParams: NavParams,
     public platform: Platform,
     public authenticationProvider: AuthenticationProvider,
-    private deviceProvider: DeviceProvider,
     private deviceAuthenticationProvider: DeviceAuthenticationProvider,
-    private screenOrientation: ScreenOrientation,
-    private insomnia: Insomnia,
   ) {
     super(platform, navCtrl, authenticationProvider);
     this.form = new FormGroup(this.getFormValidation());
@@ -70,25 +64,13 @@ export class WaitingRoomPage extends BasePageComponent {
   ionViewDidEnter(): void {
     this.store$.dispatch(new waitingRoomActions.WaitingRoomViewDidEnter());
 
-    if (super.isIos()) {
-      this.deviceProvider.enableSingleAppMode();
-      this.screenOrientation.lock(this.screenOrientation.ORIENTATIONS.PORTRAIT_PRIMARY);
-      this.insomnia.keepAwake();
-    }
-
     this.navBar.backButtonClick = (e: UIEvent) => {
       this.clickBack();
     };
   }
 
   clickBack(): void {
-    this.deviceAuthenticationProvider.triggerLockScreen()
-      .then(() => {
-        this.navCtrl.pop();
-      })
-      .catch((err) => {
-        console.log(err);
-      });
+    this.navCtrl.pop();
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
## Description and relevant Jira numbers
- Created candidate section component to be shared across Communication and Waiting Room pages. 
- Emits an event for the continue click to allow each page TS to independently handle their onSubmit().
- Implementation of the Communication page view and TS file.
- Removed call for device authentication from back click on Waiting Room page.
- Implemented call for device authentication for back click on Communication page.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name complies with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to the component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [x] Tested by QA
- [ ] PO's approval


<img width="552" alt="Screenshot 2019-05-08 at 14 50 30" src="https://user-images.githubusercontent.com/30832405/57380417-de4ff980-71a0-11e9-8a4a-3d6bb87c2f4c.png">
