### PR TITLE
MES-2930 add test report analytics

### DIFF
--- a/src/pages/journal/journal.analytics.effects.ts
+++ b/src/pages/journal/journal.analytics.effects.ts
@@ -50,6 +50,8 @@ export class JournalAnalyticsEffects {
     switchMap(
       () => {
         this.analytics.setCurrentPage(AnalyticsScreenNames.JOURNAL);
+        this.analytics.addCustomDimension(AnalyticsDimensionIndices.CANDIDATE_ID, '');
+        this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_ID, '');
         return of();
       },
     ),

--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -1,0 +1,304 @@
+import { TestBed } from '@angular/core/testing';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { StoreModule, Store } from '@ngrx/store';
+import { TestReportAnalyticsEffects } from '../test-report.analytics.effects';
+import * as journalActions from '../../journal/journal.actions';
+import * as testsActions from '../../../modules/tests/tests.actions';
+import * as testDataActions from '../../../modules/tests/test-data/test-data.actions';
+import * as testReportActions from '../test-report.actions';
+import { StoreModel } from '../../../shared/models/store.model';
+import { Competencies } from '../../../modules/tests/test-data/test-data.constants';
+import { AnalyticsProvider } from '../../../providers/analytics/analytics';
+import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
+import {
+  AnalyticsScreenNames,
+  AnalyticsEventCategories,
+  AnalyticsEvents,
+} from '../../../providers/analytics/analytics.model';
+import { fullCompetencyLabels } from '../../../shared/constants/competencies/catb-competencies';
+import { testsReducer } from '../../../modules/tests/tests.reducer';
+import { testReportPracticeModeSlot } from '../../../modules/tests/__mocks__/tests.mock';
+
+describe('Test Report Analytics Effects', () => {
+
+  let effects: TestReportAnalyticsEffects;
+  let actions: ReplaySubject<any>;
+  let analyticsProviderMock;
+  let store$: Store<StoreModel>;
+
+  beforeEach(() => {
+    actions = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: testsReducer,
+        }),
+      ],
+      providers: [
+        TestReportAnalyticsEffects,
+        provideMockActions(() => actions),
+        { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
+        Store,
+      ],
+    });
+    effects = TestBed.get(TestReportAnalyticsEffects);
+    analyticsProviderMock = TestBed.get(AnalyticsProvider);
+    store$ = TestBed.get(Store);
+  });
+
+  fdescribe('testReportViewDidEnter', () => {
+    it('should call setCurrentPage and addCustomDimension', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
+      // ACT
+      actions.next(new testReportActions.TestReportViewDidEnter());
+      // ASSERT
+      effects.testReportViewDidEnter$.subscribe((result) => {
+        expect(analyticsProviderMock.setCurrentPage).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+      });
+    });
+  });
+
+  fdescribe('addDrivingFault', () => {
+
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.AddDrivingFault({
+        competency: Competencies.controlsGears,
+        newFaultCount: 1,
+      }));
+      // ASSERT
+      effects.addDrivingFault$.subscribe((result) => {
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DRIVING_FAULT,
+          fullCompetencyLabels[Competencies.controlsGears],
+          1,
+        );
+      });
+    });
+
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      // ACT
+      actions.next(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      actions.next(new testDataActions.AddDrivingFault({
+        competency: Competencies.controlsGears,
+        newFaultCount: 1,
+      }));
+      // ASSERT
+      effects.addDrivingFault$.subscribe((result) => {
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalled();
+      });
+    });
+  });
+
+  // describe('addManoeuvreDrivingFault', () => {
+  //   it('should call logEvent for this competency', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  // });
+
+  // describe('controlledStopAddDrivingFault', () => {
+  //   it('should call logEvent for this competency', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  // });
+
+  // describe('showMeQuestionDrivingFault', () => {
+  //   it('should call logEvent for this competency', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  // });
+
+  // describe('removeDrivingFault', () => {
+  //   it('should call logEvent for this competency', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  // });
+
+  // describe('removeManoeuvreDrivingFault', () => {
+  //   it('should call logEvent for this competency', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  // });
+
+  // describe('controlledStopRemoveFault', () => {
+  //   it('should call logEvent for this competency', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  // });
+
+  // describe('showMeQuestionRemoveFault', () => {
+  //   it('should call logEvent for this competency', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
+  //     // ARRANGE
+  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  //     // ACT
+  //     actions.next(new testReportActions.TestReportViewDidEnter());
+  //     tick();
+  //     // ASSERT
+  //     effects.testReportViewDidEnter$.subscribe((result) => {
+  //       expect(result instanceof of).toBe(true);
+  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+  //       done();
+  //     });
+  //   }));
+  // });
+
+});

