### PR TITLE
MES-2343 - Added welsh test toggle to office page

### DIFF
--- a/src/modules/tests/test-slot-attributes/__tests__/test-slot-attributes.reducer.spec.ts
+++ b/src/modules/tests/test-slot-attributes/__tests__/test-slot-attributes.reducer.spec.ts
@@ -1,22 +1,35 @@
 import { TestSlotAttributes } from '@dvsa/mes-test-schema/categories/B';
 import { testSlotsAttributesReducer } from '../test-slot-attributes.reducer';
-import { PopulateTestSlotAttributes } from '../test-slot-attributes.actions';
+import { PopulateTestSlotAttributes, WelshTestChanged } from '../test-slot-attributes.actions';
 import { DateTime } from '../../../../shared/helpers/date-time';
 
 const testTime = new DateTime().toString();
 
 describe('testSlotAttributes reducer', () => {
+  const mockTestSlotAttributes: TestSlotAttributes = {
+    slotId: 1234,
+    specialNeeds: true,
+    start: testTime,
+    vehicleSlotType: 'B57mins',
+    extendedTest: true,
+    welshTest: null,
+  };
   it('should return the testSlotAttributes for populate test centre actions', () => {
-    const mockTestSlotAttributes: TestSlotAttributes = {
-      slotId: 1234,
-      specialNeeds: true,
-      start: testTime,
-      vehicleSlotType: 'B57mins',
-      extendedTest: true,
-      welshTest: true,
-    };
     const result = testSlotsAttributesReducer(null, new PopulateTestSlotAttributes(mockTestSlotAttributes));
-
     expect(result).toBe(mockTestSlotAttributes);
+  });
+  describe('[TestSlotAttributes] Welsh test changed', () => {
+    it('should set the isWelsh indicator to true when passing isWelsh payload as true', () => {
+      const isWelsh = true;
+      const action = new WelshTestChanged(isWelsh);
+      const result = testSlotsAttributesReducer(mockTestSlotAttributes, action);
+      expect(result.welshTest).toEqual(true);
+    });
+    it('should set the isWelsh indicator to false when passing isWelsh payload as false', () => {
+      const isWelsh = false;
+      const action = new WelshTestChanged(isWelsh);
+      const result = testSlotsAttributesReducer(mockTestSlotAttributes, action);
+      expect(result.welshTest).toEqual(false);
+    });
   });
 });

--- a/src/modules/tests/test-slot-attributes/test-slot-attributes.actions.ts
+++ b/src/modules/tests/test-slot-attributes/test-slot-attributes.actions.ts
@@ -2,11 +2,18 @@ import { Action } from '@ngrx/store';
 import { TestSlotAttributes } from '@dvsa/mes-test-schema/categories/B';
 
 export const POPULATE_TEST_SLOT_ATTRIBUTES = '[TestSlotAttributesEffects] Populate Test slot attributes';
+export const WELSH_TEST_CHANGED = '[TestSlotAttributes] Welsh test changed';
 
 export class PopulateTestSlotAttributes implements Action {
   readonly type = POPULATE_TEST_SLOT_ATTRIBUTES;
   constructor(public payload: TestSlotAttributes) {}
 }
 
+export class WelshTestChanged implements Action {
+  readonly type = WELSH_TEST_CHANGED;
+  constructor(public isWelsh: boolean) { }
+}
+
 export type Types =
-  | PopulateTestSlotAttributes;
+  | PopulateTestSlotAttributes
+  | WelshTestChanged;

