### PR TITLE
MES-2838 - Test Journey Bug Fixes

### DIFF
--- a/src/pages/communication-page/components/postal-address/postal-address.html
+++ b/src/pages/communication-page/components/postal-address/postal-address.html
@@ -1,6 +1,7 @@
 <ion-row class="communication-option">
     <div class="validation-bar communication-validation-bar" [class.ng-invalid]="invalid"></div>
-    <input type="radio" id="postalAddress" class="gds-radio-button" name="radioCtrl" (click)="postalRadioSelected()">
+    <input type="radio" id="postalAddress" class="gds-radio-button" name="radioCtrl"
+      (click)="postalRadioSelected()" [checked]="isPostalAddressChosen">
     <label for="postalAddress" class="radio-label">{{ 'communication.byPostLabel' | translate }}</label>
 </ion-row>
 

--- a/src/providers/test-submission/test-submission.ts
+++ b/src/providers/test-submission/test-submission.ts
@@ -7,7 +7,7 @@ import { gzipSync } from 'zlib';
 import { catchError } from 'rxjs/operators';
 import { forkJoin } from 'rxjs/observable/forkJoin';
 import { of } from 'rxjs/observable/of';
-import { isNull, unset, isObject } from 'lodash';
+import { isNull, unset, isObject, cloneDeep } from 'lodash';
 
 export interface TestToSubmit {
   index: number;
@@ -31,7 +31,8 @@ export class TestSubmissionProvider {
   submitTest = (testToSubmit: TestToSubmit): Observable<HttpResponse<any>> =>
     this.httpClient.post(
       this.urlProvider.getTestResultServiceUrl(),
-      this.compressData(this.removeNullFieldsDeep(testToSubmit.payload)),
+      this.compressData(this.removeNullFieldsDeep(cloneDeep(testToSubmit.payload))),
+      // Using cloneDeep() to prevent the initialState of the reducers from being modified
       { observe: 'response' },
     )
     // Note: Catching failures here (the inner observable) is what allows us to coordinate


### PR DESCRIPTION
## Description and relevant Jira numbers

- Fixed issue with comms page not preselecting `By Post` on resume by binding to the `[checked]` attribute

- Fixed issue with text areas being displayed with `undefined` on office page. We were changing the initial state of the reducer with `removeNullFields()` if no other reducer was running on the test. Have used cloneDeep() to create a new object that is used to remove nulls instead of modifying the original.

https://jira.i-env.net/browse/MES-2838

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