--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -8,7 +8,11 @@ import * as testsActions from '../../../modules/tests/tests.actions';
 import * as testDataActions from '../../../modules/tests/test-data/test-data.actions';
 import * as testReportActions from '../test-report.actions';
 import { StoreModel } from '../../../shared/models/store.model';
-import { Competencies } from '../../../modules/tests/test-data/test-data.constants';
+import {
+  Competencies,
+  ManoeuvreCompetencies,
+  ManoeuvreTypes,
+} from '../../../modules/tests/test-data/test-data.constants';
 import { AnalyticsProvider } from '../../../providers/analytics/analytics';
 import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
 import {
@@ -19,6 +23,10 @@ import {
 import { fullCompetencyLabels } from '../../../shared/constants/competencies/catb-competencies';
 import { testsReducer } from '../../../modules/tests/tests.reducer';
 import { testReportPracticeModeSlot } from '../../../modules/tests/__mocks__/tests.mock';
+import {
+  manoeuvreTypeLabels,
+  manoeuvreCompetencyLabels,
+} from '../components/manoeuvre-competency/manoeuvre-competency.constants';
 
 describe('Test Report Analytics Effects', () => {
 
@@ -55,13 +63,13 @@ describe('Test Report Analytics Effects', () => {
       actions.next(new testReportActions.TestReportViewDidEnter());
       // ASSERT
       effects.testReportViewDidEnter$.subscribe((result) => {
+        expect(result).toEqual({});
         expect(analyticsProviderMock.setCurrentPage).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
       });
     });
   });
 
   describe('addDrivingFault', () => {
-
     it('should call logEvent for this competency', () => {
       // ARRANGE
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
@@ -73,6 +81,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addDrivingFault$.subscribe((result) => {
+        expect(result).toEqual({});
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
@@ -81,224 +90,261 @@ describe('Test Report Analytics Effects', () => {
         );
       });
     });
-
     it('should not call logEvent for this competency when it is a practice test', () => {
       // ARRANGE
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       actions.next(new testDataActions.AddDrivingFault({
         competency: Competencies.controlsGears,
         newFaultCount: 1,
       }));
       // ASSERT
       effects.addDrivingFault$.subscribe((result) => {
-        expect(analyticsProviderMock.logEvent).toHaveBeenCalled();
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
   });
 
-  // describe('addManoeuvreDrivingFault', () => {
-  //   it('should call logEvent for this competency', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  // });
+  describe('addManoeuvreDrivingFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.AddManoeuvreDrivingFault({
+        manoeuvre: ManoeuvreTypes.reverseRight,
+        competency: ManoeuvreCompetencies.controlFault,
+      }));
+      // ASSERT
+      effects.addManoeuvreDrivingFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DRIVING_FAULT,
+          // tslint:disable-next-line:max-line-length
+          `${manoeuvreTypeLabels[ManoeuvreTypes.reverseRight]} - ${manoeuvreCompetencyLabels[ManoeuvreCompetencies.controlFault]}`,
+          1,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.AddManoeuvreDrivingFault({
+        manoeuvre: ManoeuvreTypes.reverseRight,
+        competency: ManoeuvreCompetencies.controlFault,
+      }));
+      // ASSERT
+      effects.addManoeuvreDrivingFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
 
-  // describe('controlledStopAddDrivingFault', () => {
-  //   it('should call logEvent for this competency', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  // });
+  describe('controlledStopAddDrivingFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.ControlledStopAddDrivingFault());
+      // ASSERT
+      effects.controlledStopAddDrivingFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DRIVING_FAULT,
+          fullCompetencyLabels['outcomeControlledStop'],
+          1,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.ControlledStopAddDrivingFault());
+      // ASSERT
+      effects.controlledStopAddDrivingFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
 
-  // describe('showMeQuestionDrivingFault', () => {
-  //   it('should call logEvent for this competency', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  // });
+  describe('showMeQuestionDrivingFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.ShowMeQuestionDrivingFault());
+      // ASSERT
+      effects.showMeQuestionDrivingFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DRIVING_FAULT,
+          fullCompetencyLabels['showMeQuestion'],
+          1,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.ShowMeQuestionDrivingFault());
+      // ASSERT
+      effects.showMeQuestionDrivingFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
 
-  // describe('removeDrivingFault', () => {
-  //   it('should call logEvent for this competency', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  // });
+  describe('removeDrivingFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.RemoveDrivingFault({
+        competency: Competencies.controlsGears,
+        newFaultCount: 1,
+      }));
+      // ASSERT
+      effects.removeDrivingFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.REMOVE_DRIVING_FAULT,
+          fullCompetencyLabels[Competencies.controlsGears],
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.RemoveDrivingFault({
+        competency: Competencies.controlsGears,
+        newFaultCount: 1,
+      }));
+      // ASSERT
+      effects.removeDrivingFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
 
-  // describe('removeManoeuvreDrivingFault', () => {
-  //   it('should call logEvent for this competency', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  // });
+  describe('removeManoeuvreDrivingFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.RemoveManoeuvreFault({
+        manoeuvre: ManoeuvreTypes.reverseRight,
+        competency: ManoeuvreCompetencies.controlFault,
+      }));
+      // ASSERT
+      effects.removeManoeuvreFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.REMOVE_DRIVING_FAULT,
+          // tslint:disable-next-line:max-line-length
+          `${manoeuvreTypeLabels[ManoeuvreTypes.reverseRight]} - ${manoeuvreCompetencyLabels[ManoeuvreCompetencies.controlFault]}`,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.RemoveManoeuvreFault({
+        manoeuvre: ManoeuvreTypes.reverseRight,
+        competency: ManoeuvreCompetencies.controlFault,
+      }));
+      // ASSERT
+      effects.removeManoeuvreFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
 
