### PR TITLE
Introducing category to the state

### DIFF
--- a/src/modules/tests/category/__tests__/category.reducer.spec.ts
+++ b/src/modules/tests/category/__tests__/category.reducer.spec.ts
@@ -1,0 +1,11 @@
+import { categoryReducer } from '../category.reducer';
+import { PopulateTestCategory } from '../category.actions';
+
+describe('category reducer', () => {
+  it('should return the test category for a test', () => {
+    const mockTestCategory: string = 'B';
+    const result = categoryReducer(null, new PopulateTestCategory(mockTestCategory));
+
+    expect(result).toBe(mockTestCategory);
+  });
+});

--- a/src/modules/tests/category/category.actions.ts
+++ b/src/modules/tests/category/category.actions.ts
@@ -1,0 +1,11 @@
+import { Action } from '@ngrx/store';
+
+export const POPULATE_TEST_CATEGORY = '[Journal Effects] populating test category';
+
+export class PopulateTestCategory implements Action {
+  readonly type = POPULATE_TEST_CATEGORY;
+  constructor(public payload: string) {}
+}
+
+export type Types =
+  | PopulateTestCategory;

--- a/src/modules/tests/category/category.reducer.ts
+++ b/src/modules/tests/category/category.reducer.ts
@@ -1,0 +1,18 @@
+import  * as categoryActions from './category.actions';
+import { createFeatureSelector } from '@ngrx/store';
+
+export const initialState: string = '';
+
+export const categoryReducer = (
+  state = initialState,
+  action: categoryActions.Types,
+): string => {
+  switch (action.type) {
+    case categoryActions.POPULATE_TEST_CATEGORY:
+      return action.payload;
+    default:
+      return state;
+  }
+};
+
+export const getTestCategory = createFeatureSelector<string>('category');

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -25,6 +25,7 @@ import { applicationReferenceReducer } from './application-reference/application
 import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
 import * as fakeJournalActions from '../../pages/fake-journal/fake-journal.actions';
 import { testReportPracticeSlotId } from '../../shared/mocks/test-slot-ids.mock';
+import { categoryReducer } from './category/category.reducer';
 
 export const initialState: TestsModel = {
   currentTest: { slotId: null },
@@ -93,6 +94,7 @@ const createStateObject = (state: TestsModel, action: Action, slotId: string) =>
         // slotId to the relevant sub-reducer
         ...nestedCombineReducers(
           {
+            category: categoryReducer,
             journalData:  {
               examiner: examinerReducer,
               testCentre: testCentreReducer,

--- a/src/pages/journal/journal.effects.ts
+++ b/src/pages/journal/journal.effects.ts
@@ -36,6 +36,7 @@ import { PopulateTestCentre } from '../../modules/tests/test-centre/test-centre.
 import { SetTestStatusBooked } from '../../modules/tests/test-status/test-status.actions';
 import { extractTestSlotAttributes } from '../../modules/tests/test-slot-attributes/test-slot-attributes.selector';
 import { PopulateExaminer } from '../../modules/tests/examiner/examiner.actions';
+import { PopulateTestCategory } from '../../modules/tests/category/category.actions';
 
 @Injectable()
 export class JournalEffects {
@@ -195,6 +196,7 @@ export class JournalEffects {
         new PopulateTestSlotAttributes(extractTestSlotAttributes(slot.slotData)),
         new PopulateTestCentre(this.extractTestCentre(slot.slotData)),
         new SetTestStatusBooked(startTestAction.slotId.toString()),
+        new PopulateTestCategory(slot.slotData.booking.application.testCategory),
       ];
     }),
   );


### PR DESCRIPTION
## Description and relevant Jira numbers
- Reducer and action created to store `category` in the state.

Pre-change cloudwatch log
<img width="1213" alt="Screenshot 2019-06-14 at 12 56 29" src="https://user-images.githubusercontent.com/30832405/59507767-ed168400-8ea3-11e9-8f7e-e69b2769e04c.png">

Post change cloudwatch log
<img width="1213" alt="Screenshot 2019-06-14 at 12 55 34" src="https://user-images.githubusercontent.com/30832405/59507709-bf313f80-8ea3-11e9-8e9f-a834ab14e94c.png">

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
