### PR TITLE
User now taken to debrief page when failing eye test

### DIFF
--- a/src/pages/waiting-room-to-car/components/eyesight-failure-confirmation/eyesight-failure-confirmation.html
+++ b/src/pages/waiting-room-to-car/components/eyesight-failure-confirmation/eyesight-failure-confirmation.html
@@ -4,7 +4,7 @@
       <ion-row>
         <ion-col col-auto>
         </ion-col>
-          <img id="eyesight-failure-icon" src="/assets/imgs/exclamation.png" />
+        <img id="eyesight-failure-icon" src="/assets/imgs/exclamation.png" />
         <ion-col>
           <ion-row>
             <h2 id="eyesight-failure-title">The candidate failed the eyesight test</h2>
@@ -13,8 +13,9 @@
             <label id="eyesight-failure-subtitle">Do you want to continue?</label>
           </ion-row>
           <ion-row justify-content-between>
-            <button id="confirm-eyesight-failure" class="mes-neutral-button" ion-button (click)="onContinue()"><label>Continue to debrief</label></button>
-            <button id="cancel-eyesight-failure" class="mes-neutral-button" ion-button (click)="onCancel()"><label>Cancel</label></button>
+            <button type="button" id="confirm-eyesight-failure" class="mes-neutral-button" ion-button (click)="onContinue()"><label>Continue
+                to debrief</label></button>
+            <button type="button" id="cancel-eyesight-failure" class="mes-neutral-button" ion-button (click)="onCancel()"><label>Cancel</label></button>
           </ion-row>
         </ion-col>
       </ion-row>


### PR DESCRIPTION
## Description and relevant Jira numbers

Jira: https://jira.i-env.net/browse/MES-2511

Continue to debrief/Cancel buttons called the OnSubmit method of WaitingRoomToCarPage, added type="button" to buttons in the eyetestFailureConfirmation component, now it doesn't trigger the parent onSubmit method so it doesn't move to the TestReportPage.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
