### PR TITLE
fix issue with validation when 16 driving faults and a serious or dangerous

### DIFF
--- a/mock/local-journal-non-test-activities.json
+++ b/mock/local-journal-non-test-activities.json
@@ -16,7 +16,7 @@
     {
       "slotDetail": {
         "slotId": 1000,
-        "start": "2019-06-28T09:00:00+01:00",
+        "start": "2019-07-01T09:00:00+01:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -29,7 +29,7 @@
     {
       "slotDetail": {
         "slotId": 1001,
-        "start": "2019-06-28T10:15:00+01:00",
+        "start": "2019-07-01T10:15:00+01:00",
         "duration": 57
       },
       "vehicleSlotType": "B57mins",
@@ -101,17 +101,17 @@
   "personalCommitments": [
     {
       "commitmentId": 123400,
-      "startDate": "2019-06-28",
+      "startDate": "2019-07-01",
       "startTime": "10:00:00+01:00",
-      "endDate": "2019-06-28",
+      "endDate": "2019-07-01",
       "endTime": "11:00:00+01:00",
       "activityCode": "104",
       "activityDescription": "Medical appointment"
     },
     {
       "commitmentId": 123401,
-      "startDate": "2019-07-05",
-      "endDate": "2019-07-05",
+      "startDate": "2019-07-08",
+      "endDate": "2019-07-08",
       "activityCode": "081",
       "activityDescription": "Annual Leave"
     }
@@ -120,7 +120,7 @@
     {
       "slotDetail": {
         "slotId": 1111,
-        "start": "2019-06-28T11:15:00+01:00",
+        "start": "2019-07-01T11:15:00+01:00",
         "duration": 57
       },
       "activityCode": "091",
@@ -134,7 +134,7 @@
     {
       "slotDetail": {
         "slotId": 1110,
-        "start": "2019-06-28T12:15:00+01:00",
+        "start": "2019-07-01T12:15:00+01:00",
         "duration": 57
       },
       "activityCode": "089",
@@ -148,7 +148,7 @@
     {
       "slotDetail": {
         "slotId": 1200,
-        "start": "2019-06-28T13:15:00+01:00",
+        "start": "2019-07-01T13:15:00+01:00",
         "duration": 57
       },
       "activityCode": "104",
@@ -164,7 +164,7 @@
     {
       "slotDetail": {
         "slotId": 1300,
-        "start": "2019-06-28T09:00:00+01:00",
+        "start": "2019-07-01T09:00:00+01:00",
         "duration": 90
       },
       "testCentre": {
@@ -177,7 +177,7 @@
     {
       "slotDetail": {
         "slotId": 1301,
-        "start": "2019-06-28T10:45:00+01:00",
+        "start": "2019-07-01T10:45:00+01:00",
         "duration": 90
       },
       "testCentre": {
@@ -190,7 +190,7 @@
     {
       "slotDetail": {
         "slotId": 1302,
-        "start": "2019-06-28T12:30:00+01:00",
+        "start": "2019-07-01T12:30:00+01:00",
         "duration": 90
       },
       "testCentre": {
@@ -209,7 +209,7 @@
         "centreName": "Example Test Centre 3",
         "costCode": "EXTC 3"
       },
-      "date": "2019-06-28"
+      "date": "2019-07-01"
     },
     {
       "deploymentId": 22222,
@@ -218,7 +218,7 @@
         "centreName": "Example Test Centre 4",
         "costCode": "EXTC 4"
       },
-      "date": "2019-06-28"
+      "date": "2019-07-01"
     }
   ]
 }

--- a/mock/local-journal.json
+++ b/mock/local-journal.json
@@ -50,7 +50,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1001,
-        "start": "2019-06-28T08:10:00+01:00"
+        "start": "2019-07-01T08:10:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -102,7 +102,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1003,
-        "start": "2019-06-28T10:14:00+01:00"
+        "start": "2019-07-01T10:14:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -154,7 +154,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1004,
-        "start": "2019-06-28T11:11:00+01:00"
+        "start": "2019-07-01T11:11:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -207,7 +207,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1005,
-        "start": "2019-06-28T12:38:00+01:00"
+        "start": "2019-07-01T12:38:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -262,7 +262,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1006,
-        "start": "2019-06-28T13:35:00+01:00"
+        "start": "2019-07-01T13:35:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,
@@ -309,7 +309,7 @@
       "slotDetail": {
         "duration": 57,
         "slotId": 1007,
-        "start": "2019-06-29T14:32:00+01:00"
+        "start": "2019-07-02T14:32:00+01:00"
       },
       "testCentre": {
         "centreId": 54321,

--- a/src/pages/office/components/fault-comment-card/fault-comment-card.html
+++ b/src/pages/office/components/fault-comment-card/fault-comment-card.html
@@ -5,7 +5,7 @@
     </ion-card-header>
     <ion-card-content>
       <ion-row class="mes-validated-row mes-row-separator" *ngFor="let faultComment of faultComments">
-        <fault-comment [parentForm]="formGroup" [faultComment]="faultComment" [faultType]="faultType"
+        <fault-comment [parentForm]="formGroup" [faultComment]="faultComment" [faultType]="faultType" [shouldRender]="shouldRender"
           [faultCount]="faultCount" [outcome]="outcome" (faultCommentChange)="faultCommentChanged($event)">
         </fault-comment>
       </ion-row>

--- a/src/pages/office/components/fault-comment/__tests__/fault-comment.spec.ts
+++ b/src/pages/office/components/fault-comment/__tests__/fault-comment.spec.ts
@@ -73,6 +73,7 @@ describe('FaultCommentComponent', () => {
       component.faultType = 'driving';
       component.faultCount = 16;
       component.outcome = '5';
+      component.shouldRender = true;
       const control = new FormControl(null);
       component.parentForm.addControl(`faultComment-${CommentSource.SIMPLE}-driving-signalsTimed`, control);
 
@@ -92,6 +93,27 @@ describe('FaultCommentComponent', () => {
       component.faultType = 'driving';
       component.faultCount = 15;
       component.outcome = '5';
+      const control = new FormControl(null);
+      component.parentForm.addControl(`faultComment-${CommentSource.SIMPLE}-driving-signalsTimed`, control);
+
+      component.ngOnChanges();
+      fixture.detectChanges();
+      expect(component.parentForm.
+        get(`faultComment-${CommentSource.SIMPLE}-driving-signalsTimed`).validator).toBeNull();
+    });
+
+    it('should clear validators for driving faults if > 15 driving faults and shouldRender is false', () => {
+      component.faultComment = {
+        comment: 'comment',
+        competencyDisplayName: 'Signals - timed',
+        competencyIdentifier: 'signalsTimed',
+        faultCount: 16,
+        source: CommentSource.SIMPLE,
+      };
+      component.faultType = 'driving';
+      component.faultCount = 16;
+      component.outcome = '5';
+      component.shouldRender = false;
       const control = new FormControl(null);
       component.parentForm.addControl(`faultComment-${CommentSource.SIMPLE}-driving-signalsTimed`, control);
 

--- a/src/pages/office/components/fault-comment/fault-comment.ts
+++ b/src/pages/office/components/fault-comment/fault-comment.ts
@@ -33,6 +33,10 @@ export class FaultCommentComponent implements OnChanges {
 
   @Input()
   faultCount: number;
+
+  @Input()
+  shouldRender: boolean;
+
   @Output()
   faultCommentChange = new EventEmitter<CommentedCompetency>();
 
@@ -44,15 +48,27 @@ export class FaultCommentComponent implements OnChanges {
       this.outcome, FaultCommentComponent.fieldName);
 
     // mes 2393 - need to remove validations if < 16 faults as comments can
-    // only be entered if 16 or more.
-    if (fieldVisibility === VisibilityType.NotVisible ||
-      (this.faultType === ValidFaultTypes.DRIVING &&
-        this.faultCount && this.faultCount <= FaultCommentComponent.maxFaultCount)) {
+    // only be entered if 16 or more
+    if (fieldVisibility === VisibilityType.NotVisible || this.shouldClearDrivingFaultValidators()) {
       this.parentForm.get(this.formControlName).clearValidators();
     } else {
       this.parentForm.get(this.formControlName).setValidators(Validators.required);
     }
     this.parentForm.get(this.formControlName).patchValue(this.faultComment.comment);
+  }
+
+  shouldClearDrivingFaultValidators(): boolean {
+    if (this.faultType !== ValidFaultTypes.DRIVING) {
+      return false;
+    }
+
+    if (!this.shouldRender) {
+      return true;
+    }
+
+    if (this.faultCount && this.faultCount <= FaultCommentComponent.maxFaultCount) {
+      return true;
+    }
   }
 
   faultCommentChanged(newComment: string): void {


### PR DESCRIPTION
Fix the issue where the user can not upload a journal due to validation errors on fields that aren't displayed. This occurs when there are 16 or more driving faults, and a serious or dangerous.
In this case the validator should be removed from the driving faults but this wasn't happening.

