### PR TITLE
Adding a default value of false for special needs in reducer. Adding …

### DIFF
--- a/src/modules/tests/test-slot-attributes/test-slot-attributes.reducer.ts
+++ b/src/modules/tests/test-slot-attributes/test-slot-attributes.reducer.ts
@@ -8,7 +8,7 @@ export const initialState:TestSlotAttributes = {
   start: '',
   vehicleSlotType: '',
   extendedTest: false,
-  specialNeeds: null,
+  specialNeeds: false,
 };
 
 export function testSlotsAttributesReducer(

--- a/src/modules/tests/test-slot-attributes/test-slot-attributes.selector.ts
+++ b/src/modules/tests/test-slot-attributes/test-slot-attributes.selector.ts
@@ -4,14 +4,14 @@ import { DateTime } from '../../../shared/helpers/date-time';
 export const getTestTime = (attributes: TestSlotAttributes) => DateTime.at(attributes.start).format('HH:mm');
 export const getVehicleSlotType = (attributes: TestSlotAttributes) => attributes.vehicleSlotType || '';
 export const isExtendedTest = (attributes: TestSlotAttributes) => attributes.extendedTest || false;
-export const isSpecialNeeds = (attributes: TestSlotAttributes) => attributes.specialNeeds || '';
+export const isSpecialNeeds = (attributes: TestSlotAttributes) => attributes.specialNeeds || false;
 export const getSlotId = (attributes: TestSlotAttributes) =>  attributes.slotId;
 export const isWelshTest = (attributes: TestSlotAttributes) => attributes.welshTest;
 export const extractTestSlotAttributes = (slotData): TestSlotAttributes => ({
   welshTest: slotData.booking.application.welshTest,
   slotId: slotData.slotDetail.slotId,
   start: slotData.slotDetail.start,
-  specialNeeds: slotData.booking.application.specialNeeds,
+  specialNeeds: slotData.booking.application.specialNeeds ? true : false,
   vehicleSlotType: slotData.vehicleSlotType,
   extendedTest: slotData.booking.application.extendedTest,
 });

--- a/src/pages/journal/journal.effects.ts
+++ b/src/pages/journal/journal.effects.ts
@@ -188,8 +188,6 @@ export class JournalEffects {
       const startTestAction = action as journalActions.StartTest;
 
       const slot = slots.find(slot => slot.slotData.slotDetail.slotId === startTestAction.slotId);
-      // tslint:disable-next-line:max-line-length
-      console.log(`Properties of slotDetail ${Object.getOwnPropertyNames(slot.slotData.booking.application)}`);
       return [
         new PopulateExaminer({ staffNumber: this.authProvider.getEmployeeId() }),
         new PopulateApplicationReference(slot.slotData.booking.application),

--- a/src/pages/journal/journal.effects.ts
+++ b/src/pages/journal/journal.effects.ts
@@ -188,7 +188,8 @@ export class JournalEffects {
       const startTestAction = action as journalActions.StartTest;
 
       const slot = slots.find(slot => slot.slotData.slotDetail.slotId === startTestAction.slotId);
-
+      // tslint:disable-next-line:max-line-length
+      console.log(`Properties of slotDetail ${Object.getOwnPropertyNames(slot.slotData.booking.application)}`);
       return [
         new PopulateExaminer({ staffNumber: this.authProvider.getEmployeeId() }),
         new PopulateApplicationReference(slot.slotData.booking.application),

--- a/src/pages/journal/journal.effects.ts
+++ b/src/pages/journal/journal.effects.ts
@@ -188,6 +188,7 @@ export class JournalEffects {
       const startTestAction = action as journalActions.StartTest;
 
       const slot = slots.find(slot => slot.slotData.slotDetail.slotId === startTestAction.slotId);
+
       return [
         new PopulateExaminer({ staffNumber: this.authProvider.getEmployeeId() }),
         new PopulateApplicationReference(slot.slotData.booking.application),


### PR DESCRIPTION
…a ternary operator to initialize specialNeeds (bool)

## Description and relevant Jira numbers
- ```specialNeeds``` was not being propagated through to MES backend. We now have a default value for ```specialNeeds``` and the ability to change it through the ```extractTestSlotAttributes``` function.

Pre-change cloudwatch log:
<img width="1191" alt="Screenshot 2019-06-14 at 16 02 44" src="https://user-images.githubusercontent.com/30832405/59518651-fad90300-8ebd-11e9-99ea-7a49200bc2cb.png">


Post-change cloudwatch log:
<img width="1191" alt="Screenshot 2019-06-14 at 15 55 21" src="https://user-images.githubusercontent.com/30832405/59518529-b51c3a80-8ebd-11e9-8760-7fa0589b2e05.png">

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
