### PR TITLE
MES-2270 refactor alert styling to only target select/radio modals

### DIFF
--- a/src/pages/office/components/show-me-question/show-me-question.html
+++ b/src/pages/office/components/show-me-question/show-me-question.html
@@ -7,7 +7,8 @@
     <ion-row class="spacing-row"></ion-row>
     <ion-row>
       <ion-select id="show-me-selector" placeholder="Select a question" okText="Submit" cancelText="Cancel"
-        formControlName="showMeQuestion" (ionChange)="showMeQuestionChanged($event)">
+        formControlName="showMeQuestion" (ionChange)="showMeQuestionChanged($event)"
+        [selectOptions]="{cssClass:'mes-select'}">
         <ion-option [value]="showMeQuestion" *ngFor="let showMeQuestion of showMeQuestionOptions">
           {{showMeQuestion.code}} - {{showMeQuestion.shortName}}
         </ion-option>

--- a/src/pages/office/components/weather-conditions/weather-conditions.html
+++ b/src/pages/office/components/weather-conditions/weather-conditions.html
@@ -8,7 +8,7 @@
     <ion-row>
       <ion-select value="weather" multiple="true" okText="Submit" cancelText="Cancel"
         placeholder="Select weather conditions" formControlName="weatherConditions" [class.ng-invalid]="invalid"
-        (ionChange)="weatherConditionsChanged($event)">
+        (ionChange)="weatherConditionsChanged($event)" [selectOptions]="{cssClass:'mes-select'}">
         <ion-option [value]="weatherCondition.weatherConditionDescription"
           *ngFor="let weatherCondition of weatherConditionsOptions">
           {{weatherCondition.weatherConditionNumber}} - {{weatherCondition.weatherConditionDescription}}

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.html
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.html
@@ -60,7 +60,7 @@
                   <ion-col col-58>
                     <ion-select id="tell-me-selector" value="tell-me-question" okText="Submit" cancelText="Cancel"
                       placeholder="Select a question" (ionChange)="tellMeQuestionChanged($event)"
-                      formControlName="tellMeQuestionCtrl">
+                      formControlName="tellMeQuestionCtrl" [selectOptions]="{cssClass:'mes-select'}">
                       <ion-option [value]="tellMeQuestion" *ngFor="let tellMeQuestion of tellMeQuestions">
                         {{tellMeQuestion.code}} - {{tellMeQuestion.shortName}}
                       </ion-option>

--- a/src/theme/sass-partials/_alert.scss
+++ b/src/theme/sass-partials/_alert.scss
@@ -4,6 +4,33 @@
   font-size: 19px;
   // Action buttons at the very bottom
   justify-content: space-between;
+  .alert-title {
+    font-size: 28px;
+    letter-spacing: 0.27px;
+    line-height: 40px;
+    margin-top: 8px;
+    html .text-zoom-regular & {
+      font-weight: bold;
+    }
+  }
+  .alert-message {
+    font-size: 20px;
+    letter-spacing: 0.27px;
+    line-height: 28px;
+    margin-bottom: 12px;
+  }
+  .alert-button-group {
+    height: 56px;
+    button {
+      height: 100%;
+      span.button-inner {
+        font-size: 20px;
+        color: map-get($colors-gds, gds-black)
+      }
+    }
+  }
+}
+.mes-select .alert-wrapper {
   .alert-head, .alert-message {
     display: none;
   }
@@ -58,15 +85,6 @@
       }
       div.alert-checkbox-label {
         font-weight: bold;
-      }
-    }
-  }
-  div.alert-button-group {
-    height: 56px;
-    button {
-      height: 100%;
-      span.button-inner {
-        color: map-get($colors-gds, gds-black)
       }
     }
   }


### PR DESCRIPTION
## Description and relevant Jira numbers
The header and message was being hidden on simple alert prompts - this refactor addresses that by adding a class so the styling can be added more specifically. Now we will be able to use alerts when required.

The screenshots below simply show that the styling hasn't changed.

- Change the three `ion-select` references to include a CSS class so that they can be targeted specifically
- Update the CSS for `_alert.scss` to target the new class

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing

![Screenshot 2019-05-08 at 16 19 30](https://user-images.githubusercontent.com/8069071/57387368-190c5e80-71ae-11e9-899a-a4a3bcc996ec.png)

![Screenshot 2019-05-08 at 16 19 43](https://user-images.githubusercontent.com/8069071/57387374-1d387c00-71ae-11e9-8dbc-9b84204e9f67.png)
