### PR TITLE
Fix for UI tests following rekey changes as tests in the past show dialog

### DIFF
--- a/src/pages/journal/journal-rekey-modal/journal-rekey-modal.html
+++ b/src/pages/journal/journal-rekey-modal/journal-rekey-modal.html
@@ -9,21 +9,21 @@
   </ion-row>
   <ion-row justify-content-center>
     <ion-col no-padding col-72>
-      <button ion-button class="mes-return-button start-test-button" (click)="onStartTest()">
+      <button ion-button class="mes-return-button start-test-button" (click)="onStartTest()" id="rekey-start-test-button">
         <h3>Start the test</h3>
       </button>
     </ion-col>
   </ion-row>
   <ion-row justify-content-center>
     <ion-col no-padding col-72>
-      <button ion-button class="mes-return-button rekey-test-button" (click)="onRekeyTest()">
+      <button ion-button class="mes-return-button rekey-test-button" (click)="onRekeyTest()" id="rekey-rekey-test-button">
         <h3>Rekey a paper test</h3>
       </button>
     </ion-col>
   </ion-row>
   <ion-row>
     <ion-col class="column-border-top" no-padding>
-      <button ion-button clear class="cancel-button" (click)="onCancel()">Cancel</button>
+      <button ion-button clear class="cancel-button" (click)="onCancel()" id="rekey-cancel-button">Cancel</button>
     </ion-col>
   </ion-row>
 </ion-card>

--- a/test/e2e/step-definitions/journal-steps.ts
+++ b/test/e2e/step-definitions/journal-steps.ts
@@ -1,4 +1,4 @@
-import { by } from 'protractor';
+import { by, element } from 'protractor';
 import { getElement, clickElement, onJournalPageAs } from './generic-steps';
 
 const {
@@ -28,7 +28,15 @@ When('I start the test for {string}', (candidateName) => {
   const buttonElement = getElement(by.xpath(`//button/span/h3[text()[normalize-space(.) = "Start test"]]
     [ancestor::ion-row/ion-col/ion-grid/ion-row/ion-col/candidate-link/div/button/span/
     h3[text() = "${candidateName}"]]`));
-  return clickElement(buttonElement);
+  clickElement(buttonElement);
+
+  // If the rekey dialog is shown so just select start test normally
+  const rekeyStartTestButton = element(by.id('rekey-start-test-button'));
+  rekeyStartTestButton.isPresent().then((result) => {
+    if (result) {
+      clickElement(rekeyStartTestButton);
+    }
+  });
 });
 
 When('I navigate to next day', () => {


### PR DESCRIPTION
With the latest rekey changes, any tests started before the current time (plus test duration) are presented a rekey dialog.

UI will simply start the test as if it was a normal test. Rekey scenarios to follow soon.