### PR TITLE
MES-1977- Disable Single App Mode in Practice Tests

### DIFF
--- a/src/pages/back-to-office/__tests__/back-to-office.spec.ts
+++ b/src/pages/back-to-office/__tests__/back-to-office.spec.ts
@@ -70,9 +70,16 @@ describe('BackToOfficePage', () => {
       expect(component).toBeDefined();
     });
     describe('ionViewDidEnter', () => {
-      it('should disable test inhibitions', () => {
+      it('should disable test inhibitions when not in practice mode', () => {
         component.ionViewDidEnter();
         expect(deviceProvider.disableSingleAppMode).toHaveBeenCalled();
+        expect(screenOrientation.unlock).toHaveBeenCalled();
+        expect(insomnia.allowSleepAgain).toHaveBeenCalled();
+      });
+      it('should disable test inhibitions when in practice mode', () => {
+        component.isPracticeMode = true;
+        component.ionViewDidEnter();
+        expect(deviceProvider.disableSingleAppMode).not.toHaveBeenCalled();
         expect(screenOrientation.unlock).toHaveBeenCalled();
         expect(insomnia.allowSleepAgain).toHaveBeenCalled();
       });

--- a/src/pages/back-to-office/back-to-office.ts
+++ b/src/pages/back-to-office/back-to-office.ts
@@ -31,9 +31,12 @@ export class BackToOfficePage extends PracticeableBasePageComponent {
 
   ionViewDidEnter(): void {
     if (super.isIos()) {
-      this.deviceProvider.disableSingleAppMode();
       this.screenOrientation.unlock();
       this.insomnia.allowSleepAgain();
+
+      if (!this.isPracticeMode) {
+        this.deviceProvider.disableSingleAppMode();
+      }
     }
 
     this.store$.dispatch(new BackToOfficeViewDidEnter());

--- a/src/pages/communication-page/__tests__/communication.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.spec.ts
@@ -151,9 +151,16 @@ describe('CommunicationPage', () => {
     });
 
     describe('ionViewDidEnter', () => {
-      it('should enable single app mode if on ios', () => {
+      it('should enable single app mode if on ios and not in practice mode', () => {
+        component.isPracticeMode = false;
         component.ionViewDidEnter();
         expect(deviceProvider.enableSingleAppMode).toHaveBeenCalled();
+      });
+
+      it('should note enable single app mode if on ios and in practice mode', () => {
+        component.isPracticeMode = true;
+        component.ionViewDidEnter();
+        expect(deviceProvider.enableSingleAppMode).not.toHaveBeenCalled();
       });
 
       it('should lock the screen orientation to Portrait Primary', () => {

--- a/src/pages/communication-page/communication.ts
+++ b/src/pages/communication-page/communication.ts
@@ -104,9 +104,12 @@ export class CommunicationPage extends PracticeableBasePageComponent {
     this.store$.dispatch(new CommunicationViewDidEnter());
 
     if (super.isIos()) {
-      this.deviceProvider.enableSingleAppMode();
       this.screenOrientation.lock(this.screenOrientation.ORIENTATIONS.PORTRAIT_PRIMARY);
       this.insomnia.keepAwake();
+
+      if (!this.isPracticeMode) {
+        this.deviceProvider.enableSingleAppMode();
+      }
     }
 
     this.navBar.backButtonClick = (e: UIEvent) => {

--- a/src/pages/communication-page/components/postal-address/__tests__/postal-address.spec.ts
+++ b/src/pages/communication-page/components/postal-address/__tests__/postal-address.spec.ts
@@ -2,9 +2,6 @@ import { PostalAddressComponent } from '../postal-address';
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { Store, StoreModule } from '@ngrx/store';
 import { StoreModel } from '../../../../../shared/models/store.model';
-import { DeviceProvider } from '../../../../../providers/device/device';
-import { DeviceAuthenticationProvider } from '../../../../../providers/device-authentication/device-authentication';
-import { Insomnia } from '@ionic-native/insomnia';
 import { IonicModule, NavController, NavParams, Config, Platform } from 'ionic-angular';
 import { AppModule, createTranslateLoader } from '../../../../../app/app.module';
 import { ComponentsModule } from '../../../../../components/components.module';
@@ -14,13 +11,8 @@ import {
 import { NavControllerMock, NavParamsMock, ConfigMock, PlatformMock } from 'ionic-mocks';
 import { AuthenticationProvider } from '../../../../../providers/authentication/authentication';
 import { AuthenticationProviderMock } from '../../../../../providers/authentication/__mocks__/authentication.mock';
-import { DeviceProviderMock } from '../../../../../providers/device/__mocks__/device.mock';
-import {
-  DeviceAuthenticationProviderMock,
-} from '../../../../../providers/device-authentication/__mocks__/device-authentication.mock';
 import { DateTimeProvider } from '../../../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../../../providers/date-time/__mocks__/date-time.mock';
-import { InsomniaMock } from '../../../../../shared/mocks/insomnia.mock';
 import { By } from '@angular/platform-browser';
 import { TranslateModule, TranslateLoader, TranslateService } from 'ng2-translate';
 import { Http } from '@angular/http';
@@ -95,10 +87,7 @@ describe('PostalAddressComponent', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
         { provide: Platform, useFactory: () => PlatformMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: DeviceProvider, useClass: DeviceProviderMock },
-        { provide: DeviceAuthenticationProvider, useClass: DeviceAuthenticationProviderMock },
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
-        { provide: Insomnia, useClass: InsomniaMock },
       ],
     })
       .compileComponents()

--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -24,8 +24,6 @@ import { Competencies, ExaminerActions } from '../../../modules/tests/test-data/
 import { DebriefComponentsModule } from '../components/debrief-components.module';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
-import { DeviceProvider } from '../../../providers/device/device';
-import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
 import { InsomniaMock } from '../../../shared/mocks/insomnia.mock';
 import { ScreenOrientationMock } from '../../../shared/mocks/screen-orientation.mock';
 import { TranslateModule, TranslateService } from 'ng2-translate';
@@ -112,7 +110,6 @@ describe('DebriefPage', () => {
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
         { provide: ScreenOrientation, useClass: ScreenOrientationMock },
         { provide: Insomnia, useClass: InsomniaMock },
-        { provide: DeviceProvider, useClass: DeviceProviderMock },
       ],
     })
       .compileComponents()

--- a/src/pages/health-declaration/__tests__/health-declaration.spec.ts
+++ b/src/pages/health-declaration/__tests__/health-declaration.spec.ts
@@ -9,7 +9,6 @@ import { AuthenticationProviderMock } from '../../../providers/authentication/__
 import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
 import { ComponentsModule } from './../../../components/components.module';
-import { DeviceProvider } from '../../../providers/device/device';
 import { Store, StoreModule } from '@ngrx/store';
 import { StoreModel } from '../../../shared/models/store.model';
 import { HealthDeclarationViewDidEnter } from '../health-declaration.actions';
@@ -17,7 +16,6 @@ import { DeviceAuthenticationProvider } from '../../../providers/device-authenti
 import {
   DeviceAuthenticationProviderMock,
 } from '../../../providers/device-authentication/__mocks__/device-authentication.mock';
-import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
 import * as postTestDeclarationsActions
   from '../../../modules/tests/post-test-declarations/post-test-declarations.actions';
 import * as passCompletionActions
@@ -40,7 +38,6 @@ const mockCandidate = {
 describe('HealthDeclarationPage', () => {
   let fixture: ComponentFixture<HealthDeclarationPage>;
   let component: HealthDeclarationPage;
-  let deviceProvider: DeviceProvider;
   let store$: Store<StoreModel>;
   let deviceAuthenticationProvider: DeviceAuthenticationProvider;
   let translate: TranslateService;
@@ -92,7 +89,6 @@ describe('HealthDeclarationPage', () => {
         { provide: Platform, useFactory: () => PlatformMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
-        { provide: DeviceProvider, useClass: DeviceProviderMock },
         { provide: DeviceAuthenticationProvider, useClass: DeviceAuthenticationProviderMock },
       ],
     })
@@ -100,7 +96,6 @@ describe('HealthDeclarationPage', () => {
       .then(() => {
         fixture = TestBed.createComponent(HealthDeclarationPage);
         component = fixture.componentInstance;
-        deviceProvider = TestBed.get(DeviceProvider);
         deviceAuthenticationProvider = TestBed.get(DeviceAuthenticationProvider);
         store$ = TestBed.get(Store);
         spyOn(store$, 'dispatch').and.callThrough();
@@ -119,31 +114,9 @@ describe('HealthDeclarationPage', () => {
   });
 
   describe('ionViewDidEnter', () => {
-    it('should enable single app mode if on ios and not in practice mode', () => {
-      component.isPracticeMode = false;
-      component.ionViewDidEnter();
-      expect(deviceProvider.enableSingleAppMode).toHaveBeenCalled();
-    });
-    it('should not enable single app mode if on ios and in practice mode', () => {
-      component.isPracticeMode = true;
-      component.ionViewDidEnter();
-      expect(deviceProvider.enableSingleAppMode).not.toHaveBeenCalled();
-    });
     it('should dispatch HealthDeclarationViewDidEnter', () => {
       component.ionViewDidEnter();
       expect(store$.dispatch).toHaveBeenCalledWith(new HealthDeclarationViewDidEnter());
-    });
-    describe('ionViewDidLeave', () => {
-      it('should  disable single app mode if on ios and not in practice mode', () => {
-        component.isPracticeMode = false;
-        component.ionViewDidLeave();
-        expect(deviceProvider.disableSingleAppMode).toHaveBeenCalled();
-      });
-      it('should not disable single app mode if on ios and in practice mode', () => {
-        component.isPracticeMode = true;
-        component.ionViewDidLeave();
-        expect(deviceProvider.disableSingleAppMode).not.toHaveBeenCalled();
-      });
     });
     describe('clickBack', () => {
       it('should should trigger the lock screen', () => {

--- a/src/pages/health-declaration/__tests__/health-declaration.spec.ts
+++ b/src/pages/health-declaration/__tests__/health-declaration.spec.ts
@@ -119,18 +119,30 @@ describe('HealthDeclarationPage', () => {
   });
 
   describe('ionViewDidEnter', () => {
-    it('should enable single app mode if on ios', () => {
+    it('should enable single app mode if on ios and not in practice mode', () => {
+      component.isPracticeMode = false;
       component.ionViewDidEnter();
       expect(deviceProvider.enableSingleAppMode).toHaveBeenCalled();
+    });
+    it('should not enable single app mode if on ios and in practice mode', () => {
+      component.isPracticeMode = true;
+      component.ionViewDidEnter();
+      expect(deviceProvider.enableSingleAppMode).not.toHaveBeenCalled();
     });
     it('should dispatch HealthDeclarationViewDidEnter', () => {
       component.ionViewDidEnter();
       expect(store$.dispatch).toHaveBeenCalledWith(new HealthDeclarationViewDidEnter());
     });
     describe('ionViewDidLeave', () => {
-      it('should disable single app mode if on ios', () => {
+      it('should  disable single app mode if on ios and not in practice mode', () => {
+        component.isPracticeMode = false;
         component.ionViewDidLeave();
         expect(deviceProvider.disableSingleAppMode).toHaveBeenCalled();
+      });
+      it('should not disable single app mode if on ios and in practice mode', () => {
+        component.isPracticeMode = true;
+        component.ionViewDidLeave();
+        expect(deviceProvider.disableSingleAppMode).not.toHaveBeenCalled();
       });
     });
     describe('clickBack', () => {

--- a/src/pages/health-declaration/health-declaration.ts
+++ b/src/pages/health-declaration/health-declaration.ts
@@ -8,7 +8,6 @@ import { StoreModel } from '../../shared/models/store.model';
 import { HealthDeclarationViewDidEnter } from './health-declaration.actions';
 import { Observable } from 'rxjs/Observable';
 import { FormGroup, Validators, FormControl } from '@angular/forms';
-import { DeviceProvider } from '../../providers/device/device';
 import { DeviceAuthenticationProvider } from '../../providers/device-authentication/device-authentication';
 import * as postTestDeclarationsActions
   from '../../modules/tests/post-test-declarations/post-test-declarations.actions';
@@ -73,7 +72,6 @@ export class HealthDeclarationPage extends PracticeableBasePageComponent {
     public navParams: NavParams,
     public platform: Platform,
     public authenticationProvider: AuthenticationProvider,
-    private deviceProvider: DeviceProvider,
     private deviceAuthenticationProvider: DeviceAuthenticationProvider,
     private translate: TranslateService,
     public alertController: AlertController,
@@ -85,18 +83,9 @@ export class HealthDeclarationPage extends PracticeableBasePageComponent {
 
   ionViewDidEnter(): void {
     this.store$.dispatch(new HealthDeclarationViewDidEnter());
-    if (super.isIos() && !this.isPracticeMode) {
-      this.deviceProvider.enableSingleAppMode();
-    }
     this.navBar.backButtonClick = (e: UIEvent) => {
       this.clickBack();
     };
-  }
-
-  ionViewDidLeave(): void {
-    if (super.isIos() && !this.isPracticeMode) {
-      this.deviceProvider.disableSingleAppMode();
-    }
   }
 
   clickBack(): void {

--- a/src/pages/health-declaration/health-declaration.ts
+++ b/src/pages/health-declaration/health-declaration.ts
@@ -85,7 +85,7 @@ export class HealthDeclarationPage extends PracticeableBasePageComponent {
 
   ionViewDidEnter(): void {
     this.store$.dispatch(new HealthDeclarationViewDidEnter());
-    if (super.isIos()) {
+    if (super.isIos() && !this.isPracticeMode) {
       this.deviceProvider.enableSingleAppMode();
     }
     this.navBar.backButtonClick = (e: UIEvent) => {
@@ -94,7 +94,7 @@ export class HealthDeclarationPage extends PracticeableBasePageComponent {
   }
 
   ionViewDidLeave(): void {
-    if (super.isIos()) {
+    if (super.isIos() && !this.isPracticeMode) {
       this.deviceProvider.disableSingleAppMode();
     }
   }

--- a/src/pages/journal/__tests__/journal.spec.ts
+++ b/src/pages/journal/__tests__/journal.spec.ts
@@ -18,8 +18,6 @@ import { journalReducer } from '../journal.reducer';
 import { Subscription } from 'rxjs/Subscription';
 import { SlotSelectorProvider } from '../../../providers/slot-selector/slot-selector';
 import { MockedJournalModule } from '../__mocks__/journal.module.mock';
-import { ScreenOrientation } from '@ionic-native/screen-orientation';
-import { ScreenOrientationMock } from '../../../shared/mocks/screen-orientation.mock';
 import { UnloadJournal, LoadJournal, LoadJournalSuccess } from '../journal.actions';
 import { BasePageComponent } from '../../../shared/classes/base-page';
 import { StoreModel } from '../../../shared/models/store.model';
@@ -60,7 +58,6 @@ describe('JournalPage', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
         { provide: SlotSelectorProvider, useClass: SlotSelectorProvider },
-        { provide: ScreenOrientation, useClass: ScreenOrientationMock },
         { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
         { provide: AppConfigProvider, useClass: AppConfigProviderMock },

--- a/src/pages/test-report/__tests__/test-report.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.spec.ts
@@ -41,8 +41,6 @@ import {
 import { ModalEvent } from '../test-report.constants';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
-import { DeviceProvider } from '../../../providers/device/device';
-import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
 import { InsomniaMock } from '../../../shared/mocks/insomnia.mock';
 import { ScreenOrientationMock } from '../../../shared/mocks/screen-orientation.mock';
 import { PracticeModeBanner } from '../../../components/practice-mode-banner/practice-mode-banner';
@@ -113,7 +111,6 @@ describe('TestReportPage', () => {
         { provide: TestReportValidatorProvider, useClass: TestReportValidatorProviderMock },
         { provide: ScreenOrientation, useClass: ScreenOrientationMock },
         { provide: Insomnia, useClass: InsomniaMock },
-        { provide: DeviceProvider, useClass: DeviceProviderMock },
         { provide: StatusBar, useFactory: () => StatusBarMock.instance() },
       ],
     })

--- a/src/pages/waiting-room/__tests__/waiting-room.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.spec.ts
@@ -15,8 +15,6 @@ import {
   ToggleResidencyDeclaration,
   ToggleInsuranceDeclaration,
 } from '../../../modules/tests/pre-test-declarations/pre-test-declarations.actions';
-import { DeviceProvider } from '../../../providers/device/device';
-import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
 import {
   initialState as preTestDeclarationInitialState,
 } from '../../../modules/tests/pre-test-declarations/pre-test-declarations.reducer';
@@ -26,10 +24,6 @@ import {
 } from '../../../providers/device-authentication/__mocks__/device-authentication.mock';
 import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
-import { ScreenOrientation } from '@ionic-native/screen-orientation';
-import { ScreenOrientationMock } from '../../../shared/mocks/screen-orientation.mock';
-import { Insomnia } from '@ionic-native/insomnia';
-import { InsomniaMock } from '../../../shared/mocks/insomnia.mock';
 import { SubmitWaitingRoomInfo } from '../waiting-room.actions';
 import { of } from 'rxjs/observable/of';
 import { TranslateModule, TranslateService } from 'ng2-translate';
@@ -89,11 +83,8 @@ describe('WaitingRoomPage', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
         { provide: Platform, useFactory: () => PlatformMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: DeviceProvider, useClass: DeviceProviderMock },
         { provide: DeviceAuthenticationProvider, useClass: DeviceAuthenticationProviderMock },
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
-        { provide: ScreenOrientation, useClass: ScreenOrientationMock },
-        { provide: Insomnia, useClass: InsomniaMock },
       ],
     })
       .compileComponents()


### PR DESCRIPTION
## Description and relevant Jira numbers

- Disable Single App Mode when in Practice Mode
- Removed the use of Single App Mode in Health Declaration - It's turned on in the Communication page and turned off in the Back to Office Page
- Tidied up unnecessary imports of ScreenOrientation, DeviceProvider and Insomnia in Unit Tests

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
