### PR TITLE
MES-2265: Using conductedLanguage to drive language translation on ca…

### DIFF
--- a/src/pages/communication-page/__tests__/communication.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.spec.ts
@@ -97,6 +97,7 @@ describe('CommunicationPage', () => {
                 communicationPreferences: {
                   updatedEmail: '',
                   communicationMethod: 'Post',
+                  conductedLanguage: 'Cymraeg',
                 },
               },
             },
@@ -303,6 +304,8 @@ describe('CommunicationPage', () => {
       });
       it('should render the page in Welsh for a Welsh test', (done) => {
         fixture.detectChanges();
+        component.isBookedInWelsh = true;
+        component.configureI18N(true);
         translate.onLangChange.subscribe(() => {
           fixture.detectChanges();
           expect(fixture.debugElement.query(By.css('h4')).nativeElement.innerHTML)

--- a/src/pages/communication-page/communication.ts
+++ b/src/pages/communication-page/communication.ts
@@ -84,6 +84,7 @@ export class CommunicationPage extends PracticeableBasePageComponent {
   selectProvidedEmail: boolean;
   selectNewEmail: boolean;
   conductedLanguage: string;
+  isBookedInWelsh: boolean;
 
   constructor(
     store$: Store<StoreModel>,
@@ -192,7 +193,7 @@ export class CommunicationPage extends PracticeableBasePageComponent {
       candidateProvidedEmail$.pipe(map(value => this.candidateProvidedEmail = value)),
       communicationEmail$.pipe(map(value => this.communicationEmail = value)),
       communicationType$.pipe(map(value => this.communicationType = value)),
-      welshTest$.pipe(map(isWelsh => this.configureI18N(isWelsh))),
+      welshTest$.pipe(map(isWelsh => this.isBookedInWelsh = isWelsh)),
       conductedLanguage$.pipe(map(value => this.conductedLanguage = value)),
     );
     this.subscription = merged$.subscribe();
@@ -201,6 +202,7 @@ export class CommunicationPage extends PracticeableBasePageComponent {
       this.initialiseDefaultSelections();
     }
 
+    this.configureI18N(this.conductedLanguage === CommunicationPage.welshLanguage);
     this.restoreRadiosFromState();
     this.restoreRadioValidators();
   }
@@ -208,12 +210,13 @@ export class CommunicationPage extends PracticeableBasePageComponent {
   ngOnDestroy(): void {
     super.ngOnDestroy();
     this.subscription.unsubscribe();
-    this.translate.use(this.translate.getDefaultLang());
   }
 
   configureI18N(isWelsh: boolean): void {
-    if (isWelsh) {
+    if (this.isBookedInWelsh && isWelsh) {
       this.translate.use('cy');
+    } else {
+      this.translate.use('en');
     }
   }
 
@@ -348,10 +351,9 @@ export class CommunicationPage extends PracticeableBasePageComponent {
       this.form.controls['radioCtrl'].setValue(true);
     }
 
-    if (this.conductedLanguage !== CommunicationPage.englishLanguage) {
+    if (this.isBookedInWelsh && this.conductedLanguage !== CommunicationPage.englishLanguage) {
       this.dispatchCandidateChoseToProceedInWelsh();
     }
-
   }
 
   verifyNewEmailFormControl(communicationChoice: string) {
@@ -395,9 +397,11 @@ export class CommunicationPage extends PracticeableBasePageComponent {
 
   dispatchCandidateChoseToProceedInWelsh() {
     this.store$.dispatch(new CandidateChoseToProceedWithTestInWelsh(CommunicationPage.welshLanguage));
+    this.configureI18N(this.conductedLanguage === CommunicationPage.welshLanguage);
   }
 
   dispatchCandidateChoseToProceedInEnglish() {
     this.store$.dispatch(new CandidateChoseToProceedWithTestInEnglish(CommunicationPage.englishLanguage));
+    this.configureI18N(this.conductedLanguage === CommunicationPage.welshLanguage);
   }
 }

--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -390,6 +390,8 @@ describe('DebriefPage', () => {
         store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsSignalling));
         store$.dispatch(new AddDangerousFault(Competencies.useOfMirrorsChangeDirection));
         fixture.detectChanges();
+        component.isBookedInWelsh = true;
+        component.configureI18N(true);
         translate.onLangChange.subscribe(() => {
           fixture.detectChanges();
           const drivingFaultLabel = fixture.debugElement.query(By.css('#driving-fault .counter-label')).nativeElement;

--- a/src/pages/health-declaration/__tests__/health-declaration.spec.ts
+++ b/src/pages/health-declaration/__tests__/health-declaration.spec.ts
@@ -237,6 +237,8 @@ describe('HealthDeclarationPage', () => {
       });
       it('should render the page in Welsh for a Welsh test', (done) => {
         fixture.detectChanges();
+        component.isBookedInWelsh = true;
+        component.configureI18N(true);
         translate.onLangChange.subscribe(() => {
           fixture.detectChanges();
           const declarationIntent = fixture.debugElement.query(By.css('h4')).nativeElement;

--- a/src/pages/health-declaration/health-declaration.ts
+++ b/src/pages/health-declaration/health-declaration.ts
@@ -37,6 +37,10 @@ import { TranslateService } from 'ng2-translate';
 import { getTestSlotAttributes } from '../../modules/tests/test-slot-attributes/test-slot-attributes.reducer';
 import { isWelshTest } from '../../modules/tests/test-slot-attributes/test-slot-attributes.selector';
 import { ProvisionalLicenseNotReceived } from '../../modules/tests/pass-completion/pass-completion.actions';
+import {
+  getCommunicationPreference,
+} from '../../modules/tests/communication-preferences/communication-preferences.reducer';
+import { getConductedLanguage } from '../../modules/tests/communication-preferences/communication-preferences.selector';
 
 interface HealthDeclarationPageState {
   healthDeclarationAccepted$: Observable<boolean>;
@@ -48,6 +52,7 @@ interface HealthDeclarationPageState {
   passCertificateNumber$: Observable<string>;
   licenseProvided$: Observable<boolean>;
   welshTest$: Observable<boolean>;
+  conductedLanguage$: Observable<string>;
 }
 @IonicPage()
 @Component({
@@ -55,6 +60,9 @@ interface HealthDeclarationPageState {
   templateUrl: 'health-declaration.html',
 })
 export class HealthDeclarationPage extends PracticeableBasePageComponent {
+
+  static readonly welshLanguage: string = 'Cymraeg';
+
   @ViewChild(SignatureAreaComponent)
   signatureArea: SignatureAreaComponent;
 
@@ -66,6 +74,8 @@ export class HealthDeclarationPage extends PracticeableBasePageComponent {
   healthDeclarationAccepted: boolean;
   subscription: Subscription;
   inputSubscriptions: Subscription[] = [];
+  isBookedInWelsh: boolean;
+  conductedLanguage: string;
 
   constructor(
     store$: Store<StoreModel>,
@@ -175,22 +185,25 @@ export class HealthDeclarationPage extends PracticeableBasePageComponent {
         select(getTestSlotAttributes),
         select(isWelshTest),
       ),
+      conductedLanguage$: currentTest$.pipe(
+        select(getCommunicationPreference),
+        select(getConductedLanguage),
+      ),
     };
     this.rehydrateFields();
 
-    const { welshTest$, licenseProvided$, healthDeclarationAccepted$ } = this.pageState;
+    const { welshTest$, licenseProvided$, healthDeclarationAccepted$, conductedLanguage$ } = this.pageState;
+
     const merged$ = merge(
-      welshTest$.pipe(
-        map(isWelsh => this.configureI18N(isWelsh)),
-      ),
-      licenseProvided$.pipe(
-        map(val => this.licenseProvided = val),
-      ),
-      healthDeclarationAccepted$.pipe(
-        map(val => this.healthDeclarationAccepted = val),
-      ),
+      welshTest$.pipe(map(isWelsh => this.isBookedInWelsh = isWelsh)),
+      licenseProvided$.pipe(map(val => this.licenseProvided = val)),
+      healthDeclarationAccepted$.pipe(map(val => this.healthDeclarationAccepted = val)),
+      conductedLanguage$.pipe(map(language => this.conductedLanguage = language)),
     );
+
+    this.configureI18N(this.conductedLanguage === HealthDeclarationPage.welshLanguage);
     this.subscription = merged$.subscribe();
+
   }
 
   rehydrateFields(): void {
@@ -215,7 +228,7 @@ export class HealthDeclarationPage extends PracticeableBasePageComponent {
   }
 
   configureI18N(isWelsh: boolean): void {
-    if (isWelsh) {
+    if (this.isBookedInWelsh && isWelsh) {
       this.translate.use('cy');
     }
   }

--- a/src/pages/waiting-room/__tests__/waiting-room.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.spec.ts
@@ -78,6 +78,11 @@ describe('WaitingRoomPage', () => {
                   welshTest: false,
                 },
               },
+              communicationPreferences: {
+                updatedEmaill: 'test@mail.com',
+                communicationMethod: 'Email',
+                conductedLanguage: 'Cymraeg',
+              },
             },
           },
         })),


### PR DESCRIPTION
…ndidate facing pages

## Description and relevant Jira numbers

- Communication, Waiting Room, Debrief and Health Declaration pages now use `conductedLanguage` to determine if a translation is required from English to Welsh.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
