### PR TITLE
Mes 2313 send tests in interval

### DIFF
--- a/src/modules/tests/__tests__/tests.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.effects.spec.ts
@@ -14,6 +14,10 @@ import { initialState, testsReducer } from '../tests.reducer';
 import { TestSubmissionProvider } from '../../../providers/test-submission/test-submission';
 import { TestSubmissionProviderMock } from '../../../providers/test-submission/__mocks__/test-submission.mock';
 import { Store, StoreModule } from '@ngrx/store';
+import { NetworkStateProvider } from '../../../providers/network-state/network-state';
+import { NetworkStateProviderMock } from '../../../providers/network-state/__mocks__/network-state.mock';
+import { AppConfigProvider } from '../../../providers/app-config/app-config';
+import { AppConfigProviderMock } from '../../../providers/app-config/__mocks__/app-config.mock';
 
 describe('Tests Effects', () => {
 
@@ -32,8 +36,10 @@ describe('Tests Effects', () => {
       providers: [
         TestsEffects,
         provideMockActions(() => actions$),
+        { provide: AppConfigProvider, useClass: AppConfigProviderMock },
         { provide: TestPersistenceProvider, useClass: TestPersistenceProviderMock },
         { provide: TestSubmissionProvider, useClass: TestSubmissionProviderMock },
+        { provide: NetworkStateProvider, useClass: NetworkStateProviderMock },
         Store,
       ],
     });

--- a/src/modules/tests/__tests__/tests.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.effects.spec.ts
@@ -102,11 +102,12 @@ describe('Tests Effects', () => {
 
   describe('sendTestSuccessEffect', () => {
     it('should dispatch the TestStatusSubmitted action', (done) => {
+      const currentTestSlotId = '12345';
       // ACT
-      actions$.next(new testsActions.SendTestSuccess());
+      actions$.next(new testsActions.SendTestSuccess(currentTestSlotId));
       // ASSERT
       effects.sendTestSuccessEffect$.subscribe((result) => {
-        expect(result).toEqual(new testStatusActions.TestStatusSubmitted());
+        expect(result).toEqual(new testStatusActions.SetTestStatusSubmitted(currentTestSlotId));
         done();
       });
     });

--- a/src/modules/tests/__tests__/tests.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.effects.spec.ts
@@ -107,7 +107,12 @@ describe('Tests Effects', () => {
       actions$.next(new testsActions.SendTestSuccess(currentTestSlotId));
       // ASSERT
       effects.sendTestSuccessEffect$.subscribe((result) => {
-        expect(result).toEqual(new testStatusActions.SetTestStatusSubmitted(currentTestSlotId));
+        if (result instanceof testStatusActions.SetTestStatusSubmitted)  {
+          expect(result).toEqual(new testStatusActions.SetTestStatusSubmitted(currentTestSlotId));
+        }
+        if (result instanceof testsActions.PersistTests) {
+          expect(result).toEqual(new testsActions.PersistTests());
+        }
         done();
       });
     });

--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -3,8 +3,6 @@ import * as journalActions from '../../../pages/journal/journal.actions';
 import * as candidateReducer from '../candidate/candidate.reducer';
 import * as preTestDeclarationsReducer from '../pre-test-declarations/pre-test-declarations.reducer';
 import { PreTestDeclarations } from '@dvsa/mes-test-schema/categories/B';
-import { TestStatus } from '../test-status/test-status.model';
-import * as testStatusReducer from '../test-status/test-status.reducer';
 import { TestsModel } from '../tests.model';
 import * as testActions from './../tests.actions';
 import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
@@ -149,24 +147,6 @@ describe('testsReducer', () => {
     expect(preTestDeclarationsReducer.preTestDeclarationsReducer).toHaveBeenCalled();
     expect(result.startedTests['123'].journalData.candidate).toBe(newCandidate);
     expect(result.startedTests['123'].preTestDeclarations).toBe(preTestDeclarations);
-  });
-
-  it('should track test lifecycles independently of the started tests', () => {
-    const testStatusReducerResult = TestStatus.Started;
-    spyOn(testStatusReducer, 'testStatusReducer').and.returnValue(testStatusReducerResult);
-    const state: TestsModel = {
-      currentTest: { slotId: '123' },
-      startedTests: {},
-      testStatus: {
-        456: TestStatus.Decided,
-      },
-    };
-
-    const result = testsReducer(state, new journalActions.JournalViewDidEnter());
-
-    expect(testStatusReducer.testStatusReducer).toHaveBeenCalled();
-    expect(result.testStatus['123']).toBe(TestStatus.Started);
-    expect(result.testStatus['456']).toBe(TestStatus.Decided);
   });
 
   it('should assign the slot ID as the current test when a test is activated', () => {

--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -22,7 +22,7 @@ describe('testsReducer', () => {
     const state = {
       currentTest: { slotId: null },
       startedTests: {},
-      testLifecycles: {},
+      testStatus: {},
     };
     const slotId = 123;
     const action = new journalActions.StartTest(slotId);
@@ -36,7 +36,7 @@ describe('testsReducer', () => {
     const state = {
       currentTest: { slotId: null },
       startedTests: {},
-      testLifecycles: {},
+      testStatus: {},
     };
     const slotId = 'practice_123';
     const action = new testActions.StartPracticeTest(slotId);
@@ -126,7 +126,7 @@ describe('testsReducer', () => {
     const state = {
       currentTest: { slotId: null },
       startedTests: {},
-      testLifecycles: {},
+      testStatus: {},
     };
     const slotId = '123';
     const action = new testActions.StartPracticeTest(slotId);
@@ -140,7 +140,7 @@ describe('testsReducer', () => {
     const state: TestsModel = {
       currentTest: { slotId: null },
       startedTests: {},
-      testLifecycles: {},
+      testStatus: {},
     };
 
     const result = testsReducer(state, new journalActions.StartTest(123));
@@ -157,7 +157,7 @@ describe('testsReducer', () => {
     const state: TestsModel = {
       currentTest: { slotId: '123' },
       startedTests: {},
-      testLifecycles: {
+      testStatus: {
         456: TestStatus.Decided,
       },
     };
@@ -165,15 +165,15 @@ describe('testsReducer', () => {
     const result = testsReducer(state, new journalActions.JournalViewDidEnter());
 
     expect(testStatusReducer.testStatusReducer).toHaveBeenCalled();
-    expect(result.testLifecycles['123']).toBe(TestStatus.Started);
-    expect(result.testLifecycles['456']).toBe(TestStatus.Decided);
+    expect(result.testStatus['123']).toBe(TestStatus.Started);
+    expect(result.testStatus['456']).toBe(TestStatus.Decided);
   });
 
   it('should assign the slot ID as the current test when a test is activated', () => {
     const state: TestsModel = {
       currentTest: { slotId: '123' },
       startedTests: {},
-      testLifecycles: {},
+      testStatus: {},
     };
 
     const result = testsReducer(state, new journalActions.ActivateTest(456));

--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -103,7 +103,7 @@ describe('testsReducer', () => {
           activityCode: null,
         },
       },
-      testLifecycles: {},
+      testStatus: {},
     };
     const slotId = 'practice_1';
     const action = new testActions.StartPracticeTest(slotId);

--- a/src/modules/tests/__tests__/tests.selector.spec.ts
+++ b/src/modules/tests/__tests__/tests.selector.spec.ts
@@ -56,7 +56,7 @@ describe('testsSelector', () => {
         journal,
         appInfo,
         logs,
-        tests: { startedTests: { 123: currentTest }, currentTest: { slotId: '123' }, testLifecycles: {} },
+        tests: { startedTests: { 123: currentTest }, currentTest: { slotId: '123' }, testStatus: {} },
       };
 
       const result = getCurrentTest(state.tests);
@@ -70,7 +70,7 @@ describe('testsSelector', () => {
       const testState: TestsModel = {
         currentTest: { slotId: null },
         startedTests: {},
-        testLifecycles: { 12345: TestStatus.Decided },
+        testStatus: { 12345: TestStatus.Decided },
       };
 
       const result = getTestStatus(testState, 12345);
@@ -82,7 +82,7 @@ describe('testsSelector', () => {
       const testState: TestsModel = {
         currentTest: { slotId: null },
         startedTests: {},
-        testLifecycles: {},
+        testStatus: {},
       };
 
       const result = getTestStatus(testState, 12345);
@@ -251,7 +251,7 @@ describe('testsSelector', () => {
     const testState: TestsModel = {
       currentTest: { slotId: null },
       startedTests: {},
-      testLifecycles: { 12345: TestStatus.Decided },
+      testStatus: { 12345: TestStatus.Decided },
     };
     it('should return false when no tests started', () => {
       const result = isPracticeTest(testState);

--- a/src/modules/tests/test-status/__tests__/test-status.reducer.spec.ts
+++ b/src/modules/tests/test-status/__tests__/test-status.reducer.spec.ts
@@ -1,34 +1,41 @@
-import { initialState, testStatusReducer } from '../test-status.reducer';
+import { testStatusReducer } from '../test-status.reducer';
 import { TestStatus } from '../test-status.model';
 import {
-  TestStatusStarted,
-  TestStatusDecided,
-  TestStatusCompleted,
-  TestStatusSubmitted,
+  SetTestStatusBooked,
+  SetTestStatusStarted,
+  SetTestStatusDecided,
+  SetTestStatusCompleted,
+  SetTestStatusSubmitted,
 } from '../test-status.actions';
 
 describe('test status reducer', () => {
-  it('should have the initial state of NotStarted', () => {
-    expect(initialState).toBe(TestStatus.Booked);
+  const slotId = '1003';
+  const initialState = {
+    [slotId]: '',
+  };
+
+  it('shoule move test status to booked when SetTestStatusBooked', () => {
+    const result = testStatusReducer(initialState, new SetTestStatusBooked(slotId));
+    expect(result[slotId]).toBe(TestStatus.Booked);
   });
 
-  it('should move the test to started when receiving the TestStatusStarted action', () => {
-    const result = testStatusReducer(TestStatus.Booked, new TestStatusStarted());
-    expect(result).toBe(TestStatus.Started);
+  it('should move the test to started when receiving the SetTestStatusStarted action', () => {
+    const result = testStatusReducer(initialState, new SetTestStatusStarted(slotId));
+    expect(result[slotId]).toBe(TestStatus.Started);
   });
 
   it('should change the test to decided when receiving the TestStatusDecided action', () => {
-    const result = testStatusReducer(TestStatus.Started, new TestStatusDecided());
-    expect(result).toBe(TestStatus.Decided);
+    const result = testStatusReducer(initialState, new SetTestStatusDecided(slotId));
+    expect(result[slotId]).toBe(TestStatus.Decided);
   });
 
   it('should change the test to completed when receiving the TestStatusCompleted action', () => {
-    const result = testStatusReducer(TestStatus.Decided, new TestStatusCompleted());
-    expect(result).toBe(TestStatus.Completed);
+    const result = testStatusReducer(initialState, new SetTestStatusCompleted(slotId));
+    expect(result[slotId]).toBe(TestStatus.Completed);
   });
 
   it('should change the test to submitted when receiving the TestStatusSubmitted action', () => {
-    const result = testStatusReducer(TestStatus.Submitted, new TestStatusSubmitted());
-    expect(result).toBe(TestStatus.Submitted);
+    const result = testStatusReducer(initialState, new SetTestStatusSubmitted(slotId));
+    expect(result[slotId]).toBe(TestStatus.Submitted);
   });
 });

--- a/src/modules/tests/test-status/test-status.actions.ts
+++ b/src/modules/tests/test-status/test-status.actions.ts
@@ -1,10 +1,10 @@
 import { Action } from '@ngrx/store';
 
-export const SET_TEST_STATUS_BOOKED = '[???] Set Test Status to Booked';
-export const SET_TEST_STATUS_STARTED = '[???] Set Test Status to Started';
-export const SET_TEST_STATUS_DECIDED = '[???] Set Test Status to Decided';
-export const SET_TEST_STATUS_COMPLETED = '[???] Set Test Status to Completed';
-export const SET_TEST_STATUS_SUBMITTED = '[???] Set Test Status to Submitted';
+export const SET_TEST_STATUS_BOOKED = '[JournalEffects] Set Test Status to Booked';
+export const SET_TEST_STATUS_STARTED = '[WaitingRoomEffects] Set Test Status to Started';
+export const SET_TEST_STATUS_DECIDED = '[DebriefEffects] Set Test Status to Decided';
+export const SET_TEST_STATUS_COMPLETED = '[OfficeEffects] Set Test Status to Completed';
+export const SET_TEST_STATUS_SUBMITTED = '[TestsEffects] Set Test Status to Submitted';
 
 export class SetTestStatusBooked implements Action {
   readonly type = SET_TEST_STATUS_BOOKED;

--- a/src/modules/tests/test-status/test-status.actions.ts
+++ b/src/modules/tests/test-status/test-status.actions.ts
@@ -1,30 +1,39 @@
 import { Action } from '@ngrx/store';
 
-// TODO: These actions are not relatable to an action in the app. Rename needed.
+export const SET_TEST_STATUS_BOOKED = '[???] Set Test Status to Booked';
+export const SET_TEST_STATUS_STARTED = '[???] Set Test Status to Started';
+export const SET_TEST_STATUS_DECIDED = '[???] Set Test Status to Decided';
+export const SET_TEST_STATUS_COMPLETED = '[???] Set Test Status to Completed';
+export const SET_TEST_STATUS_SUBMITTED = '[???] Set Test Status to Submitted';
 
-export const TEST_STATUS_STARTED = '[Test status] Started';
-export const TEST_STATUS_DECIDED = '[Test status] Decided';
-export const TEST_STATUS_COMPLETED = '[Tests status] Completed';
-export const TEST_STATUS_SUBMITTED = '[Tests status] Submitted';
-
-export class TestStatusStarted implements Action {
-  readonly type = TEST_STATUS_STARTED;
+export class SetTestStatusBooked implements Action {
+  readonly type = SET_TEST_STATUS_BOOKED;
+  constructor(public slotId: string) {}
 }
 
-export class TestStatusDecided implements Action {
-  readonly type = TEST_STATUS_DECIDED;
+export class SetTestStatusStarted implements Action {
+  readonly type = SET_TEST_STATUS_STARTED;
+  constructor(public slotId: string) {}
 }
 
-export class TestStatusCompleted implements Action {
-  readonly type = TEST_STATUS_COMPLETED;
+export class SetTestStatusDecided implements Action {
+  readonly type = SET_TEST_STATUS_DECIDED;
+  constructor(public slotId: string) {}
 }
 
-export class TestStatusSubmitted implements Action {
-  readonly type = TEST_STATUS_SUBMITTED;
+export class SetTestStatusCompleted implements Action {
+  readonly type = SET_TEST_STATUS_COMPLETED;
+  constructor(public slotId: string) {}
+}
+
+export class SetTestStatusSubmitted implements Action {
+  readonly type = SET_TEST_STATUS_SUBMITTED;
+  constructor(public slotId: string) {}
 }
 
 export type Types =
-  | TestStatusStarted
-  | TestStatusDecided
-  | TestStatusCompleted
-  | TestStatusSubmitted;
+  | SetTestStatusBooked
+  | SetTestStatusStarted
+  | SetTestStatusDecided
+  | SetTestStatusCompleted
+  | SetTestStatusSubmitted;

--- a/src/modules/tests/test-status/test-status.reducer.ts
+++ b/src/modules/tests/test-status/test-status.reducer.ts
@@ -5,7 +5,6 @@ import * as testStatusActions from './test-status.actions';
 export const initialState = {};
 
 export function testStatusReducer(state = initialState, action: testStatusActions.Types): {} {
-
   switch (action.type) {
     case testStatusActions.SET_TEST_STATUS_BOOKED:
       return {

--- a/src/modules/tests/test-status/test-status.reducer.ts
+++ b/src/modules/tests/test-status/test-status.reducer.ts
@@ -2,24 +2,39 @@ import { TestStatus } from './test-status.model';
 import { createFeatureSelector } from '@ngrx/store';
 import * as testStatusActions from './test-status.actions';
 
-export const initialState = TestStatus.Booked;
+export const initialState = {};
 
-export function testStatusReducer(
-  state = initialState,
-  action,
-): TestStatus {
+export function testStatusReducer(state = initialState, action: testStatusActions.Types): {} {
+
   switch (action.type) {
-    case testStatusActions.TEST_STATUS_STARTED:
-      return TestStatus.Started;
-    case testStatusActions.TEST_STATUS_DECIDED:
-      return TestStatus.Decided;
-    case testStatusActions.TEST_STATUS_COMPLETED:
-      return TestStatus.Completed;
-    case testStatusActions.TEST_STATUS_SUBMITTED:
-      return TestStatus.Submitted;
+    case testStatusActions.SET_TEST_STATUS_BOOKED:
+      return {
+        ...state,
+        [action.slotId]: TestStatus.Booked,
+      };
+    case testStatusActions.SET_TEST_STATUS_STARTED:
+      return {
+        ...state,
+        [action.slotId]: TestStatus.Started,
+      };
+    case testStatusActions.SET_TEST_STATUS_DECIDED:
+      return {
+        ...state,
+        [action.slotId]: TestStatus.Decided,
+      };
+    case testStatusActions.SET_TEST_STATUS_COMPLETED:
+      return {
+        ...state,
+        [action.slotId]: TestStatus.Completed,
+      };
+    case testStatusActions.SET_TEST_STATUS_SUBMITTED:
+      return {
+        ...state,
+        [action.slotId]: TestStatus.Submitted,
+      };
     default:
       return state;
   }
 }
 
-export const getCandidate = createFeatureSelector<TestStatus>('testStatus');
+export const getTestStatus = createFeatureSelector<TestStatus>('testStatus');

--- a/src/modules/tests/tests.actions.ts
+++ b/src/modules/tests/tests.actions.ts
@@ -64,6 +64,7 @@ export class SendTest implements Action {
 
 export class SendTestSuccess implements Action {
   readonly type = SEND_TEST_SUCCESS;
+  constructor(public slotId: string) {}
 }
 
 export class SendTestFailure implements Action {

--- a/src/modules/tests/tests.actions.ts
+++ b/src/modules/tests/tests.actions.ts
@@ -3,6 +3,10 @@ import { TestsModel } from './tests.model';
 import { ActivityCode, StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
 
 export const START_SENDING_COMPLETED_TESTS = '[???] Start Sending Completed Test';
+export const SEND_COMPLETED_TESTS = '[TestsEffects] Send Completed Tests';
+export const SEND_COMPLETED_TESTS_SUCCESS = '[TestsEffects] Send Completed Tests Success';
+export const SEND_COMPLETED_TESTS_FAILURE = '[TestsEffects] Send Completed Tests Failure';
+
 export const SEND_TEST = '[TestsEffects] Send Test';
 export const SEND_TEST_SUCCESS = '[Tests] Send Test Success';
 export const SEND_TEST_FAILURE = '[Tests] Send Test Failure';
@@ -40,6 +44,19 @@ export class StartSendingCompletedTests implements Action {
   readonly type = START_SENDING_COMPLETED_TESTS;
 }
 
+export class SendCompletedTests implements Action {
+  readonly type = SEND_COMPLETED_TESTS;
+}
+
+export class SendCompletedTestsSuccess implements Action {
+  readonly type = SEND_COMPLETED_TESTS_SUCCESS;
+  constructor(public completedTestIds: string[]) {}
+}
+
+export class SendCompletedTestsFailure implements Action {
+  readonly type = SEND_COMPLETED_TESTS_FAILURE;
+}
+
 export class SendTest implements Action {
   readonly type = SEND_TEST;
   constructor(public payload: StandardCarTestCATBSchema) {}
@@ -60,6 +77,9 @@ export type Types =
   | SetActivityCode
   | StartPracticeTest
   | StartSendingCompletedTests
+  | SendCompletedTests
+  | SendCompletedTestsSuccess
+  | SendCompletedTestsFailure
   | SendTest
   | SendTestSuccess
   | SendTestFailure;

--- a/src/modules/tests/tests.actions.ts
+++ b/src/modules/tests/tests.actions.ts
@@ -2,7 +2,7 @@ import { Action } from '@ngrx/store';
 import { TestsModel } from './tests.model';
 import { ActivityCode, StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
 
-export const START_SENDING_COMPLETED_TESTS = '[???] Start Sending Completed Test';
+export const START_SENDING_COMPLETED_TESTS = '[TestsEffects] Start Sending Completed Test';
 export const SEND_COMPLETED_TESTS = '[TestsEffects] Send Completed Tests';
 export const SEND_COMPLETED_TESTS_SUCCESS = '[TestsEffects] Send Completed Tests Success';
 export const SEND_COMPLETED_TESTS_FAILURE = '[TestsEffects] Send Completed Tests Failure';

--- a/src/modules/tests/tests.model.ts
+++ b/src/modules/tests/tests.model.ts
@@ -8,5 +8,5 @@ export interface CurrentTest {
 export interface TestsModel {
   currentTest: CurrentTest;
   startedTests: { [slotId: string]: StandardCarTestCATBSchema };
-  testLifecycles: { [slotId: string]: TestStatus };
+  testStatus: { [slotId: string]: TestStatus };
 }

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -3,6 +3,7 @@ import * as testActions from './tests.actions';
 
 import { TestsModel } from './tests.model';
 import { startsWith } from 'lodash';
+import * as testStatusActions from './test-status/test-status.actions';
 import { combineReducers, Action, createFeatureSelector } from '@ngrx/store';
 import { nestedCombineReducers } from 'nested-combine-reducers';
 
@@ -27,7 +28,7 @@ import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
 export const initialState: TestsModel = {
   currentTest: { slotId: null },
   startedTests: {},
-  testLifecycles: {},
+  testStatus: {},
 };
 
 /**
@@ -132,10 +133,7 @@ const createStateObject = (state: TestsModel, action: Action, slotId: string) =>
     currentTest: {
       slotId,
     },
-    testLifecycles: {
-      ...state.testLifecycles,
-      [slotId]: testStatusReducer(state.testLifecycles[slotId], action),
-    },
+    testStatus: testStatusReducer(state.testStatus[slotId], action as testStatusActions.Types),
   };
 };
 

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -133,7 +133,7 @@ const createStateObject = (state: TestsModel, action: Action, slotId: string) =>
     currentTest: {
       slotId,
     },
-    testStatus: testStatusReducer(state.testStatus[slotId], action as testStatusActions.Types),
+    testStatus: testStatusReducer(state.testStatus, action as testStatusActions.Types),
   };
 };
 

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -58,14 +58,14 @@ export function testsReducer(
       };
     case testActions.START_PRACTICE_TEST:
       const { [slotId]: removedStartedTest, ...updatedStartedTests } = state.startedTests;
-      const { [slotId]: removedTestLifecycle, ...updatedTestLifecycles } = state.testLifecycles;
+      const { [slotId]: removedTestStatus, ...updatedTestStatus } = state.testStatus;
       const newState = {
         ...state,
         currentTest: {
           ...initialState.currentTest,
         },
         startedTests: updatedStartedTests,
-        testLifecycles: updatedTestLifecycles,
+        testStatus: updatedTestStatus,
       };
       return slotId ? createStateObject(newState, action, slotId) : state;
     default:

--- a/src/modules/tests/tests.selector.ts
+++ b/src/modules/tests/tests.selector.ts
@@ -14,9 +14,7 @@ const outcomeStatus: any[] = [
   { outcomeCode: '5', outcomeText: 'Unsuccessful', outcomeColour: 'mes-red' },
 ];
 
-export const getCurrentTestSlotId = (tests: TestsModel) => {
-  return tests.currentTest.slotId;
-};
+export const getCurrentTestSlotId = (tests: TestsModel) => tests.currentTest.slotId;
 
 export const getCurrentTest = (tests: TestsModel) => {
   const currentTestSlotId = tests.currentTest.slotId;

--- a/src/modules/tests/tests.selector.ts
+++ b/src/modules/tests/tests.selector.ts
@@ -14,6 +14,10 @@ const outcomeStatus: any[] = [
   { outcomeCode: '5', outcomeText: 'Unsuccessful', outcomeColour: 'mes-red' },
 ];
 
+export const getCurrentTestSlotId = (tests: TestsModel) => {
+  return tests.currentTest.slotId;
+};
+
 export const getCurrentTest = (tests: TestsModel) => {
   const currentTestSlotId = tests.currentTest.slotId;
   return tests.startedTests[currentTestSlotId];
@@ -21,7 +25,7 @@ export const getCurrentTest = (tests: TestsModel) => {
 
 export const getJournalData = (test: StandardCarTestCATBSchema): JournalData => test.journalData;
 
-export const getTestStatus = (tests: TestsModel, slotId: number) => tests.testLifecycles[slotId] || TestStatus.Booked;
+export const getTestStatus = (tests: TestsModel, slotId: number) => tests.testStatus[slotId] || TestStatus.Booked;
 
 export const getTestOutcome = (test: StandardCarTestCATBSchema) => test.activityCode;
 

--- a/src/pages/back-to-office/__tests__/back-to-office.spec.ts
+++ b/src/pages/back-to-office/__tests__/back-to-office.spec.ts
@@ -10,7 +10,7 @@ import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
 import { StoreModule, Store } from '@ngrx/store';
 import { StoreModel } from '../../../shared/models/store.model';
-import { TestStatusDecided } from '../../../modules/tests/test-status/test-status.actions';
+import { SetTestStatusDecided } from '../../../modules/tests/test-status/test-status.actions';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
 import { DeviceProvider } from '../../../providers/device/device';
@@ -75,7 +75,8 @@ describe('BackToOfficePage', () => {
       });
       it('should dispatch actions to change the test status and to persist the tests', () => {
         component.ionViewDidEnter();
-        expect(store$.dispatch).toHaveBeenCalledWith(new TestStatusDecided());
+        const fakeDummySlotId = 'fakeDummySlotId';
+        expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusDecided(fakeDummySlotId));
         expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
       });
     });

--- a/src/pages/back-to-office/__tests__/back-to-office.spec.ts
+++ b/src/pages/back-to-office/__tests__/back-to-office.spec.ts
@@ -10,14 +10,12 @@ import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
 import { StoreModule, Store } from '@ngrx/store';
 import { StoreModel } from '../../../shared/models/store.model';
-import { SetTestStatusDecided } from '../../../modules/tests/test-status/test-status.actions';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
 import { DeviceProvider } from '../../../providers/device/device';
 import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
 import { InsomniaMock } from '../../../shared/mocks/insomnia.mock';
 import { ScreenOrientationMock } from '../../../shared/mocks/screen-orientation.mock';
-import { PersistTests } from '../../../modules/tests/tests.actions';
 
 describe('BackToOfficePage', () => {
   let fixture: ComponentFixture<BackToOfficePage>;
@@ -72,12 +70,6 @@ describe('BackToOfficePage', () => {
         expect(deviceProvider.disableSingleAppMode).toHaveBeenCalled();
         expect(screenOrientation.unlock).toHaveBeenCalled();
         expect(insomnia.allowSleepAgain).toHaveBeenCalled();
-      });
-      it('should dispatch actions to change the test status and to persist the tests', () => {
-        component.ionViewDidEnter();
-        const fakeDummySlotId = 'fakeDummySlotId';
-        expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusDecided(fakeDummySlotId));
-        expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
       });
     });
   });

--- a/src/pages/back-to-office/back-to-office.ts
+++ b/src/pages/back-to-office/back-to-office.ts
@@ -5,11 +5,9 @@ import { AuthenticationProvider } from '../../providers/authentication/authentic
 import { Store } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { BackToOfficeViewDidEnter } from './back-to-office.actions';
-import { SetTestStatusDecided } from '../../modules/tests/test-status/test-status.actions';
 import { DeviceProvider } from '../../providers/device/device';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
-import { PersistTests } from '../../modules/tests/tests.actions';
 
 @IonicPage()
 @Component({
@@ -38,10 +36,6 @@ export class BackToOfficePage extends BasePageComponent {
       this.insomnia.allowSleepAgain();
     }
 
-    // TODO: change this dummy slot id
-    const dummySlotId = 'dummySlotId';
-    this.store$.dispatch(new SetTestStatusDecided(dummySlotId));
-    this.store$.dispatch(new PersistTests());
     this.store$.dispatch(new BackToOfficeViewDidEnter());
   }
 

--- a/src/pages/back-to-office/back-to-office.ts
+++ b/src/pages/back-to-office/back-to-office.ts
@@ -5,7 +5,7 @@ import { AuthenticationProvider } from '../../providers/authentication/authentic
 import { Store } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { BackToOfficeViewDidEnter } from './back-to-office.actions';
-import { TestStatusDecided } from '../../modules/tests/test-status/test-status.actions';
+import { SetTestStatusDecided } from '../../modules/tests/test-status/test-status.actions';
 import { DeviceProvider } from '../../providers/device/device';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
@@ -37,7 +37,10 @@ export class BackToOfficePage extends BasePageComponent {
       this.screenOrientation.unlock();
       this.insomnia.allowSleepAgain();
     }
-    this.store$.dispatch(new TestStatusDecided());
+
+    // TODO: change this dummy slot id
+    const dummySlotId = 'dummySlotId';
+    this.store$.dispatch(new SetTestStatusDecided(dummySlotId));
     this.store$.dispatch(new PersistTests());
     this.store$.dispatch(new BackToOfficeViewDidEnter());
   }

--- a/src/pages/communication-page/__tests__/communication.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.spec.ts
@@ -60,7 +60,7 @@ describe('CommunicationPage', () => {
           currentTest: {
             slotId: '123',
           },
-          testLifecycles: {},
+          testStatus: {},
           startedTests: {
             123: {
               preTestDeclarations: preTestDeclarationInitialState,

--- a/src/pages/debrief/__tests__/debrief.effects.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.effects.spec.ts
@@ -1,0 +1,58 @@
+import { DebriefEffects } from '../debrief.effects';
+import { TestBed } from '@angular/core/testing';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { StoreModule, Store } from '@ngrx/store';
+import { provideMockActions } from '@ngrx/effects/testing';
+import * as debriefActions from '../debrief.actions';
+import * as testStatusActions from '../../../modules/tests/test-status/test-status.actions';
+import * as testsActions from '../../../modules/tests/tests.actions';
+
+describe('Debrief Effects', () => {
+
+  let effects: DebriefEffects;
+  let actions$: any;
+
+  const currentSlotId = '1234';
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: () => ({
+            currentTest: {
+              slotId: currentSlotId,
+            },
+            testStatus: {},
+            startedTests: {},
+          }),
+        }),
+      ],
+      providers: [
+        DebriefEffects,
+        provideMockActions(() => actions$),
+        Store,
+      ],
+    });
+    effects = TestBed.get(DebriefEffects);
+  });
+
+  describe('endDebriefEffect', () => {
+
+    it('should return SET_STATUS_DECIDED & PERSIST_TESTS actions', (done) => {
+      actions$.next(new debriefActions.EndDebrief());
+
+      effects.endDebriefEffect$.subscribe((result) => {
+        if (result instanceof testStatusActions.SetTestStatusDecided) {
+          expect(result).toEqual(new testStatusActions.SetTestStatusDecided(currentSlotId));
+        }
+        if (result instanceof testsActions.PersistTests) {
+          expect(result).toEqual(new testsActions.PersistTests());
+        }
+        done();
+      });
+    });
+
+  });
+
+});

--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -64,7 +64,7 @@ describe('DebriefPage', () => {
             currentTest: {
               slotId: '123',
             },
-            testLifecycles: {},
+            testStatus: {},
             startedTests: {
               123: {
                 testSlotAttributes,

--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -20,7 +20,6 @@ import {
   TogglePlanningEco,
 } from '../../../modules/tests/test-data/test-data.actions';
 import { Competencies, ExaminerActions } from '../../../modules/tests/test-data/test-data.constants';
-import { PersistTests } from '../../../modules/tests/tests.actions';
 import { DebriefComponentsModule } from '../components/debrief-components.module';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
@@ -32,6 +31,7 @@ import { TranslateModule, TranslateService } from 'ng2-translate';
 import { fullCompetencyLabels } from '../../../shared/constants/competencies/catb-competencies';
 import { TestSlotAttributes } from '@dvsa/mes-test-schema/categories/B';
 import { PopulateTestSlotAttributes } from '../../../modules/tests/test-slot-attributes/test-slot-attributes.actions';
+import { EndDebrief } from '../debrief.actions';
 
 describe('DebriefPage', () => {
   let fixture: ComponentFixture<DebriefPage>;
@@ -233,7 +233,7 @@ describe('DebriefPage', () => {
     describe('endDebrief', () => {
       it('should dispatch the PersistTests action', () => {
         component.endDebrief();
-        expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests);
+        expect(store$.dispatch).toHaveBeenCalledWith(new EndDebrief);
       });
       it('should navigate to PassFinalisationPage when outcome = pass', () => {
         component.outcome = 'Pass';

--- a/src/pages/debrief/debrief.actions.ts
+++ b/src/pages/debrief/debrief.actions.ts
@@ -1,10 +1,16 @@
 import { Action } from '@ngrx/store';
 
-export const DEBRIEF_VIEW_DID_ENTER = '[DebriefPage] Debrief view did enter';
+export const DEBRIEF_VIEW_DID_ENTER = '[DebriefPage] Debrief View Did Enter';
+export const END_DEBRIEF = '[DebriefPage] End Debrief';
 
 export class DebriefViewDidEnter implements Action {
   readonly type = DEBRIEF_VIEW_DID_ENTER;
 }
 
+export class EndDebrief implements Action {
+  readonly type = END_DEBRIEF;
+}
+
 export type Types =
-  | DebriefViewDidEnter;
+  | DebriefViewDidEnter
+  | EndDebrief;

--- a/src/pages/debrief/debrief.effects.ts
+++ b/src/pages/debrief/debrief.effects.ts
@@ -11,14 +11,14 @@ import { getTests } from '../../modules/tests/tests.reducer';
 import { getCurrentTestSlotId } from '../../modules/tests/tests.selector';
 
 @Injectable()
-export class WaitingRoomEffects {
+export class DebriefEffects {
   constructor(
     private actions$: Actions,
     private store$: Store<StoreModel>,
   ) {}
 
   @Effect()
-  completeTestEffect$ = this.actions$.pipe(
+  endDebriefEffect$ = this.actions$.pipe(
     ofType(debriefActions.END_DEBRIEF),
     withLatestFrom(
       this.store$.pipe(

--- a/src/pages/debrief/debrief.effects.ts
+++ b/src/pages/debrief/debrief.effects.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { Effect, Actions, ofType } from '@ngrx/effects';
+import { switchMap, withLatestFrom } from 'rxjs/operators';
+
+import * as debriefActions from './debrief.actions';
+import * as testStatusActions from '../../modules/tests/test-status/test-status.actions';
+import * as testsActions from '../../modules/tests/tests.actions';
+import { StoreModel } from '../../shared/models/store.model';
+import { Store, select } from '@ngrx/store';
+import { getTests } from '../../modules/tests/tests.reducer';
+import { getCurrentTestSlotId } from '../../modules/tests/tests.selector';
+
+@Injectable()
+export class WaitingRoomEffects {
+  constructor(
+    private actions$: Actions,
+    private store$: Store<StoreModel>,
+  ) {}
+
+  @Effect()
+  completeTestEffect$ = this.actions$.pipe(
+    ofType(debriefActions.END_DEBRIEF),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        select(getCurrentTestSlotId),
+      ),
+    ),
+    switchMap(([action, slotId]) => {
+      return [
+        new testStatusActions.SetTestStatusDecided(slotId),
+        new testsActions.PersistTests(),
+      ];
+    }),
+  );
+}

--- a/src/pages/debrief/debrief.module.ts
+++ b/src/pages/debrief/debrief.module.ts
@@ -7,6 +7,7 @@ import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import { ComponentsModule } from '../../components/components.module';
 import { DebriefComponentsModule } from './components/debrief-components.module';
 import { TranslateModule } from 'ng2-translate';
+import { DebriefEffects } from './debrief.effects';
 
 @NgModule({
   declarations: [
@@ -15,7 +16,10 @@ import { TranslateModule } from 'ng2-translate';
   imports: [
     DebriefComponentsModule,
     IonicPageModule.forChild(DebriefPage),
-    EffectsModule.forFeature([DebriefAnalyticsEffects]),
+    EffectsModule.forFeature([
+      DebriefEffects,
+      DebriefAnalyticsEffects,
+    ]),
     ComponentsModule,
     TranslateModule,
   ],

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -3,8 +3,8 @@ import { BasePageComponent } from '../../shared/classes/base-page';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
-import { DebriefViewDidEnter } from '../../pages/debrief/debrief.actions';
 import { getCurrentTest, isPracticeTest, getJournalData } from '../../modules/tests/tests.selector';
+import { DebriefViewDidEnter, EndDebrief } from '../../pages/debrief/debrief.actions';
 import { Observable } from 'rxjs/Observable';
 import { getTests } from '../../modules/tests/tests.reducer';
 import { getTestData } from '../../modules/tests/test-data/test-data.reducer';
@@ -31,7 +31,6 @@ import {
 } from './debrief.selector';
 import { CompetencyOutcome } from '../../shared/models/competency-outcome';
 import { MultiFaultAssignableCompetency } from '../../shared/models/fault-marking.model';
-import { PersistTests } from '../../modules/tests/tests.actions';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
 import { TranslateService } from 'ng2-translate';
@@ -200,7 +199,7 @@ export class DebriefPage extends BasePageComponent {
       this.navController.popToRoot();
       return;
     }
-    this.store$.dispatch(new PersistTests());
+    this.store$.dispatch(new EndDebrief());
     if (this.outcome === 'Pass') {
       this.navController.push('PassFinalisationPage');
       return;

--- a/src/pages/health-declaration/__tests__/health-declaration.spec.ts
+++ b/src/pages/health-declaration/__tests__/health-declaration.spec.ts
@@ -65,7 +65,7 @@ describe('HealthDeclarationPage', () => {
             currentTest: {
               slotId: '123',
             },
-            testLifecycles: {},
+            testStatus: {},
             startedTests: {
               123: {
                 postTestDeclarations: {

--- a/src/pages/journal/__tests__/journal.effects.spec.ts
+++ b/src/pages/journal/__tests__/journal.effects.spec.ts
@@ -172,7 +172,7 @@ describe('Journal Effects', () => {
     actions$.next(new journalActions.SelectPreviousDay());
     // ASSERT
     effects.selectPreviousDayEffect$.subscribe((result) => {
-      if (result instanceof journalActions.SetSelectedDate)  {
+      if (result instanceof journalActions.SetSelectedDate) {
         expect(result).toEqual(new journalActions.SetSelectedDate(selectedDate));
       }
       if (result instanceof journalActions.JournalNavigateDay) {

--- a/src/pages/journal/components/test-slot/__tests__/test-slot.spec.ts
+++ b/src/pages/journal/components/test-slot/__tests__/test-slot.spec.ts
@@ -24,7 +24,7 @@ import { StoreModule, Store } from '@ngrx/store';
 import { testsReducer } from '../../../../../modules/tests/tests.reducer';
 import { TestStatus } from '../../../../../modules/tests/test-status/test-status.model';
 import { StoreModel } from '../../../../../shared/models/store.model';
-import { TestStatusDecided } from '../../../../../modules/tests/test-status/test-status.actions';
+import { SetTestStatusDecided } from '../../../../../modules/tests/test-status/test-status.actions';
 import { of } from 'rxjs/observable/of';
 import { StartTest } from '../../../journal.actions';
 import { SubmissionStatusComponent } from '../../submission-status/submission-status';
@@ -295,7 +295,7 @@ describe('TestSlotComponent', () => {
       it('should pass test status decided to the test-outcome component when the outcome observable changes', () => {
         fixture.detectChanges();
         store$.dispatch(new StartTest(mockSlot.slotDetail.slotId));
-        store$.dispatch(new TestStatusDecided());
+        store$.dispatch(new SetTestStatusDecided(mockSlot.slotDetail.slotId.toString()));
         fixture.detectChanges();
 
         const testOutcomeSubComponent = fixture.debugElement.query(

--- a/src/pages/journal/journal.effects.ts
+++ b/src/pages/journal/journal.effects.ts
@@ -31,6 +31,7 @@ import { PopulateCandidateDetails } from '../../modules/tests/candidate/candidat
 import { TestSlotAttributes, TestCentre } from '@dvsa/mes-test-schema/categories/B';
 import { PopulateTestSlotAttributes } from '../../modules/tests/test-slot-attributes/test-slot-attributes.actions';
 import { PopulateTestCentre } from '../../modules/tests/test-centre/test-centre.actions';
+import { SetTestStatusBooked } from '../../modules/tests/test-status/test-status.actions';
 
 @Injectable()
 export class JournalEffects {
@@ -173,6 +174,7 @@ export class JournalEffects {
         new PopulateCandidateDetails(slot.slotData.booking.candidate),
         new PopulateTestSlotAttributes(this.extractTestSlotAttributes(slot.slotData)),
         new PopulateTestCentre(this.extractTestCentre(slot.slotData)),
+        new SetTestStatusBooked(startTestAction.slotId.toString()),
       ];
     }),
   );

--- a/src/pages/journal/journal.ts
+++ b/src/pages/journal/journal.ts
@@ -79,7 +79,6 @@ export class JournalPage extends BasePageComponent implements OnInit, OnDestroy 
   }
 
   ngOnInit(): void {
-
     this.pageState = {
       selectedDate$: this.store$.pipe(
         select(getJournalState),

--- a/src/pages/login/__tests__/login.spec.ts
+++ b/src/pages/login/__tests__/login.spec.ts
@@ -40,6 +40,8 @@ import { DataStoreProvider } from '../../../providers/data-store/data-store';
 import { DataStoreProviderMock } from '../../../providers/data-store/__mocks__/data-store.mock';
 import { SecureStorage } from '@ionic-native/secure-storage';
 import { SecureStorageMock } from '@ionic-native-mocks/secure-storage';
+import { LoadLog, StartSendingLogs } from '../../../modules/logs/logs.actions';
+import { StartSendingCompletedTests } from '../../../modules/tests/tests.actions';
 
 describe('LoginPage', () => {
   let fixture: ComponentFixture<LoginPage>;
@@ -210,6 +212,15 @@ describe('LoginPage', () => {
 
       expect(component.isUserNotAuthorised()).toBeTruthy();
     });
+
+    it('should dispatch LOAD_LOG, START_SENDING_LOGS, START_SENDING_COMPLETED_LOGS action', fakeAsync(() => {
+      component.login();
+      tick();
+
+      expect(store$.dispatch).toHaveBeenCalledWith(new LoadLog());
+      expect(store$.dispatch).toHaveBeenCalledWith(new StartSendingLogs());
+      expect(store$.dispatch).toHaveBeenCalledWith(new StartSendingCompletedTests());
+    }));
   });
 
   describe('Async order of events in the login() method', () => {

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -23,7 +23,7 @@ import { StartSendingLogs, LoadLog } from '../../modules/logs/logs.actions';
 import { NetworkStateProvider } from '../../providers/network-state/network-state';
 import { SecureStorage } from '@ionic-native/secure-storage';
 import { DataStoreProvider } from '../../providers/data-store/data-store';
-import { LoadPersistedTests } from '../../modules/tests/tests.actions';
+import { LoadPersistedTests, StartSendingCompletedTests } from '../../modules/tests/tests.actions';
 import { AppConfigError } from '../../providers/app-config/app-config.constants';
 
 @IonicPage()
@@ -94,6 +94,9 @@ export class LoginPage extends BasePageComponent {
 
       this.analytics.initialiseAnalytics();
       this.store$.dispatch(new StartSendingLogs());
+
+      this.store$.dispatch(new StartSendingCompletedTests());
+
       this.handleLoadingUI(false);
       this.validateDeviceType();
 

--- a/src/pages/office/__tests__/office.effects.spec.ts
+++ b/src/pages/office/__tests__/office.effects.spec.ts
@@ -5,12 +5,12 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import * as testSummaryActions from '../../../modules/tests/test-summary/test-summary.actions';
 import * as testDataActions from '../../../modules/tests/test-data/test-data.actions';
 import * as testActions  from '../../../modules/tests/tests.actions';
-import { testSummaryReducer } from '../../../modules/tests/test-summary/test-summary.reducer';
+import * as testStatusActions from '../../../modules/tests/test-status/test-status.actions';
+import * as officeActions from '../office.actions';
 import { StoreModule, Store } from '@ngrx/store';
 import { Actions } from '@ngrx/effects';
 import { empty } from 'rxjs/Observable/empty';
 import { Observable } from 'rxjs/Observable';
-import { testDataReducer } from '../../../modules/tests/test-data/test-data.reducer';
 import { Competencies } from '../../../modules/tests/test-data/test-data.constants';
 
 export class TestActions extends Actions {
@@ -28,14 +28,21 @@ describe('Test Office Data Effects', () => {
   let effects: OfficeEffects;
   let actions$: any;
 
+  const currentSlotId = '1234';
+
   beforeEach(() => {
     actions$ = new ReplaySubject(1);
     TestBed.configureTestingModule({
       imports: [
 
         StoreModule.forRoot({
-          testSummary: testSummaryReducer,
-          testData: testDataReducer,
+          tests: () => ({
+            currentTest: {
+              slotId: currentSlotId,
+            },
+            testStatus: {},
+            startedTests: {},
+          }),
         }),
       ],
       providers: [
@@ -201,6 +208,24 @@ describe('Test Office Data Effects', () => {
         done();
       });
     });
+  });
+
+  describe('submitWaitingRoomInfoEffect', () => {
+
+    it('should return SET_STATUS_DECIDED & PERSIST_TESTS actions', (done) => {
+      actions$.next(new officeActions.CompleteTest());
+
+      effects.completeTestEffect$.subscribe((result) => {
+        if (result instanceof testStatusActions.SetTestStatusCompleted) {
+          expect(result).toEqual(new testStatusActions.SetTestStatusCompleted(currentSlotId));
+        }
+        if (result instanceof testActions.PersistTests) {
+          expect(result).toEqual(new testActions.PersistTests());
+        }
+        done();
+      });
+    });
+
   });
 
 });

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -45,7 +45,7 @@ import {
   ActivityCodeDescription,
 } from '../components/termination-code/termination-code.constants';
 import { ActivityCodes } from '../../../shared/models/activity-codes';
-import { TestStatusCompleted } from '../../../modules/tests/test-status/test-status.actions';
+import { CompleteTest } from '../office.actions';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficePage>;
@@ -78,7 +78,7 @@ describe('OfficePage', () => {
             currentTest: {
               slotId: '123',
             },
-            testLifecycles: {},
+            testStatus: {},
             startedTests: {
               123: {
                 vehicleDetails: {},
@@ -164,8 +164,7 @@ describe('OfficePage', () => {
       it('should successfully end the test', () => {
         component.completeTest();
 
-        expect(store$.dispatch).toHaveBeenCalledWith(new TestStatusCompleted());
-        expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
+        expect(store$.dispatch).toHaveBeenCalledWith(new CompleteTest());
       });
     });
   });

--- a/src/pages/office/office.actions.ts
+++ b/src/pages/office/office.actions.ts
@@ -1,10 +1,16 @@
 import { Action } from '@ngrx/store';
 
 export const OFFICE_VIEW_DID_ENTER = '[OfficePage] Office view did enter';
+export const COMPLETE_TEST = '[OfficePage] Complete Test';
 
 export class OfficeViewDidEnter implements Action {
   readonly type = OFFICE_VIEW_DID_ENTER;
 }
 
+export class CompleteTest implements Action {
+  readonly type = COMPLETE_TEST;
+}
+
 export type OfficeActionTypes =
+  | CompleteTest
   | OfficeViewDidEnter;

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -13,6 +13,7 @@ import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import {
   OfficeViewDidEnter,
+  CompleteTest,
 } from './office.actions';
 import { Observable } from 'rxjs/Observable';
 import { FormGroup } from '@angular/forms';
@@ -95,7 +96,6 @@ import { MultiFaultAssignableCompetency, CommentedCompetency } from '../../share
 import { OutcomeBehaviourMapProvider } from '../../providers/outcome-behaviour-map/outcome-behaviour-map';
 import { behaviourMap } from './office-behaviour-map';
 import { TerminationCode, terminationCodeList } from './components/termination-code/termination-code.constants';
-import { TestStatusCompleted } from '../../modules/tests/test-status/test-status.actions';
 
 interface OfficePageState {
   activityCode$: Observable<TerminationCode>;
@@ -418,8 +418,7 @@ export class OfficePage extends BasePageComponent {
   }
 
   completeTest() {
-    this.store$.dispatch(new TestStatusCompleted());
-    this.store$.dispatch(new PersistTests());
+    this.store$.dispatch(new CompleteTest());
     this.popToRoot();
   }
 }

--- a/src/pages/test-report/__tests__/test-report.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.spec.ts
@@ -79,7 +79,7 @@ describe('TestReportPage', () => {
             currentTest: {
               slotId: '123',
             },
-            testLifecycles: {},
+            testStatus: {},
             startedTests: {
               123: {
                 testData: initialState,

--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
@@ -69,7 +69,7 @@ describe('WaitingRoomToCarPage', () => {
             currentTest: {
               slotId: '123',
             },
-            testLifecycles: {},
+            testStatus: {},
             startedTests: {
               123: {
                 vehicleDetails: {},

--- a/src/pages/waiting-room/__tests__/waiting-room.effects.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.effects.spec.ts
@@ -1,0 +1,58 @@
+import { WaitingRoomEffects } from '../waiting-room.effects';
+import { TestBed } from '@angular/core/testing';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { StoreModule, Store } from '@ngrx/store';
+import { provideMockActions } from '@ngrx/effects/testing';
+import * as waitingRoomActions from '../waiting-room.actions';
+import * as testStatusActions from '../../../modules/tests/test-status/test-status.actions';
+import * as testsActions from '../../../modules/tests/tests.actions';
+
+describe('Waiting Room Effects', () => {
+
+  let effects: WaitingRoomEffects;
+  let actions$: any;
+
+  const currentSlotId = '1234';
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: () => ({
+            currentTest: {
+              slotId: currentSlotId,
+            },
+            testStatus: {},
+            startedTests: {},
+          }),
+        }),
+      ],
+      providers: [
+        WaitingRoomEffects,
+        provideMockActions(() => actions$),
+        Store,
+      ],
+    });
+    effects = TestBed.get(WaitingRoomEffects);
+  });
+
+  describe('submitWaitingRoomInfoEffect', () => {
+
+    it('should return SET_STATUS_DECIDED & PERSIST_TESTS actions', (done) => {
+      actions$.next(new waitingRoomActions.SubmitWaitingRoomInfo());
+
+      effects.submitWaitingRoomInfoEffect$.subscribe((result) => {
+        if (result instanceof testStatusActions.SetTestStatusStarted) {
+          expect(result).toEqual(new testStatusActions.SetTestStatusStarted(currentSlotId));
+        }
+        if (result instanceof testsActions.PersistTests) {
+          expect(result).toEqual(new testsActions.PersistTests());
+        }
+        done();
+      });
+    });
+
+  });
+
+});

--- a/src/pages/waiting-room/__tests__/waiting-room.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.spec.ts
@@ -30,7 +30,7 @@ import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { ScreenOrientationMock } from '../../../shared/mocks/screen-orientation.mock';
 import { Insomnia } from '@ionic-native/insomnia';
 import { InsomniaMock } from '../../../shared/mocks/insomnia.mock';
-import { PersistTests } from '../../../modules/tests/tests.actions';
+import { SubmitWaitingRoomInfo } from '../waiting-room.actions';
 import { of } from 'rxjs/observable/of';
 import { TranslateModule, TranslateService } from 'ng2-translate';
 import { Subscription } from 'rxjs/Subscription';
@@ -173,14 +173,14 @@ describe('WaitingRoomPage', () => {
     });
   });
   describe('onSubmit', () => {
-    it('should dispatch the PersistTests action', fakeAsync(() => {
+    it('should dispatch the SubmitWaitingRoomInfo action', fakeAsync(() => {
       const form = component.form;
       form.get('insuranceCheckboxCtrl').setValue(true);
       form.get('residencyCheckboxCtrl').setValue(true);
       form.get('signatureAreaCtrl').setValue('sig');
       component.onSubmit();
       tick();
-      expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
+      expect(store$.dispatch).toHaveBeenCalledWith(new SubmitWaitingRoomInfo());
     }));
   });
   describe('rehydrateFields', () => {

--- a/src/pages/waiting-room/__tests__/waiting-room.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.spec.ts
@@ -63,7 +63,7 @@ describe('WaitingRoomPage', () => {
           currentTest: {
             slotId: '123',
           },
-          testLifecycles: {},
+          testStatus: {},
           startedTests: {
             123: {
               preTestDeclarations: preTestDeclarationInitialState,

--- a/src/pages/waiting-room/waiting-room.actions.ts
+++ b/src/pages/waiting-room/waiting-room.actions.ts
@@ -1,10 +1,16 @@
 import { Action } from '@ngrx/store';
 
-export const WAITING_ROOM_VIEW_DID_ENTER = '[WaitingRoomPage] Waiting room did enter';
+export const WAITING_ROOM_VIEW_DID_ENTER = '[WaitingRoomPage] Waiting Room Did Enter';
+export const SUBMIT_WAITING_ROOM_INFO = '[WaitingRoomPage] Submit Waiting Room Info';
 
 export class WaitingRoomViewDidEnter implements Action {
   readonly type = WAITING_ROOM_VIEW_DID_ENTER;
 }
 
+export class SubmitWaitingRoomInfo implements Action {
+  readonly type = SUBMIT_WAITING_ROOM_INFO;
+}
+
 export type Types =
-  | WaitingRoomViewDidEnter;
+  | WaitingRoomViewDidEnter
+  | SubmitWaitingRoomInfo;

--- a/src/pages/waiting-room/waiting-room.effects.ts
+++ b/src/pages/waiting-room/waiting-room.effects.ts
@@ -18,7 +18,7 @@ export class WaitingRoomEffects {
   ) {}
 
   @Effect()
-  completeTestEffect$ = this.actions$.pipe(
+  submitWaitingRoomInfoEffect$ = this.actions$.pipe(
     ofType(waitingRoomActions.SUBMIT_WAITING_ROOM_INFO),
     withLatestFrom(
       this.store$.pipe(

--- a/src/pages/waiting-room/waiting-room.effects.ts
+++ b/src/pages/waiting-room/waiting-room.effects.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { Effect, Actions, ofType } from '@ngrx/effects';
+import { switchMap, withLatestFrom } from 'rxjs/operators';
+
+import * as waitingRoomActions from './waiting-room.actions';
+import * as testStatusActions from '../../modules/tests/test-status/test-status.actions';
+import * as testsActions from '../../modules/tests/tests.actions';
+import { StoreModel } from '../../shared/models/store.model';
+import { Store, select } from '@ngrx/store';
+import { getTests } from '../../modules/tests/tests.reducer';
+import { getCurrentTestSlotId } from '../../modules/tests/tests.selector';
+
+@Injectable()
+export class WaitingRoomEffects {
+  constructor(
+    private actions$: Actions,
+    private store$: Store<StoreModel>,
+  ) {}
+
+  @Effect()
+  completeTestEffect$ = this.actions$.pipe(
+    ofType(waitingRoomActions.SUBMIT_WAITING_ROOM_INFO),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        select(getCurrentTestSlotId),
+      ),
+    ),
+    switchMap(([action, slotId]) => {
+      return [
+        new testStatusActions.SetTestStatusStarted(slotId),
+        new testsActions.PersistTests(),
+      ];
+    }),
+  );
+}

--- a/src/pages/waiting-room/waiting-room.module.ts
+++ b/src/pages/waiting-room/waiting-room.module.ts
@@ -7,6 +7,7 @@ import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import { ComponentsModule } from '../../components/components.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from 'ng2-translate';
+import { WaitingRoomEffects } from './waiting-room.effects';
 
 @NgModule({
   declarations: [
@@ -14,7 +15,10 @@ import { TranslateModule } from 'ng2-translate';
   ],
   imports: [
     IonicPageModule.forChild(WaitingRoomPage),
-    EffectsModule.forFeature([WaitingRoomAnalyticsEffects]),
+    EffectsModule.forFeature([
+      WaitingRoomEffects,
+      WaitingRoomAnalyticsEffects,
+    ]),
     ComponentsModule,
     ReactiveFormsModule,
     TranslateModule,

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -23,8 +23,6 @@ import { map } from 'rxjs/operators';
 import { getCurrentTest, getJournalData } from '../../modules/tests/tests.selector';
 import { DeviceAuthenticationProvider } from '../../providers/device-authentication/device-authentication';
 import { getTests } from '../../modules/tests/tests.reducer';
-import { TestStatusStarted } from '../../modules/tests/test-status/test-status.actions';
-import { PersistTests } from '../../modules/tests/tests.actions';
 import { TranslateService } from 'ng2-translate';
 import { merge } from 'rxjs/observable/merge';
 import { Subscription } from 'rxjs/Subscription';
@@ -170,13 +168,13 @@ export class WaitingRoomPage extends BasePageComponent implements OnInit, OnDest
   residencyDeclarationChanged(): void {
     this.store$.dispatch(new preTestDeclarationsActions.ToggleResidencyDeclaration());
   }
+
   onSubmit() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
       this.deviceAuthenticationProvider.triggerLockScreen()
         .then(() => {
-          this.store$.dispatch(new TestStatusStarted());
-          this.store$.dispatch(new PersistTests());
+          this.store$.dispatch(new waitingRoomActions.SubmitWaitingRoomInfo());
           this.navCtrl.push('WaitingRoomToCarPage');
         })
         .catch((err) => {

--- a/src/providers/test-persistence/__tests__/test-persistence.spec.ts
+++ b/src/providers/test-persistence/__tests__/test-persistence.spec.ts
@@ -11,7 +11,7 @@ describe('TestPersistenceProvider', () => {
   const testState: TestsModel = {
     currentTest: { slotId: '123' },
     startedTests: {},
-    testLifecycles: {},
+    testStatus: {},
   };
 
   beforeEach(() => {
@@ -45,7 +45,7 @@ describe('TestPersistenceProvider', () => {
       const persistedTestsModel: TestsModel = {
         currentTest: { slotId: '1' },
         startedTests: {},
-        testLifecycles: {},
+        testStatus: {},
       };
       dataStoreProvider.getItem.and.returnValue(JSON.stringify(persistedTestsModel));
 


### PR DESCRIPTION
### Refactor test statuses

- Making so that the status of a test can be changed using the slotId to identify the test
- Extracting some of the status changes to the effects
- Also setting the Decided status of a test when we End Debrief

### Send tests in interval

- Setting up an interval which dispatches a send completed tests action every 15 mins (this is configured in the configuration microservice)
- After the test have been sent we change the status of those tests to Submitted