### PR TITLE
Feature DES 2546: Fix journal refresh

### DIFF
--- a/src/pages/journal/journal.effects.ts
+++ b/src/pages/journal/journal.effects.ts
@@ -176,23 +176,6 @@ export class JournalEffects {
   );
 
   @Effect()
-  loadJournalSuccessEffect$ = this.actions$.pipe(
-    ofType(journalActions.LOAD_JOURNAL_SUCCESS),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getJournalState),
-        map(getSelectedDate),
-      ),
-    ),
-    switchMap(([action, selectedDate]) => {
-      if (this.dateTimeProvider.now().daysDiff(selectedDate) < 0) {
-        return of(new journalActions.SetSelectedDate(selectedDate));
-      }
-      return of();
-    }),
-  );
-
-  @Effect()
   startTestEffect$ = this.actions$.pipe(
     ofType(journalActions.START_TEST),
     withLatestFrom(

--- a/src/pages/journal/journal.effects.ts
+++ b/src/pages/journal/journal.effects.ts
@@ -186,7 +186,7 @@ export class JournalEffects {
     ),
     switchMap(([action, selectedDate]) => {
       if (this.dateTimeProvider.now().daysDiff(selectedDate) < 0) {
-        return of(new journalActions.SetSelectedDate(this.dateTimeProvider.now().format('YYYY-MM-DD')));
+        return of(new journalActions.SetSelectedDate(selectedDate));
       }
       return of();
     }),


### PR DESCRIPTION
## Description and relevant Jira numbers
- Removing `loadJournalSuccessEffect` to prevent automatic journal refreshes redirecting DEs to the current date.
- A ticket is being raised to enable manual refreshes to redirect to the current date.
## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:
- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
