### PR TITLE
MES-2319 clear practice test state on end test

### DIFF
--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -103,4 +103,9 @@ describe('testsReducer', () => {
 
     expect(result.currentTest.slotId).toBe('456');
   });
+
+  it('should reset the practice test state when a test is ended', () => {
+    // TODO
+  });
+
 });

--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -7,6 +7,7 @@ import { TestStatus } from '../test-status/test-status.model';
 import * as testStatusReducer from '../test-status/test-status.reducer';
 import { TestsModel } from '../tests.model';
 import * as testActions from './../tests.actions';
+import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 
 describe('testsReducer', () => {
   const newCandidate = { candidate: { candidateId: 456 } };
@@ -104,8 +105,77 @@ describe('testsReducer', () => {
     expect(result.currentTest.slotId).toBe('456');
   });
 
-  it('should reset the practice test state when a test is ended', () => {
-    // TODO
+  it('should reset the practice test state when a test is ended and preserve other test states', () => {
+    const state: TestsModel = {
+      currentTest: { slotId: 'practice_1' },
+      startedTests: {
+        1: {
+          testData: {
+            dangerousFaults: {},
+            drivingFaults: {
+              clearance: 1,
+            },
+            manoeuvres: {},
+            seriousFaults: {
+              signalsTimed: true,
+            },
+            testRequirements: {},
+            ETA: {},
+            eco: {},
+            controlledStop: {},
+            vehicleChecks: {
+              tellMeQuestion: {
+                outcome: 'DF',
+              },
+              showMeQuestion: {
+                outcome: 'S',
+              },
+            },
+          },
+          category: '',
+          id: '',
+          journalData: null,
+          activityCode: null,
+        },
+        practice_1: {
+          testData: {
+            dangerousFaults: {},
+            drivingFaults: {
+              moveOffSafety: 1,
+            },
+            manoeuvres: {},
+            seriousFaults: {
+              positioningNormalDriving: true,
+            },
+            testRequirements: {},
+            ETA: {},
+            eco: {},
+            controlledStop: {},
+            vehicleChecks: {
+              tellMeQuestion: {
+                outcome: 'DF',
+              },
+              showMeQuestion: {},
+            },
+          },
+          category: '',
+          id: '',
+          journalData: null,
+          activityCode: null,
+        },
+      },
+      testLifecycles: {},
+    };
+
+    const result = testsReducer(state, new testActions.EndPracticeTest());
+    expect(result.startedTests['practice_1'].testData.seriousFaults.positioningNormalDriving).toBeUndefined();
+    expect(result.startedTests['practice_1'].testData.drivingFaults.moveOffSafety).toBeUndefined();
+    expect(result.startedTests['practice_1'].testData.vehicleChecks.tellMeQuestion.outcome).toBeUndefined();
+
+    expect(result.startedTests[1].testData.seriousFaults.signalsTimed).toBeTruthy();
+    expect(result.startedTests[1].testData.drivingFaults.clearance).toBeTruthy();
+    expect(result.startedTests[1].testData.vehicleChecks.tellMeQuestion.outcome).toEqual(CompetencyOutcome.DF);
+    expect(result.startedTests[1].testData.vehicleChecks.showMeQuestion.outcome).toEqual(CompetencyOutcome.S);
   });
 
 });

--- a/src/modules/tests/tests.actions.ts
+++ b/src/modules/tests/tests.actions.ts
@@ -12,6 +12,7 @@ export const LOAD_PERSISTED_TESTS = '[Tests] Load persisted';
 export const LOAD_PERSISTED_TESTS_SUCCESS = '[Tests] Load persisted success';
 export const SET_ACTIVITY_CODE = '[Tests] Set activity code';
 export const START_PRACTICE_TEST = '[Tests] Start practice test';
+export const END_PRACTICE_TEST = '[Tests] End practice test';
 
 export class PersistTests implements Action {
   readonly type = PERSIST_TESTS;
@@ -34,6 +35,10 @@ export class SetActivityCode implements Action {
 export class StartPracticeTest implements Action {
   readonly type = START_PRACTICE_TEST;
   constructor(public slotId: string) { }
+}
+
+export class EndPracticeTest implements Action {
+  readonly type = END_PRACTICE_TEST;
 }
 
 export class StartSendingCompletedTests implements Action {
@@ -59,6 +64,7 @@ export type Types =
   | LoadPersistedTestsSuccess
   | SetActivityCode
   | StartPracticeTest
+  | EndPracticeTest
   | StartSendingCompletedTests
   | SendTest
   | SendTestSuccess

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -50,6 +50,18 @@ export function testsReducer(
           },
         },
       };
+    case testActions.END_PRACTICE_TEST:
+      const { [slotId]: removedStartedTest, ...updatedStartedTests } = state.startedTests;
+      const { [slotId]: removedTestLifecycle, ...updatedTestLifecycles } = state.testLifecycles;
+      const newState = {
+        ...state,
+        currentTest: {
+          ...initialState.currentTest,
+        },
+        startedTests: updatedStartedTests,
+        testLifecycles: updatedTestLifecycles,
+      };
+      return createStateObject(newState, action, slotId);
     default:
       return slotId ? createStateObject(state, action, slotId) : state;
   }

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -31,7 +31,7 @@ import {
 } from './debrief.selector';
 import { CompetencyOutcome } from '../../shared/models/competency-outcome';
 import { MultiFaultAssignableCompetency } from '../../shared/models/fault-marking.model';
-import { PersistTests } from '../../modules/tests/tests.actions';
+import { PersistTests, EndPracticeTest } from '../../modules/tests/tests.actions';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
 
@@ -179,9 +179,12 @@ export class DebriefPage extends BasePageComponent {
   }
 
   ionViewDidLeave(): void {
-    if (super.isIos() && this.isPracticeTest) {
-      this.screenOrientation.unlock();
-      this.insomnia.allowSleepAgain();
+    if (this.isPracticeTest) {
+      this.store$.dispatch(new EndPracticeTest());
+      if (super.isIos()) {
+        this.screenOrientation.unlock();
+        this.insomnia.allowSleepAgain();
+      }
     }
   }
 


### PR DESCRIPTION
## Description and relevant Jira numbers
- Reset the state of the practice test when it ends

I don't remove the practice test from the store as this causes pages that are still subscribed to the test state to error. Instead, I reset the state by essentially creating a new test report state via `createStateObject`.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