-  // describe('controlledStopRemoveFault', () => {
-  //   it('should call logEvent for this competency', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  // });
+  describe('controlledStopRemoveFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.ControlledStopRemoveFault());
+      // ASSERT
+      effects.controlledStopRemoveFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.REMOVE_FAULT,
+          fullCompetencyLabels['outcomeControlledStop'],
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.ControlledStopRemoveFault());
+      // ASSERT
+      effects.controlledStopRemoveFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
 
-  // describe('showMeQuestionRemoveFault', () => {
-  //   it('should call logEvent for this competency', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  //   it('should not call logEvent for this competency when it is a practice test', fakeAsync((done) => {
-  //     // ARRANGE
-  //     spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-  //     // ACT
-  //     actions.next(new testReportActions.TestReportViewDidEnter());
-  //     tick();
-  //     // ASSERT
-  //     effects.testReportViewDidEnter$.subscribe((result) => {
-  //       expect(result instanceof of).toBe(true);
-  //       expect(effects.analytics.logEvent).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
-  //       done();
-  //     });
-  //   }));
-  // });
+  describe('showMeQuestionRemoveFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.ShowMeQuestionRemoveFault());
+      // ASSERT
+      effects.showMeQuestionRemoveFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.REMOVE_FAULT,
+          fullCompetencyLabels['showMeQuestion'],
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.ShowMeQuestionRemoveFault());
+      // ASSERT
+      effects.showMeQuestionRemoveFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
 
 });

--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -47,7 +47,7 @@ describe('Test Report Analytics Effects', () => {
     store$ = TestBed.get(Store);
   });
 
