### PR TITLE
Add right padding to labels

### DIFF
--- a/src/theme/sass-partials/_row.scss
+++ b/src/theme/sass-partials/_row.scss
@@ -20,6 +20,7 @@
   }
   .component-label {
     padding-left: 32px;
+    padding-right: 16px;
   }
   .spacing-row,
   .validation-message-row {


### PR DESCRIPTION
## Description and relevant Jira numbers

Add padding to labels on debrief page. See screenshots.

### Screenshots

### Before

<img width="666" alt="Screenshot 2019-06-20 at 13 30 28" src="https://user-images.githubusercontent.com/44976690/59853104-1f265b00-9368-11e9-8e53-c7fb1ffe6efb.png">

### After

<img width="663" alt="Screenshot 2019-06-20 at 13 35 21" src="https://user-images.githubusercontent.com/44976690/59853118-251c3c00-9368-11e9-9fc7-2cf5736c84a5.png">

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
