### PR TITLE
mes-1774: Adding view components for new email and email provided at the time o…

### DIFF
--- a/src/modules/tests/candidate/candidate.selector.ts
+++ b/src/modules/tests/candidate/candidate.selector.ts
@@ -18,3 +18,5 @@ export const formatDriverNumber = (driverNumber: string) => {
   }
   return driverNumber;
 };
+
+export const getCandidateEmailAddress = (candidate: Candidate) => candidate.emailAddress ? candidate.emailAddress : '';

--- a/src/modules/tests/communication-preferences/communication-preferences.actions.ts
+++ b/src/modules/tests/communication-preferences/communication-preferences.actions.ts
@@ -1,0 +1,29 @@
+import { Action } from '@ngrx/store';
+import { CommunicationMethod } from '@dvsa/mes-test-schema/categories/B';
+
+export const CANDIDATE_CONFIRMED_COMMUNICATION_PREFERENCE_AS_EMAIL
+  = '[Communication page] Candidate confirmed communication preferences as email';
+export const CANDIDATE_CONFIRMED_COMMUNICATION_PREFERENCE_AS_POST
+  = '[Communication page] Candidate confirmed communication preferences as post';
+export const CANDIDATE_CONFIRMED_COMMUNICATION_PREFERENCE_AS_SUPPORT_CENTRE
+  = '[Communication page] Candidate confirmed communication preferences as support centre';
+
+export class CandidateChoseEmailAsCommunicationPreference implements Action {
+  readonly type = CANDIDATE_CONFIRMED_COMMUNICATION_PREFERENCE_AS_EMAIL;
+  constructor(public updatedEmail: string, public communicationMethod: CommunicationMethod) {}
+}
+
+export class CandidateChosePostAsCommunicationPreference implements Action {
+  readonly type = CANDIDATE_CONFIRMED_COMMUNICATION_PREFERENCE_AS_POST;
+  constructor(public communicationMethod: CommunicationMethod) { }
+}
+
+export class CandidateChoseSupportCentreAsCommunicationPreference implements Action {
+  readonly type = CANDIDATE_CONFIRMED_COMMUNICATION_PREFERENCE_AS_SUPPORT_CENTRE;
+  constructor(public communicationMethod: CommunicationMethod) { }
+}
+
+export type Types =
+  | CandidateChoseEmailAsCommunicationPreference
+  | CandidateChosePostAsCommunicationPreference
+  | CandidateChoseSupportCentreAsCommunicationPreference;

--- a/src/modules/tests/communication-preferences/communication-preferences.reducer.ts
+++ b/src/modules/tests/communication-preferences/communication-preferences.reducer.ts
@@ -1,0 +1,36 @@
+import { CommunicationPreferences } from '@dvsa/mes-test-schema/categories/B';
+import * as communicationPrefActions from './communication-preferences.actions';
+import { createFeatureSelector } from '@ngrx/store';
+
+export const initialState: CommunicationPreferences = {
+  updatedEmail: '',
+  communicationMethod: null,
+};
+
+export const communicationPreferencesReducer = (
+  state = initialState,
+  action: communicationPrefActions.Types,
+): CommunicationPreferences => {
+  switch (action.type) {
+    case communicationPrefActions.CANDIDATE_CONFIRMED_COMMUNICATION_PREFERENCE_AS_EMAIL:
+      return {
+        ...state,
+        updatedEmail: action.updatedEmail,
+        communicationMethod: action.communicationMethod,
+      };
+    case communicationPrefActions.CANDIDATE_CONFIRMED_COMMUNICATION_PREFERENCE_AS_POST:
+      return {
+        ...state,
+        communicationMethod: action.communicationMethod,
+      };
+    case communicationPrefActions.CANDIDATE_CONFIRMED_COMMUNICATION_PREFERENCE_AS_SUPPORT_CENTRE:
+      return {
+        ...state,
+        communicationMethod: action.communicationMethod,
+      };
+    default:
+      return state;
+  }
+};
+
+export const getCommunicationPreference = createFeatureSelector<CommunicationPreferences>('communicationPreferences');

