### PR TITLE
Update ui test support ios12 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can run the Appium testsuite against an iOS simulator.
 
 Pre-requisites
 
-- iPad Pro 10.5 Simulator running iOS 12.1 (If you are running the latest version of XCode you will need to manually download this `XCode > Preferences ... > Components > iOS 12.1 Simulator`)
+- iPad Pro 10.5 Simulator running iOS 12.1 (If you are running the latest version of XCode you will need to manually download this `XCode > Preferences ... > Components > iOS 12.1 Simulator`). iOS 12.1 is the default but there is now support for 12.2 which may save you having to download the 12.1 simulator (see below)
 - Carthage (`brew install carthage` - https://github.com/appium/appium/blob/HEAD/docs/en/drivers/ios-xcuitest.md - dependancy of XCUITest driver)
 - Notes : if you get /usr/local/share/man issues 
           try: sudo chown -R $(whoami):admin /usr/local/share/man (don't sudo brew)
@@ -66,7 +66,7 @@ Pre-requisites
 To run against the simulator
 
 - Build the application `ionic cordova build ios -- --buildFlag="-UseModernBuildSystem=0" --emulator`
-- Run Appium `npx appium`
+- Run Appium `npx appium` (To reduce wait times you can install appium globally and use that instead)
 - Add/Update the test/e2e/test.config.ts
 - In another tab execute the simulator based testsuite `npm run test:e2e-simulator-bdd`
 - Once complete generate the report `npm run test:generate-report`
@@ -74,6 +74,8 @@ To run against the simulator
 You can run individual features e.g. `npm run test:e2e-simulator-bdd -- --specs='test/e2e/features/01-login.feature'`
 
 You can also run an individual tag e.g. `npm run test:e2e-simulator-bdd -- --cucumberOpts.tags='@smoke'`
+
+To run against a simulator with a different iOS version e.g. `npm run test:e2e-simulator-bdd -- --capabilities.platformVersion='12.2'`
 
 #### Troubleshooting
 

--- a/e2e-simulator-bdd.conf.js
+++ b/e2e-simulator-bdd.conf.js
@@ -5,7 +5,7 @@ exports.config = {
   allScriptsTimeout: 11000,
   capabilities: {
     platformName: 'iOS',
-    platformVersion: '12.1',
+    platformVersion: '12.2',
     deviceName: 'iPad Pro (10.5-inch)',
     browserName: '',
     autoWebview: true,

--- a/e2e-simulator-bdd.conf.js
+++ b/e2e-simulator-bdd.conf.js
@@ -5,7 +5,7 @@ exports.config = {
   allScriptsTimeout: 11000,
   capabilities: {
     platformName: 'iOS',
-    platformVersion: '12.2',
+    platformVersion: '12.1',
     deviceName: 'iPad Pro (10.5-inch)',
     browserName: '',
     autoWebview: true,

--- a/test/e2e/step-definitions/generic-steps.ts
+++ b/test/e2e/step-definitions/generic-steps.ts
@@ -31,7 +31,7 @@ Given('I am not logged in', () => {
       browser.wait(ExpectedConditions.presenceOf(usernameFld));
 
       // Switch back to WEBVIEW context
-      browser.driver.selectContext(webviewContext);
+      browser.driver.selectContext(getParentContext(webviewContext));
     });
   });
 });
@@ -83,7 +83,7 @@ Then('I should see the Microsoft login page', () => {
       expect(usernameFld.isPresent()).to.eventually.be.true;
 
       // Switch back to WEBVIEW context
-      browser.driver.selectContext(webviewContext);
+      browser.driver.selectContext(getParentContext(webviewContext));
     });
   });
 });
