### PR TITLE
Adds spinner to app initialisation on login page

### DIFF
--- a/src/pages/login/__tests__/login.spec.ts
+++ b/src/pages/login/__tests__/login.spec.ts
@@ -1,6 +1,13 @@
 import { ComponentFixture, async, TestBed, tick, fakeAsync } from '@angular/core/testing';
-import { IonicModule, NavController, NavParams, Config, Platform } from 'ionic-angular';
-import { NavControllerMock, NavParamsMock, ConfigMock, PlatformMock, SplashScreenMock } from 'ionic-mocks';
+import { IonicModule, NavController, NavParams, Config, Platform, LoadingController } from 'ionic-angular';
+import {
+  NavControllerMock,
+  NavParamsMock,
+  ConfigMock,
+  PlatformMock,
+  SplashScreenMock,
+  LoadingControllerMock,
+} from 'ionic-mocks';
 import { Store , StoreModule } from '@ngrx/store';
 import { StoreModel } from '../../../shared/models/store.model';
 import { AppModule } from '../../../app/app.module';
@@ -48,6 +55,7 @@ describe('LoginPage', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
         { provide: Platform, useFactory: () => PlatformMock.instance() },
         { provide: SplashScreen, useFactory: () => SplashScreenMock.instance() },
+        { provide: LoadingController, useFactory: () => LoadingControllerMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
         { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
         { provide: AppConfigProvider, useClass: AppConfigProviderMock },
@@ -83,8 +91,11 @@ describe('LoginPage', () => {
         jasmine.createSpy('authenticationProvider.login').and.returnValue(Promise.resolve());
       component.initialisePersistentStorage =
         jasmine.createSpy('component.initialisePersistentStorage').and.callThrough();
+      component.handleLoadingUI =
+        jasmine.createSpy('component.handleLoadingUI').and.callThrough();
       component.login();
       tick();
+      expect(component.handleLoadingUI).toHaveBeenCalledWith(true);
       expect(component.initialisePersistentStorage).toHaveBeenCalled();
       expect(appConfigProvider.loadRemoteConfig).toHaveBeenCalled();
       expect(navController.setRoot).toHaveBeenCalledWith('JournalPage');
@@ -98,8 +109,11 @@ describe('LoginPage', () => {
       authenticationProvider.login =
         jasmine.createSpy('authenticationProvider.login')
           .and.returnValue(Promise.reject(AuthenticationError.NO_INTERNET));
+      component.handleLoadingUI =
+        jasmine.createSpy('component.handleLoadingUI').and.callThrough();
       component.login();
       tick();
+      expect(component.handleLoadingUI).toHaveBeenCalledWith(false);
       expect(component.authenticationError === AuthenticationError.NO_INTERNET);
       expect(component.hasUserLoggedOut).toBeFalsy();
       expect(splashScreen.hide).toHaveBeenCalled();

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -30,7 +30,6 @@ export class LoginPage extends BasePageComponent {
   hasUserLoggedOut: boolean = false;
   hasDeviceTypeError: boolean = false;
   unauthenticatedMode: boolean = false;
-  isLoading: boolean = false;
 
   constructor(
     public navCtrl: NavController,

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { IonicPage, NavController, NavParams, Platform } from 'ionic-angular';
+import { IonicPage, NavController, NavParams, Platform, Loading, LoadingController } from 'ionic-angular';
 import { SplashScreen } from '@ionic-native/splash-screen';
 import { Store } from '@ngrx/store';
 
@@ -26,9 +26,11 @@ export class LoginPage extends BasePageComponent {
 
   authenticationError: AuthenticationError;
   deviceTypeError: DeviceError;
+  loadingSpinner: Loading;
   hasUserLoggedOut: boolean = false;
   hasDeviceTypeError: boolean = false;
   unauthenticatedMode: boolean = false;
+  isLoading: boolean = false;
 
   constructor(
     public navCtrl: NavController,
@@ -43,6 +45,7 @@ export class LoginPage extends BasePageComponent {
     public deviceProvider: DeviceProvider,
     public secureStorage: SecureStorage,
     public dataStore: DataStoreProvider,
+    public loadingController: LoadingController,
   ) {
     super(platform, navCtrl, authenticationProvider, false);
 
@@ -62,6 +65,7 @@ export class LoginPage extends BasePageComponent {
   }
 
   login = async (): Promise<any> => {
+    this.handleLoadingUI(true);
     await this.platform.ready();
 
     this.initialiseAppConfig()
@@ -73,8 +77,10 @@ export class LoginPage extends BasePageComponent {
       .then(() => this.appConfigProvider.loadRemoteConfig())
       .then(() => this.analytics.initialiseAnalytics())
       .then(() => this.store$.dispatch(new StartSendingLogs()))
+      .then(() => this.handleLoadingUI(false))
       .then(() => this.validateDeviceType())
       .catch((error: AuthenticationError) => {
+        this.handleLoadingUI(false);
         if (error === AuthenticationError.USER_CANCELLED) {
           this.analytics.logException(error, true);
         }
@@ -142,5 +148,20 @@ export class LoginPage extends BasePageComponent {
 
   isUserNotAuthorised = (): boolean => {
     return !this.hasUserLoggedOut && this.authenticationError === AuthenticationError.USER_NOT_AUTHORISED;
+  }
+
+  handleLoadingUI = (isLoading: boolean): void => {
+    if (isLoading) {
+      this.loadingSpinner = this.loadingController.create({
+        spinner: 'circles',
+        content: 'App initialising...',
+      });
+      this.loadingSpinner.present();
+      return;
+    }
+    if (this.loadingSpinner) {
+      this.loadingSpinner.dismiss();
+      this.loadingSpinner = null;
+    }
   }
 }


### PR DESCRIPTION
## Description and relevant Jira numbers
The login screen does a lot of work to initialise the app (config, auth, persistent storage, analytics etc.). This means that there can be a significant wait for the user whilst they are logging in and before they reach the Journal screen.

This PR adds a loading spinner with a message 'App initialising...' to the login screen which keeps it distinct from the journal spinner. This may come in handy when debugging app startup problems later on.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

**Screenshot**
![IMG_AD2F1389B485-1](https://user-images.githubusercontent.com/33695049/57394184-c1c1ba80-71bc-11e9-8b44-be6143e8baa8.jpeg)
