### PR TITLE
Mes 2179 addition of full journey ui tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "test:jasmine-ci": "karma start ./test-config/karma.conf.js --single-run",
     "test:jasmine-coverage": "karma start ./test-config/karma.conf.js --coverage",
     "test:e2e-simulator-bdd": "protractor e2e-simulator-bdd.conf.js",
+    "test:e2e-simulator-bdd-smoke": "protractor e2e-simulator-bdd.conf.js --cucumberOpts.tags='@smoke'",
+    "test:e2e-simulator-bdd-extended": "protractor e2e-simulator-bdd.conf.js --specs='test/e2e/extended/*.feature'",
     "test:generate-report": "node generateTestReport.js",
     "gitSecrets": "git secrets --scan",
     "scanRepo": "git log -p -n 15 | scanrepo",

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -17,7 +17,7 @@
     <ion-col col-36 class="align-col-right">
       <h2>{{pageState.startTime$ | async}}</h2>
       <h3>test outcome:
-        <span
+        <span id="office-page-test-outcome"
           [ngClass]="(pageState.isPassed$ | async) ? 'mes-green' : 'mes-red'">{{pageState.testOutcomeText$ | async}}</span>
       </h3>
     </ion-col>

--- a/test/e2e/extended/cat-b-scenarios.feature
+++ b/test/e2e/extended/cat-b-scenarios.feature
@@ -106,6 +106,54 @@ Feature: Extended category B test scenarios
       And I upload the test
       Then I should see the "Journal" page
 
+   Scenario: Candidate passes a test with 15 driver faults
+      Given I am logged in as "mobexaminer1" and I have a test for "Mrs Jane Doe"
+      When I start the test for "Mrs Jane Doe"
+      And the candidate enters a new email address
+      And the candidate confirms their communication preference
+      Then I should see the "Declaration - Jane Doe" page
+      And the candidate completes the declaration page
+      And I proceed to the car
+      Then I should see the "Jane Doe" page
+      And I complete the waiting room to car page
+      Then I should see the "Test report - Jane Doe" page
+      When I add a "Accelerator" driver fault
+      And I add a "Safety" driver fault
+      And I add a "Safety" driver fault
+      And I add a "Lane discipline" driver fault
+      And I add a "Accelerator" driver fault
+      And I add a "Safety" driver fault
+      And I add a "Lane discipline" driver fault
+      And I add a "Lane discipline" driver fault
+      And I add a "Approach speed" driver fault
+      And I add a "Approach speed" driver fault
+      And I add a "Signalling" driver fault
+      And I add a "Timed" driver fault
+      And I add a "Clearance" driver fault
+      And I add a "Signalling" driver fault
+      And I add a "Signalling" driver fault
+      Then the driver fault count is "15"
+      When I complete the test
+      And I continue to debrief
+      Then I should see the Debrief page with outcome "Passed"
+      And I see a "driving" fault for "Use of mirrors - Signalling"
+      And I see a "driving" fault for "Move off - Safety"
+      And I see a "driving" fault for "Positioning - Lane discipline"
+      And I see a "driving" fault for "Controls - Accelerator"
+      And I see a "driving" fault for "Junctions - Approach speed"
+      And I see a "driving" fault for "Signals - Timed"
+      And I see a "driving" fault for "Clearance"
+      When I end the debrief
+      Then I should see the "Test debrief - Jane Doe" page
+      And I complete the pass details
+      And I complete the health declaration
+      Then I am on the back to office page
+      And I continue to the office write up
+      Then I should see the "Office" page
+      And I complete the office write up
+      And I upload the test
+      Then I should see the "Journal" page
+
    # This will fail until MES-2673 is fixed
    Scenario: Candidate fails a test with a dangerous and 16 driver faults
       Given I am logged in as "mobexaminer1" and I have a test for "Miss Theresa Shaw"

