### PR TITLE
MES-2297 end practice mode

### DIFF
--- a/src/modules/tests/__mocks__/tests.mock.ts
+++ b/src/modules/tests/__mocks__/tests.mock.ts
@@ -32,7 +32,7 @@ export const candidate: Candidate = {
 
 export const practiceSlot = {
   slotDetail: {
-    slotId: 1,
+    slotId: 'practice_1',
     duration: 57,
     start: '2019-01-01T10:14:00+00:00',
   },

--- a/src/modules/tests/__tests__/tests.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.effects.spec.ts
@@ -8,7 +8,8 @@ import * as testsActions from '../tests.actions';
 import { TestsModel } from '../tests.model';
 import { PopulateApplicationReference } from '../application-reference/application-reference.actions';
 import { PopulateCandidateDetails } from '../candidate/candidate.actions';
-import { application, candidate } from '../__mocks__/tests.mock';
+import { application, candidate, practiceSlot } from '../__mocks__/tests.mock';
+import { initialState } from '../tests.reducer';
 
 describe('Tests Effects', () => {
 
@@ -47,9 +48,11 @@ describe('Tests Effects', () => {
     it('should respond to a LOAD_PERSISTED_TESTS action by loading tests and dispatching a success action', (done) => {
       // ARRANGE
       const persistedTests: TestsModel = {
-        currentTest: { slotId: '123' },
-        startedTests: {},
-        testLifecycles: {},
+        ...initialState,
+        currentTest: {
+          ...initialState.currentTest,
+          slotId: '123',
+        },
       };
       testPersistenceProviderMock.loadPersistedTests.and.returnValue(Promise.resolve(persistedTests));
       // ACT
@@ -66,7 +69,7 @@ describe('Tests Effects', () => {
   describe('startPracticeTestEffect', () => {
     it('should dispatch the PopulateApplicationReference and PopulateCandidateDetails action', (done) => {
       // ACT
-      actions$.next(new testsActions.StartPracticeTest(1));
+      actions$.next(new testsActions.StartPracticeTest(practiceSlot.slotDetail.slotId));
       // ASSERT
       effects.startPracticeTestEffect$.subscribe((result) => {
         if (result instanceof PopulateApplicationReference)  {

--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -6,6 +6,7 @@ import { PreTestDeclarations } from '@dvsa/mes-test-schema/categories/B';
 import { TestStatus } from '../test-status/test-status.model';
 import * as testStatusReducer from '../test-status/test-status.reducer';
 import { TestsModel } from '../tests.model';
+import * as testActions from './../tests.actions';
 
 describe('testsReducer', () => {
   const newCandidate = { candidate: { candidateId: 456 } };
@@ -28,6 +29,34 @@ describe('testsReducer', () => {
     const output = testsReducer(state, action);
 
     expect(output.currentTest.slotId).toBe('123');
+  });
+
+  it('should use the payload of a start practice test action to setup state for a new test', () => {
+    const state = {
+      currentTest: { slotId: null },
+      startedTests: {},
+      testLifecycles: {},
+    };
+    const slotId = 'practice_123';
+    const action = new testActions.StartPracticeTest(slotId);
+
+    const output = testsReducer(state, action);
+
+    expect(output.currentTest.slotId).toBe('practice_123');
+  });
+
+  it('should ensure that all slot ids for practice tests are prefixed with _practice ', () => {
+    const state = {
+      currentTest: { slotId: null },
+      startedTests: {},
+      testLifecycles: {},
+    };
+    const slotId = '123';
+    const action = new testActions.StartPracticeTest(slotId);
+
+    const output = testsReducer(state, action);
+
+    expect(output.currentTest.slotId).toBe('practice_123');
   });
 
   it('should derive the sub-states from sub-reducers', () => {

--- a/src/modules/tests/__tests__/tests.selector.spec.ts
+++ b/src/modules/tests/__tests__/tests.selector.spec.ts
@@ -5,6 +5,7 @@ import {
   isPassed,
   getTestOutcomeText,
   getTerminationCode,
+  isPracticeTest,
 } from '../tests.selector';
 import { JournalModel } from '../../../pages/journal/journal.model';
 import { AppInfoModel } from '../../app-info/app-info.model';
@@ -245,4 +246,27 @@ describe('testsSelector', () => {
       expect(terminationCode.description).toEqual(ActivityCodeDescription.DVSA_RADIO_FAILURE);
     });
   });
+
+  describe('isPracticeTest', () => {
+    const testState: TestsModel = {
+      currentTest: { slotId: null },
+      startedTests: {},
+      testLifecycles: { 12345: TestStatus.Decided },
+    };
+    it('should return false when no tests started', () => {
+      const result = isPracticeTest(testState);
+      expect(result).toBeFalsy();
+    });
+    it('should return false when slot id is numeric', () => {
+      testState.currentTest.slotId = '1';
+      const result = isPracticeTest(testState);
+      expect(result).toBeFalsy();
+    });
+    it('should return true when slot id starts with practice', () => {
+      testState.currentTest.slotId = 'practice_1';
+      const result = isPracticeTest(testState);
+      expect(result).toBeTruthy();
+    });
+  });
+
 });

--- a/src/modules/tests/tests.actions.ts
+++ b/src/modules/tests/tests.actions.ts
@@ -28,7 +28,7 @@ export class SetActivityCode implements Action {
 
 export class StartPracticeTest implements Action {
   readonly type = START_PRACTICE_TEST;
-  constructor(public slotId: number) { }
+  constructor(public slotId: string) { }
 }
 
 export type Types =

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -17,8 +17,9 @@ import { testCentreReducer } from './test-centre/test-centre.reducer';
 import { testSlotsAttributesReducer } from './test-slot-attributes/test-slot-attributes.reducer';
 import { examinerReducer } from './examiner/examiner.reducer';
 import { TestsModel } from './tests.model';
+import { startsWith } from 'lodash';
 
-const initialState: TestsModel = {
+export const initialState: TestsModel = {
   currentTest: { slotId: null },
   startedTests: {},
   testLifecycles: {},
@@ -55,9 +56,14 @@ export function testsReducer(
 }
 
 const deriveSlotId = (state: TestsModel, action: Action): string | null => {
+  if (action instanceof testActions.StartPracticeTest) {
+    if (!startsWith(action.slotId, 'practice_')) {
+      return `practice_${action.slotId}`;
+    }
+    return `${action.slotId}`;
+  }
   if (action instanceof journalActions.StartTest
-      || action instanceof journalActions.ActivateTest
-      || action instanceof testActions.StartPracticeTest) {
+      || action instanceof journalActions.ActivateTest) {
     return `${action.slotId}`;
   }
   return (state.currentTest && state.currentTest.slotId) ? state.currentTest.slotId : null;

--- a/src/modules/tests/tests.selector.ts
+++ b/src/modules/tests/tests.selector.ts
@@ -2,6 +2,7 @@ import { TestStatus } from './test-status/test-status.model';
 import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
 import { TestsModel } from './tests.model';
 import { terminationCodeList } from '../../pages/office/components/termination-code/termination-code.constants';
+import { startsWith } from 'lodash';
 
 // temporary determination of test failure and success until service
 // that imnplements full business logic is implemented.
@@ -54,3 +55,5 @@ export const getTerminationCode = (test: StandardCarTestCATBSchema) => {
   return terminationCodeList[terminationCodeIndex];
 
 };
+
+export const isPracticeTest = (tests: TestsModel) => startsWith(tests.currentTest.slotId, 'practice_');

--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -197,6 +197,11 @@ describe('DebriefPage', () => {
         component.endDebrief();
         expect(navController.push).toHaveBeenCalledWith('BackToOfficePage');
       });
+      it('should navigate back to the root when this is a practice test', () => {
+        component.isPracticeTest = true;
+        component.endDebrief();
+        expect(navController.popToRoot).toHaveBeenCalled();
+      });
 
     });
   });

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -48,7 +48,7 @@ export class DebriefPage extends BasePageComponent {
 
   // Used for now to test displaying pass/fail/terminated messages
   public outcome: string;
-  private isPracticeTest: boolean;
+  public isPracticeTest: boolean;
 
   constructor(
     private store$: Store<StoreModel>,

--- a/src/pages/journal/components/practice-card/practice-card.ts
+++ b/src/pages/journal/components/practice-card/practice-card.ts
@@ -6,6 +6,7 @@ import { StartPracticeTest } from '../../../../modules/tests/tests.actions';
 import { TellMeQuestionDrivingFault, TellMeQuestionCorrect }
   from '../../../../modules/tests/test-data/test-data.actions';
 import { ModalEvent } from '../practice-test-modal/practice-test-modal.constants';
+import { practiceSlot } from '../../../../modules/tests/__mocks__/tests.mock';
 
 @Component({
   selector: 'practice-card',
@@ -14,7 +15,7 @@ import { ModalEvent } from '../practice-test-modal/practice-test-modal.constants
 
 export class PracticeCardComponent {
 
-  slotId: number = 1;
+  slotId: string = practiceSlot.slotDetail.slotId;
   modal: Modal;
 
   constructor(


### PR DESCRIPTION
## Description and relevant Jira numbers
To be able to end practice mode we need to know if we're conducting a practice test. My first iteration of this had a property called `isPracticeMode` stored on the state, but after discussions I decided that this wasn't the best as it was separate from `currentTest`, `startedTest` and `testLifecycles` and so there was the worry that it could become detached / different.

This version uses the slot ID to determine if the test is a practice test. The slot ID is prefixed with `practice_` and a selector can then be used to determine what sort of test this is.

Would welcome any thoughts on this.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
