### PR TITLE
MES-1882: Ensure we can retrieve journals when logging in as a different user

### DIFF
--- a/mock/local-journal-non-test-activities.json
+++ b/mock/local-journal-non-test-activities.json
@@ -16,7 +16,7 @@
     {
       "slotDetail": {
         "slotId": 1000,
-        "start": "2019-05-24T09:00:00+01:00",
+        "start": "2019-05-28T09:00:00+01:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -29,7 +29,7 @@
     {
       "slotDetail": {
         "slotId": 1001,
-        "start": "2019-05-24T10:15:00+01:00",
+        "start": "2019-05-28T10:15:00+01:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -101,17 +101,17 @@
   "personalCommitments": [
     {
       "commitmentId": 123400,
-      "startDate": "2019-05-24",
+      "startDate": "2019-05-28",
       "startTime": "10:00:00+01:00",
-      "endDate": "2019-05-24",
+      "endDate": "2019-05-28",
       "endTime": "11:00:00+01:00",
       "activityCode": "104",
       "activityDescription": "Medical appointment"
     },
     {
       "commitmentId": 123401,
-      "startDate": "2019-05-31",
-      "endDate": "2019-05-31",
+      "startDate": "2019-06-04",
+      "endDate": "2019-06-04",
       "activityCode": "081",
       "activityDescription": "Annual Leave"
     }
@@ -120,7 +120,7 @@
     {
       "slotDetail": {
         "slotId": 1111,
-        "start": "2019-05-24T11:15:00+01:00",
+        "start": "2019-05-28T11:15:00+01:00",
         "duration": 57
       },
       "activityCode": "091",
@@ -134,7 +134,7 @@
     {
       "slotDetail": {
         "slotId": 1110,
-        "start": "2019-05-24T12:15:00+01:00",
+        "start": "2019-05-28T12:15:00+01:00",
         "duration": 57
       },
       "activityCode": "089",
@@ -148,7 +148,7 @@
     {
       "slotDetail": {
         "slotId": 1200,
-        "start": "2019-05-24T13:15:00+01:00",
+        "start": "2019-05-28T13:15:00+01:00",
         "duration": 57
       },
       "activityCode": "104",
@@ -164,7 +164,7 @@
     {
       "slotDetail": {
         "slotId": 1300,
-        "start": "2019-05-24T09:00:00+01:00",
+        "start": "2019-05-28T09:00:00+01:00",
         "duration": 90
       },
       "testCentre": {
@@ -177,7 +177,7 @@
     {
       "slotDetail": {
         "slotId": 1301,
-        "start": "2019-05-24T10:45:00+01:00",
+        "start": "2019-05-28T10:45:00+01:00",
         "duration": 90
       },
       "testCentre": {
@@ -190,7 +190,7 @@
     {
       "slotDetail": {
         "slotId": 1302,
-        "start": "2019-05-24T12:30:00+01:00",
+        "start": "2019-05-28T12:30:00+01:00",
         "duration": 90
       },
       "testCentre": {
@@ -209,7 +209,7 @@
         "centreName": "Example Test Centre 3",
         "costCode": "EXTC 3"
       },
-      "date": "2019-05-24"
+      "date": "2019-05-28"
     },
     {
       "deploymentId": 22222,
@@ -218,7 +218,7 @@
         "centreName": "Example Test Centre 4",
         "costCode": "EXTC 4"
       },
-      "date": "2019-05-24"
+      "date": "2019-05-28"
     }
   ]
 }

--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -48,7 +48,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1001,
-        "start": "2019-05-24T08:10:00+01:00"
+        "start": "2019-05-28T08:10:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -98,7 +98,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1003,
-        "start": "2019-05-24T10:14:00+01:00"
+        "start": "2019-05-28T10:14:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -148,7 +148,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1004,
-        "start": "2019-05-24T11:11:00+01:00"
+        "start": "2019-05-28T11:11:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -199,7 +199,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1005,
-        "start": "2019-05-24T12:38:00+01:00"
+        "start": "2019-05-28T12:38:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -252,7 +252,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1006,
-        "start": "2019-05-24T13:35:00+01:00"
+        "start": "2019-05-28T13:35:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -297,7 +297,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1007,
-        "start": "2019-05-25T14:32:00+01:00"
+        "start": "2019-05-29T14:32:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,

--- a/src/pages/journal/__tests__/journal.reducer.spec.ts
+++ b/src/pages/journal/__tests__/journal.reducer.spec.ts
@@ -37,10 +37,12 @@ describe('Journal Reducer', () => {
         ],
       };
 
-      const action = new LoadJournalSuccess(actionPayload,
-                                            ConnectionStatus.ONLINE,
-                                            false,
-                                            new Date());
+      const action = new LoadJournalSuccess(
+        actionPayload,
+        ConnectionStatus.ONLINE,
+        false,
+        new Date(),
+      );
 
       const state = {
         ...initialState,
@@ -71,11 +73,24 @@ describe('Journal Reducer', () => {
       const result = journalReducer(stateWithJournals, action);
       expect(result.slots).toEqual({});
     });
+    it('should reset the rest of the journal to default state', () => {
+      const stateWithJournals = {
+        isLoading: true,
+        lastRefreshed: new Date(),
+        selectedDate: 'dummy',
+        slots: { ['2019-01-13']: [new SlotItem({}, false)] },
+      };
+      const action = new UnloadJournal();
+      const result = journalReducer(stateWithJournals, action);
+      expect(result.isLoading).toBe(false);
+      expect(result.lastRefreshed).toBeNull();
+      expect(result.selectedDate).toBe('');
+    });
   });
 
   describe('[JournalPage] Unset error', () => {
     it('should remove any journal error in the state', () => {
-      const stateWithError = { ...initialState, error: { message: '', status: 0, statusText: '' }  };
+      const stateWithError = { ...initialState, error: { message: '', status: 0, statusText: '' } };
       const action = new UnsetError();
       const result = journalReducer(stateWithError, action);
       expect(result.error).toBeUndefined();
@@ -89,7 +104,7 @@ describe('Journal Reducer', () => {
         ...initialState,
         selectedDate: slotDate,
         slots: {
-          [`${slotDate}`] : [new SlotItem({ slotDetail: { slotId:1234 } }, true)],
+          [`${slotDate}`]: [new SlotItem({ slotDetail: { slotId: 1234 } }, true)],
         },
       };
       const action = new ClearChangedSlot(1234);

--- a/src/pages/journal/journal.reducer.ts
+++ b/src/pages/journal/journal.reducer.ts
@@ -27,7 +27,7 @@ export function journalReducer(state = initialState, action: journalActions.Jour
         // TODO: The reducer has to get the lastRefreshed date from the action
         // And should not do any logic
         lastRefreshed: (action.onlineOffline ===
-          ConnectionStatus.ONLINE  && !action.unAuthenticatedMode) ? new Date() : action.lastRefreshed,
+          ConnectionStatus.ONLINE && !action.unAuthenticatedMode) ? new Date() : action.lastRefreshed,
         isLoading: false,
         slots: action.payload,
       };
@@ -38,10 +38,7 @@ export function journalReducer(state = initialState, action: journalActions.Jour
         error: action.payload,
       };
     case journalActions.UNLOAD_JOURNAL:
-      return {
-        ...state,
-        slots: {},
-      };
+      return initialState;
     case journalActions.UNSET_ERROR:
       const { error, ...stateWithoutError } = state;
       return {


### PR DESCRIPTION
## Description and relevant Jira numbers
* Fixing an issue introduced by #449 
* The `lastRefreshed` was maintained in the state even after logout
* This means that we would get HTTP 304 for journals on the new user without having any journal slots cached
* Reset the entire journal state when unloading, including `lastRefreshed`.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