--- a/test/e2e/extended/cat-b-scenarios.feature
+++ b/test/e2e/extended/cat-b-scenarios.feature
@@ -98,11 +98,10 @@ Feature: Extended category B test scenarios
       Then I am on the back to office page
       And I continue to the office write up
       Then I should see the "Office" page
+      And the office page test outcome is "Terminated"
       When I select activity code "4 - Fail in the interests of public safety"
-      # test outcome is Unsuccessful
-      # Independent driving N/A available
-      # Show me question N/A - Not applicable
-      And I complete the office write up
+      Then the office page test outcome is "Unsuccessful"
+      When I complete the office write up with Not applicable to independent driving and show me question
       And I enter a comment for "dangerous" fault "Use of speed"
       And I upload the test
       Then I should see the "Journal" page

--- a/test/e2e/extended/cat-b-scenarios.feature
+++ b/test/e2e/extended/cat-b-scenarios.feature
@@ -1,0 +1,151 @@
+Feature: Extended category B test scenarios
+
+   Scenario: Examiner completes a passed test with driver faults
+      Given I am logged in as "mobexaminer1" and I have a test for "Miss Florence Pearson"
+      When I start the test for "Miss Florence Pearson"
+      And the candidate enters a new email address
+      And the candidate confirms their communication preference
+      Then I should see the "Declaration - Florence Pearson" page
+      And the candidate completes the declaration page
+      And I proceed to the car
+      Then I should see the "Florence Pearson" page
+      And I complete the waiting room to car page
+      Then I should see the "Test report - Florence Pearson" page
+      When I add a "Accelerator" driver fault
+      And I add a "Timed" driver fault
+      And I add a "Clearance" driver fault
+      And I add a "Signalling" driver fault
+      And I add a "Timed" driver fault
+      Then the driver fault count is "5"
+      And I complete the test
+      And I continue to debrief
+      Then I should see the Debrief page with outcome "Passed"
+      When I end the debrief
+      Then I should see the "Test debrief - Florence Pearson" page
+      And I complete the pass details
+      And I complete the health declaration
+      Then I am on the back to office page
+      And I continue to the office write up
+      Then I should see the "Office" page
+      And I complete the office write up
+      And I upload the test
+      Then I should see the "Journal" page
+
+   Scenario: Candidate fails a test with a single dangerous fault
+      Given I am logged in as "mobexaminer1" and I have a test for "Mr Ali Campbell"
+      When I start the test for "Mr Ali Campbell"
+      And the candidate requests to receive results by post
+      And the candidate confirms their communication preference
+      Then I should see the "Declaration - Ali Campbell" page
+      And the candidate completes the declaration page
+      And I proceed to the car
+      Then I should see the "Ali Campbell" page
+      And I complete the waiting room to car page
+      Then I should see the "Test report - Ali Campbell" page
+      When I add a "Use of speed" dangerous fault
+      And I add a "Safety" driver fault
+      And I add a "Lane discipline" driver fault
+      When I complete the test
+      And I continue to debrief
+      Then I should see the Debrief page with outcome "Unsuccessful"
+      When I end the debrief
+      Then I am on the back to office page
+      And I continue to the office write up
+      Then I should see the "Office" page
+      And I complete the office write up
+      And I enter a comment for "dangerous" fault "Use of speed"
+      And I upload the test
+      Then I should see the "Journal" page
+
+   Scenario: Candidate fails a test with a single serious fault
+      When I start the test for "Mrs Jane Doe"
+      And the candidate confirms their communication preference
+      Then I should see the "Declaration - Jane Doe" page
+      And the candidate completes the declaration page
+      And I proceed to the car
+      Then I should see the "Jane Doe" page
+      And I complete the waiting room to car page with a tell me driver fault
+      Then I should see the "Test report - Jane Doe" page
+      When I add a "Accelerator" serious fault
+      When I complete the test
+      And I continue to debrief
+      Then I should see the Debrief page with outcome "Unsuccessful"
+      When I end the debrief
+      Then I am on the back to office page
+      And I continue to the office write up
+      Then I should see the "Office" page
+      And I complete the office write up
+      And I enter a comment for "serious" fault "Controls - Accelerator"
+      And I upload the test
+      Then I should see the "Journal" page
+
+   Scenario: Examiner terminates the test in the interests of public safety
+      Given I am logged in as "mobexaminer1" and I have a test for "Mr James Brown"
+      When I start the test for "Mr James Brown"
+      And the candidate enters a new email address
+      And the candidate confirms their communication preference
+      Then I should see the "Declaration - James Brown" page
+      And the candidate completes the declaration page
+      And I proceed to the car
+      Then I should see the "James Brown" page
+      And I complete the waiting room to car page
+      Then I should see the "Test report - James Brown" page
+      When I add a "Use of speed" dangerous fault
+      And I end and terminate the test
+      Then I should see the Debrief page with outcome "Terminated"
+      And I see a "dangerous" fault for "Use of speed"
+      When I end the debrief
+      Then I am on the back to office page
+      And I continue to the office write up
+      Then I should see the "Office" page
+      When I select activity code "4 - Fail in the interests of public safety"
+      # test outcome is Unsuccessful
+      # Independent driving N/A available
+      # Show me question N/A - Not applicable
+      And I complete the office write up
+      And I enter a comment for "dangerous" fault "Use of speed"
+      And I upload the test
+      Then I should see the "Journal" page
+
+   # This will fail until MES-2673 is fixed
+   Scenario: Candidate fails a test with a dangerous and 16 driver faults
+      Given I am logged in as "mobexaminer1" and I have a test for "Miss Theresa Shaw"
+      When I start the test for "Miss Theresa Shaw"
+      Then I should see the "Declaration - Theresa Shaw" page
+      And the candidate requests to receive results by post
+      And the candidate confirms their communication preference
+      Then I should see the "Declaration - Theresa Shaw" page
+      And the candidate completes the declaration page
+      And I proceed to the car
+      Then I should see the "Theresa Shaw" page
+      And I complete the waiting room to car page
+      Then I should see the "Test report - Theresa Shaw" page
+      When I add a "Accelerator" driver fault
+      And I add a "Safety" driver fault
+      And I add a "Safety" driver fault
+      And I add a "Lane discipline" driver fault
+      And I add a "Accelerator" driver fault
+      And I add a "Safety" driver fault
+      And I add a "Lane discipline" driver fault
+      And I add a "Lane discipline" driver fault
+      And I add a "Approach speed" driver fault
+      And I add a "Approach speed" driver fault
+      And I add a "Signalling" driver fault
+      And I add a "Timed" driver fault
+      And I add a "Clearance" driver fault
+      And I add a "Signalling" driver fault
+      And I add a "Signalling" driver fault
+      And I add a "Signalling" driver fault
+      And I add a "Use of speed" dangerous fault
+      Then the driver fault count is "16"
+      When I complete the test
+      And I continue to debrief
+      Then I should see the Debrief page with outcome "Unsuccessful"
+      When I end the debrief
+      Then I am on the back to office page
+      And I continue to the office write up
+      Then I should see the "Office" page
+      And I complete the office write up
+      And I enter a comment for "dangerous" fault "Use of speed"
+      And I upload the test
+      Then I should see the "Journal" page

