### PR TITLE
MES-2864 Fix navigation issue on prod builds

### DIFF
--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -239,11 +239,11 @@ export class DebriefPage extends PracticeableBasePageComponent {
       return;
     }
     this.navController.push(BACK_TO_OFFICE_PAGE).then(() => {
-      const testReportPage = this.navController.getViews().find(view => view.name === TEST_REPORT_PAGE);
+      const testReportPage = this.navController.getViews().find(view => view.id === TEST_REPORT_PAGE);
       if (testReportPage) {
         this.navController.removeView(testReportPage);
       }
-      const debriefPage = this.navController.getViews().find(view => view.name === DEBRIEF_PAGE);
+      const debriefPage = this.navController.getViews().find(view => view.id === DEBRIEF_PAGE);
       if (debriefPage) {
         this.navController.removeView(debriefPage);
       }

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -243,9 +243,10 @@ export class DebriefPage extends PracticeableBasePageComponent {
       if (testReportPage) {
         this.navController.removeView(testReportPage);
       }
-      this.navController.removeView(
-        this.navController.getViews().find(view => view.name === DEBRIEF_PAGE),
-      );
+      const debriefPage = this.navController.getViews().find(view => view.name === DEBRIEF_PAGE);
+      if (debriefPage) {
+        this.navController.removeView(debriefPage);
+      }
     });
   }
 

--- a/src/pages/health-declaration/health-declaration.ts
+++ b/src/pages/health-declaration/health-declaration.ts
@@ -282,7 +282,7 @@ export class HealthDeclarationPage extends PracticeableBasePageComponent {
         this.navController.push(BACK_TO_OFFICE_PAGE).then(() => {
           this.navController.getViews().forEach((view) => {
             if (includes([TEST_REPORT_PAGE, DEBRIEF_PAGE, PASS_FINALISATION_PAGE, HEALTH_DECLARATION_PAGE],
-              view.name)) {
+              view.id)) {
               this.navController.removeView(view);
             }
           });

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.ts
@@ -276,9 +276,10 @@ export class WaitingRoomToCarPage extends PracticeableBasePageComponent {
     if (this.form.valid) {
       this.navController.push(TEST_REPORT_PAGE).then(() => {
         // remove Waiting Room To Car Page
-        this.navController.removeView(
-          this.navController.getViews().find(view => view.name === WAITING_ROOM_TO_CAR_PAGE),
-        );
+        const view = this.navController.getViews().find(view => view.name === WAITING_ROOM_TO_CAR_PAGE);
+        if (view) {
+          this.navController.removeView(view);
+        }
       });
     }
   }

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.ts
@@ -276,7 +276,7 @@ export class WaitingRoomToCarPage extends PracticeableBasePageComponent {
     if (this.form.valid) {
       this.navController.push(TEST_REPORT_PAGE).then(() => {
         // remove Waiting Room To Car Page
-        const view = this.navController.getViews().find(view => view.name === WAITING_ROOM_TO_CAR_PAGE);
+        const view = this.navController.getViews().find(view => view.id === WAITING_ROOM_TO_CAR_PAGE);
         if (view) {
           this.navController.removeView(view);
         }

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -195,11 +195,11 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
         .then(() => {
           this.store$.dispatch(new waitingRoomActions.SubmitWaitingRoomInfo());
           this.navController.push(WAITING_ROOM_TO_CAR_PAGE).then(() => {
-            const communicationPage = this.navController.getViews().find(view => view.name === COMMUNICATION_PAGE);
+            const communicationPage = this.navController.getViews().find(view => view.id === COMMUNICATION_PAGE);
             if (communicationPage) {
               this.navController.removeView(communicationPage);
             }
-            const waitingRoomPage = this.navController.getViews().find(view => view.name === WAITING_ROOM_PAGE);
+            const waitingRoomPage = this.navController.getViews().find(view => view.id === WAITING_ROOM_PAGE);
             if (waitingRoomPage) {
               this.navController.removeView(waitingRoomPage);
             }

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -199,9 +199,10 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
             if (communicationPage) {
               this.navController.removeView(communicationPage);
             }
-            this.navController.removeView(
-              this.navController.getViews().find(view => view.name === WAITING_ROOM_PAGE),
-            );
+            const waitingRoomPage = this.navController.getViews().find(view => view.name === WAITING_ROOM_PAGE);
+            if (waitingRoomPage) {
+              this.navController.removeView(waitingRoomPage);
+            }
           });
         })
         .catch((err) => {

--- a/src/shared/classes/practiceable-base-page.ts
+++ b/src/shared/classes/practiceable-base-page.ts
@@ -77,7 +77,7 @@ export abstract class PracticeableBasePageComponent extends BasePageComponent im
   exitPracticeMode = (): void => {
     // As per bug request for Ionic 3 we need to get and pass in the view controller
     // for the page we want to get back to - https://github.com/ionic-team/ionic/issues/13672
-    this.navController.popTo(this.navController.getViews().find(view => view.name === FakeJournalPage.name));
+    this.navController.popTo(this.navController.getViews().find(view => view.id === FakeJournalPage.name));
   }
 
 }


### PR DESCRIPTION
## Description and relevant Jira numbers
The minification during the build process meant that the method used to find views and remove them from the nav stack failed :(

This PR switches the method of finding the view to use the `id` property of the view instead of the `name`.

In addition, there are extra checks before removing the view to ensure that if the view isn't found, it doesn't call `removeView` with a null value (doing this will remove the first page from the nav stack - which is not good).

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
