### PR TITLE
MES-1969 Add analytics to WR and WRTC screens

### DIFF
--- a/src/modules/tests/candidate/__tests__/candidate-selector.spec.ts
+++ b/src/modules/tests/candidate/__tests__/candidate-selector.spec.ts
@@ -4,6 +4,7 @@ import {
   formatDriverNumber,
   getUntitledCandidateName,
   getPostalAddress,
+  getCandidateId,
 } from '../candidate.selector';
 import { Candidate } from '@dvsa/mes-test-schema/categories/B';
 
@@ -23,6 +24,7 @@ describe('candidate selector', () => {
       addressLine5: 'United Kingdom',
       postcode: 'NG1 6HY',
     },
+    candidateId: 1001,
   };
   describe('getCandidateName', () => {
     it('should produce first and last name with a title prefix', () => {
@@ -54,6 +56,12 @@ describe('candidate selector', () => {
   describe('getPostalAddress', () => {
     it('should output the address', () => {
       expect(getPostalAddress(candidate)).toEqual(candidate.candidateAddress);
+    });
+  });
+
+  describe('getCandidateId', () => {
+    it('should output the candidate ID', () => {
+      expect(getCandidateId(candidate)).toEqual(1001);
     });
   });
 });

--- a/src/modules/tests/candidate/candidate.selector.ts
+++ b/src/modules/tests/candidate/candidate.selector.ts
@@ -22,3 +22,5 @@ export const formatDriverNumber = (driverNumber: string) => {
 export const getCandidateEmailAddress = (candidate: Candidate) => candidate.emailAddress ? candidate.emailAddress : '';
 
 export const getPostalAddress = (candidate: Candidate) => candidate.candidateAddress;
+
+export const getCandidateId = (candidate: Candidate) => candidate.candidateId;

--- a/src/pages/journal/journal.analytics.effects.ts
+++ b/src/pages/journal/journal.analytics.effects.ts
@@ -61,8 +61,7 @@ export class JournalAnalyticsEffects {
           AnalyticsDimensionIndices.JOURNAL_DAYS_FROM_TODAY,
           this.analytics.getDiffDays(action.day).toString());
 
-        this.analytics.setCurrentPage(
-          `${this.analytics.getDescriptiveDate(action.day)} ${AnalyticsScreenNames.JOURNAL}`);
+        this.analytics.setCurrentPage(AnalyticsScreenNames.JOURNAL);
 
         return of();
       },

--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
@@ -1,0 +1,121 @@
+import { WaitingRoomToCarAnalyticsEffects } from '../waiting-room-to-car.analytics.effects';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { StoreModule, Store } from '@ngrx/store';
+import { provideMockActions } from '@ngrx/effects/testing';
+import * as waitingRoomToCarActions from '../waiting-room-to-car.actions';
+import { AnalyticsProvider } from '../../../providers/analytics/analytics';
+import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
+import { of } from 'rxjs/observable/of';
+import {
+  AnalyticsDimensionIndices,
+  AnalyticsScreenNames,
+  AnalyticsErrorTypes,
+} from '../../../providers/analytics/analytics.model';
+
+describe('Waiting Room To Car Analytics Effects', () => {
+
+  let effects: WaitingRoomToCarAnalyticsEffects;
+  let analyticsProviderMock;
+  let actions$: any;
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: () => ({
+            currentTest: {
+              slotId: '123',
+            },
+            testStatus: {},
+            startedTests: {
+              123: {
+                vehicleDetails: {},
+                accompaniment: {},
+                testData: {},
+                journalData: {
+                  candidate: {
+                    candidateId: 1001,
+                  },
+                },
+              },
+            },
+          }),
+        }),
+      ],
+      providers: [
+        WaitingRoomToCarAnalyticsEffects,
+        { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
+        provideMockActions(() => actions$),
+        Store,
+      ],
+    });
+    effects = TestBed.get(WaitingRoomToCarAnalyticsEffects);
+    analyticsProviderMock = TestBed.get(AnalyticsProvider);
+  });
+
+  describe('waitingRoomToCarViewDidEnter', () => {
+    it('should call setCurrentPage and addCustomDimension', fakeAsync((done) => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'addCustomDimension').and.callThrough();
+      spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
+      // ACT
+      actions$.next(new waitingRoomToCarActions.WaitingRoomToCarViewDidEnter());
+      tick();
+      // ASSERT
+      effects.waitingRoomToCarViewDidEnter$.subscribe((result) => {
+        expect(result instanceof of).toBe(true);
+        expect(effects.analytics.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(effects.analytics.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, '123');
+        expect(effects.analytics.setCurrentPage)
+          .toHaveBeenCalledWith(AnalyticsScreenNames.WAITING_ROOM_TO_CAR);
+        done();
+      });
+    }));
+
+  });
+
+  describe('waitingRoomToCarError', () => {
+    it('should call logError', fakeAsync((done) => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logError').and.callThrough();
+      // ACT
+      actions$.next(new waitingRoomToCarActions.WaitingRoomToCarError('error 123'));
+      tick();
+      // ASSERT
+      effects.waitingRoomToCarError$.subscribe((result) => {
+        expect(result instanceof of).toBe(true);
+        expect(effects.analytics.logError)
+        // tslint:disable-next-line:max-line-length
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${AnalyticsScreenNames.WAITING_ROOM_TO_CAR})`,
+          'error 123');
+        done();
+      });
+    }));
+
+  });
+
+  describe('waitingRoomToCarValidationError', () => {
+    it('should call logError', fakeAsync((done) => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logError').and.callThrough();
+      // ACT
+      actions$.next(new waitingRoomToCarActions.WaitingRoomToCarValidationError('formControl1'));
+      tick();
+      // ASSERT
+      effects.waitingRoomToCarValidationError$.subscribe((result) => {
+        expect(result instanceof of).toBe(true);
+        expect(effects.analytics.logError)
+        // tslint:disable-next-line:max-line-length
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${AnalyticsScreenNames.WAITING_ROOM_TO_CAR})`,
+          'formControl1');
+        done();
+      });
+    }));
+
+  });
+
+});