@@ -190,7 +190,7 @@ export const logInToApplication = (username, password) => {
       signInButtonElement.click();
 
       // Switch back to WEBVIEW context
-      browser.driver.selectContext(webviewContext);
+      browser.driver.selectContext(getParentContext(webviewContext));
 
       // Wait for journal page to load
       const refreshButton = element(by.xpath('//button/span/span/span[text() = "Refresh"]'));
@@ -213,22 +213,26 @@ export const loggedInAs = (staffNumber) => {
  * Logs out of the application and takes them to the login page if they were logged in else returns current page
  */
 export const logout = () => {
-  browser.wait(ExpectedConditions.presenceOf(element(by.xpath('//ion-app'))));
-  browser.wait(ExpectedConditions.stalenessOf(element(by.className('click-block-active'))));
-  const logout = element(by.xpath('//button/span/span[contains(text(), "Logout")]'));
-  logout.isPresent().then((result) => {
-    if (result) {
-      browser.wait(ExpectedConditions.elementToBeClickable(logout));
-      logout.click().then(() => {
-        // After logout click sign in to get us to the login screen
-        browser.sleep(TEST_CONFIG.ACTION_WAIT);
-        browser.wait(ExpectedConditions.stalenessOf(element(by.className('click-block-active'))));
-        const signIn = element(by.xpath('//span[contains(text(), "Sign in")]'));
-        clickElement(signIn);
-      });
-    } else {
-      return Promise.resolve();
-    }
+  browser.driver.getCurrentContext().then((webviewContext) => {
+    browser.driver.selectContext(getParentContext(webviewContext));
+    browser.wait(ExpectedConditions.presenceOf(element(by.xpath('//ion-app'))));
+    browser.wait(ExpectedConditions.stalenessOf(element(by.className('click-block-active'))));
+    const logout = element(by.xpath('//button/span/span[contains(text(), "Logout")]'));
+    logout.isPresent().then((result) => {
+      if (result) {
+        browser.wait(ExpectedConditions.elementToBeClickable(logout));
+        logout.click().then(() => {
+          // After logout click sign in to get us to the login screen
+          browser.sleep(TEST_CONFIG.ACTION_WAIT);
+          browser.driver.selectContext(getParentContext(webviewContext));
+          browser.wait(ExpectedConditions.stalenessOf(element(by.className('click-block-active'))));
+          const signIn = element(by.xpath('//span[contains(text(), "Sign in")]'));
+          clickElement(signIn);
+        });
+      } else {
+        return Promise.resolve();
+      }
+    });
   });
 };
 
@@ -294,7 +298,7 @@ export const enterPasscode = () => {
       browser.actions().sendKeys('PASSWORD').sendKeys(Key.ENTER).perform();
 
       // Switch back to WEBVIEW context
-      browser.driver.selectContext(webviewContext).then(() => {
+      browser.driver.selectContext(getParentContext(webviewContext)).then(() => {
         browser.driver.sleep(TEST_CONFIG.PAGE_LOAD_WAIT);
       });
     });
@@ -362,4 +366,8 @@ const getPageType = (pageName : string) => {
     default:
       return 'page-waiting-room';
   }
+};
+
+export const getParentContext = (currentContext: string) => {
+  return `${currentContext.substring(0, currentContext.indexOf('.'))}.1`;
 };

--- a/test/e2e/step-definitions/generic-steps.ts
+++ b/test/e2e/step-definitions/generic-steps.ts
@@ -306,21 +306,6 @@ export const enterPasscode = () => {
 };
 
 /**
- * Alternative way to enter text where the field element does not allow direct text entry.
- * Works by setting focus on the field and then sending browser actions rather than element actions.
- * @param field the field to enter the text into
- * @param text  the text you wish to enter into the field
- */
-export const enterTextIndirect = (field, text) => {
-  // Wait for field to be present
-  browser.wait(ExpectedConditions.presenceOf(field));
-  // Set focus on the field
-  field.click();
-  // Enter the text using browser actions rather than field send keys
-  browser.actions().sendKeys(text).perform();
-};
-
-/**
  * Output the page source to a file - For debug purposes only
  * @param fileName the name of the file to output to
  */

--- a/test/e2e/step-definitions/testreport-steps.ts
+++ b/test/e2e/step-definitions/testreport-steps.ts
@@ -1,5 +1,5 @@
 import { Then, When } from 'cucumber';
-import { getElement, clickElement } from './generic-steps';
+import { getElement, clickElement, getParentContext } from './generic-steps';
 import { browser, by, element, ExpectedConditions } from 'protractor';
 import { TEST_CONFIG } from '../test.config';
 
@@ -32,7 +32,7 @@ const completeLegalRequirements = () => {
       });
 
       // Switch back to WEBVIEW context
-      browser.driver.selectContext(webviewContext);
+      browser.driver.selectContext(getParentContext(webviewContext));
     });
   });
 };

--- a/test/e2e/step-definitions/waitingroomtocar-steps.ts
+++ b/test/e2e/step-definitions/waitingroomtocar-steps.ts
@@ -1,6 +1,6 @@
 import { When } from 'cucumber';
 import { getElement, clickElement, enterTextIndirect } from './generic-steps';
-import { element, by } from 'protractor';
+import { element, by, browser } from 'protractor';
 
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
@@ -44,8 +44,13 @@ const completeWaitingRoomPage = (withDriverFault: boolean, manualTransmission: b
   const transmissionRadio = getElement(by.id(transmissionSelector));
   clickElement(transmissionRadio);
 
-  const registrationField = element(by.id('registration'));
-  enterTextIndirect(registrationField, 'ABC');
+  const registrationField = getElement(by.id('registration'));
+  clickElement(registrationField);
+  browser.executeScript('document.getElementById("registration").value = "ABC";');
+
+  browser.driver.sleep(2000);
+
+  registrationField.sendKeys('123');
 
   const submitWRTC = getElement(by.xpath('//button[span[h3[text()="Continue to test report"]]]'));
   clickElement(submitWRTC);


### PR DESCRIPTION
Updates to support iOS 12.2. These changes have been made to handle differences in Appium on different iOS 12.2 compared to 12.1.

A bug has been raised with Appium - https://github.com/appium/appium/issues/12682 to get this issue fixed however in the mean time the framework has been updated to handle both versions.

This work around can be removed if the bug fix is implemented by Appium

Note the default iOS version that the automation is run against is still 12.1