### PR TITLE
MES-2319 clear practice test state

### DIFF
--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -103,4 +103,9 @@ describe('testsReducer', () => {
 
     expect(result.currentTest.slotId).toBe('456');
   });
+
+  it('should reset the practice test state when a test is ended', () => {
+    // TODO
+  });
+
 });

--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -46,66 +46,7 @@ describe('testsReducer', () => {
     expect(output.currentTest.slotId).toBe('practice_123');
   });
 
-  it('should ensure that all slot ids for practice tests are prefixed with _practice ', () => {
-    const state = {
-      currentTest: { slotId: null },
-      startedTests: {},
-      testLifecycles: {},
-    };
-    const slotId = '123';
-    const action = new testActions.StartPracticeTest(slotId);
-
-    const output = testsReducer(state, action);
-
-    expect(output.currentTest.slotId).toBe('practice_123');
-  });
-
-  it('should derive the sub-states from sub-reducers', () => {
-    const state: TestsModel = {
-      currentTest: { slotId: null },
-      startedTests: {},
-      testLifecycles: {},
-    };
-
-    const result = testsReducer(state, new journalActions.StartTest(123));
-
-    expect(candidateReducer.candidateReducer).toHaveBeenCalled();
-    expect(preTestDeclarationsReducer.preTestDeclarationsReducer).toHaveBeenCalled();
-    expect(result.startedTests['123'].candidate).toBe(newCandidate);
-    expect(result.startedTests['123'].preTestDeclarations).toBe(preTestDeclarations);
-  });
-
-  it('should track test lifecycles independently of the started tests', () => {
-    const testStatusReducerResult = TestStatus.Started;
-    spyOn(testStatusReducer, 'testStatusReducer').and.returnValue(testStatusReducerResult);
-    const state: TestsModel = {
-      currentTest: { slotId: '123' },
-      startedTests: {},
-      testLifecycles: {
-        456: TestStatus.Decided,
-      },
-    };
-
-    const result = testsReducer(state, new journalActions.JournalViewDidEnter());
-
-    expect(testStatusReducer.testStatusReducer).toHaveBeenCalled();
-    expect(result.testLifecycles['123']).toBe(TestStatus.Started);
-    expect(result.testLifecycles['456']).toBe(TestStatus.Decided);
-  });
-
-  it('should assign the slot ID as the current test when a test is activated', () => {
-    const state: TestsModel = {
-      currentTest: { slotId: '123' },
-      startedTests: {},
-      testLifecycles: {},
-    };
-
-    const result = testsReducer(state, new journalActions.ActivateTest(456));
-
-    expect(result.currentTest.slotId).toBe('456');
-  });
-
-  it('should reset the practice test state when a test is ended and preserve other test states', () => {
+  it('should reset the state when a practice test is started and not affect other tests', () => {
     const state: TestsModel = {
       currentTest: { slotId: 'practice_1' },
       startedTests: {
@@ -166,16 +107,78 @@ describe('testsReducer', () => {
       },
       testLifecycles: {},
     };
+    const slotId = 'practice_1';
+    const action = new testActions.StartPracticeTest(slotId);
 
-    const result = testsReducer(state, new testActions.EndPracticeTest());
-    expect(result.startedTests['practice_1'].testData.seriousFaults.positioningNormalDriving).toBeUndefined();
-    expect(result.startedTests['practice_1'].testData.drivingFaults.moveOffSafety).toBeUndefined();
-    expect(result.startedTests['practice_1'].testData.vehicleChecks.tellMeQuestion.outcome).toBeUndefined();
+    const output = testsReducer(state, action);
 
-    expect(result.startedTests[1].testData.seriousFaults.signalsTimed).toBeTruthy();
-    expect(result.startedTests[1].testData.drivingFaults.clearance).toBeTruthy();
-    expect(result.startedTests[1].testData.vehicleChecks.tellMeQuestion.outcome).toEqual(CompetencyOutcome.DF);
-    expect(result.startedTests[1].testData.vehicleChecks.showMeQuestion.outcome).toEqual(CompetencyOutcome.S);
+    expect(output.startedTests['practice_1'].testData.seriousFaults.positioningNormalDriving).toBeUndefined();
+    expect(output.startedTests['practice_1'].testData.drivingFaults.moveOffSafety).toBeUndefined();
+    expect(output.startedTests['practice_1'].testData.vehicleChecks.tellMeQuestion.outcome).toBeUndefined();
+
+    expect(output.startedTests[1].testData.seriousFaults.signalsTimed).toBeTruthy();
+    expect(output.startedTests[1].testData.drivingFaults.clearance).toBeTruthy();
+    expect(output.startedTests[1].testData.vehicleChecks.tellMeQuestion.outcome).toEqual(CompetencyOutcome.DF);
+    expect(output.startedTests[1].testData.vehicleChecks.showMeQuestion.outcome).toEqual(CompetencyOutcome.S);
+  });
+
+  it('should ensure that all slot ids for practice tests are prefixed with _practice ', () => {
+    const state = {
+      currentTest: { slotId: null },
+      startedTests: {},
+      testLifecycles: {},
+    };
+    const slotId = '123';
+    const action = new testActions.StartPracticeTest(slotId);
+
+    const output = testsReducer(state, action);
+
+    expect(output.currentTest.slotId).toBe('practice_123');
+  });
+
+  it('should derive the sub-states from sub-reducers', () => {
+    const state: TestsModel = {
+      currentTest: { slotId: null },
+      startedTests: {},
+      testLifecycles: {},
+    };
+
+    const result = testsReducer(state, new journalActions.StartTest(123));
+
+    expect(candidateReducer.candidateReducer).toHaveBeenCalled();
+    expect(preTestDeclarationsReducer.preTestDeclarationsReducer).toHaveBeenCalled();
+    expect(result.startedTests['123'].candidate).toBe(newCandidate);
+    expect(result.startedTests['123'].preTestDeclarations).toBe(preTestDeclarations);
+  });
+
+  it('should track test lifecycles independently of the started tests', () => {
+    const testStatusReducerResult = TestStatus.Started;
+    spyOn(testStatusReducer, 'testStatusReducer').and.returnValue(testStatusReducerResult);
+    const state: TestsModel = {
+      currentTest: { slotId: '123' },
+      startedTests: {},
+      testLifecycles: {
+        456: TestStatus.Decided,
+      },
+    };
+
+    const result = testsReducer(state, new journalActions.JournalViewDidEnter());
+
+    expect(testStatusReducer.testStatusReducer).toHaveBeenCalled();
+    expect(result.testLifecycles['123']).toBe(TestStatus.Started);
+    expect(result.testLifecycles['456']).toBe(TestStatus.Decided);
+  });
+
+  it('should assign the slot ID as the current test when a test is activated', () => {
+    const state: TestsModel = {
+      currentTest: { slotId: '123' },
+      startedTests: {},
+      testLifecycles: {},
+    };
+
+    const result = testsReducer(state, new journalActions.ActivateTest(456));
+
+    expect(result.currentTest.slotId).toBe('456');
   });
 
 });

--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -7,6 +7,7 @@ import { TestStatus } from '../test-status/test-status.model';
 import * as testStatusReducer from '../test-status/test-status.reducer';
 import { TestsModel } from '../tests.model';
 import * as testActions from './../tests.actions';
+import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 
 describe('testsReducer', () => {
   const newCandidate = { candidate: { candidateId: 456 } };
@@ -104,8 +105,77 @@ describe('testsReducer', () => {
     expect(result.currentTest.slotId).toBe('456');
   });
 
-  it('should reset the practice test state when a test is ended', () => {
-    // TODO
+  it('should reset the practice test state when a test is ended and preserve other test states', () => {
+    const state: TestsModel = {
+      currentTest: { slotId: 'practice_1' },
+      startedTests: {
+        1: {
+          testData: {
+            dangerousFaults: {},
+            drivingFaults: {
+              clearance: 1,
+            },
+            manoeuvres: {},
+            seriousFaults: {
+              signalsTimed: true,
+            },
+            testRequirements: {},
+            ETA: {},
+            eco: {},
+            controlledStop: {},
+            vehicleChecks: {
+              tellMeQuestion: {
+                outcome: 'DF',
+              },
+              showMeQuestion: {
+                outcome: 'S',
+              },
+            },
+          },
+          category: '',
+          id: '',
+          journalData: null,
+          activityCode: null,
+        },
+        practice_1: {
+          testData: {
+            dangerousFaults: {},
+            drivingFaults: {
+              moveOffSafety: 1,
+            },
+            manoeuvres: {},
+            seriousFaults: {
+              positioningNormalDriving: true,
+            },
+            testRequirements: {},
+            ETA: {},
+            eco: {},
+            controlledStop: {},
+            vehicleChecks: {
+              tellMeQuestion: {
+                outcome: 'DF',
+              },
+              showMeQuestion: {},
+            },
+          },
+          category: '',
+          id: '',
+          journalData: null,
+          activityCode: null,
+        },
+      },
+      testLifecycles: {},
+    };
+
+    const result = testsReducer(state, new testActions.EndPracticeTest());
+    expect(result.startedTests['practice_1'].testData.seriousFaults.positioningNormalDriving).toBeUndefined();
+    expect(result.startedTests['practice_1'].testData.drivingFaults.moveOffSafety).toBeUndefined();
+    expect(result.startedTests['practice_1'].testData.vehicleChecks.tellMeQuestion.outcome).toBeUndefined();
+
+    expect(result.startedTests[1].testData.seriousFaults.signalsTimed).toBeTruthy();
+    expect(result.startedTests[1].testData.drivingFaults.clearance).toBeTruthy();
+    expect(result.startedTests[1].testData.vehicleChecks.tellMeQuestion.outcome).toEqual(CompetencyOutcome.DF);
+    expect(result.startedTests[1].testData.vehicleChecks.showMeQuestion.outcome).toEqual(CompetencyOutcome.S);
   });
 
 });

--- a/src/modules/tests/tests.actions.ts
+++ b/src/modules/tests/tests.actions.ts
@@ -12,6 +12,7 @@ export const LOAD_PERSISTED_TESTS = '[Tests] Load persisted';
 export const LOAD_PERSISTED_TESTS_SUCCESS = '[Tests] Load persisted success';
 export const SET_ACTIVITY_CODE = '[Tests] Set activity code';
 export const START_PRACTICE_TEST = '[Tests] Start practice test';
+export const END_PRACTICE_TEST = '[Tests] End practice test';
 
 export class PersistTests implements Action {
   readonly type = PERSIST_TESTS;
@@ -34,6 +35,10 @@ export class SetActivityCode implements Action {
 export class StartPracticeTest implements Action {
   readonly type = START_PRACTICE_TEST;
   constructor(public slotId: string) { }
+}
+
+export class EndPracticeTest implements Action {
+  readonly type = END_PRACTICE_TEST;
 }
 
 export class StartSendingCompletedTests implements Action {
@@ -59,6 +64,7 @@ export type Types =
   | LoadPersistedTestsSuccess
   | SetActivityCode
   | StartPracticeTest
+  | EndPracticeTest
   | StartSendingCompletedTests
   | SendTest
   | SendTestSuccess

--- a/src/modules/tests/tests.actions.ts
+++ b/src/modules/tests/tests.actions.ts
@@ -12,7 +12,6 @@ export const LOAD_PERSISTED_TESTS = '[Tests] Load persisted';
 export const LOAD_PERSISTED_TESTS_SUCCESS = '[Tests] Load persisted success';
 export const SET_ACTIVITY_CODE = '[Tests] Set activity code';
 export const START_PRACTICE_TEST = '[Tests] Start practice test';
-export const END_PRACTICE_TEST = '[Tests] End practice test';
 
 export class PersistTests implements Action {
   readonly type = PERSIST_TESTS;
@@ -35,10 +34,6 @@ export class SetActivityCode implements Action {
 export class StartPracticeTest implements Action {
   readonly type = START_PRACTICE_TEST;
   constructor(public slotId: string) { }
-}
-
-export class EndPracticeTest implements Action {
-  readonly type = END_PRACTICE_TEST;
 }
 
 export class StartSendingCompletedTests implements Action {
@@ -64,7 +59,6 @@ export type Types =
   | LoadPersistedTestsSuccess
   | SetActivityCode
   | StartPracticeTest
-  | EndPracticeTest
   | StartSendingCompletedTests
   | SendTest
   | SendTestSuccess

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -50,7 +50,7 @@ export function testsReducer(
           },
         },
       };
-    case testActions.END_PRACTICE_TEST:
+    case testActions.START_PRACTICE_TEST:
       const { [slotId]: removedStartedTest, ...updatedStartedTests } = state.startedTests;
       const { [slotId]: removedTestLifecycle, ...updatedTestLifecycles } = state.testLifecycles;
       const newState = {
@@ -61,7 +61,7 @@ export function testsReducer(
         startedTests: updatedStartedTests,
         testLifecycles: updatedTestLifecycles,
       };
-      return createStateObject(newState, action, slotId);
+      return slotId ? createStateObject(newState, action, slotId) : state;
     default:
       return slotId ? createStateObject(state, action, slotId) : state;
   }

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -50,6 +50,18 @@ export function testsReducer(
           },
         },
       };
+    case testActions.END_PRACTICE_TEST:
+      const { [slotId]: removedStartedTest, ...updatedStartedTests } = state.startedTests;
+      const { [slotId]: removedTestLifecycle, ...updatedTestLifecycles } = state.testLifecycles;
+      const newState = {
+        ...state,
+        currentTest: {
+          ...initialState.currentTest,
+        },
+        startedTests: updatedStartedTests,
+        testLifecycles: updatedTestLifecycles,
+      };
+      return createStateObject(newState, action, slotId);
     default:
       return slotId ? createStateObject(state, action, slotId) : state;
   }

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -180,7 +180,6 @@ export class DebriefPage extends BasePageComponent {
 
   ionViewDidLeave(): void {
     if (this.isPracticeTest) {
-      // this.store$.dispatch(new EndPracticeTest());
       if (super.isIos()) {
         this.screenOrientation.unlock();
         this.insomnia.allowSleepAgain();

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -31,7 +31,7 @@ import {
 } from './debrief.selector';
 import { CompetencyOutcome } from '../../shared/models/competency-outcome';
 import { MultiFaultAssignableCompetency } from '../../shared/models/fault-marking.model';
-import { PersistTests, EndPracticeTest } from '../../modules/tests/tests.actions';
+import { PersistTests } from '../../modules/tests/tests.actions';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
 
@@ -180,7 +180,7 @@ export class DebriefPage extends BasePageComponent {
 
   ionViewDidLeave(): void {
     if (this.isPracticeTest) {
-      this.store$.dispatch(new EndPracticeTest());
+      // this.store$.dispatch(new EndPracticeTest());
       if (super.isIos()) {
         this.screenOrientation.unlock();
         this.insomnia.allowSleepAgain();

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -31,7 +31,7 @@ import {
 } from './debrief.selector';
 import { CompetencyOutcome } from '../../shared/models/competency-outcome';
 import { MultiFaultAssignableCompetency } from '../../shared/models/fault-marking.model';
-import { PersistTests } from '../../modules/tests/tests.actions';
+import { PersistTests, EndPracticeTest } from '../../modules/tests/tests.actions';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
 
@@ -179,9 +179,12 @@ export class DebriefPage extends BasePageComponent {
   }
 
   ionViewDidLeave(): void {
-    if (super.isIos() && this.isPracticeTest) {
-      this.screenOrientation.unlock();
-      this.insomnia.allowSleepAgain();
+    if (this.isPracticeTest) {
+      this.store$.dispatch(new EndPracticeTest());
+      if (super.isIos()) {
+        this.screenOrientation.unlock();
+        this.insomnia.allowSleepAgain();
+      }
     }
   }
 

--- a/src/pages/test-report/__tests__/test-report.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.effects.spec.ts
@@ -131,5 +131,10 @@ describe('Test Report Effects', () => {
       });
     });
 
+    it('should not dispatch an action requesting the test data to be saved when triggered', () => {
+      // When something is filtered, nothing happens - the pipe function will not call the next operator.
+      // TODO - think about how this could be tested
+    });
+
   });
 });

--- a/src/pages/test-report/test-report.effects.ts
+++ b/src/pages/test-report/test-report.effects.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { switchMap, withLatestFrom, map, concatMap, delay } from 'rxjs/operators';
+import { switchMap, withLatestFrom, map, concatMap, delay, filter } from 'rxjs/operators';
 import { TestReportValidatorProvider } from '../../providers/test-report-validator/test-report-validator';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { getTests } from '../../modules/tests/tests.reducer';
-import { getCurrentTest } from '../../modules/tests/tests.selector';
+import { getCurrentTest, isPracticeTest } from '../../modules/tests/tests.selector';
 import { getTestData } from '../../modules/tests/test-data/test-data.reducer';
 import { getCatBLegalRequirements } from '../../modules/tests/test-data/test-data.selector';
 import * as testReportActions from './test-report.actions';
@@ -104,7 +104,14 @@ export class TestReportEffects {
       testDataActions.TOGGLE_ETA,
       testDataActions.TOGGLE_LEGAL_REQUIREMENT,
     ),
-    delay(1000), // Added a 1 second delay to allow other actions to complete/effects to fire
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isPracticeTest),
+      ),
+    ),
+    filter(([action, isPracticeTest]) => !isPracticeTest),
+    delay(1000), // Added a 1 second delay to allow other action to complete/effects to fire
     map(() => new testsActions.PersistTests()),
   );
 }


### PR DESCRIPTION
## Description and relevant Jira numbers
- reset the state of the practice test when it is started

The state is reset by removing the practice test from the state and creating a new test state via createStateObject.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