--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
@@ -188,12 +188,12 @@ describe('WaitingRoomToCarPage', () => {
       component.onSubmit();
       tick();
       expect(store$.dispatch)
-        .toHaveBeenCalledWith(new WaitingRoomToCarValidationError('requiredControl1 is invalid'));
+        .toHaveBeenCalledWith(new WaitingRoomToCarValidationError('requiredControl1 is blank'));
       expect(store$.dispatch)
-        .toHaveBeenCalledWith(new WaitingRoomToCarValidationError('requiredControl2 is invalid'));
+        .toHaveBeenCalledWith(new WaitingRoomToCarValidationError('requiredControl2 is blank'));
       expect(store$.dispatch)
         .not
-        .toHaveBeenCalledWith(new WaitingRoomToCarValidationError('notRequiredControl is invalid'));
+        .toHaveBeenCalledWith(new WaitingRoomToCarValidationError('notRequiredControl is blank'));
     }));
   });
 });

--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { ComponentFixture, async, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { IonicModule, NavController, NavParams, Config, Platform } from 'ionic-angular';
 import { NavControllerMock, NavParamsMock, ConfigMock, PlatformMock } from 'ionic-mocks';
 
@@ -38,6 +38,8 @@ import { EyesightTestComponent } from '../components/eyesight-test/eyesight-test
 import { TellMeQuestion } from '../../../providers/question/tell-me-question.model';
 import { TellMeQuestionSelected } from '../../../modules/tests/test-data/test-data.actions';
 import { PracticeModeBanner } from '../../../components/practice-mode-banner/practice-mode-banner';
+import { WaitingRoomToCarValidationError } from '../waiting-room-to-car.actions';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
 
 describe('WaitingRoomToCarPage', () => {
   let fixture: ComponentFixture<WaitingRoomToCarPage>;
@@ -172,5 +174,26 @@ describe('WaitingRoomToCarPage', () => {
       component.ionViewWillLeave();
       expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
     });
+  });
+  describe('onSubmit', () => {
+    it('should dispatch the appropriate WaitingRoomToCarValidationError actions', fakeAsync(() => {
+      fixture.detectChanges();
+
+      component.form = new FormGroup({
+        requiredControl1: new FormControl(null, [Validators.required]),
+        requiredControl2: new FormControl(null, [Validators.required]),
+        notRequiredControl: new FormControl(null),
+      });
+
+      component.onSubmit();
+      tick();
+      expect(store$.dispatch)
+        .toHaveBeenCalledWith(new WaitingRoomToCarValidationError('requiredControl1 is invalid'));
+      expect(store$.dispatch)
+        .toHaveBeenCalledWith(new WaitingRoomToCarValidationError('requiredControl2 is invalid'));
+      expect(store$.dispatch)
+        .not
+        .toHaveBeenCalledWith(new WaitingRoomToCarValidationError('notRequiredControl is invalid'));
+    }));
   });
 });

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.actions.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.actions.ts
@@ -1,10 +1,23 @@
 import { Action } from '@ngrx/store';
 
-export const WAITING_ROOM_TO_CAR_VIEW_DID_ENTER = '[WaitingRoomToCarPage] Waiting roomn to car did enter';
+export const WAITING_ROOM_TO_CAR_VIEW_DID_ENTER = '[WaitingRoomToCarPage] Waiting Room To Car Did Enter';
+export const WAITING_ROOM_TO_CAR_ERROR = '[WaitingRoomToCarPage] Waiting Room To Car Error';
+export const WAITING_ROOM_TO_CAR_VALIDATION_ERROR = '[WaitingRoomToCarPage] Waiting Room To Car Validation Error';
 
 export class WaitingRoomToCarViewDidEnter implements Action {
   readonly type = WAITING_ROOM_TO_CAR_VIEW_DID_ENTER;
 }
 
+export class WaitingRoomToCarError implements Action {
+  readonly type = WAITING_ROOM_TO_CAR_ERROR;
+  constructor(public errorMessage: string) { }
+}
+
+export class WaitingRoomToCarValidationError implements Action {
+  readonly type = WAITING_ROOM_TO_CAR_VALIDATION_ERROR;
+  constructor(public errorMessage: string) { }
+}
 export type Types =
-  | WaitingRoomToCarViewDidEnter;
+  | WaitingRoomToCarViewDidEnter
+  | WaitingRoomToCarError
+  | WaitingRoomToCarValidationError;

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.analytics.effects.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.analytics.effects.ts
@@ -1,15 +1,19 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
-import { switchMap } from 'rxjs/operators';
+import { switchMap, withLatestFrom } from 'rxjs/operators';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
-import {
-  AnalyticsScreenNames,
-} from '../../providers/analytics/analytics.model';
+import { AnalyticsScreenNames, AnalyticsDimensionIndices } from '../../providers/analytics/analytics.model';
 import {
   WAITING_ROOM_TO_CAR_VIEW_DID_ENTER,
   WaitingRoomToCarViewDidEnter,
 } from '../../pages/waiting-room-to-car/waiting-room-to-car.actions';