--- a/src/modules/tests/communication-preferences/communication-preferences.selector.ts
+++ b/src/modules/tests/communication-preferences/communication-preferences.selector.ts
@@ -1,0 +1,8 @@
+import { CommunicationPreferences } from '@dvsa/mes-test-schema/categories/B';
+
+export const getCommunicationPreferenceUpdatedEmail
+  = (communicationPreferences: CommunicationPreferences) =>
+    communicationPreferences.updatedEmail ? communicationPreferences.updatedEmail : '';
+
+export const getCommunicationPreferenceType
+  = (communicationPreferences: CommunicationPreferences) => communicationPreferences.communicationMethod;

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -18,6 +18,7 @@ import { testSlotsAttributesReducer } from './test-slot-attributes/test-slot-att
 import { examinerReducer } from './examiner/examiner.reducer';
 import { TestsModel } from './tests.model';
 import { startsWith } from 'lodash';
+import { communicationPreferencesReducer } from './communication-preferences/communication-preferences.reducer';
 
 export const initialState: TestsModel = {
   currentTest: { slotId: null },
@@ -108,6 +109,7 @@ const createStateObject = (state: TestsModel, action: Action, slotId: string) =>
             testSlotAttributes: testSlotsAttributesReducer,
             examiner: examinerReducer,
             testCentre: testCentreReducer,
+            communicationPreferences: communicationPreferencesReducer,
           },
         // @ts-ignore
       )(state.startedTests[slotId], action),

--- a/src/pages/communication-page/__tests__/communication.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.spec.ts
@@ -22,6 +22,9 @@ import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
 import { ScreenOrientationMock } from '../../../shared/mocks/screen-orientation.mock';
 import { InsomniaMock } from '../../../shared/mocks/insomnia.mock';
