### PR TITLE
Update how the test result is calculated

### DIFF
--- a/src/modules/tests/test-data/__tests__/test-data.selector.spec.ts
+++ b/src/modules/tests/test-data/__tests__/test-data.selector.spec.ts
@@ -15,6 +15,8 @@ import {
   hasVehicleChecksBeenCompleted,
   getCatBLegalRequirements,
   getShowMeQuestionOptions,
+  getSeriousFaultSummaryCount,
+  getDangerousFaultSummaryCount,
 } from '../test-data.selector';
 import { Competencies } from '../test-data.constants';
 import { CompetencyOutcome } from '../../../../shared/models/competency-outcome';
@@ -108,6 +110,66 @@ describe('TestDataSelectors', () => {
   describe('getDrivingFaultSummaryCount', () => {
     it('should return the driving fault count correctly', () => {
       expect(getDrivingFaultSummaryCount(state)).toBe(3);
+    });
+  });
+
+  describe('getSeriousFaultSummaryCount', () => {
+    it('should return the serious faults count', () => {
+      expect(getSeriousFaultSummaryCount(state)).toBe(1);
+    });
+    it('should return the correct count of serious faults', () => {
+      const failedState: TestData = {
+        ...state,
+        manoeuvres: {
+          forwardPark: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+        controlledStop: {
+          selected: true,
+          fault: CompetencyOutcome.S,
+        },
+        vehicleChecks: {
+          tellMeQuestion: {
+            outcome: CompetencyOutcome.DF,
+          },
+          showMeQuestion: {
+            outcome: CompetencyOutcome.S,
+          },
+        },
+      };
+      expect(getSeriousFaultSummaryCount(failedState)).toBe(4);
+    });
+  });
+
+  describe('getDangerousFaultSummaryCount', () => {
+    it('should return the dangerous faults count', () => {
+      expect(getDangerousFaultSummaryCount(state)).toBe(1);
+    });
+    it('should return the correct number of dangerous faults', () => {
+      const failedState: TestData = {
+        ...state,
+        manoeuvres: {
+          forwardPark: {
+            selected: true,
+            controlFault: CompetencyOutcome.D,
+          },
+        },
+        controlledStop: {
+          selected: true,
+          fault: CompetencyOutcome.D,
+        },
+        vehicleChecks: {
+          tellMeQuestion: {
+            outcome: CompetencyOutcome.DF,
+          },
+          showMeQuestion: {
+            outcome: CompetencyOutcome.D,
+          },
+        },
+      };
+      expect(getDangerousFaultSummaryCount(failedState)).toBe(4);
     });
   });
 

--- a/src/modules/tests/test-data/test-data.selector.ts
+++ b/src/modules/tests/test-data/test-data.selector.ts
@@ -31,6 +31,44 @@ export const getDrivingFaultSummaryCount = (data: TestData): number => {
   return result;
 };
 
+export const getSeriousFaultSummaryCount = (data: TestData): number => {
+
+  // The way how we store serious faults differs for certain competencies
+  // Because of this we need to pay extra attention on summing up all of them
+  const { seriousFaults, manoeuvres, controlledStop, vehicleChecks } = data;
+
+  const seriousFaultSumOfSimpleCompetencies = Object.keys(pickBy(seriousFaults)).length;
+  const controlledStopSeriousFaults = (controlledStop && controlledStop.fault === CompetencyOutcome.S) ? 1 : 0;
+  const vehicleCheckSeriousFaults = get(vehicleChecks, 'showMeQuestion.outcome') === CompetencyOutcome.S ? 1 : 0;
+
+  const result =
+    seriousFaultSumOfSimpleCompetencies +
+    sumManoeuvreFaults(manoeuvres, CompetencyOutcome.S) +
+    vehicleCheckSeriousFaults +
+    controlledStopSeriousFaults;
+
+  return result;
+};
+
+export const getDangerousFaultSummaryCount = (data: TestData): number => {
+
+  // The way how we store serious faults differs for certain competencies
+  // Because of this we need to pay extra attention on summing up all of them
+  const { dangerousFaults, manoeuvres, controlledStop, vehicleChecks } = data;
+
+  const dangerousFaultSumOfSimpleCompetencies = Object.keys(pickBy(dangerousFaults)).length;
+  const controlledStopDangerousFaults = (controlledStop && controlledStop.fault === CompetencyOutcome.D) ? 1 : 0;
+  const vehicleCheckDangerousFaults = get(vehicleChecks, 'showMeQuestion.outcome') === CompetencyOutcome.D ? 1 : 0;
+
+  const result =
+    dangerousFaultSumOfSimpleCompetencies +
+    sumManoeuvreFaults(manoeuvres, CompetencyOutcome.D) +
+    vehicleCheckDangerousFaults +
+    controlledStopDangerousFaults;
+
+  return result;
+};
+
 export const sumVehicleCheckFaults = (vehicleChecks: VehicleChecks): number => {
 
   const { showMeQuestion, tellMeQuestion } = vehicleChecks;

--- a/src/modules/tests/test-data/test-data.selector.ts
+++ b/src/modules/tests/test-data/test-data.selector.ts
@@ -38,8 +38,8 @@ export const getSeriousFaultSummaryCount = (data: TestData): number => {
   const { seriousFaults, manoeuvres, controlledStop, vehicleChecks } = data;
 
   const seriousFaultSumOfSimpleCompetencies = Object.keys(pickBy(seriousFaults)).length;
+  const vehicleCheckSeriousFaults = vehicleChecks.showMeQuestion.outcome === CompetencyOutcome.S ? 1 : 0;
   const controlledStopSeriousFaults = (controlledStop && controlledStop.fault === CompetencyOutcome.S) ? 1 : 0;
-  const vehicleCheckSeriousFaults = get(vehicleChecks, 'showMeQuestion.outcome') === CompetencyOutcome.S ? 1 : 0;
 
   const result =
     seriousFaultSumOfSimpleCompetencies +
@@ -57,9 +57,9 @@ export const getDangerousFaultSummaryCount = (data: TestData): number => {
   const { dangerousFaults, manoeuvres, controlledStop, vehicleChecks } = data;
 
   const dangerousFaultSumOfSimpleCompetencies = Object.keys(pickBy(dangerousFaults)).length;
+  const vehicleCheckDangerousFaults = vehicleChecks.showMeQuestion.outcome === CompetencyOutcome.D ? 1 : 0;
   const controlledStopDangerousFaults = (controlledStop && controlledStop.fault === CompetencyOutcome.D) ? 1 : 0;
-  const vehicleCheckDangerousFaults = get(vehicleChecks, 'showMeQuestion.outcome') === CompetencyOutcome.D ? 1 : 0;
-
+  
   const result =
     dangerousFaultSumOfSimpleCompetencies +
     sumManoeuvreFaults(manoeuvres, CompetencyOutcome.D) +

--- a/src/providers/test-result/test-result.ts
+++ b/src/providers/test-result/test-result.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { TestData, ActivityCode } from '@dvsa/mes-test-schema/categories/B';
 import { ActivityCodes } from '../../shared/models/activity-codes';
-import { getDrivingFaultSummaryCount } from '../../modules/tests/test-data/test-data.selector';
-import { getSeriousOrDangerousFaults } from '../../pages/debrief/debrief.selector';
+import { getDrivingFaultSummaryCount, getSeriousFaultSummaryCount, getDangerousFaultSummaryCount }
+  from '../../modules/tests/test-data/test-data.selector';
 import { Observable } from 'rxjs/Observable';
 import { of } from 'rxjs/observable/of';
 
@@ -10,11 +10,12 @@ import { of } from 'rxjs/observable/of';
 export class TestResultProvider {
 
   calculateCatBTestResult = (testData: TestData): Observable<ActivityCode> => {
-    if (getSeriousOrDangerousFaults(testData.dangerousFaults).length > 0) {
+
+    if (getSeriousFaultSummaryCount(testData) > 0) {
       return of(ActivityCodes.FAIL);
     }
 
-    if (getSeriousOrDangerousFaults(testData.seriousFaults).length > 0) {
+    if (getDangerousFaultSummaryCount(testData) > 0) {
       return of(ActivityCodes.FAIL);
     }
 

--- a/src/providers/test-result/test-result.ts
+++ b/src/providers/test-result/test-result.ts
@@ -11,11 +11,11 @@ export class TestResultProvider {
 
   calculateCatBTestResult = (testData: TestData): Observable<ActivityCode> => {
 
-    if (getSeriousFaultSummaryCount(testData) > 0) {
+    if (getDangerousFaultSummaryCount(testData) > 0) {
       return of(ActivityCodes.FAIL);
     }
 
-    if (getDangerousFaultSummaryCount(testData) > 0) {
+    if (getSeriousFaultSummaryCount(testData) > 0) {
       return of(ActivityCodes.FAIL);
     }
 


### PR DESCRIPTION
## Description and relevant Jira numbers
Szabi and I spotted a bug in how the test result was calculated. Previously it used selectors that were specific to the Debrief page. This meant that if the selectors were changed to make the debrief page behave differently it could affect the test result (not good).

This PR addresses that:
- create a new selector to return count of dangerous faults
- create a new selector to return count of serious faults
- update the test results component to use the new selectors


## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [X] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