--- a/test/e2e/features/99-fulljourney.feature
+++ b/test/e2e/features/99-fulljourney.feature
@@ -104,8 +104,11 @@ Feature: Full end to end journey
       When I end the test
       And I continue to debrief
       Then I should see the Debrief page with outcome "Unsuccessful"
+      And I see a "dangerous" fault for "Use of speed"
+      And I see a "serious" fault for "Controls - Accelerator"
 
       When I end the debrief
+
       Then I am on the back to office page
       And I continue to the office write up
       Then I should see the "Office" page
@@ -201,6 +204,13 @@ Feature: Full end to end journey
       When I complete the test
       And I continue to debrief
       Then I should see the Debrief page with outcome "Passed"
+      And I see a "driving" fault for "Use of mirrors - Signalling"
+      And I see a "driving" fault for "Move off - Safety"
+      And I see a "driving" fault for "Positioning - Lane discipline"
+      And I see a "driving" fault for "Controls - Accelerator"
+      And I see a "driving" fault for "Junctions - Approach speed"
+      And I see a "driving" fault for "Signals - Timed"
+      And I see a "driving" fault for "Clearance"
       When I end the debrief
       Then I should see the "Test debrief - Jane Doe" page
       And I complete the pass details
@@ -243,6 +253,13 @@ Feature: Full end to end journey
       When I complete the test
       And I continue to debrief
       Then I should see the Debrief page with outcome "Unsuccessful"
