### PR TITLE
Mes 2571 format address bug

### DIFF
--- a/src/pages/communication-page/components/postal-address/__tests__/postal-address.spec.ts
+++ b/src/pages/communication-page/components/postal-address/__tests__/postal-address.spec.ts
@@ -105,6 +105,8 @@ describe('PostalAddressComponent', () => {
   describe('DOM', () => {
 
     it('should display the correct address fields when address populated', () => {
+      component.isPostalAddressChosen = true;
+      component.postalAddress = mockAddress;
       fixture.whenStable().then(() => {
         fixture.detectChanges();
         expect(fixture.debugElement.query(By.css('#addressLine1'))).not.toBeNull();
@@ -117,6 +119,7 @@ describe('PostalAddressComponent', () => {
     });
 
     it('should display the no address fields when address is empty', () => {
+      component.isPostalAddressChosen = true;
       component.postalAddress = null;
       fixture.whenStable().then(() => {
         fixture.detectChanges();

--- a/src/pages/communication-page/components/postal-address/postal-address.ts
+++ b/src/pages/communication-page/components/postal-address/postal-address.ts
@@ -32,7 +32,7 @@ export class PostalAddressComponent {
 
   formatAddress(address: Address): Address {
     const regex = new RegExp('[0-9]', 'g');
-    const formattedAddress: Address = address;
+    const formattedAddress: Address = Object.assign({}, address);
     Object.keys(formattedAddress).forEach(res => formattedAddress[res] = formattedAddress[res].replace(regex, 'x'));
     return formattedAddress;
   }


### PR DESCRIPTION
## Description and relevant Jira numbers

~Fixed a bug where the postal address was being formatted in by referencing the state rather than a separate object.
https://jira.i-env.net/browse/MES-2571

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