+import { StoreModel } from '../../shared/models/store.model';
+import { Store, select } from '@ngrx/store';
+import { getTests } from '../../modules/tests/tests.reducer';
+import { getCurrentTestSlotId, getCurrentTest, getJournalData } from '../../modules/tests/tests.selector';
+import { getCandidate } from '../../modules/tests/candidate/candidate.reducer';
+import { getCandidateId } from '../../modules/tests/candidate/candidate.selector';
 
 @Injectable()
 export class WaitingRoomToCarAnalyticsEffects {
@@ -17,6 +21,7 @@ export class WaitingRoomToCarAnalyticsEffects {
   constructor(
     public analytics: AnalyticsProvider,
     private actions$: Actions,
+    private store$: Store<StoreModel>,
   ) {
     this.analytics.initialiseAnalytics()
           .then(() => {})
@@ -29,7 +34,22 @@ export class WaitingRoomToCarAnalyticsEffects {
   @Effect()
   waitingRoomToCarViewDidEnter$ = this.actions$.pipe(
     ofType(WAITING_ROOM_TO_CAR_VIEW_DID_ENTER),
-    switchMap((action: WaitingRoomToCarViewDidEnter) => {
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        select(getCurrentTestSlotId),
+      ),
+      this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getJournalData),
+        select(getCandidate),
+        select(getCandidateId),
+        ),
+    ),
+    switchMap(([action, slotId, candidateId]: [WaitingRoomToCarViewDidEnter, string, number]) => {
+      this.analytics.addCustomDimension(AnalyticsDimensionIndices.CANDIDATE_ID, `${candidateId}`);
+      this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_ID, `${slotId}`);
       this.analytics.setCurrentPage(AnalyticsScreenNames.WAITING_ROOM_TO_CAR);
       return of();
     }),

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.analytics.effects.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.analytics.effects.ts
@@ -3,10 +3,18 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
 import { switchMap, withLatestFrom } from 'rxjs/operators';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
-import { AnalyticsScreenNames, AnalyticsDimensionIndices } from '../../providers/analytics/analytics.model';
+import {
+  AnalyticsScreenNames,
+  AnalyticsDimensionIndices,
+  AnalyticsErrorTypes,
+} from '../../providers/analytics/analytics.model';
 import {
   WAITING_ROOM_TO_CAR_VIEW_DID_ENTER,
   WaitingRoomToCarViewDidEnter,
+  WAITING_ROOM_TO_CAR_ERROR,
+  WaitingRoomToCarError,
+  WAITING_ROOM_TO_CAR_VALIDATION_ERROR,
+  WaitingRoomToCarValidationError,
 } from '../../pages/waiting-room-to-car/waiting-room-to-car.actions';
 import { StoreModel } from '../../shared/models/store.model';
 import { Store, select } from '@ngrx/store';
@@ -51,6 +59,26 @@ export class WaitingRoomToCarAnalyticsEffects {
       this.analytics.addCustomDimension(AnalyticsDimensionIndices.CANDIDATE_ID, `${candidateId}`);
       this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_ID, `${slotId}`);
       this.analytics.setCurrentPage(AnalyticsScreenNames.WAITING_ROOM_TO_CAR);
+      return of();
+    }),
+  );
+
+  @Effect()
+  waitingRoomToCarError$ = this.actions$.pipe(
+    ofType(WAITING_ROOM_TO_CAR_ERROR),
+    switchMap((action: WaitingRoomToCarError) => {
+      this.analytics.logError(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${AnalyticsScreenNames.WAITING_ROOM_TO_CAR})`,
+        action.errorMessage);
+      return of();
+    }),
+  );
+
+  @Effect()
+  waitingRoomToCarValidationError$ = this.actions$.pipe(
+    ofType(WAITING_ROOM_TO_CAR_VALIDATION_ERROR),
+    switchMap((action: WaitingRoomToCarValidationError) => {
+      this.analytics.logError(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${AnalyticsScreenNames.WAITING_ROOM_TO_CAR})`,
+        action.errorMessage);
       return of();
     }),
   );

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.ts
@@ -285,7 +285,7 @@ export class WaitingRoomToCarPage extends PracticeableBasePageComponent {
       Object.keys(this.form.controls).forEach((controlName) => {
         if (this.form.controls[controlName].invalid) {
           this.store$.dispatch(new waitingRoomToCarActions.WaitingRoomToCarValidationError(
-            `${controlName} is invalid`,
+            `${controlName} is blank`,
           ));
         }
       });

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.ts
@@ -283,7 +283,7 @@ export class WaitingRoomToCarPage extends PracticeableBasePageComponent {
       });
     } else {
       Object.keys(this.form.controls).forEach((controlName) => {
-        if (this.isCtrlDirtyAndInvalid(controlName)) {
+        if (this.form.controls[controlName].invalid) {
           this.store$.dispatch(new waitingRoomToCarActions.WaitingRoomToCarValidationError(
             `${controlName} is invalid`,
           ));

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.ts
@@ -4,7 +4,7 @@ import { PracticeableBasePageComponent } from '../../shared/classes/practiceable
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
-import { WaitingRoomToCarViewDidEnter } from './waiting-room-to-car.actions';
+import * as waitingRoomToCarActions from './waiting-room-to-car.actions';
 import { Observable } from 'rxjs/Observable';
 import { GearboxCategory } from '@dvsa/mes-test-schema/categories/B';
 import { getCurrentTest, getJournalData } from '../../modules/tests/tests.selector';
@@ -228,7 +228,7 @@ export class WaitingRoomToCarPage extends PracticeableBasePageComponent {
   }
 
   ionViewDidEnter(): void {
-    this.store$.dispatch(new WaitingRoomToCarViewDidEnter());
+    this.store$.dispatch(new waitingRoomToCarActions.WaitingRoomToCarViewDidEnter());
   }
 
   ionViewWillLeave(): void {
@@ -279,6 +279,14 @@ export class WaitingRoomToCarPage extends PracticeableBasePageComponent {
         const view = this.navController.getViews().find(view => view.id === WAITING_ROOM_TO_CAR_PAGE);
         if (view) {
           this.navController.removeView(view);
+        }
+      });
+    } else {
+      Object.keys(this.form.controls).forEach((controlName) => {
+        if (this.isCtrlDirtyAndInvalid(controlName)) {
+          this.store$.dispatch(new waitingRoomToCarActions.WaitingRoomToCarValidationError(
+            `${controlName} is invalid`,
+          ));
         }
       });
     }

--- a/src/pages/waiting-room/__tests__/waiting-room.analytics.effects.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.analytics.effects.spec.ts
@@ -1,0 +1,120 @@
+import { WaitingRoomAnalyticsEffects } from '../waiting-room.analytics.effects';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { StoreModule, Store } from '@ngrx/store';
+import { provideMockActions } from '@ngrx/effects/testing';
+import * as waitingRoomActions from '../waiting-room.actions';
+import { AnalyticsProvider } from '../../../providers/analytics/analytics';
+import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
+import { of } from 'rxjs/observable/of';
+import {
+  AnalyticsDimensionIndices,
+  AnalyticsScreenNames,
+  AnalyticsErrorTypes,
+} from '../../../providers/analytics/analytics.model';
+
+describe('Waiting Room Analytics Effects', () => {
+
+  let effects: WaitingRoomAnalyticsEffects;
+  let analyticsProviderMock;
+  let actions$: any;
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: () => ({
+            currentTest: {
+              slotId: '123',
+            },
+            testStatus: {},
+            startedTests: {
+              123: {
+                vehicleDetails: {},
+                accompaniment: {},
+                testData: {},
+                journalData: {
+                  candidate: {
+                    candidateId: 1001,
+                  },
+                },
+              },
+            },
+          }),
+        }),
+      ],
+      providers: [
+        WaitingRoomAnalyticsEffects,
+        { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
+        provideMockActions(() => actions$),
+        Store,
+      ],
+    });
+    effects = TestBed.get(WaitingRoomAnalyticsEffects);
+    analyticsProviderMock = TestBed.get(AnalyticsProvider);
+  });
+
+  describe('waitingRoomViewDidEnter', () => {
+    it('should call setCurrentPage and addCustomDimension', fakeAsync((done) => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'addCustomDimension').and.callThrough();
+      spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
+      // ACT
+      actions$.next(new waitingRoomActions.WaitingRoomViewDidEnter());
+      tick();
+      // ASSERT
+      effects.waitingRoomViewDidEnter$.subscribe((result) => {
+        expect(result instanceof of).toBe(true);
+        expect(effects.analytics.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(effects.analytics.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, '123');
+        expect(effects.analytics.setCurrentPage)
+          .toHaveBeenCalledWith(AnalyticsScreenNames.WAITING_ROOM);
+        done();
+      });
+    }));
+
+  });
+
+  describe('submitWaitingRoomInfoError', () => {
+    it('should call logError', fakeAsync((done) => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logError').and.callThrough();
+      // ACT
+      actions$.next(new waitingRoomActions.SubmitWaitingRoomInfoError('error 123'));
+      tick();
+      // ASSERT
+      effects.submitWaitingRoomInfoError$.subscribe((result) => {
+        expect(result instanceof of).toBe(true);
+
+        expect(effects.analytics.logError)
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${AnalyticsScreenNames.WAITING_ROOM})`,
+          'error 123');
+        done();
+      });
+    }));
+
+  });
+
+  describe('submitWaitingRoomInfoErrorValidation', () => {
+    it('should call logError', fakeAsync((done) => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logError').and.callThrough();
+      // ACT
+      actions$.next(new waitingRoomActions.WaitingRoomValidationError('formControl1'));
+      tick();
+      // ASSERT
+      effects.submitWaitingRoomInfoErrorValidation$.subscribe((result) => {
+        expect(result instanceof of).toBe(true);
+        expect(effects.analytics.logError)
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${AnalyticsScreenNames.WAITING_ROOM})`,
+          'formControl1');
+        done();
+      });
+    }));
+
+  });
+
+});