--- a/src/modules/tests/test-slot-attributes/test-slot-attributes.reducer.ts
+++ b/src/modules/tests/test-slot-attributes/test-slot-attributes.reducer.ts
@@ -18,6 +18,11 @@ export function testSlotsAttributesReducer(
   switch (action.type) {
     case testSlotAttributesActions.POPULATE_TEST_SLOT_ATTRIBUTES:
       return action.payload;
+    case testSlotAttributesActions.WELSH_TEST_CHANGED:
+      return {
+        ...state,
+        welshTest: action.isWelsh,
+      };
   }
   return state;
 }

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -317,7 +317,7 @@ describe('OfficePage', () => {
   });
 
   describe('isWelshChanged', () => {
-    it('should', () => {
+    it('should dispatch a WelshTestChanged action', () => {
       const isWelsh = true;
       component.isWelshChanged(isWelsh);
       expect(store$.dispatch).toHaveBeenCalledWith(new WelshTestChanged(isWelsh));

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -46,6 +46,8 @@ import {
 } from '../components/termination-code/termination-code.constants';
 import { ActivityCodes } from '../../../shared/models/activity-codes';
 import { CompleteTest } from '../office.actions';
+import { WelshTestChanged } from '../../../modules/tests/test-slot-attributes/test-slot-attributes.actions';
+import { LanguagePreferencesComponent } from '../components/language-preference/language-preferences';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficePage>;
@@ -68,6 +70,7 @@ describe('OfficePage', () => {
         MockComponent(IndependentDrivingComponent),
         MockComponent(FaultCommentCardComponent),
         MockComponent(TerminationCodeComponent),
+        MockComponent(LanguagePreferencesComponent),
       ],
       imports: [
         IonicModule,
@@ -310,6 +313,14 @@ describe('OfficePage', () => {
     it('should call the popToRoot method in the navcontroller', () => {
       component.popToRoot();
       expect(navCtrl.popToRoot).toHaveBeenCalled();
+    });
+  });
+
+  describe('isWelshChanged', () => {
+    it('should', () => {
+      const isWelsh = true;
+      component.isWelshChanged(isWelsh);
+      expect(store$.dispatch).toHaveBeenCalledWith(new WelshTestChanged(isWelsh));
     });
   });
 });

--- a/src/pages/office/components/language-preference/__tests__/language-preferences.spec.ts
+++ b/src/pages/office/components/language-preference/__tests__/language-preferences.spec.ts
@@ -26,27 +26,20 @@ describe('LanguagePreferencesComponent', () => {
       });
   }));
 
-  describe('Class', () => {
-    it('should compile', () => {
-      expect(component).toBeDefined();
-      expect(component).not.toBeNull();
-    });
-  });
-
   describe('ngOnChanges', () => {
     it('should add the form control for the language preference radio', () => {
       component.ngOnChanges();
-      expect(component.formGroup.get('language-preferences')).not.toBeNull;
+      expect(component.formGroup.get('languagePreferences')).not.toBeNull;
     });
     it('should set the value of the validation to true if isWelsh is true', () => {
       component.isWelsh = true;
       component.ngOnChanges();
-      expect(component.formGroup.get('language-preferences').value).toEqual(true);
+      expect(component.formGroup.get('languagePreferences').value).toEqual(true);
     });
     it('should set the value of the validation to false if isWelsh is false', () => {
       component.isWelsh = false;
       component.ngOnChanges();
-      expect(component.formGroup.get('language-preferences').value).toEqual(false);
+      expect(component.formGroup.get('languagePreferences').value).toEqual(false);
     });
   });
 

--- a/src/pages/office/components/language-preference/__tests__/language-preferences.spec.ts
+++ b/src/pages/office/components/language-preference/__tests__/language-preferences.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { LanguagePreferencesComponent } from '../language-preferences';
+import { IonicModule } from 'ionic-angular';
+import { AppModule } from '../../../../../app/app.module';
+import { FormGroup } from '@angular/forms';
+
+describe('LanguagePreferencesComponent', () => {
+  let fixture: ComponentFixture<LanguagePreferencesComponent>;
+  let component: LanguagePreferencesComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        LanguagePreferencesComponent,
+      ],
+      imports: [
+        IonicModule,
+        AppModule,
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(LanguagePreferencesComponent);
+        component = fixture.componentInstance;
+        component.formGroup = new FormGroup({});
+      });
+  }));
+
+  describe('Class', () => {
+    it('should compile', () => {
+      expect(component).toBeDefined();
+      expect(component).not.toBeNull();
+    });
+  });
+
+  describe('ngOnChanges', () => {
+    it('should add the form control for the language preference radio', () => {
+      component.ngOnChanges();
+      expect(component.formGroup.get('language-preferences')).not.toBeNull;
+    });
+    it('should set the value of the validation to true if isWelsh is true', () => {
+      component.isWelsh = true;
+      component.ngOnChanges();
+      expect(component.formGroup.get('language-preferences').value).toEqual(true);
+    });
+    it('should set the value of the validation to false if isWelsh is false', () => {
+      component.isWelsh = false;
+      component.ngOnChanges();
+      expect(component.formGroup.get('language-preferences').value).toEqual(false);
+    });
+  });
+
+});

--- a/src/pages/office/components/language-preference/language-preferences.html
+++ b/src/pages/office/components/language-preference/language-preferences.html
@@ -7,14 +7,14 @@
       <ion-row class="spacing-row"></ion-row>
       <ion-row>
         <ion-col col-32>
