### PR TITLE
MES-1882: Handle HTTP 304 when fetching journals

### DIFF
--- a/mock/local-journal-non-test-activities.json
+++ b/mock/local-journal-non-test-activities.json
@@ -16,7 +16,7 @@
     {
       "slotDetail": {
         "slotId": 1000,
-        "start": "2019-05-23T09:00:00+01:00",
+        "start": "2019-05-24T09:00:00+01:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -29,7 +29,7 @@
     {
       "slotDetail": {
         "slotId": 1001,
-        "start": "2019-05-23T10:15:00+01:00",
+        "start": "2019-05-24T10:15:00+01:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -101,17 +101,17 @@
   "personalCommitments": [
     {
       "commitmentId": 123400,
-      "startDate": "2019-05-23",
+      "startDate": "2019-05-24",
       "startTime": "10:00:00+01:00",
-      "endDate": "2019-05-23",
+      "endDate": "2019-05-24",
       "endTime": "11:00:00+01:00",
       "activityCode": "104",
       "activityDescription": "Medical appointment"
     },
     {
       "commitmentId": 123401,
-      "startDate": "2019-05-30",
-      "endDate": "2019-05-30",
+      "startDate": "2019-05-31",
+      "endDate": "2019-05-31",
       "activityCode": "081",
       "activityDescription": "Annual Leave"
     }
@@ -120,7 +120,7 @@
     {
       "slotDetail": {
         "slotId": 1111,
-        "start": "2019-05-23T11:15:00+01:00",
+        "start": "2019-05-24T11:15:00+01:00",
         "duration": 57
       },
       "activityCode": "091",
@@ -134,7 +134,7 @@
     {
       "slotDetail": {
         "slotId": 1110,
-        "start": "2019-05-23T12:15:00+01:00",
+        "start": "2019-05-24T12:15:00+01:00",
         "duration": 57
       },
       "activityCode": "089",
@@ -148,7 +148,7 @@
     {
       "slotDetail": {
         "slotId": 1200,
-        "start": "2019-05-23T13:15:00+01:00",
+        "start": "2019-05-24T13:15:00+01:00",
         "duration": 57
       },
       "activityCode": "104",
@@ -164,7 +164,7 @@
     {
       "slotDetail": {
         "slotId": 1300,
-        "start": "2019-05-23T09:00:00+01:00",
+        "start": "2019-05-24T09:00:00+01:00",
         "duration": 90
       },
       "testCentre": {
@@ -177,7 +177,7 @@
     {
       "slotDetail": {
         "slotId": 1301,
-        "start": "2019-05-23T10:45:00+01:00",
+        "start": "2019-05-24T10:45:00+01:00",
         "duration": 90
       },
       "testCentre": {
@@ -190,7 +190,7 @@
     {
       "slotDetail": {
         "slotId": 1302,
-        "start": "2019-05-23T12:30:00+01:00",
+        "start": "2019-05-24T12:30:00+01:00",
         "duration": 90
       },
       "testCentre": {
@@ -209,7 +209,7 @@
         "centreName": "Example Test Centre 3",
         "costCode": "EXTC 3"
       },
-      "date": "2019-05-23"
+      "date": "2019-05-24"
     },
     {
       "deploymentId": 22222,
@@ -218,7 +218,7 @@
         "centreName": "Example Test Centre 4",
         "costCode": "EXTC 4"
       },
-      "date": "2019-05-23"
+      "date": "2019-05-24"
     }
   ]
 }

--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -48,7 +48,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1001,
-        "start": "2019-05-23T08:10:00+01:00"
+        "start": "2019-05-24T08:10:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -98,7 +98,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1003,
-        "start": "2019-05-23T10:14:00+01:00"
+        "start": "2019-05-24T10:14:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -148,7 +148,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1004,
-        "start": "2019-05-23T11:11:00+01:00"
+        "start": "2019-05-24T11:11:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -199,7 +199,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1005,
-        "start": "2019-05-23T12:38:00+01:00"
+        "start": "2019-05-24T12:38:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -252,7 +252,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1006,
-        "start": "2019-05-23T13:35:00+01:00"
+        "start": "2019-05-24T13:35:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -297,7 +297,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1007,
-        "start": "2019-05-24T14:32:00+01:00"
+        "start": "2019-05-25T14:32:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,

--- a/src/pages/journal/__tests__/journal.effects.spec.ts
+++ b/src/pages/journal/__tests__/journal.effects.spec.ts
@@ -105,6 +105,29 @@ describe('Journal Effects', () => {
 
   });
 
+  it('should dispatch the success action when an error is thrown indicating HTTP 304 for the journal', (done) => {
+    // ARRANGE
+    spyOn(journalProvider, 'getJournal').and.callThrough();
+    spyOn(journalProvider, 'saveJournalForOffline').and.callThrough();
+    spyOn(slotProvider, 'detectSlotChanges').and.callThrough();
+    spyOn(slotProvider, 'extendWithEmptyDays').and.callThrough();
+    spyOn(slotProvider, 'getRelevantSlots').and.callThrough();
+    (<any>journalProvider).setupHttp304Error();
+    // ACT
+    actions$.next(new journalActions.LoadJournal());
+    // ASSERT
+    effects.loadJournal$.subscribe((result) => {
+      expect(journalProvider.getJournal).toHaveBeenCalled();
+      expect(journalProvider.saveJournalForOffline).not.toHaveBeenCalled();
+      expect(slotProvider.detectSlotChanges).not.toHaveBeenCalledWith({}, JournalProviderMock.mockJournal);
+      expect(slotProvider.extendWithEmptyDays).not.toHaveBeenCalled();
+      expect(slotProvider.getRelevantSlots).not.toHaveBeenCalled();
+      expect(result instanceof journalActions.LoadJournalSuccess).toBe(true);
+      done();
+    });
+
+  });
+
   it('should dispatch the failure action when the journal fails to load', (done) => {
     // ARRANGE
     spyOn(journalProvider, 'getJournal').and.throwError;
@@ -147,7 +170,7 @@ describe('Journal Effects', () => {
     actions$.next(new journalActions.SelectNextDay());
     // ASSERT
     effects.selectNextDayEffect$.subscribe((result) => {
-      if (result instanceof journalActions.SetSelectedDate)  {
+      if (result instanceof journalActions.SetSelectedDate) {
         expect(result).toEqual(new journalActions.SetSelectedDate(nextDay));
       }
       if (result instanceof journalActions.JournalNavigateDay) {

--- a/src/pages/journal/journal.effects.ts
+++ b/src/pages/journal/journal.effects.ts
@@ -88,6 +88,7 @@ export class JournalEffects {
                   lastRefreshed,
                 ));
               }
+              return of(err);
             }),
           );
       }),

--- a/src/pages/journal/journal.effects.ts
+++ b/src/pages/journal/journal.effects.ts
@@ -68,13 +68,27 @@ export class JournalEffects {
             tap((journalData: ExaminerWorkSchedule) => this.journalProvider.saveJournalForOffline(journalData)),
             map((journalData: ExaminerWorkSchedule) => this.slotProvider.detectSlotChanges(slots, journalData)),
             map((slots: any[]) => groupBy(slots, this.slotProvider.getSlotDate)),
-            map((slots: {[k: string]: SlotItem[]}) => this.slotProvider.extendWithEmptyDays(slots)),
-            map((slots: {[k: string]: SlotItem[]}) => this.slotProvider.getRelevantSlots(slots)),
-            map((slots: {[k: string]: SlotItem[]}) =>
-              new journalActions.LoadJournalSuccess(slots,
-                                                    this.networkStateProvider.getNetworkState(),
-                                                    this.authProvider.isInUnAuthenticatedMode(),
-                                                    lastRefreshed)),
+            map((slots: { [k: string]: SlotItem[] }) => this.slotProvider.extendWithEmptyDays(slots)),
+            map((slots: { [k: string]: SlotItem[] }) => this.slotProvider.getRelevantSlots(slots)),
+            map((slots: { [k: string]: SlotItem[] }) =>
+              new journalActions.LoadJournalSuccess(
+                slots,
+                this.networkStateProvider.getNetworkState(),
+                this.authProvider.isInUnAuthenticatedMode(),
+                lastRefreshed,
+              ),
+            ),
+            catchError((err) => {
+              // For HTTP 304 NOT_MODIFIED we just use the slots we already have cached
+              if (err.status === 304) {
+                return of(new journalActions.LoadJournalSuccess(
+                  slots,
+                  this.networkStateProvider.getNetworkState(),
+                  this.authProvider.isInUnAuthenticatedMode(),
+                  lastRefreshed,
+                ));
+              }
+            }),
           );
       }),
     );

--- a/src/providers/journal/__mocks__/journal.mock.ts
+++ b/src/providers/journal/__mocks__/journal.mock.ts
@@ -1,6 +1,7 @@
 import { ExaminerWorkSchedule } from './../../../shared/models/DJournal';
 import { of } from 'rxjs/observable/of';
 import { Observable } from 'rxjs/Observable';
+import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 
 const localJournalJson = require('../../../../mock/local-journal.json');
 
@@ -8,8 +9,17 @@ export class JournalProviderMock {
 
   static mockJournal: ExaminerWorkSchedule = localJournalJson;
 
+  private do304ErrorNextCall = false;
+
   public getJournal(): Observable<ExaminerWorkSchedule> {
+    if (this.do304ErrorNextCall) {
+      return ErrorObservable.create({ status: 304 });
+    }
     return of(JournalProviderMock.mockJournal);
   }
-  public saveJournalForOffline = () => {};
+  public saveJournalForOffline = () => { };
+
+  public setupHttp304Error() {
+    this.do304ErrorNextCall = true;
+  }
 }

--- a/src/providers/journal/journal.ts
+++ b/src/providers/journal/journal.ts
@@ -26,7 +26,7 @@ export class JournalProvider {
     public networkStateProvider: NetworkStateProvider,
     private appConfigProvider: AppConfigProvider,
     private dateTimeProvider: DateTimeProvider,
-  ) {}
+  ) { }
 
   getJournal(lastRefreshed: Date): Observable<ExaminerWorkSchedule> {
     const staffNumber = this.authProvider.getEmployeeId();
@@ -34,13 +34,13 @@ export class JournalProvider {
     const networkStatus = this.networkStateProvider.getNetworkState();
     if (lastRefreshed === null) {
       if (!this.authProvider.isInUnAuthenticatedMode() &&
-      networkStatus === ConnectionStatus.ONLINE) {
+        networkStatus === ConnectionStatus.ONLINE) {
         return this.http.get(journalUrl);
       }
       return this.getOfflineJournal();
     }
 
-    const modifiedSinceValue = DateTime.at(lastRefreshed).format('ddd[,] D MMM YYYY HH:mm:ss [GMT]');
+    const modifiedSinceValue = lastRefreshed.toUTCString();
     const options = {
       headers: new HttpHeaders().set('If-Modified-Since', modifiedSinceValue),
     };
@@ -91,7 +91,7 @@ export class JournalProvider {
         dateStored: this.dateTimeProvider.now().format('YYYY/MM/DD'),
         data: journalData,
       };
-      this.dataStore.setItem('JOURNAL', JSON.stringify(journalDataToStore)).then((response) => {});
+      this.dataStore.setItem('JOURNAL', JSON.stringify(journalDataToStore)).then((response) => { });
     }
   }
 
@@ -101,7 +101,7 @@ export class JournalProvider {
    * @returns boolean
    */
 
-  isCacheTooOld = (dateStored: DateTime, now: DateTime):boolean => {
+  isCacheTooOld = (dateStored: DateTime, now: DateTime): boolean => {
     return dateStored.daysDiff(now) > this.appConfigProvider.getAppConfig().daysToCacheJournalData;
   }
 
@@ -117,7 +117,7 @@ export class JournalProvider {
       dateStored: this.dateTimeProvider.now().format('YYYY/MM/DD'),
       data: emptyJournalData,
     };
-    this.dataStore.setItem('JOURNAL', JSON.stringify(journalDataToStore)).then(() => {});
+    this.dataStore.setItem('JOURNAL', JSON.stringify(journalDataToStore)).then(() => { });
     return emptyJournalData;
   }
 


### PR DESCRIPTION
## Description and relevant Jira numbers
* Journal service returns HTTP 304 when there are no changes as per https://github.com/dvsa/mes-journal-service/pull/28.
* Handle this gracefully by using the journal slots already cached on the device.
* Simplify how the `If-Modified-Since` header on the journal request is generated.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
