### PR TITLE
Fix initialise conducted language

### DIFF
--- a/src/pages/communication-page/communication.ts
+++ b/src/pages/communication-page/communication.ts
@@ -357,6 +357,8 @@ export class CommunicationPage extends PracticeableBasePageComponent {
 
     if (this.isBookedInWelsh && this.conductedLanguage !== CommunicationPage.englishLanguage) {
       this.dispatchCandidateChoseToProceedInWelsh();
+    } else {
+      this.dispatchCandidateChoseToProceedInEnglish();
     }
   }
 


### PR DESCRIPTION
## Description and relevant Jira numbers
- `conductedLanguage` was not initialised to `English` for English booked tests. This presented issues downstream. 
- `conductedLanguage` is now initialised to `English`.
## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
