### PR TITLE
fix bug with d255 no radio button causing validation error

### DIFF
--- a/src/pages/office/components/d255/d255.ts
+++ b/src/pages/office/components/d255/d255.ts
@@ -57,10 +57,9 @@ export class D255Component implements OnChanges {
   }
 
   getD255OrDefault(): string | null {
-    if (this.d255) {
+    if (this.d255 !== null) {
       return this.d255 ? ValidD255Values.YES : ValidD255Values.NO;
     }
-
     if (this.outcomeBehaviourProvider.hasDefault(this.outcome, D255Component.fieldName)) {
       const defaultValue = this.outcomeBehaviourProvider.getDefault(this.outcome, D255Component.fieldName);
       this.d255Changed(defaultValue);


### PR DESCRIPTION
Fix bug introduced by refactoring - where selecting the D255 No radio button on the office page caused the field to be considered invalid.
