### PR TITLE
MES-2504: Correctly size termination code select in landscape

### DIFF
--- a/src/pages/office/components/activity-code/activity-code.html
+++ b/src/pages/office/components/activity-code/activity-code.html
@@ -6,7 +6,7 @@
     <ion-col align-self-center>
       <ion-row class="spacing-row"></ion-row>
       <ion-row>
-        <ion-select id="activity-code-selector" placeholder="Select a activity code" okText="Submit" cancelText="Cancel"
+        <ion-select id="activity-code-selector" placeholder="Select an activity code" okText="Submit" cancelText="Cancel"
           formControlName="activityCode" (ionChange)="activityCodeChanged($event)" [selectOptions]="{cssClass:'mes-select activity-code-select'}" [disabled]="isSelectDisabled()">
           <ion-option [value]="activityCode" [disabled]="isOptionDisabled(activityCode.activityCode)" *ngFor="let activityCode of activityCodeOptions">
             {{activityCode.activityCode}} - {{activityCode.description}}

--- a/src/pages/office/components/activity-code/activity-code.scss
+++ b/src/pages/office/components/activity-code/activity-code.scss
@@ -1,6 +1,10 @@
 .activity-code-select {
   .alert-wrapper div.alert-radio-group {
     max-height: 800px;
+
+    @media (orientation: landscape) {
+      max-height: 500px;
+    }
   }
   .alert-radio-label {
     white-space: normal;


### PR DESCRIPTION
## Description and relevant Jira numbers

Set a max height for the termination code select in landscape.

<img width="874" alt="Screenshot 2019-07-03 at 16 08 01" src="https://user-images.githubusercontent.com/44976690/60603539-dfbb2e00-9dad-11e9-820e-375a449de85b.png">

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
