### PR TITLE
reset outcome when choosing terminate after navigating back to test r…

### DIFF
--- a/mock/local-journal-non-test-activities.json
+++ b/mock/local-journal-non-test-activities.json
@@ -16,7 +16,7 @@
     {
       "slotDetail": {
         "slotId": 1000,
-        "start": "2019-06-07T09:00:00+01:00",
+        "start": "2019-06-10T09:00:00+01:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -29,7 +29,7 @@
     {
       "slotDetail": {
         "slotId": 1001,
-        "start": "2019-06-07T10:15:00+01:00",
+        "start": "2019-06-10T10:15:00+01:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -101,17 +101,17 @@
   "personalCommitments": [
     {
       "commitmentId": 123400,
-      "startDate": "2019-06-07",
+      "startDate": "2019-06-10",
       "startTime": "10:00:00+01:00",
-      "endDate": "2019-06-07",
+      "endDate": "2019-06-10",
       "endTime": "11:00:00+01:00",
       "activityCode": "104",
       "activityDescription": "Medical appointment"
     },
     {
       "commitmentId": 123401,
-      "startDate": "2019-06-14",
-      "endDate": "2019-06-14",
+      "startDate": "2019-06-17",
+      "endDate": "2019-06-17",
       "activityCode": "081",
       "activityDescription": "Annual Leave"
     }
@@ -120,7 +120,7 @@
     {
       "slotDetail": {
         "slotId": 1111,
-        "start": "2019-06-07T11:15:00+01:00",
+        "start": "2019-06-10T11:15:00+01:00",
         "duration": 57
       },
       "activityCode": "091",
@@ -134,7 +134,7 @@
     {
       "slotDetail": {
         "slotId": 1110,
-        "start": "2019-06-07T12:15:00+01:00",
+        "start": "2019-06-10T12:15:00+01:00",
         "duration": 57
       },
       "activityCode": "089",
@@ -148,7 +148,7 @@
     {
       "slotDetail": {
         "slotId": 1200,
-        "start": "2019-06-07T13:15:00+01:00",
+        "start": "2019-06-10T13:15:00+01:00",
         "duration": 57
       },
       "activityCode": "104",
@@ -164,7 +164,7 @@
     {
       "slotDetail": {
         "slotId": 1300,
-        "start": "2019-06-07T09:00:00+01:00",
+        "start": "2019-06-10T09:00:00+01:00",
         "duration": 90
       },
       "testCentre": {
@@ -177,7 +177,7 @@
     {
       "slotDetail": {
         "slotId": 1301,
-        "start": "2019-06-07T10:45:00+01:00",
+        "start": "2019-06-10T10:45:00+01:00",
         "duration": 90
       },
       "testCentre": {
@@ -190,7 +190,7 @@
     {
       "slotDetail": {
         "slotId": 1302,
-        "start": "2019-06-07T12:30:00+01:00",
+        "start": "2019-06-10T12:30:00+01:00",
         "duration": 90
       },
       "testCentre": {
@@ -209,7 +209,7 @@
         "centreName": "Example Test Centre 3",
         "costCode": "EXTC 3"
       },
-      "date": "2019-06-07"
+      "date": "2019-06-10"
     },
     {
       "deploymentId": 22222,
@@ -218,7 +218,7 @@
         "centreName": "Example Test Centre 4",
         "costCode": "EXTC 4"
       },
-      "date": "2019-06-07"
+      "date": "2019-06-10"
     }
   ]
 }

--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -48,7 +48,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1001,
-        "start": "2019-06-07T08:10:00+01:00"
+        "start": "2019-06-10T08:10:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -98,7 +98,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1003,
-        "start": "2019-06-07T10:14:00+01:00"
+        "start": "2019-06-10T10:14:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -148,7 +148,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1004,
-        "start": "2019-06-07T11:11:00+01:00"
+        "start": "2019-06-10T11:11:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -199,7 +199,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1005,
-        "start": "2019-06-07T12:38:00+01:00"
+        "start": "2019-06-10T12:38:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -252,7 +252,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1006,
-        "start": "2019-06-07T13:35:00+01:00"
+        "start": "2019-06-10T13:35:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -297,7 +297,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1007,
-        "start": "2019-06-08T14:32:00+01:00"
+        "start": "2019-06-11T14:32:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,

--- a/src/pages/test-report/test-report.ts
+++ b/src/pages/test-report/test-report.ts
@@ -25,6 +25,7 @@ import { ModalEvent } from './test-report.constants';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
 import { StatusBar } from '@ionic-native/status-bar';
+import { SetActivityCode } from '../../modules/tests/tests.actions';
 
 interface TestReportPageState {
   candidateUntitledName$: Observable<string>;
@@ -201,6 +202,7 @@ export class TestReportPage extends PracticeableBasePageComponent {
         this.navCtrl.push('DebriefPage');
         break;
       case ModalEvent.TERMINATE:
+        this.store$.dispatch(new SetActivityCode(null));
         this.navCtrl.push('DebriefPage');
         break;
     }


### PR DESCRIPTION
Fix bug where test outcome was not being reset when going back from the debrief page (on a test pass or fail) and then setting the test as terminated.