+import { ProvidedEmailComponent } from '../components/provided-email/provided-email';
+import { NewEmailComponent } from '../components/new-email/new-email';
+import { By } from '@angular/platform-browser';
 
 describe('CommunicationPage', () => {
   let fixture: ComponentFixture<CommunicationPage>;
@@ -38,12 +41,15 @@ describe('CommunicationPage', () => {
       firstName: 'Joe',
       lastName: 'Blogs',
     },
+    emailAddress: 'testemail@mes',
   };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
         CommunicationPage,
+        ProvidedEmailComponent,
+        NewEmailComponent,
       ],
       imports: [
         IonicModule,
@@ -99,6 +105,21 @@ describe('CommunicationPage', () => {
       expect(component).toBeDefined();
     });
 
+    describe('Changing preferred email', () => {
+      it('should display the provided email input when selected', () => {
+        fixture.whenStable().then(() => {
+          const providedEmail = fixture.debugElement.query(By.css('#providedEmail'));
+          providedEmail.triggerEventHandler('click', null);
+          expect(fixture.debugElement.query(By.css('#providedEmailInput'))).toBeDefined();
+        });
+      });
+      it('should display the new email input when selected', () => {
+        const newEmail = fixture.debugElement.query(By.css('#newEmail'));
+        newEmail.triggerEventHandler('click', null);
+        expect(fixture.debugElement.query(By.css('#newEmailInput'))).toBeDefined();
+      });
+    });
+
     describe('ionViewDidEnter', () => {
       it('should enable single app mode if on ios', () => {
         component.ionViewDidEnter();
@@ -117,25 +138,6 @@ describe('CommunicationPage', () => {
       });
 
     });
-  });
-
-  describe('ionViewDidEnter', () => {
-    it('should enable single app mode if on ios', () => {
-      component.ionViewDidEnter();
-      expect(deviceProvider.enableSingleAppMode).toHaveBeenCalled();
-    });
-
-    it('should lock the screen orientation to Portrait Primary', () => {
-      component.ionViewDidEnter();
-      expect(screenOrientation.lock)
-        .toHaveBeenCalledWith(screenOrientation.ORIENTATIONS.PORTRAIT_PRIMARY);
-    });
-
-    it('should keep the device awake', () => {
-      component.ionViewDidEnter();
-      expect(insomnia.keepAwake).toHaveBeenCalled();
-    });
-
   });
 
   describe('clickBack', () => {

--- a/src/pages/communication-page/communication.actions.ts
+++ b/src/pages/communication-page/communication.actions.ts
@@ -1,10 +1,31 @@
 import { Action } from '@ngrx/store';
 
 export const COMMUNICATION_VIEW_DID_ENTER = '[CommunicationPage] Communication page did enter';
+export const COMMUNICATION_VIEW_CHOSE_EMAIL_PROVIDED_AT_BOOKING =
+'[CommunicationPage] Communication page chose email provided at booking';
+export const COMMUNICATION_VIEW_CHOSE_NEW_EMAIL =
+  '[CommunicationPage] Communication page chose new email';
+export const COMMUNICATION_VIEW_ADDED_NEW_CANDIDATE_EMAIL = '[CommunicationPage] Added new candidate email';
 
 export class CommunicationViewDidEnter implements Action {
   readonly type = COMMUNICATION_VIEW_DID_ENTER;
 }
 
+export class CommunicationViewChoseEmailProvidedAtBooking implements Action {
+  readonly type = COMMUNICATION_VIEW_CHOSE_EMAIL_PROVIDED_AT_BOOKING;
+}
+
+export class CommunicationViewChoseNewEmail implements Action {
+  readonly type = COMMUNICATION_VIEW_CHOSE_NEW_EMAIL;
+}
+
+export class CommunicationViewInputNewEmail implements Action {
+  readonly type = COMMUNICATION_VIEW_ADDED_NEW_CANDIDATE_EMAIL;
+  constructor(public payload: string) {}
+}
+
 export type Types =
-  | CommunicationViewDidEnter;
+  | CommunicationViewDidEnter
+  | CommunicationViewChoseEmailProvidedAtBooking
+  | CommunicationViewChoseNewEmail
+  | CommunicationViewInputNewEmail;

--- a/src/pages/communication-page/communication.html
+++ b/src/pages/communication-page/communication.html
@@ -6,15 +6,54 @@
     </ion-buttons>
   </ion-navbar>
 </ion-header>
+
 <ion-content no-bounce>
   <lock-screen-indicator></lock-screen-indicator>
-  <form>
-    <candidate-section [candidateName]="pageState.candidateName$ | async"
-      [candidateDriverNumber]="pageState.candidateDriverNumber$ | async" (continueClickEvent)="onSubmit()">
-    </candidate-section>
-    <div class="mes-full-width-card-separator"></div>
-    <div class="mes-full-width-card" id="declaration-section">
-      <h3>Select how to receive the test results</h3>
-    </div>
-  </form>
+  <div>
+    <form [formGroup]="form">
+      <candidate-section [candidateName]="pageState.candidateName$ | async"
+        [candidateDriverNumber]="pageState.candidateDriverNumber$ | async" (continueClickEvent)="onSubmit()">
+      </candidate-section>
+      <div class="mes-full-width-card-separator"></div>
+      <div class="mes-full-width-card" id="declaration-section">
+
+        <ion-row class="mes-validated-row">
+          <ion-col>
+            <h4>Select how to receive the test results</h4>
+          <div class="validation-bar"></div>
+          <ion-col align-self-center>
+
+            <provided-email [formGroup]="form"
+              [shouldRender]="pageState.candidateProvidedEmail$ | async"
+              [providedEmailAddress]="pageState.candidateProvidedEmail$ | async"
+              [providedEmailAddressChosen]="isSelected('providedEmail')"
+              (providedEmailRadioSelect)="dispatchCandidateChoseProvidedEmail('providedEmail')">
+            </provided-email>
+
+            <new-email [formGroup]="form"
+              [newEmailAddress]="pageState.candiateNewEmail$ | async"
+              [newEmailAddressChosen]="isSelected('newEmail')"
+              (newEmailRadioSelect)="setCommunicationType('newEmail')"
+              (newEmailTextChange)="dispatchCandidateChoseNewEmail($event)">
+            </new-email>
+
+            <ion-row class="communication-option">
+              <input type="radio" id="post" class="gds-radio-button" name="communicationChoice"
+                (click)="setCommunicationType('post')" [value]="post">
+              <label for="post" class="radio-label">By post</label>
+            </ion-row>
+            <ion-row class="communication-option">
+              <input type="radio" id="support-centre" class="gds-radio-button" name="communicationChoice"
+                (click)="setCommunicationType('support-centre')" [value]="SC">
+              <label for="support-centre" class="radio-label">By calling the support centre</label>
+            </ion-row>
+            <ion-row class="validation-message-row" align-items-center>
+              <div class="validation-text"></div>
+            </ion-row>
+          </ion-col>
+          </ion-col>
+        </ion-row>
+      </div>
+    </form>
+  </div>
 </ion-content>

--- a/src/pages/communication-page/communication.module.ts
+++ b/src/pages/communication-page/communication.module.ts
@@ -3,10 +3,14 @@ import { IonicPageModule } from 'ionic-angular';
 import { ComponentsModule } from '../../components/components.module';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import { CommunicationPage } from './communication';
+import { ProvidedEmailComponent } from './components/provided-email/provided-email';
+import { NewEmailComponent } from './components/new-email/new-email';
 
 @NgModule({
   declarations: [
     CommunicationPage,
+    ProvidedEmailComponent,
+    NewEmailComponent,
   ],
   imports: [
     IonicPageModule.forChild(CommunicationPage),

--- a/src/pages/communication-page/communication.scss
+++ b/src/pages/communication-page/communication.scss
@@ -2,4 +2,42 @@ communication {
   ion-content>div {
     background-color: map-get($colors, "mes-white");
   }
+
+  .communication-option {
+    padding: 10px 5px;
+  }
+
+  .communication-box {
+    margin: 10px 0px 10px 26px;
+    border-left: 4px solid;
+    border-color: map-get($colors-gds, "gds-grey-2");
+  }
+
+  .communication-helper-text {
+    font-size: 23px;
+    color: map-get($colors-gds, "gds-grey-1");
+    margin-bottom: 10px;
+  }
+
+  .provided-email-textbox {
+    width: 40%;
+    border: 2px solid map-get($colors-gds, "gds-lavendar");
+    height: 48px;
+    padding: 10px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    background-color: map-get($colors-gds, "gds-lavendar");
+    font-weight: 500;
+  }
+
+  .new-email-textbox {
+    width: 40%;
+    border-radius: 6px;
+    border: 2px solid map-get($colors-gds, "gds-black");
+    height: 48px;
+    padding: 10px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    text-transform: lowercase;
+  }
 }

--- a/src/pages/communication-page/communication.ts
+++ b/src/pages/communication-page/communication.ts
@@ -1,7 +1,7 @@
 import { IonicPage, Navbar, Platform, NavController } from 'ionic-angular';
 import { Component, ViewChild } from '@angular/core';
 import { BasePageComponent } from '../../shared/classes/base-page';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
 import { Observable } from 'rxjs/Observable';
 import { StoreModel } from '../../shared/models/store.model';
@@ -18,14 +18,32 @@ import {
   getUntitledCandidateName,
   getCandidateDriverNumber,
   formatDriverNumber,
+  getCandidateEmailAddress,
 } from '../../modules/tests/candidate/candidate.selector';
-import { CommunicationViewDidEnter } from './communication.actions';
-import { map } from 'rxjs/operators';
+import {
+  CommunicationViewDidEnter,
+} from './communication.actions';
+import { map, take } from 'rxjs/operators';
+import {
+  getCommunicationPreference,
+ } from '../../modules/tests/communication-preferences/communication-preferences.reducer';
+import {
+  getCommunicationPreferenceUpdatedEmail, getCommunicationPreferenceType,
+} from '../../modules/tests/communication-preferences/communication-preferences.selector';
+import { merge } from 'rxjs/observable/merge';
+import { CommunicationMethod } from '@dvsa/mes-test-schema/categories/B';
+import { Subscription } from 'rxjs/Subscription';
+import {
+  CandidateChoseEmailAsCommunicationPreference,
+} from '../../modules/tests/communication-preferences/communication-preferences.actions';
 
 interface CommunicationPageState {
   candidateName$: Observable<string>;
   candidateUntitledName$: Observable<string>;
   candidateDriverNumber$: Observable<string>;
+  candidateProvidedEmail$: Observable<string>;
+  communicationEmail$: Observable<string>;
+  communicationType$: Observable<string>;
 }
 @IonicPage()
 @Component({
@@ -33,11 +51,22 @@ interface CommunicationPageState {
   templateUrl: 'communication.html',
 })
 export class CommunicationPage extends BasePageComponent {
-  @ViewChild(Navbar) navBar: Navbar;
+
+  readonly providedEmail = 'providedEmail';
+  readonly newEmail = 'newEmail';
+
+  @ViewChild(Navbar)
+  navBar: Navbar;
 
   form: FormGroup;
-
+  subscription: Subscription;
+  communicationChoice: string;
   pageState: CommunicationPageState;
+  communicationMethodForEmail: CommunicationMethod;
+  communicationMethodForPost: CommunicationMethod;
+  communicationMethodForSupportCentre: CommunicationMethod;
+  candidateProvidedEmail: string;
+  communicationEmail: string;
 
   constructor(
     private store$: Store<StoreModel>,
@@ -50,6 +79,10 @@ export class CommunicationPage extends BasePageComponent {
     private insomnia: Insomnia,
   ) {
     super(platform, navCtrl, authenticationProvider);
+    this.form = new FormGroup(this.getFormValidation());
+    this.communicationMethodForEmail = 'Email';
+    this.communicationMethodForPost = 'Post';
+    this.communicationMethodForSupportCentre = 'Support Centre';
   }
 
   ionViewDidEnter(): void {
@@ -96,10 +129,75 @@ export class CommunicationPage extends BasePageComponent {
         select(getCandidateDriverNumber),
         map(formatDriverNumber),
       ),
+      candidateProvidedEmail$: currentTest$.pipe(
+        select(getCandidate),
+        select(getCandidateEmailAddress),
+        take(1),
+      ),
+      communicationEmail$: this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getCommunicationPreference),
+        select(getCommunicationPreferenceUpdatedEmail),
+      ),
+      communicationType$: currentTest$.pipe(
+        select(getCommunicationPreference),
+        select(getCommunicationPreferenceType),
+      ),
     };
+
+    const {
+      candidateProvidedEmail$,
+      communicationEmail$,
+    } = this.pageState;
+
+    const merged$ = merge(
+      candidateProvidedEmail$.pipe(map(value => this.candidateProvidedEmail = value)),
+      communicationEmail$.pipe(map(value => this.communicationEmail = value)),
+    );
+    this.subscription = merged$.subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
   }
 
   onSubmit() {
     this.navController.push('WaitingRoomPage');
+  }
+
+  dispatchCandidateChoseProvidedEmail(emailType: string) {
+    this.setCommunicationType(emailType);
+    this.store$.dispatch(
+      new CandidateChoseEmailAsCommunicationPreference(this.candidateProvidedEmail, this.communicationMethodForEmail),
+    );
+  }
+
+  dispatchCandidateChoseNewEmail(newEmail: string): void {
+    this.store$.dispatch(
+      new CandidateChoseEmailAsCommunicationPreference(newEmail, this.communicationMethodForEmail),
+    );
+  }
+
+  setCommunicationType(communicationChoice: string) {
+    this.communicationChoice = communicationChoice;
+  }
+
+  isSelected(communicationChoice: string) {
+    return (this.communicationChoice === communicationChoice);
+  }
+
+  getFormValidation(): { [key: string]: FormControl } {
+    return {
+      communicationChoiceCtrl: new FormControl('', [Validators.required]),
+    };
+  }
+
+  isCtrlDirtyAndInvalid(controlName: string): boolean {
+    return !this.form.value[controlName] && this.form.get(controlName).dirty;
+  }
+
+  verifyCandidateChoseProvidedEmail() {
+    return (this.communicationEmail === '') || (this.communicationEmail === this.candidateProvidedEmail);
   }
 }

--- a/src/pages/communication-page/components/new-email/new-email.html
+++ b/src/pages/communication-page/components/new-email/new-email.html
@@ -1,0 +1,26 @@
+<ion-row class="communication-option">
+  <input type="radio" id="newEmail" class="gds-radio-button" name="communicationChoice"
+    (click)="newEmailRadioSelected()"
+    [value]="newEmail">
+  <label for="newEmail" class="radio-label">By email (new email)</label>
+</ion-row>
+<ion-row *ngIf="newEmailAddressChosen" class="communication-box">
+  <ion-col col-6></ion-col>
+  <ion-col>
+    <ion-row>
+      <span class="communication-helper-text">Enter the email address you want us to send your results
+        to.</span>
+    </ion-row>
+    <ion-row [formGroup]="formGroup">
+      <input id="newEmailInput" class="new-email-textbox mes-data" type="text-area"
+        formControlName="newEmailCtrl"
+        [value]="''" (change)="newEmailTextChanged($event.target.value)"
+        [class.ng-invalid]="invalid">
+    </ion-row>
+    <ion-row class="validation-message-row" align-items-center>
+      <div class="validation-text" [class.ng-invalid]="invalid">
+        Please enter a valid email
+      </div>
+    </ion-row>
+  </ion-col>
+</ion-row>

--- a/src/pages/communication-page/components/new-email/new-email.ts
+++ b/src/pages/communication-page/components/new-email/new-email.ts
@@ -1,0 +1,52 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'new-email',
+  templateUrl: 'new-email.html',
+})
+export class NewEmailComponent implements OnChanges {
+
+  readonly newEmail = 'newEmail';
+  readonly newEmailCtrl = 'newEmailCtrl';
+
+  @Input()
+  formGroup: FormGroup;
+
+  @Input()
+  newEmailAddress: string;
+
+  @Input()
+  newEmailAddressChosen: boolean;
+
+  @Output()
+  newEmailRadioSelect = new EventEmitter<string>();
+
+  @Output()
+  newEmailTextChange = new EventEmitter<string>();
+
+  private formControl: FormControl;
+
+  ngOnChanges(): void {
+    if (!this.formControl) {
+      this.formControl = new FormControl(null, [Validators.email]);
+      this.formGroup.addControl(this.newEmailCtrl, this.formControl);
+    }
+    this.formControl.patchValue(this.newEmailCtrl);
+  }
+
+  newEmailRadioSelected() {
+    this.newEmailRadioSelect.emit(this.newEmail);
+  }
+
+  newEmailTextChanged(email: string) {
+    if (this.formControl.valid) {
+      this.newEmailTextChange.emit(email);
+    }
+  }
+
+  get invalid(): boolean {
+    return !this.formControl.valid && this.formControl.dirty;
+  }
+
+}

--- a/src/pages/communication-page/components/provided-email/provided-email.html
+++ b/src/pages/communication-page/components/provided-email/provided-email.html
@@ -1,0 +1,21 @@
+<div *ngIf="shouldRender">
+  <ion-row class="spacing-row"></ion-row>
+  <ion-row class="communication-option">
+    <input type="radio" id="providedEmail" name="communicationChoice" class="gds-radio-button"
+      (click)="providedEmailRadioSelected()" [value]="providedEmail">
+    <label for="providedEmail" class="radio-label">By email (provided at time of booking)</label>
+  </ion-row>
+  <ion-row *ngIf="providedEmailAddressChosen" class="communication-box">
+    <ion-col col-6></ion-col>
+    <ion-col>
+      <ion-row>
+        <span class="communication-helper-text">The following email address was used when booking the
+          test: </span>
+      </ion-row>
+      <ion-row>
+        <input id="providedEmailInput" class="provided-email-textbox" type="text-area" [value]="providedEmailAddress"
+          disabled>
+      </ion-row>
+    </ion-col>
+  </ion-row>
+</div>

--- a/src/pages/communication-page/components/provided-email/provided-email.ts
+++ b/src/pages/communication-page/components/provided-email/provided-email.ts
@@ -1,0 +1,25 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+
+@Component({
+  selector: 'provided-email',
+  templateUrl: 'provided-email.html',
+})
+export class ProvidedEmailComponent {
+
+  readonly providedEmail = 'providedEmail';
+  @Input()
+  providedEmailAddress: string;
+
+  @Input()
+  shouldRender: boolean;
+
+  @Input()
+  providedEmailAddressChosen: boolean;
+
+  @Output()
+  providedEmailRadioSelect = new EventEmitter<string>();
+
+  providedEmailRadioSelected() {
+    this.providedEmailRadioSelect.emit(this.providedEmail);
+  }
+}

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -63,6 +63,7 @@ $colors-gds: (
   gds-bright-purple: #912b88,
   gds-pink: #d53880,
   gds-light-pink: #f499be,
+  gds-lavendar: #e8f0fe,
 );
 
 // Shared Variables


### PR DESCRIPTION
…f booking on the

communication page.

 Reducer, actions and selector for communication preferences.(How the candidate wishes
to receive their results).

## Description and relevant Jira numbers

- Created two components. One for emails provided at the time of booking, the other to input a new email address.
- Implemented a reducer, actions and selector for the ```CommunicationPreferences``` entity in the schema.
- Dispatch an action when a candidate selects the provided email.
- Dispatch an action when the candidate inputs a new email. 
- Validation on new email input to ensure it is a valid email format
- Added the new reducer to ```combineReducers()```

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

<img width="514" alt="Screenshot 2019-05-16 at 08 25 44" src="https://user-images.githubusercontent.com/30832405/57834501-58d9d400-77b4-11e9-8a11-601f08e7623b.png">

<img width="514" alt="Screenshot 2019-05-16 at 08 26 07" src="https://user-images.githubusercontent.com/30832405/57834515-5d9e8800-77b4-11e9-80a3-769ffff847b4.png">

<img width="514" alt="Screenshot 2019-05-16 at 08 26 19" src="https://user-images.githubusercontent.com/30832405/57834522-62633c00-77b4-11e9-841f-d3bdda585657.png">