--- a/src/pages/waiting-room/__tests__/waiting-room.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.spec.ts
@@ -185,9 +185,9 @@ describe('WaitingRoomPage', () => {
       form.get('signatureAreaCtrl').setValue(null);
       component.onSubmit();
       tick();
-      expect(store$.dispatch).toHaveBeenCalledWith(new WaitingRoomValidationError('insuranceCheckboxCtrl is invalid'));
-      expect(store$.dispatch).toHaveBeenCalledWith(new WaitingRoomValidationError('residencyCheckboxCtrl is invalid'));
-      expect(store$.dispatch).toHaveBeenCalledWith(new WaitingRoomValidationError('signatureAreaCtrl is invalid'));
+      expect(store$.dispatch).toHaveBeenCalledWith(new WaitingRoomValidationError('insuranceCheckboxCtrl is blank'));
+      expect(store$.dispatch).toHaveBeenCalledWith(new WaitingRoomValidationError('residencyCheckboxCtrl is blank'));
+      expect(store$.dispatch).toHaveBeenCalledWith(new WaitingRoomValidationError('signatureAreaCtrl is blank'));
     }));
   });
   describe('rehydrateFields', () => {

--- a/src/pages/waiting-room/__tests__/waiting-room.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../providers/device-authentication/__mocks__/device-authentication.mock';
 import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
-import { SubmitWaitingRoomInfo } from '../waiting-room.actions';
+import { SubmitWaitingRoomInfo, WaitingRoomValidationError } from '../waiting-room.actions';
 import { of } from 'rxjs/observable/of';
 import { TranslateModule, TranslateService } from 'ng2-translate';
 import { Subscription } from 'rxjs/Subscription';
@@ -177,6 +177,17 @@ describe('WaitingRoomPage', () => {
       component.onSubmit();
       tick();
       expect(store$.dispatch).toHaveBeenCalledWith(new SubmitWaitingRoomInfo());
+    }));
+    it('should dispatch the WaitingRoomValidationError action', fakeAsync(() => {
+      const form = component.form;
+      form.get('insuranceCheckboxCtrl').setValue(false);
+      form.get('residencyCheckboxCtrl').setValue(false);
+      form.get('signatureAreaCtrl').setValue(null);
+      component.onSubmit();
+      tick();
+      expect(store$.dispatch).toHaveBeenCalledWith(new WaitingRoomValidationError('insuranceCheckboxCtrl is invalid'));
+      expect(store$.dispatch).toHaveBeenCalledWith(new WaitingRoomValidationError('residencyCheckboxCtrl is invalid'));
+      expect(store$.dispatch).toHaveBeenCalledWith(new WaitingRoomValidationError('signatureAreaCtrl is invalid'));
     }));
   });
   describe('rehydrateFields', () => {

--- a/src/pages/waiting-room/waiting-room.actions.ts
+++ b/src/pages/waiting-room/waiting-room.actions.ts
@@ -3,7 +3,7 @@ import { Action } from '@ngrx/store';
 export const WAITING_ROOM_VIEW_DID_ENTER = '[WaitingRoomPage] Waiting Room Did Enter';
 export const SUBMIT_WAITING_ROOM_INFO = '[WaitingRoomPage] Submit Waiting Room Info';
 export const SUBMIT_WAITING_ROOM_INFO_ERROR = '[WaitingRoomPage] Submit Waiting Room Info Error';
-export const SUBMIT_WAITING_ROOM_INFO_VALIDATION_ERROR = '[WaitingRoomPage] Submit Waiting Room Info Validation Error';
+export const WAITING_ROOM_VALIDATION_ERROR = '[WaitingRoomPage] Waiting Room Validation Error';
 
 export class WaitingRoomViewDidEnter implements Action {
   readonly type = WAITING_ROOM_VIEW_DID_ENTER;
@@ -18,8 +18,8 @@ export class SubmitWaitingRoomInfoError implements Action {
   constructor(public errorMessage: string) { }
 }
 
-export class SubmitWaitingRoomInfoValidationError implements Action {
-  readonly type = SUBMIT_WAITING_ROOM_INFO_VALIDATION_ERROR;
+export class WaitingRoomValidationError implements Action {
+  readonly type = WAITING_ROOM_VALIDATION_ERROR;
   constructor(public errorMessage: string) { }
 }
 
@@ -27,4 +27,4 @@ export type Types =
   | WaitingRoomViewDidEnter
   | SubmitWaitingRoomInfo
   | SubmitWaitingRoomInfoError
-  | SubmitWaitingRoomInfoValidationError;
+  | WaitingRoomValidationError;

--- a/src/pages/waiting-room/waiting-room.actions.ts
+++ b/src/pages/waiting-room/waiting-room.actions.ts
@@ -15,12 +15,12 @@ export class SubmitWaitingRoomInfo implements Action {
 
 export class SubmitWaitingRoomInfoError implements Action {
   readonly type = SUBMIT_WAITING_ROOM_INFO_ERROR;
-  constructor(public errorDescription: string, public errorMessage: string) { }
+  constructor(public errorMessage: string) { }
 }
 
 export class SubmitWaitingRoomInfoValidationError implements Action {
   readonly type = SUBMIT_WAITING_ROOM_INFO_VALIDATION_ERROR;
-  constructor(public errorDescription: string, public errorMessage: string) { }
+  constructor(public errorMessage: string) { }
 }
 
 export type Types =

--- a/src/pages/waiting-room/waiting-room.actions.ts
+++ b/src/pages/waiting-room/waiting-room.actions.ts
@@ -2,6 +2,8 @@ import { Action } from '@ngrx/store';
 
 export const WAITING_ROOM_VIEW_DID_ENTER = '[WaitingRoomPage] Waiting Room Did Enter';
 export const SUBMIT_WAITING_ROOM_INFO = '[WaitingRoomPage] Submit Waiting Room Info';
+export const SUBMIT_WAITING_ROOM_INFO_ERROR = '[WaitingRoomPage] Submit Waiting Room Info Error';
+export const SUBMIT_WAITING_ROOM_INFO_VALIDATION_ERROR = '[WaitingRoomPage] Submit Waiting Room Info Validation Error';
 
 export class WaitingRoomViewDidEnter implements Action {
   readonly type = WAITING_ROOM_VIEW_DID_ENTER;
@@ -11,6 +13,18 @@ export class SubmitWaitingRoomInfo implements Action {
   readonly type = SUBMIT_WAITING_ROOM_INFO;
 }
 
+export class SubmitWaitingRoomInfoError implements Action {
+  readonly type = SUBMIT_WAITING_ROOM_INFO_ERROR;
+  constructor(public errorDescription: string, public errorMessage: string) { }
+}
+
+export class SubmitWaitingRoomInfoValidationError implements Action {
+  readonly type = SUBMIT_WAITING_ROOM_INFO_VALIDATION_ERROR;
+  constructor(public errorDescription: string, public errorMessage: string) { }
+}
+
 export type Types =
   | WaitingRoomViewDidEnter
-  | SubmitWaitingRoomInfo;
+  | SubmitWaitingRoomInfo
+  | SubmitWaitingRoomInfoError
+  | SubmitWaitingRoomInfoValidationError;

--- a/src/pages/waiting-room/waiting-room.analytics.effects.ts
+++ b/src/pages/waiting-room/waiting-room.analytics.effects.ts
@@ -1,15 +1,19 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
-import { switchMap } from 'rxjs/operators';
+import { switchMap, withLatestFrom } from 'rxjs/operators';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
-import {
-  AnalyticsScreenNames,
-} from '../../providers/analytics/analytics.model';
+import { AnalyticsScreenNames, AnalyticsDimensionIndices } from '../../providers/analytics/analytics.model';
 import {
   WAITING_ROOM_VIEW_DID_ENTER,
   WaitingRoomViewDidEnter,
 } from '../../pages/waiting-room/waiting-room.actions';
+import { StoreModel } from '../../shared/models/store.model';
+import { Store, select } from '@ngrx/store';
+import { getTests } from '../../modules/tests/tests.reducer';
+import { getCurrentTestSlotId, getCurrentTest, getJournalData } from '../../modules/tests/tests.selector';
+import { getCandidate } from '../../modules/tests/candidate/candidate.reducer';
+import { getCandidateId } from '../../modules/tests/candidate/candidate.selector';
 
 @Injectable()
 export class WaitingRoomAnalyticsEffects {
@@ -17,19 +21,35 @@ export class WaitingRoomAnalyticsEffects {
   constructor(
     public analytics: AnalyticsProvider,
     private actions$: Actions,
+    private store$: Store<StoreModel>,
   ) {
     this.analytics.initialiseAnalytics()
-          .then(() => {})
-          .catch(() => {
-            console.log('error initialising analytics');
-          },
+    .then(() => {})
+    .catch(() => {
+      console.log('error initialising analytics');
+    },
     );
   }
 
   @Effect()
   waitingRoomViewDidEnter$ = this.actions$.pipe(
     ofType(WAITING_ROOM_VIEW_DID_ENTER),
-    switchMap((action: WaitingRoomViewDidEnter) => {
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        select(getCurrentTestSlotId),
+      ),
+      this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getJournalData),
+        select(getCandidate),
+        select(getCandidateId),
+        ),
+    ),
+    switchMap(([action, slotId, candidateId]: [WaitingRoomViewDidEnter, string, number]) => {
+      this.analytics.addCustomDimension(AnalyticsDimensionIndices.CANDIDATE_ID, `${candidateId}`);
+      this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_ID, `${slotId}`);
       this.analytics.setCurrentPage(AnalyticsScreenNames.WAITING_ROOM);
       return of();
     }),

--- a/src/pages/waiting-room/waiting-room.analytics.effects.ts
+++ b/src/pages/waiting-room/waiting-room.analytics.effects.ts
@@ -64,7 +64,7 @@ export class WaitingRoomAnalyticsEffects {
   );
 
   @Effect()
-  submitWaitingRoomInfoErrorEffect$ = this.actions$.pipe(
+  submitWaitingRoomInfoError$ = this.actions$.pipe(
     ofType(SUBMIT_WAITING_ROOM_INFO_ERROR),
     switchMap((action: SubmitWaitingRoomInfoError) => {
       this.analytics.logError(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${AnalyticsScreenNames.WAITING_ROOM})`,
@@ -74,7 +74,7 @@ export class WaitingRoomAnalyticsEffects {
   );
 
   @Effect()
-  submitWaitingRoomInfoErrorValidationEffect$ = this.actions$.pipe(
+  submitWaitingRoomInfoErrorValidation$ = this.actions$.pipe(
     ofType(WAITING_ROOM_VALIDATION_ERROR),
     switchMap((action: WaitingRoomValidationError) => {
       this.analytics.logError(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${AnalyticsScreenNames.WAITING_ROOM})`,

--- a/src/pages/waiting-room/waiting-room.analytics.effects.ts
+++ b/src/pages/waiting-room/waiting-room.analytics.effects.ts
@@ -13,8 +13,8 @@ import {
   WaitingRoomViewDidEnter,
   SUBMIT_WAITING_ROOM_INFO_ERROR,
   SubmitWaitingRoomInfoError,
-  SUBMIT_WAITING_ROOM_INFO_VALIDATION_ERROR,
-  SubmitWaitingRoomInfoValidationError,
+  WAITING_ROOM_VALIDATION_ERROR,
+  WaitingRoomValidationError,
 } from '../../pages/waiting-room/waiting-room.actions';
 import { StoreModel } from '../../shared/models/store.model';
 import { Store, select } from '@ngrx/store';
@@ -75,8 +75,8 @@ export class WaitingRoomAnalyticsEffects {
 
   @Effect()
   submitWaitingRoomInfoErrorValidationEffect$ = this.actions$.pipe(
-    ofType(SUBMIT_WAITING_ROOM_INFO_VALIDATION_ERROR),
-    switchMap((action: SubmitWaitingRoomInfoValidationError) => {
+    ofType(WAITING_ROOM_VALIDATION_ERROR),
+    switchMap((action: WaitingRoomValidationError) => {
       this.analytics.logError(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${AnalyticsScreenNames.WAITING_ROOM})`,
         action.errorMessage);
       return of();

--- a/src/pages/waiting-room/waiting-room.analytics.effects.ts
+++ b/src/pages/waiting-room/waiting-room.analytics.effects.ts
@@ -7,6 +7,10 @@ import { AnalyticsScreenNames, AnalyticsDimensionIndices } from '../../providers
 import {
   WAITING_ROOM_VIEW_DID_ENTER,
   WaitingRoomViewDidEnter,
+  SUBMIT_WAITING_ROOM_INFO_ERROR,
+  SubmitWaitingRoomInfoError,
+  SUBMIT_WAITING_ROOM_INFO_VALIDATION_ERROR,
+  SubmitWaitingRoomInfoValidationError,
 } from '../../pages/waiting-room/waiting-room.actions';
 import { StoreModel } from '../../shared/models/store.model';
 import { Store, select } from '@ngrx/store';
@@ -51,6 +55,24 @@ export class WaitingRoomAnalyticsEffects {
       this.analytics.addCustomDimension(AnalyticsDimensionIndices.CANDIDATE_ID, `${candidateId}`);
       this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_ID, `${slotId}`);
       this.analytics.setCurrentPage(AnalyticsScreenNames.WAITING_ROOM);
+      return of();
+    }),
+  );
+
+  @Effect()
+  submitWaitingRoomInfoErrorEffect$ = this.actions$.pipe(
+    ofType(SUBMIT_WAITING_ROOM_INFO_ERROR),
+    switchMap((action: SubmitWaitingRoomInfoError) => {
+      this.analytics.logError(`${action.errorDescription} (${AnalyticsScreenNames.WAITING_ROOM})`, action.errorMessage);
+      return of();
+    }),
+  );
+
+  @Effect()
+  submitWaitingRoomInfoErrorValidationEffect$ = this.actions$.pipe(
+    ofType(SUBMIT_WAITING_ROOM_INFO_VALIDATION_ERROR),
+    switchMap((action: SubmitWaitingRoomInfoValidationError) => {
+      this.analytics.logError(`${action.errorDescription} (${AnalyticsScreenNames.WAITING_ROOM})`, action.errorMessage);
       return of();
     }),
   );

--- a/src/pages/waiting-room/waiting-room.analytics.effects.ts
+++ b/src/pages/waiting-room/waiting-room.analytics.effects.ts
@@ -3,7 +3,11 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
 import { switchMap, withLatestFrom } from 'rxjs/operators';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
-import { AnalyticsScreenNames, AnalyticsDimensionIndices } from '../../providers/analytics/analytics.model';
+import {
+  AnalyticsScreenNames,
+  AnalyticsDimensionIndices,
+  AnalyticsErrorTypes,
+} from '../../providers/analytics/analytics.model';
 import {
   WAITING_ROOM_VIEW_DID_ENTER,
   WaitingRoomViewDidEnter,
@@ -63,7 +67,8 @@ export class WaitingRoomAnalyticsEffects {
   submitWaitingRoomInfoErrorEffect$ = this.actions$.pipe(
     ofType(SUBMIT_WAITING_ROOM_INFO_ERROR),
     switchMap((action: SubmitWaitingRoomInfoError) => {
-      this.analytics.logError(`${action.errorDescription} (${AnalyticsScreenNames.WAITING_ROOM})`, action.errorMessage);
+      this.analytics.logError(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${AnalyticsScreenNames.WAITING_ROOM})`,
+        action.errorMessage);
       return of();
     }),
   );
@@ -72,7 +77,8 @@ export class WaitingRoomAnalyticsEffects {
   submitWaitingRoomInfoErrorValidationEffect$ = this.actions$.pipe(
     ofType(SUBMIT_WAITING_ROOM_INFO_VALIDATION_ERROR),
     switchMap((action: SubmitWaitingRoomInfoValidationError) => {
-      this.analytics.logError(`${action.errorDescription} (${AnalyticsScreenNames.WAITING_ROOM})`, action.errorMessage);
+      this.analytics.logError(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${AnalyticsScreenNames.WAITING_ROOM})`,
+        action.errorMessage);
       return of();
     }),
   );

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -33,6 +33,8 @@ import {
 } from '../../modules/tests/communication-preferences/communication-preferences.reducer';
 import { getConductedLanguage } from '../../modules/tests/communication-preferences/communication-preferences.selector';
 import { COMMUNICATION_PAGE, WAITING_ROOM_PAGE, WAITING_ROOM_TO_CAR_PAGE } from '../page-names.constants';
+import { AnalyticsProvider } from '../../providers/analytics/analytics';
+import { AnalyticsScreenNames } from '../../providers/analytics/analytics.model';
 
 interface WaitingRoomPageState {
   insuranceDeclarationAccepted$: Observable<boolean>;
@@ -77,6 +79,7 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
     public authenticationProvider: AuthenticationProvider,
     private deviceAuthenticationProvider: DeviceAuthenticationProvider,
     private translate: TranslateService,
+    public analytics: AnalyticsProvider,
   ) {
     super(platform, navController, authenticationProvider, store$);
     this.form = new FormGroup(this.getFormValidation());
@@ -208,6 +211,14 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
         .catch((err) => {
           console.log(err);
         });
+    } else {
+      const validation = this.getFormValidation();
+      Object.keys(validation).forEach((controlName) => {
+        if (this.isCtrlDirtyAndInvalid(controlName)) {
+          console.log(`${controlName} is invalid`);
+          this.analytics.logError(`Validation error (${AnalyticsScreenNames.WAITING_ROOM})`, `${controlName}`);
+        }
+      });
     }
   }
 

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -211,7 +211,7 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
     } else {
       Object.keys(this.form.controls).forEach((controlName) => {
         if (this.form.controls[controlName].invalid) {
-          this.store$.dispatch(new waitingRoomActions.WaitingRoomValidationError(`${controlName} is invalid`));
+          this.store$.dispatch(new waitingRoomActions.WaitingRoomValidationError(`${controlName} is blank`));
         }
       });
     }

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -207,7 +207,6 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
         })
         .catch((err) => {
           this.store$.dispatch(new waitingRoomActions.SubmitWaitingRoomInfoError(
-            'Error submitting Waiting Room Info',
             err,
           ));
         });
@@ -215,7 +214,6 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
       Object.keys(this.getFormValidation()).forEach((controlName) => {
         if (this.isCtrlDirtyAndInvalid(controlName)) {
           this.store$.dispatch(new waitingRoomActions.SubmitWaitingRoomInfoValidationError(
-            `Validation error`,
             `${controlName} is invalid`,
           ));
         }

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -206,16 +206,12 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
           });
         })
         .catch((err) => {
-          this.store$.dispatch(new waitingRoomActions.SubmitWaitingRoomInfoError(
-            err,
-          ));
+          this.store$.dispatch(new waitingRoomActions.SubmitWaitingRoomInfoError(err));
         });
     } else {
-      Object.keys(this.getFormValidation()).forEach((controlName) => {
+      Object.keys(this.form.controls).forEach((controlName) => {
         if (this.isCtrlDirtyAndInvalid(controlName)) {
-          this.store$.dispatch(new waitingRoomActions.SubmitWaitingRoomInfoValidationError(
-            `${controlName} is invalid`,
-          ));
+          this.store$.dispatch(new waitingRoomActions.WaitingRoomValidationError(`${controlName} is invalid`));
         }
       });
     }

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -210,7 +210,7 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
         });
     } else {
       Object.keys(this.form.controls).forEach((controlName) => {
-        if (this.isCtrlDirtyAndInvalid(controlName)) {
+        if (this.form.controls[controlName].invalid) {
           this.store$.dispatch(new waitingRoomActions.WaitingRoomValidationError(`${controlName} is invalid`));
         }
       });

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -34,7 +34,6 @@ import {
 import { getConductedLanguage } from '../../modules/tests/communication-preferences/communication-preferences.selector';
 import { COMMUNICATION_PAGE, WAITING_ROOM_PAGE, WAITING_ROOM_TO_CAR_PAGE } from '../page-names.constants';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
-import { AnalyticsScreenNames } from '../../providers/analytics/analytics.model';
 
 interface WaitingRoomPageState {
   insuranceDeclarationAccepted$: Observable<boolean>;
@@ -209,14 +208,18 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
           });
         })
         .catch((err) => {
-          console.log(err);
+          this.store$.dispatch(new waitingRoomActions.SubmitWaitingRoomInfoError(
+            'Error submitting Waiting Room Info',
+            err,
+          ));
         });
     } else {
-      const validation = this.getFormValidation();
-      Object.keys(validation).forEach((controlName) => {
+      Object.keys(this.getFormValidation()).forEach((controlName) => {
         if (this.isCtrlDirtyAndInvalid(controlName)) {
-          console.log(`${controlName} is invalid`);
-          this.analytics.logError(`Validation error (${AnalyticsScreenNames.WAITING_ROOM})`, `${controlName}`);
+          this.store$.dispatch(new waitingRoomActions.SubmitWaitingRoomInfoValidationError(
+            `Validation error`,
+            `${controlName} is invalid`,
+          ));
         }
       });
     }

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -33,7 +33,6 @@ import {
 } from '../../modules/tests/communication-preferences/communication-preferences.reducer';
 import { getConductedLanguage } from '../../modules/tests/communication-preferences/communication-preferences.selector';
 import { COMMUNICATION_PAGE, WAITING_ROOM_PAGE, WAITING_ROOM_TO_CAR_PAGE } from '../page-names.constants';
-import { AnalyticsProvider } from '../../providers/analytics/analytics';
 
 interface WaitingRoomPageState {
   insuranceDeclarationAccepted$: Observable<boolean>;
@@ -78,7 +77,6 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
     public authenticationProvider: AuthenticationProvider,
     private deviceAuthenticationProvider: DeviceAuthenticationProvider,
     private translate: TranslateService,
-    public analytics: AnalyticsProvider,
   ) {
     super(platform, navController, authenticationProvider, store$);
     this.form = new FormGroup(this.getFormValidation());

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -57,8 +57,8 @@ export enum AnalyticsDimensionIndices {
     JOURNAL_DAYS_FROM_TODAY = 2,
     CANDIDATE_WITH_SPECIAL_NEEDS = 3,
     CANDIDATE_WITH_CHECK = 4,
-    CANDIDATE_ID= 5,
-    TEST_ID= 6,
+    CANDIDATE_ID = 5,
+    TEST_ID = 6,
   }
 
 export enum JournalRefreshModes {

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -58,6 +58,7 @@ export enum AnalyticsDimensionIndices {
     CANDIDATE_WITH_SPECIAL_NEEDS = 3,
     CANDIDATE_WITH_CHECK = 4,
     CANDIDATE_ID= 5,
+    TEST_ID= 6,
   }
 
 export enum JournalRefreshModes {

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -65,3 +65,8 @@ export enum JournalRefreshModes {
     MANUAL = 'MANUAL',
     AUTOMATIC = 'AUTOMATIC',
   }
+
+export enum AnalyticsErrorTypes {
+    SUBMIT_FORM_ERROR = 'submit form error',
+    VALIDATION_ERROR = 'validation error',
+  }


### PR DESCRIPTION
## Description and relevant Jira numbers
Created analytics effects for the Waiting Room and Waiting Room To Car pages.
For logging screen views and custom dimensions, data is returned from the store.
For logging errors, the error is passed to the action as a payload.

When a form is invalid, the controls are iterated over and a new validation error `xxxx control is invalid` is raised for each control.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

![Screenshot 2019-07-08 at 16 07 57](https://user-images.githubusercontent.com/8069071/60821060-b37f2300-a19a-11e9-9725-4a2537f05aab.png)