-          <input type="radio" id="lang-pref-english" class="gds-radio-button" name="language-preferences"
-            formControlName="language-preferences" value=false [checked]="(isWelsh === false)"
+          <input type="radio" id="lang-pref-english" class="gds-radio-button" name="languagePreferences"
+            formControlName="languagePreferences" value=false [checked]="(isWelsh === false)"
             (change)="isWelshChanged($event.target.value)">
           <label for="lang-pref-english" class="radio-label">English</label>
         </ion-col>
         <ion-col col-32>
-          <input type="radio" id="lang-pref-welsh" class="gds-radio-button" name="language-preferences"
-            formControlName="language-preferences" [class.ng-invalid]="invalid" value=true
+          <input type="radio" id="lang-pref-welsh" class="gds-radio-button" name="languagePreferences"
+            formControlName="languagePreferences" [class.ng-invalid]="invalid" value=true
             [checked]="(isWelsh === true)" (change)="isWelshChanged($event.target.value)">
           <label for="lang-pref-welsh" class="radio-label">Cymraeg</label>
         </ion-col>

--- a/src/pages/office/components/language-preference/language-preferences.html
+++ b/src/pages/office/components/language-preference/language-preferences.html
@@ -1,0 +1,26 @@
+<ion-row class="mes-validated-row mes-row-separator" id="lang-pref-card" [formGroup]="formGroup">
+    <div class="validation-bar"></div>
+    <ion-col class="component-label" col-32 align-self-center>
+      <label>Test Language</label>
+    </ion-col>
+    <ion-col align-self-center>
+      <ion-row class="spacing-row"></ion-row>
+      <ion-row>
+        <ion-col col-32>
+          <input type="radio" id="lang-pref-english" class="gds-radio-button" name="language-preferences"
+            formControlName="language-preferences" value=false [checked]="(isWelsh === false)"
+            (change)="isWelshChanged($event.target.value)">
+          <label for="lang-pref-english" class="radio-label">English</label>
+        </ion-col>
+        <ion-col col-32>
+          <input type="radio" id="lang-pref-welsh" class="gds-radio-button" name="language-preferences"
+            formControlName="language-preferences" [class.ng-invalid]="invalid" value=true
+            [checked]="(isWelsh === true)" (change)="isWelshChanged($event.target.value)">
+          <label for="lang-pref-welsh" class="radio-label">Welsh</label>
+        </ion-col>
+      </ion-row>
+      <ion-row class="validation-message-row" align-items-center>
+        <div class="validation-text"></div>
+      </ion-row>
+    </ion-col>
+  </ion-row>

--- a/src/pages/office/components/language-preference/language-preferences.html
+++ b/src/pages/office/components/language-preference/language-preferences.html
@@ -1,7 +1,7 @@
 <ion-row class="mes-validated-row mes-row-separator" id="lang-pref-card" [formGroup]="formGroup">
     <div class="validation-bar"></div>
     <ion-col class="component-label" col-32 align-self-center>
-      <label>Test Language</label>
+      <label>Test language</label>
     </ion-col>
     <ion-col align-self-center>
       <ion-row class="spacing-row"></ion-row>
@@ -16,7 +16,7 @@
           <input type="radio" id="lang-pref-welsh" class="gds-radio-button" name="language-preferences"
             formControlName="language-preferences" [class.ng-invalid]="invalid" value=true
             [checked]="(isWelsh === true)" (change)="isWelshChanged($event.target.value)">
-          <label for="lang-pref-welsh" class="radio-label">Welsh</label>
+          <label for="lang-pref-welsh" class="radio-label">Cymraeg</label>
         </ion-col>
       </ion-row>
       <ion-row class="validation-message-row" align-items-center>

--- a/src/pages/office/components/language-preference/language-preferences.ts
+++ b/src/pages/office/components/language-preference/language-preferences.ts
@@ -17,7 +17,7 @@ export class LanguagePreferencesComponent implements OnChanges {
   welshChanged = new EventEmitter<boolean>();
 
   private formControl: FormControl;
-  private formField: string = 'language-preferences';
+  private formField: string = 'languagePreferences';
 
   ngOnChanges(): void {
     this.formControl = new FormControl('', Validators.required);

--- a/src/pages/office/components/language-preference/language-preferences.ts
+++ b/src/pages/office/components/language-preference/language-preferences.ts
@@ -1,0 +1,35 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'language-preferences',
+  templateUrl: 'language-preferences.html',
+})
+export class LanguagePreferencesComponent implements OnChanges {
+
+  @Input()
+  isWelsh: boolean;
+
+  @Input()
+  formGroup: FormGroup;
+
+  @Output()
+  welshChanged = new EventEmitter<boolean>();
+
+  private formControl: FormControl;
+  private formField: string = 'language-preferences';
+
+  ngOnChanges(): void {
+    this.formControl = new FormControl('', Validators.required);
+    this.formGroup.addControl(this.formField, this.formControl);
+    this.formGroup.get(this.formField).setValidators([Validators.required]);
+    this.formControl.patchValue(this.isWelsh);
+  }
+
+  isWelshChanged(isWelsh: boolean): void {
+    if (this.formControl.valid) {
+      this.welshChanged.emit(isWelsh);
+    }
+  }
+
+}

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -94,6 +94,9 @@
               [additionalInformation]="pageState.additionalInformation$ | async" [formGroup]="form"
               [outcome]="pageState.testOutcome$ | async"
               (additionalInformationChange)="additionalInformationChanged($event)"></additional-information>