+      And I see a "driving" fault for "Use of mirrors - Signalling"
+      And I see a "driving" fault for "Move off - Safety"
+      And I see a "driving" fault for "Positioning - Lane discipline"
+      And I see a "driving" fault for "Controls - Accelerator"
+      And I see a "driving" fault for "Junctions - Approach speed"
+      And I see a "driving" fault for "Signals - Timed"
+      And I see a "driving" fault for "Clearance"
       When I end the debrief
       Then I am on the back to office page
       And I continue to the office write up

--- a/test/e2e/features/99-fulljourney.feature
+++ b/test/e2e/features/99-fulljourney.feature
@@ -25,6 +25,7 @@ Feature: Full end to end journey
       And I upload the test
       Then I should see the "Journal" page
 
+   @wip
    Scenario: Examiner completes a failed test with various faults
       Given I am logged in as "mobexaminer1" and I have a test for "Mrs Jane Doe"
 
@@ -106,6 +107,11 @@ Feature: Full end to end journey
       Then I should see the Debrief page with outcome "Unsuccessful"
       And I see a "dangerous" fault for "Use of speed"
       And I see a "serious" fault for "Controls - Accelerator"
+      And I see a "driving" fault for "Move off - Safety"
+      And I see a "driving" fault for "Controls - Accelerator"
+      And I see a "driving" fault for "Reverse right"
+      And I see a "driving" fault for "Controlled stop"
+      And I see a "driving" fault for "Vehicle checks"
 
       When I end the debrief
 

--- a/test/e2e/features/99-fulljourney.feature
+++ b/test/e2e/features/99-fulljourney.feature
@@ -25,7 +25,6 @@ Feature: Full end to end journey
       And I upload the test
       Then I should see the "Journal" page
 
-   @wip
    Scenario: Examiner completes a failed test with various faults
       Given I am logged in as "mobexaminer1" and I have a test for "Mrs Jane Doe"
 

--- a/test/e2e/features/99-fulljourney.feature
+++ b/test/e2e/features/99-fulljourney.feature
@@ -113,7 +113,6 @@ Feature: Full end to end journey
       And I see a "driving" fault for "Vehicle checks"
 
       When I end the debrief
-
       Then I am on the back to office page
       And I continue to the office write up
       Then I should see the "Office" page
@@ -176,54 +175,6 @@ Feature: Full end to end journey
       When I enter a candidate description
       And I complete the debrief witnessed
       And I complete the weather conditions