-  fdescribe('testReportViewDidEnter', () => {
+  describe('testReportViewDidEnter', () => {
     it('should call setCurrentPage and addCustomDimension', () => {
       // ARRANGE
       spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
@@ -60,7 +60,7 @@ describe('Test Report Analytics Effects', () => {
     });
   });
 
-  fdescribe('addDrivingFault', () => {
+  describe('addDrivingFault', () => {
 
     it('should call logEvent for this competency', () => {
       // ARRANGE

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -25,7 +25,7 @@ import {
 export class TestReportAnalyticsEffects {
 
   constructor(
-    public analytics: AnalyticsProvider,
+    private analytics: AnalyticsProvider,
     private actions$: Actions,
     private store$: Store<StoreModel>,
   ) {
@@ -42,7 +42,7 @@ export class TestReportAnalyticsEffects {
     ofType(TEST_REPORT_VIEW_DID_ENTER),
     switchMap((action: TestReportViewDidEnter) => {
       this.analytics.setCurrentPage(AnalyticsScreenNames.TEST);
-      return of();
+      return of({});
     }),
   );
 
@@ -63,8 +63,9 @@ export class TestReportAnalyticsEffects {
         AnalyticsEventCategories.TEST_REPORT,
         AnalyticsEvents.ADD_DRIVING_FAULT,
         fullCompetencyLabels[action.payload.competency],
+        action.payload.newFaultCount,
       );
-      return of();
+      return of({});
     }),
   );
 
@@ -85,8 +86,9 @@ export class TestReportAnalyticsEffects {
         AnalyticsEventCategories.TEST_REPORT,
         AnalyticsEvents.ADD_DRIVING_FAULT,
         `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
+        1,
       );
-      return of();
+      return of({});
     }),
   );
 
@@ -107,8 +109,9 @@ export class TestReportAnalyticsEffects {
         AnalyticsEventCategories.TEST_REPORT,
         AnalyticsEvents.ADD_DRIVING_FAULT,
         fullCompetencyLabels['outcomeControlledStop'],
+        1,
       );
-      return of();
+      return of({});
     }),
   );
 
@@ -129,8 +132,9 @@ export class TestReportAnalyticsEffects {
         AnalyticsEventCategories.TEST_REPORT,
         AnalyticsEvents.ADD_DRIVING_FAULT,
         'Show me question', // TODO remove magic string
+        1,
       );
-      return of();
+      return of({});
     }),
   );
 
@@ -152,7 +156,7 @@ export class TestReportAnalyticsEffects {
         AnalyticsEvents.REMOVE_DRIVING_FAULT,
         fullCompetencyLabels[action.payload.competency],
       );
-      return of();
+      return of({});
     }),
   );
 
@@ -174,7 +178,7 @@ export class TestReportAnalyticsEffects {
         AnalyticsEvents.REMOVE_DRIVING_FAULT,
         `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
       );
-      return of();
+      return of({});
     }),
   );
 
@@ -196,7 +200,7 @@ export class TestReportAnalyticsEffects {
         AnalyticsEvents.REMOVE_FAULT,
         fullCompetencyLabels['outcomeControlledStop'],
       );
-      return of();
+      return of({});
     }),
   );
 
@@ -218,7 +222,7 @@ export class TestReportAnalyticsEffects {
         AnalyticsEvents.REMOVE_FAULT,
         'Show me question', // TODO remove magic string
       );
-      return of();
+      return of({});
     }),
   );
 

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
-import { switchMap, concatMap, withLatestFrom, map, filter } from 'rxjs/operators';
+import { switchMap, concatMap, withLatestFrom, map } from 'rxjs/operators';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
@@ -57,14 +57,15 @@ export class TestReportAnalyticsEffects {
         map(isTestReportPracticeTest),
       ),
     ),
-    filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
     concatMap(([action, isTestReportPracticeTest]: [testDataActions.AddDrivingFault, boolean]) => {
-      this.analytics.logEvent(
-        AnalyticsEventCategories.TEST_REPORT,
-        AnalyticsEvents.ADD_DRIVING_FAULT,
-        fullCompetencyLabels[action.payload.competency],
-        action.payload.newFaultCount,
-      );
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DRIVING_FAULT,
+          fullCompetencyLabels[action.payload.competency],
+          action.payload.newFaultCount,
+        );
+      }
       return of({});
     }),
   );
