### PR TITLE
MES-2336 - Typescript upgrade & Fix for Tests Reducer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,14 @@
         "source-map": "^0.5.6",
         "typescript": "~2.6.1",
         "webpack-sources": "^1.0.1"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+          "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+          "dev": true
+        }
       }
     },
     "@angular-devkit/core": {
@@ -24769,9 +24777,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.4.tgz",
+      "integrity": "sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "ts-loader": "^3.5.0",
     "ts-node": "^7.0.1",
     "tslint-config-airbnb": "^5.11.1",
-    "typescript": "~2.6.2",
+    "typescript": "^2.8.4",
     "xml2js": "^0.4.19"
   },
   "platforms": [

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -118,6 +118,12 @@ const createStateObject = (state: TestsModel, action: Action, slotId: string) =>
             communicationPreferences: communicationPreferencesReducer,
           }, combineReducers,
         )(
+          // The redux pattern necessitates that the state tree be initialised
+          // with all its properties declared. This conflicts with the
+          // 'StandardCarTestCATBSchema' TS interface as many of its properties are optional (?).
+          // In order to reconcile the TS interface and the redux reducer pattern we use
+          // the TS 'Required' mapped type which The 'Required' type which strips ? modifiers
+          // from all properties of 'StandardCarTestCATBSchema', thus making all properties required.
           state.startedTests[slotId] as Required<StandardCarTestCATBSchema>,
           action,
         ),

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -22,6 +22,7 @@ import { testCentreReducer } from './test-centre/test-centre.reducer';
 import { testSlotsAttributesReducer } from './test-slot-attributes/test-slot-attributes.reducer';
 import { candidateReducer } from './candidate/candidate.reducer';
 import { applicationReferenceReducer } from './application-reference/application-reference.reducer';
+import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
 
 export const initialState: TestsModel = {
   currentTest: { slotId: null },
@@ -116,8 +117,10 @@ const createStateObject = (state: TestsModel, action: Action, slotId: string) =>
             testSummary: testSummaryReducer,
             communicationPreferences: communicationPreferencesReducer,
           }, combineReducers,
-        // @ts-ignore
-        )(state.startedTests[slotId], action),
+        )(
+          state.startedTests[slotId] as Required<StandardCarTestCATBSchema>,
+          action,
+        ),
       },
     },
     currentTest: {


### PR DESCRIPTION
## Description and relevant Jira numbers

- Upgrades Typescript to version 2.8 
- Fixes the required types issue in the tests reducer

Thanks to @ammarhaiderbjss  for finding a solution.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