-      And I upload the test
-      Then I should see the "Journal" page
-
-   Scenario: Candidate passes a test with 15 driver faults
-      Given I am logged in as "mobexaminer1" and I have a test for "Mrs Jane Doe"
-      When I start the test for "Mrs Jane Doe"
-      And the candidate enters a new email address
-      And the candidate confirms their communication preference
-      Then I should see the "Declaration - Jane Doe" page
-      And the candidate completes the declaration page
-      And I proceed to the car
-      Then I should see the "Jane Doe" page
-      And I complete the waiting room to car page
-      Then I should see the "Test report - Jane Doe" page
-      When I add a "Accelerator" driver fault
-      And I add a "Safety" driver fault
-      And I add a "Safety" driver fault
-      And I add a "Lane discipline" driver fault
-      And I add a "Accelerator" driver fault
-      And I add a "Safety" driver fault
-      And I add a "Lane discipline" driver fault
-      And I add a "Lane discipline" driver fault
-      And I add a "Approach speed" driver fault
-      And I add a "Approach speed" driver fault
-      And I add a "Signalling" driver fault
-      And I add a "Timed" driver fault
-      And I add a "Clearance" driver fault
-      And I add a "Signalling" driver fault
-      And I add a "Signalling" driver fault
-      Then the driver fault count is "15"
-      When I complete the test
-      And I continue to debrief
-      Then I should see the Debrief page with outcome "Passed"
-      And I see a "driving" fault for "Use of mirrors - Signalling"
-      And I see a "driving" fault for "Move off - Safety"
-      And I see a "driving" fault for "Positioning - Lane discipline"
-      And I see a "driving" fault for "Controls - Accelerator"
-      And I see a "driving" fault for "Junctions - Approach speed"
-      And I see a "driving" fault for "Signals - Timed"
-      And I see a "driving" fault for "Clearance"
-      When I end the debrief
-      Then I should see the "Test debrief - Jane Doe" page
-      And I complete the pass details
-      And I complete the health declaration
-      Then I am on the back to office page
-      And I continue to the office write up
-      Then I should see the "Office" page
-      And I complete the office write up
       And I upload the test
       Then I should see the "Journal" page
 

--- a/test/e2e/features/99-fulljourney.feature
+++ b/test/e2e/features/99-fulljourney.feature
@@ -170,3 +170,90 @@ Feature: Full end to end journey
       And I complete the weather conditions
       And I upload the test
       Then I should see the "Journal" page
+
+   Scenario: Candidate passes a test with 15 driver faults
+      Given I am logged in as "mobexaminer1" and I have a test for "Mrs Jane Doe"
+      When I start the test for "Mrs Jane Doe"
+      And the candidate enters a new email address
+      And the candidate confirms their communication preference
+      Then I should see the "Declaration - Jane Doe" page
+      And the candidate completes the declaration page
+      And I proceed to the car
+      Then I should see the "Jane Doe" page
+      And I complete the waiting room to car page
+      Then I should see the "Test report - Jane Doe" page
+      When I add a "Accelerator" driver fault
+      And I add a "Safety" driver fault
+      And I add a "Safety" driver fault
+      And I add a "Lane discipline" driver fault
+      And I add a "Accelerator" driver fault
+      And I add a "Safety" driver fault
+      And I add a "Lane discipline" driver fault
+      And I add a "Lane discipline" driver fault
+      And I add a "Approach speed" driver fault
+      And I add a "Approach speed" driver fault
+      And I add a "Signalling" driver fault
+      And I add a "Timed" driver fault
+      And I add a "Clearance" driver fault
+      And I add a "Signalling" driver fault
+      And I add a "Signalling" driver fault
+      Then the driver fault count is "15"
+      When I complete the test
+      And I continue to debrief
+      Then I should see the Debrief page with outcome "Passed"
+      When I end the debrief
+      Then I should see the "Test debrief - Jane Doe" page
+      And I complete the pass details
+      And I complete the health declaration
+      Then I am on the back to office page
+      And I continue to the office write up
+      Then I should see the "Office" page
+      And I complete the office write up
+      And I upload the test
+      Then I should see the "Journal" page
+
+   Scenario: Candidate fails a test with 16 driver faults
+      Given I am logged in as "mobexaminer1" and I have a test for "Miss Florence Pearson"
+      When I start the test for "Miss Florence Pearson"
+      And the candidate enters a new email address
+      And the candidate confirms their communication preference
+      Then I should see the "Declaration - Florence Pearson" page
+      And the candidate completes the declaration page
+      And I proceed to the car
+      Then I should see the "Florence Pearson" page
+      And I complete the waiting room to car page
+      Then I should see the "Test report - Florence Pearson" page
+      When I add a "Accelerator" driver fault
+      And I add a "Safety" driver fault
+      And I add a "Safety" driver fault
+      And I add a "Lane discipline" driver fault
+      And I add a "Accelerator" driver fault
+      And I add a "Safety" driver fault
+      And I add a "Lane discipline" driver fault
+      And I add a "Lane discipline" driver fault
+      And I add a "Approach speed" driver fault
+      And I add a "Approach speed" driver fault
+      And I add a "Signalling" driver fault
+      And I add a "Timed" driver fault
+      And I add a "Clearance" driver fault
+      And I add a "Signalling" driver fault
+      And I add a "Signalling" driver fault
+      And I add a "Signalling" driver fault
+      Then the driver fault count is "16"
+      When I complete the test
+      And I continue to debrief
+      Then I should see the Debrief page with outcome "Unsuccessful"
+      When I end the debrief
+      Then I am on the back to office page
+      And I continue to the office write up
+      Then I should see the "Office" page
+      And I complete the office write up
+      And I enter a comment for "driving" fault "Use of mirrors - Signalling"
+      And I enter a comment for "driving" fault "Move off - Safety"
+      And I enter a comment for "driving" fault "Positioning - Lane discipline"
+      And I enter a comment for "driving" fault "Controls - Accelerator"
+      And I enter a comment for "driving" fault "Junctions - Approach speed"
+      And I enter a comment for "driving" fault "Signals - Timed"
+      And I enter a comment for "driving" fault "Clearance"
+      And I upload the test
+      Then I should see the "Journal" page