@@ -80,14 +81,15 @@ export class TestReportAnalyticsEffects {
         map(isTestReportPracticeTest),
       ),
     ),
-    filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
     concatMap(([action, isTestReportPracticeTest]: [testDataActions.AddManoeuvreDrivingFault, boolean]) => {
-      this.analytics.logEvent(
-        AnalyticsEventCategories.TEST_REPORT,
-        AnalyticsEvents.ADD_DRIVING_FAULT,
-        `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
-        1,
-      );
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DRIVING_FAULT,
+          `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
+          1,
+        );
+      }
       return of({});
     }),
   );
@@ -103,14 +105,15 @@ export class TestReportAnalyticsEffects {
         map(isTestReportPracticeTest),
       ),
     ),
-    filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
-    concatMap(() => {
-      this.analytics.logEvent(
-        AnalyticsEventCategories.TEST_REPORT,
-        AnalyticsEvents.ADD_DRIVING_FAULT,
-        fullCompetencyLabels['outcomeControlledStop'],
-        1,
-      );
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ControlledStopAddDrivingFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DRIVING_FAULT,
+          fullCompetencyLabels['outcomeControlledStop'],
+          1,
+        );
+      }
       return of({});
     }),
   );
@@ -126,14 +129,15 @@ export class TestReportAnalyticsEffects {
         map(isTestReportPracticeTest),
       ),
     ),
-    filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
-    concatMap(() => {
-      this.analytics.logEvent(
-        AnalyticsEventCategories.TEST_REPORT,
-        AnalyticsEvents.ADD_DRIVING_FAULT,
-        'Show me question', // TODO remove magic string
-        1,
-      );
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ShowMeQuestionDrivingFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DRIVING_FAULT,
+          fullCompetencyLabels['showMeQuestion'],
+          1,
+        );
+      }
       return of({});
     }),
   );
@@ -149,19 +153,20 @@ export class TestReportAnalyticsEffects {
         map(isTestReportPracticeTest),
       ),
     ),
-    filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
     concatMap(([action, isTestReportPracticeTest]: [testDataActions.RemoveDrivingFault, boolean]) => {
-      this.analytics.logEvent(
-        AnalyticsEventCategories.TEST_REPORT,
-        AnalyticsEvents.REMOVE_DRIVING_FAULT,
-        fullCompetencyLabels[action.payload.competency],
-      );
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.REMOVE_DRIVING_FAULT,
+          fullCompetencyLabels[action.payload.competency],
+        );
+      }
       return of({});
     }),
   );
 
   @Effect()
-  removeManoeuvreDrivingFault$ = this.actions$.pipe(
+  removeManoeuvreFault$ = this.actions$.pipe(
     ofType(
       testDataActions.REMOVE_MANOEUVRE_FAULT,
     ),
@@ -171,13 +176,14 @@ export class TestReportAnalyticsEffects {
         map(isTestReportPracticeTest),
       ),
     ),
-    filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
     concatMap(([action, isTestReportPracticeTest]: [testDataActions.RemoveManoeuvreFault, boolean]) => {
-      this.analytics.logEvent(
-        AnalyticsEventCategories.TEST_REPORT,
-        AnalyticsEvents.REMOVE_DRIVING_FAULT,
-        `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
-      );
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.REMOVE_DRIVING_FAULT,
+          `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
+        );
+      }
       return of({});
     }),
   );
@@ -193,13 +199,14 @@ export class TestReportAnalyticsEffects {
         map(isTestReportPracticeTest),
       ),
     ),
-    filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
-    concatMap(() => {
-      this.analytics.logEvent(
-        AnalyticsEventCategories.TEST_REPORT,
-        AnalyticsEvents.REMOVE_FAULT,
-        fullCompetencyLabels['outcomeControlledStop'],
-      );
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ControlledStopRemoveFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.REMOVE_FAULT,
+          fullCompetencyLabels['outcomeControlledStop'],
+        );
+      }
       return of({});
     }),
   );
