### PR TITLE
Allowing DEs to view previous day

### DIFF
--- a/src/pages/journal/components/test-slot/test-slot.ts
+++ b/src/pages/journal/components/test-slot/test-slot.ts
@@ -95,7 +95,7 @@ export class TestSlotComponent implements SlotComponent, OnInit, OnDestroy {
     }
 
     const startDate = new DateTime(this.slot.slotDetail.start);
-    if (startDate.daysDiff(this.dateTimeProvider.now()) !== 0) {
+    if (startDate.daysDiff(this.dateTimeProvider.now()) < 0) {
       return false;
     }
 

--- a/src/pages/journal/journal.selector.ts
+++ b/src/pages/journal/journal.selector.ts
@@ -27,9 +27,15 @@ export const canNavigateToPreviousDay = (journal: JournalModel, today: DateTime)
 };
 
 export const canNavigateToNextDay = (journal: JournalModel): boolean => {
-  const availableDays = getAvailableDays(journal);
-  const nextDay = DateTime.at(journal.selectedDate).add(1, Duration.DAY).format('YYYY-MM-DD');
-  const today = DateTime.at(DateTime.today()).format('YYYY-MM-DD');
+  let traverseWeekend = false;
+  const nextDayAsDate = DateTime.at(journal.selectedDate).add(1, Duration.DAY).format('YYYY-MM-DD');
+  const dayAfterTomorrowAsDate = DateTime.at(DateTime.today()).add(2, Duration.DAY).format('YYYY-MM-DD');
+  const nextDayAsDay = DateTime.at(journal.selectedDate).add(1, Duration.DAY).day();
 
-  return availableDays.includes(nextDay) || nextDay < today;
+  // if the current day is a Friday(5) or Saturday(6), allow navigation to the Monday.
+  if ((DateTime.at(DateTime.today()).day() === 5 || DateTime.at(DateTime.today()).day() === 6) && nextDayAsDay !== 2) {
+    traverseWeekend = true;
+  }
+
+  return nextDayAsDate < dayAfterTomorrowAsDate || traverseWeekend;
 };

--- a/src/pages/journal/journal.ts
+++ b/src/pages/journal/journal.ts
@@ -176,10 +176,10 @@ export class JournalPage extends BasePageComponent implements OnInit, OnDestroy 
   }
 
   private createSlots = (emission: any) => {
-    if (!Array.isArray(emission)) return;
-
     // Clear any dynamically created slots before adding the latest
     this.slotContainer.clear();
+
+    if (!Array.isArray(emission)) return;
 
     if (emission.length === 0) return;
 

--- a/src/providers/slot/slot.ts
+++ b/src/providers/slot/slot.ts
@@ -69,25 +69,11 @@ export class SlotProvider {
   }
 
   /**
-   * Slice the journal slots and get the slots only for the relevant days
-   * | From regular working weekday we can see the next working weekday
-   * | From Friday we can navigate through weekend till Monday
    * @param slots Journal slots
    * @returns Only the relevant slots
    */
   getRelevantSlots = (slots: {[k: string]: SlotItem[]}): {[k: string]: SlotItem[]} => {
-    // we have to take in consideration if it's Friday
-    // so that we can navigate through the weekend till the next working weekday (Monday)
-    // if it's not Friday
-    // we need to check if it's Saturday so that we can navigate till Monday
-    // otherwise we just go to next day
-    const friday = 5;
-    const saturday = 6;
-    const today = this.dateTimeProvider.now().day();
-    const daysAhead = today === friday ? 4 : today === saturday ? 3 : 2;
-
     return Object.keys(slots)
-      .slice(0, daysAhead)
       .reduce(
         (acc: {[k: string]: SlotItem[]}, date) => ({
           ...acc,


### PR DESCRIPTION
## Description and relevant Jira numbers
- Journal data was previously populating slots in the past fortnight with ```slotData``` from the current day.
- `this.slotContainer.clear()` is now called before a check on `emission` in `createSlots()` to ensure the container does not hold onto irrelevant slots.
- `getRelevantSlots` no longer slices the slots, nor does it handle logic to navigate weekends. This has been added to `canNavigateToNextDay` in `journal.selector.ts`

<img width="505" alt="Screenshot 2019-06-25 at 17 05 08" src="https://user-images.githubusercontent.com/30832405/60115426-cee73880-976d-11e9-8dde-fed3d56b1f0f.png">
<img width="505" alt="Screenshot 2019-06-25 at 17 05 14" src="https://user-images.githubusercontent.com/30832405/60115430-d1499280-976d-11e9-81f4-8da5df2d63ed.png">
<img width="505" alt="Screenshot 2019-06-25 at 17 05 32" src="https://user-images.githubusercontent.com/30832405/60115435-d3135600-976d-11e9-8c21-e3999dd5d507.png">


## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [x] Tested by QA
- [ ] PO's approval