--- a/test/e2e/step-definitions/debrief-steps.ts
+++ b/test/e2e/step-definitions/debrief-steps.ts
@@ -35,6 +35,12 @@ Then('I should see the Debrief page with outcome {string}', (outcome) => {
   return expect(testOutcome.getText()).to.eventually.equal(outcome);
 });
 
+Then('I see a {string} fault for {string}', (faultSeverity, faultDescription) => {
+  const faultElement = getElement(by.xpath(`//ion-card[@id = '${faultSeverity}-fault']
+  //div[text() = '${faultDescription}']`));
+  return expect(faultElement.isPresent()).to.eventually.be.true;
+});
+
 const continuePassFinalisation = () => {
   const continueButton = getElement(by.xpath('//page-pass-finalisation//button[span[h3[text() = "Continue"]]]'));
   clickElement(continueButton);

--- a/test/e2e/step-definitions/generic-steps.ts
+++ b/test/e2e/step-definitions/generic-steps.ts
@@ -236,7 +236,7 @@ export const logout = () => {
  * @param fieldElement the element to click
  */
 export const clickElement = (fieldElement) => {
-  browser.wait(ExpectedConditions.presenceOf(fieldElement));
+  browser.wait(ExpectedConditions.elementToBeClickable(fieldElement));
   fieldElement.click().then((promise) => {
     return isReady(promise);
   });

--- a/test/e2e/step-definitions/generic-steps.ts
+++ b/test/e2e/step-definitions/generic-steps.ts
@@ -218,6 +218,7 @@ export const logout = () => {
   const logout = element(by.xpath('//button/span/span[contains(text(), "Logout")]'));
   logout.isPresent().then((result) => {
     if (result) {
+      browser.wait(ExpectedConditions.elementToBeClickable(logout));
       logout.click().then(() => {
         // After logout click sign in to get us to the login screen
         browser.sleep(TEST_CONFIG.ACTION_WAIT);

--- a/test/e2e/step-definitions/office-steps.ts
+++ b/test/e2e/step-definitions/office-steps.ts
@@ -9,10 +9,20 @@ const expect = chai.expect;
 
 When('I complete the office write up', () => {
   enterRouteNumber('2');
-  enterIndependentDriving();
+  enterIndependentDriving('satnav');
   enterCandidateDescription();
   enterDebriefWitnessed();
-  enterShowMe();
+  enterShowMe('S5 - Horn');
+  enterWeatherConditions();
+  enterD255();
+});
+
+When('I complete the office write up with Not applicable to independent driving and show me question', () => {
+  enterRouteNumber('4');
+  enterIndependentDriving('na');
+  enterCandidateDescription();
+  enterDebriefWitnessed();
+  enterShowMe('N/A - Not applicable');
   enterWeatherConditions();
   enterD255();
 });
@@ -73,6 +83,11 @@ Then('the tell me question should be {string}', (tellMeQuestion : string) => {
   return expect(tellMeQuestionField.getText()).to.eventually.equal(tellMeQuestion);
 });
 
+Then('the office page test outcome is {string}', (testOutcome : string) => {
+  const testOutcomeField = getElement(by.id('office-page-test-outcome'));
+  return expect(testOutcomeField.getText()).to.eventually.equal(testOutcome);
+});
+
 const clickUploadButton = () => {
   const submitTestButton = getElement(by.xpath('//button[span[h3[text() = "Upload"]]]'));
   clickElement(submitTestButton);
@@ -100,15 +115,15 @@ const enterDebriefWitnessed = () => {
   clickElement(debriefWitnessedRadio);
 };
 
-const enterIndependentDriving = () => {
-  const satnavRadio = getElement(by.id('independent-driving-satnav'));
+const enterIndependentDriving = (type) => {
+  const satnavRadio = getElement(by.id(`independent-driving-${type}`));
   clickElement(satnavRadio);
 };
 
-const enterShowMe = () => {
+const enterShowMe = (value) => {
   const showMeSelector = getElement(by.id('show-me-selector'));
   clickElement(showMeSelector);
-  const showMeItem = getElement(by.xpath('//button/span/div[normalize-space(text()) = "S5 - Horn"]'));
+  const showMeItem = getElement(by.xpath(`//button/span/div[normalize-space(text()) = '${value}']`));
   clickElement(showMeItem);
   const submitDialog = getElement(by.xpath('//button[span[text() = "Submit"]]'));
   clickElement(submitDialog);

--- a/test/e2e/step-definitions/testreport-steps.ts
+++ b/test/e2e/step-definitions/testreport-steps.ts
@@ -32,7 +32,6 @@ const completeLegalRequirements = () => {
   });
 };
 
-
 When('I end the test', () => {
   endTest();
 });
@@ -40,6 +39,12 @@ When('I end the test', () => {
 When('I continue to debrief', () => {
   const continueToDebriefButton = getElement(by.xpath('//button[span[h3[text() = "Continue to debrief"]]]'));
   clickElement(continueToDebriefButton);
+});
+
+When('I end and terminate the test', () => {
+  endTest();
+  const terminateTestButton = getElement(by.xpath('//button[span[text() = "Terminate test"]]'));
+  clickElement(terminateTestButton);
 });
 
 When('I complete the test', () => {
@@ -55,7 +60,7 @@ When('I add a Show me / Tell me driver fault', () => {
 });
 
 When('I add a Controlled Stop driver fault', () => {
-  longPressButton(getElement(by.className('controlled-stop-competency')))
+  longPressButton(getElement(by.className('controlled-stop-competency')));
 });
 
 When('I add a {string} driver fault', (competency) => {
@@ -156,7 +161,7 @@ const clickManoeuvresButton = () => {
 
 When('I add a manoeuvre', () => {
   clickManoeuvresButton();
-  
+
   const reverseRightRadio = getElement(by.id('manoeuvres-reverse-right-radio'));
   clickElement(reverseRightRadio);
 });


### PR DESCRIPTION
Addition of extra full journey UI tests. 

Also adds in extended regression tests which are to be executed against the release candidate but does not form part of the standard build pipeline. This is the ensure that the pipeline UI test do not exceed 30 minutes but offer a good spread of test coverage offering a high level of confidence in the build.