@@ -215,13 +222,14 @@ export class TestReportAnalyticsEffects {
         map(isTestReportPracticeTest),
       ),
     ),
-    filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
-    concatMap(() => {
-      this.analytics.logEvent(
-        AnalyticsEventCategories.TEST_REPORT,
-        AnalyticsEvents.REMOVE_FAULT,
-        'Show me question', // TODO remove magic string
-      );
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ShowMeQuestionRemoveFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.REMOVE_FAULT,
+          fullCompetencyLabels['showMeQuestion'],
+        );
+      }
       return of({});
     }),
   );

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -134,4 +134,92 @@ export class TestReportAnalyticsEffects {
     }),
   );
 
+  @Effect()
+  removeDrivingFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.REMOVE_DRIVING_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.RemoveDrivingFault, boolean]) => {
+      this.analytics.logEvent(
+        AnalyticsEventCategories.TEST_REPORT,
+        AnalyticsEvents.REMOVE_DRIVING_FAULT,
+        fullCompetencyLabels[action.payload.competency],
+      );
+      return of();
+    }),
+  );
+
+  @Effect()
+  removeManoeuvreDrivingFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.REMOVE_MANOEUVRE_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.RemoveManoeuvreFault, boolean]) => {
+      this.analytics.logEvent(
+        AnalyticsEventCategories.TEST_REPORT,
+        AnalyticsEvents.REMOVE_DRIVING_FAULT,
+        `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
+      );
+      return of();
+    }),
+  );
+
+  @Effect()
+  controlledStopRemoveFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.CONTROLLED_STOP_REMOVE_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
+    concatMap(() => {
+      this.analytics.logEvent(
+        AnalyticsEventCategories.TEST_REPORT,
+        AnalyticsEvents.REMOVE_FAULT,
+        fullCompetencyLabels['outcomeControlledStop'],
+      );
+      return of();
+    }),
+  );
+
+  @Effect()
+  showMeQuestionRemoveFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.SHOW_ME_QUESTION_REMOVE_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
+    concatMap(() => {
+      this.analytics.logEvent(
+        AnalyticsEventCategories.TEST_REPORT,
+        AnalyticsEvents.REMOVE_FAULT,
+        'Show me question', // TODO remove magic string
+      );
+      return of();
+    }),
+  );
+
 }

--- a/src/providers/analytics/__mocks__/analytics.mock.ts
+++ b/src/providers/analytics/__mocks__/analytics.mock.ts
@@ -11,7 +11,7 @@ export class AnalyticsProviderMock implements IAnalyticsProvider {
       resolve();
     })
 
-  logEvent(category: string, event: string, params?: any) {}
+  logEvent(category: string, event: string, label?: string, value?: number) {}
 
   addCustomDimension(key: number, value: string) {}
 
@@ -20,4 +20,6 @@ export class AnalyticsProviderMock implements IAnalyticsProvider {
   logException(message: string, fatal: boolean) {}
 
   setUserId(userId: string) {}
+
+  setDeviceId(deviceId: string) {}
 }

--- a/src/providers/analytics/__tests__/analytics.spec.ts
+++ b/src/providers/analytics/__tests__/analytics.spec.ts
@@ -1,0 +1,77 @@
+import { TestBed } from '@angular/core/testing';
+import { AnalyticsProvider } from '../analytics';
+import { PlatformMock, GoogleAnalyticsMock } from 'ionic-mocks';
+import { AppConfigProviderMock } from '../../app-config/__mocks__/app-config.mock';
+import { DeviceProviderMock } from '../../device/__mocks__/device.mock';
+import { AuthenticationProviderMock } from '../../authentication/__mocks__/authentication.mock';
+import { AppConfigProvider } from '../../app-config/app-config';
+import { GoogleAnalytics } from '@ionic-native/google-analytics';
+import { Platform } from 'ionic-angular';
+import { DeviceProvider } from '../../device/device';
+import { AuthenticationProvider } from '../../authentication/authentication';
+
+describe('Analytics Provider', () => {
+
+  let analyticsProvider: AnalyticsProvider;
+  let googleAnalyticsMock: GoogleAnalyticsMock;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        AnalyticsProvider,
+        { provide: AppConfigProvider, useClass: AppConfigProviderMock },
+        { provide: GoogleAnalytics, useFactory: () => GoogleAnalyticsMock.instance() },
+        { provide: Platform, useFactory: () => PlatformMock.instance() },
+        { provide: DeviceProvider, useClass: DeviceProviderMock },
+        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
+      ],
+    });
+
+    analyticsProvider = TestBed.get(AnalyticsProvider);
+    googleAnalyticsMock = TestBed.get(GoogleAnalytics);
+
+  });
+
+  describe('setUserId', () => {
+    it('should hash the userId for 123 correctly', () => {
+      expect(googleAnalyticsMock).toBeDefined();
+      analyticsProvider.setUserId('123');
+      // tslint:disable-next-line:max-line-length
+      expect(analyticsProvider.uniqueUserId).toEqual('a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3');
+    });
+    it('should hash the userId for 456 correctly', () => {
+      expect(googleAnalyticsMock).toBeDefined();
+      analyticsProvider.setUserId('456');
+      // tslint:disable-next-line:max-line-length
+      expect(analyticsProvider.uniqueUserId).toEqual('b3a8e0e1f9ab1bfe3a36f231f676f78bb30a519d2b21e6c530c0eee8ebb4a5d0');
+    });
+    it('should hash the userId consistently when no value is available', () => {
+      expect(googleAnalyticsMock).toBeDefined();
+      analyticsProvider.setUserId('');
+      // tslint:disable-next-line:max-line-length
+      expect(analyticsProvider.uniqueUserId).toEqual('ba691ba042bcedd9a61a36f5969026bc95859dccdc7e47f24e6bce35673baf2f');
+    });
+  });
+
+  describe('setDeviceId', () => {
+    it('should hash the userId for abcdef123456 correctly', () => {
+      expect(googleAnalyticsMock).toBeDefined();
+      analyticsProvider.setDeviceId('abcdef123456');
+      // tslint:disable-next-line:max-line-length
+      expect(analyticsProvider.uniqueDeviceId).toEqual('da4ec3358a10c9b0872eb877953cc7b07af5f4d75e4c1cb0597cbbf41e5dbe35');
+    });
+    it('should hash the userId for aabbccddeeff correctly', () => {
+      expect(googleAnalyticsMock).toBeDefined();
+      analyticsProvider.setDeviceId('aabbccddeeff');
+      // tslint:disable-next-line:max-line-length
+      expect(analyticsProvider.uniqueDeviceId).toEqual('c1799564f2eefcaf63dd2e5cc08573e63856222a232dab2d91a17b232830d430');
+    });
+    it('should hash the userId consistently when no value is available', () => {
+      expect(googleAnalyticsMock).toBeDefined();
+      analyticsProvider.setDeviceId('');
+      // tslint:disable-next-line:max-line-length
+      expect(analyticsProvider.uniqueDeviceId).toEqual('96ed066cad78965eafb18fdffbc37509aa98ff9dc21b9781589eebba01d5be3e');
+    });
+  });
+
+});

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -41,6 +41,7 @@ export enum AnalyticsEventCategories {
     AUTHENTICATION = 'authentication',
     BACK_TO_OFFICE = 'back to office',
     POST_TEST = 'post-test',
+    TEST_REPORT = 'test report',
   }
 
 export enum AnalyticsEvents {
@@ -56,6 +57,15 @@ export enum AnalyticsEvents {
     SAVE_WRITE_UP = 'save write-up',
     SUBMIT_TEST = 'submit test',
     RESUME_WRITE_UP = 'resume write-up',
+    ADD_DRIVING_FAULT = 'add driving fault',
+    ADD_SERIOUS_FAULT = 'add serious fault',
+    ADD_DANGEROUS_FAULT = 'add dangerous fault',
+    REMOVE_DRIVING_FAULT = 'remove driving fault',
+    REMOVE_SERIOUS_FAULT = 'remove serious fault',
+    REMOVE_DANGEROUS_FAULT = 'remove dangerous fault',
+    SELECT_SERIOUS_MODE = 'select serious mode',
+    SELECT_DANGEROUS_MODE = 'select dangerous mode',
+    SELECT_REMOVE_MODE = 'select remove mode',
   }
 
 export enum AnalyticsDimensionIndices {
@@ -69,6 +79,7 @@ export enum AnalyticsDimensionIndices {
     NUMBER_OF_SERIOUS_FAULTS = 8,
     NUMBER_OF_DANGEROUS_FAULTS = 9,
     METHOD = 10,
+    USER_ID = 11,
   }
 
 export enum JournalRefreshModes {

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -63,6 +63,7 @@ export enum AnalyticsEvents {
     REMOVE_DRIVING_FAULT = 'remove driving fault',
     REMOVE_SERIOUS_FAULT = 'remove serious fault',
     REMOVE_DANGEROUS_FAULT = 'remove dangerous fault',
+    REMOVE_FAULT = 'remove fault',
     SELECT_SERIOUS_MODE = 'select serious mode',
     SELECT_DANGEROUS_MODE = 'select dangerous mode',
     SELECT_REMOVE_MODE = 'select remove mode',

--- a/src/providers/analytics/analytics.ts
+++ b/src/providers/analytics/analytics.ts
@@ -16,8 +16,8 @@ export class AnalyticsProvider implements IAnalyticsProvider {
   uniqueUserId: string;
   constructor(
     private appConfig: AppConfigProvider,
-    public ga: GoogleAnalytics,
-    public platform: Platform,
+    private ga: GoogleAnalytics,
+    private platform: Platform,
     private device: DeviceProvider,
     private authProvider: AuthenticationProvider,
   ) { }
@@ -62,6 +62,7 @@ export class AnalyticsProvider implements IAnalyticsProvider {
   }
 
   logEvent(category: string, event: string, label?: string, value?: number): void {
+    console.log('logEvent', category, event, label), value;
     this.platform.ready().then(() => {
       this.ga
         .startTrackerWithId(this.googleAnalyticsKey)
@@ -75,6 +76,7 @@ export class AnalyticsProvider implements IAnalyticsProvider {
   }
 
   addCustomDimension(key: number, value: string): void {
+    console.log('addCustomDimension', key, value);
     this.ga
       .startTrackerWithId(this.googleAnalyticsKey)
       .then(() => {

--- a/src/shared/constants/competencies/catb-competencies.ts
+++ b/src/shared/constants/competencies/catb-competencies.ts
@@ -40,4 +40,5 @@ export enum fullCompetencyLabels {
   positionNormalStops = 'Position/normal stop',
   awarenessPlanning = 'Awareness planning',
   outcomeControlledStop = 'Controlled stop',
+  showMeQuestion = 'Show me question',
 }


### PR DESCRIPTION
## Description and relevant Jira numbers
- Added effects to log analytics during the test report. 
- Don't log analytics during practice tests.

I return `of({})` rather than `of()` in the effects so that an observable is created and next is emitted.

I haven't used `filter` so that I can always return an observable, allowing me to test that the analytics mock is not called after starting a practice test. Instead I just test for practice mode in the body of the `concatMap` function.

One drawback I see from my tests is that even though I subscribe to the observable, if it's never created, the expect statements won't execute. e.g.

```
// ARRANGE
spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
store$.dispatch(new journalActions.StartTest(123456));
// ACT
actions.next(new testDataActions.AddDrivingFault({
  competency: Competencies.controlsGears,
  newFaultCount: 1,
}));
// ASSERT
effects.addDrivingFault$.subscribe((result) => {
  // *** this might not get called ***
  expect(result).toEqual({});
  expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
    AnalyticsEventCategories.TEST_REPORT,
    AnalyticsEvents.ADD_DRIVING_FAULT,
    fullCompetencyLabels[Competencies.controlsGears],
    1,
  );
});
```

## Progress

**This PR**
- [x] Add driving faults
- [x] Remove driving faults

**Future PR**
- [ ] Add serious faults
- [ ] Remove serious faults
- [ ] Add dangerous faults
- [ ] Remove dangerous faults

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
