### PR TITLE
Updating test parallel executors

### DIFF
--- a/test-config/karma.conf.js
+++ b/test-config/karma.conf.js
@@ -63,6 +63,11 @@ module.exports = function(config) {
     },
     browsers: ['ChromeHeadless'],
     singleRun: true,
+
+    parallelOptions: {
+      executors: 4
+    },
+
     customLaunchers: {
       ChromeHeadless: {
         base: 'Chrome',
@@ -74,7 +79,7 @@ module.exports = function(config) {
         ]
       }
     },
-    browserNoActivityTimeout: 60000,
+    browserNoActivityTimeout: 60000
   };
 
   config.set(_config);

--- a/test-config/karma.conf.js
+++ b/test-config/karma.conf.js
@@ -63,11 +63,6 @@ module.exports = function(config) {
     },
     browsers: ['ChromeHeadless'],
     singleRun: true,
-
-    parallelOptions: {
-      executors: 4
-    },
-
     customLaunchers: {
       ChromeHeadless: {
         base: 'Chrome',

--- a/test-config/karma.conf.js
+++ b/test-config/karma.conf.js
@@ -64,6 +64,10 @@ module.exports = function(config) {
     browsers: ['ChromeHeadless'],
     singleRun: true,
 
+    parallelOptions: {
+      executors: 4
+    },
+
     customLaunchers: {
       ChromeHeadless: {
         base: 'Chrome',

--- a/test-config/karma.conf.js
+++ b/test-config/karma.conf.js
@@ -78,7 +78,8 @@ module.exports = function(config) {
           '--remote-debugging-port=9222'
         ]
       }
-    }
+    },
+    browserNoActivityTimeout: 60000,
   };
 
   config.set(_config);


### PR DESCRIPTION
Tweaking setting for karma parallel for build pipeline.

Set to 4 executors and increased timeout to 60 seconds.