### PR TITLE
Bugfix - add class to make tell me select modal correct height

### DIFF
--- a/src/pages/waiting-room-to-car/components/tell-me-question/tell-me-question.html
+++ b/src/pages/waiting-room-to-car/components/tell-me-question/tell-me-question.html
@@ -2,7 +2,7 @@
         <ion-col col-58>
           <ion-select value="tellMeQuestion" id="tell-me-selector" okText="Submit" cancelText="Cancel"
           placeholder="Select a question" (ionChange)="tellMeQuestionChanged($event)"
-            formControlName="tellMeQuestion">
+            formControlName="tellMeQuestion" [selectOptions]="{cssClass:'mes-select'}">
             <ion-option  
                 *ngFor="let currentTellMeQuestion of tellMeQuestions"
                 [value]="currentTellMeQuestion">


### PR DESCRIPTION
## Description and relevant Jira numbers
As part of the refactor, the select modal lost it's class.

Before
![IMG_0037](https://user-images.githubusercontent.com/8069071/57714015-7fd8be80-766b-11e9-93fc-b2e640d13d3c.PNG)

After
![Screenshot 2019-05-14 at 17 10 34](https://user-images.githubusercontent.com/8069071/57714002-78191a00-766b-11e9-8a1a-bb96f10374d9.png)