+
+            <language-preferences [formGroup]="form" [isWelsh]="pageState.isWelshTest$ | async"
+              (welshChanged)="isWelshChanged($event)"></language-preferences>
           </div>
         </ion-grid>
       </ion-card-content>

--- a/src/pages/office/office.module.ts
+++ b/src/pages/office/office.module.ts
@@ -17,6 +17,7 @@ import { AdditionalInformationComponent } from './components/additional-informat
 import { IndependentDrivingComponent } from './components/independent-driving/independent-driving';
 import { OfficeEffects } from './office.effects';
 import { TerminationCodeComponent } from './components/termination-code/termination-code';
+import { LanguagePreferencesComponent } from './components/language-preference/language-preferences';
 
 @NgModule({
   declarations: [
@@ -31,6 +32,7 @@ import { TerminationCodeComponent } from './components/termination-code/terminat
     AdditionalInformationComponent,
     IndependentDrivingComponent,
     TerminationCodeComponent,
+    LanguagePreferencesComponent,
   ],
   imports: [
     IonicPageModule.forChild(OfficePage),

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -61,7 +61,7 @@ import {
 import { ShowMeQuestion } from '../../providers/question/show-me-question.model';
 import { QuestionProvider } from '../../providers/question/question';
 import { getTestSlotAttributes } from '../../modules/tests/test-slot-attributes/test-slot-attributes.reducer';
-import { getTestTime } from '../../modules/tests/test-slot-attributes/test-slot-attributes.selector';
+import { getTestTime, isWelshTest } from '../../modules/tests/test-slot-attributes/test-slot-attributes.selector';
 import {
   getETA,
   getETAFaultText,
@@ -98,6 +98,7 @@ import { MultiFaultAssignableCompetency, CommentedCompetency } from '../../share
 import { OutcomeBehaviourMapProvider } from '../../providers/outcome-behaviour-map/outcome-behaviour-map';
 import { behaviourMap } from './office-behaviour-map';
 import { TerminationCode, terminationCodeList } from './components/termination-code/termination-code.constants';
+import { WelshTestChanged } from '../../modules/tests/test-slot-attributes/test-slot-attributes.actions';
 
 interface OfficePageState {
   activityCode$: Observable<TerminationCode>;
@@ -142,6 +143,7 @@ interface OfficePageState {
   weatherConditions$: Observable<WeatherConditions[]>;
   dangerousFaults$: Observable<CommentedCompetency[]>;
   seriousFaults$: Observable<CommentedCompetency[]>;
+  isWelshTest$: Observable<boolean>;
 }
 
 @IonicPage()
@@ -428,6 +430,11 @@ export class OfficePage extends PracticeableBasePageComponent {
         select(getTestSummary),
         select(getWeatherConditions),
       ),
+      isWelshTest$: currentTest$.pipe(
+        select(getJournalData),
+        select(getTestSlotAttributes),
+        select(isWelshTest),
+      ),
     };
   }
 
@@ -498,6 +505,10 @@ export class OfficePage extends PracticeableBasePageComponent {
     this.store$.dispatch(
       new AddDangerousFaultComment(dangerousFaultComment.competencyIdentifier, dangerousFaultComment.comment),
     );
+  }
+
+  isWelshChanged(isWelsh: boolean) {
+    this.store$.dispatch(new WelshTestChanged(isWelsh));
   }
 
   seriousFaultCommentChanged(seriousFaultComment: CommentedCompetency) {


### PR DESCRIPTION
## Description and relevant Jira numbers
Adding the welsh and english radio buttons to the office page. They are pre-populated from the welshTest boolean and allow you to change it during the write up.
https://jira.i-env.net/browse/MES-2343

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

<img width="383" alt="Screenshot 2019-05-30 at 16 58 19" src="https://user-images.githubusercontent.com/47523567/58645907-283d8280-82fc-11e9-8228-e73a9bad283e.png">