### PR TITLE
Mes 2931 serious dangerous faults analytics

### DIFF
--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -107,6 +107,70 @@ describe('Test Report Analytics Effects', () => {
     });
   });
 
+  describe('addSeriousFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.AddSeriousFault(Competencies.controlsGears));
+      // ASSERT
+      effects.addSeriousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_SERIOUS_FAULT,
+          fullCompetencyLabels[Competencies.controlsGears],
+          1,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.AddSeriousFault(Competencies.controlsGears));
+      // ASSERT
+      effects.addSeriousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('addDangerousFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.AddDangerousFault(Competencies.controlsGears));
+      // ASSERT
+      effects.addDangerousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DANGEROUS_FAULT,
+          fullCompetencyLabels[Competencies.controlsGears],
+          1,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.AddDangerousFault(Competencies.controlsGears));
+      // ASSERT
+      effects.addDangerousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('addManoeuvreDrivingFault', () => {
     it('should call logEvent for this competency', () => {
       // ARRANGE
@@ -146,6 +210,84 @@ describe('Test Report Analytics Effects', () => {
     });
   });
 
+  describe('addManoeuvreSeriousFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.AddManoeuvreSeriousFault({
+        manoeuvre: ManoeuvreTypes.reverseRight,
+        competency: ManoeuvreCompetencies.controlFault,
+      }));
+      // ASSERT
+      effects.addManoeuvreSeriousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_SERIOUS_FAULT,
+          // tslint:disable-next-line:max-line-length
+          `${manoeuvreTypeLabels[ManoeuvreTypes.reverseRight]} - ${manoeuvreCompetencyLabels[ManoeuvreCompetencies.controlFault]}`,
+          1,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.AddManoeuvreSeriousFault({
+        manoeuvre: ManoeuvreTypes.reverseRight,
+        competency: ManoeuvreCompetencies.controlFault,
+      }));
+      // ASSERT
+      effects.addManoeuvreSeriousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('addManoeuvreDangerousFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.AddManoeuvreDangerousFault({
+        manoeuvre: ManoeuvreTypes.reverseRight,
+        competency: ManoeuvreCompetencies.controlFault,
+      }));
+      // ASSERT
+      effects.addManoeuvreDangerousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DANGEROUS_FAULT,
+          // tslint:disable-next-line:max-line-length
+          `${manoeuvreTypeLabels[ManoeuvreTypes.reverseRight]} - ${manoeuvreCompetencyLabels[ManoeuvreCompetencies.controlFault]}`,
+          1,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.AddManoeuvreDangerousFault({
+        manoeuvre: ManoeuvreTypes.reverseRight,
+        competency: ManoeuvreCompetencies.controlFault,
+      }));
+      // ASSERT
+      effects.addManoeuvreDangerousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('controlledStopAddDrivingFault', () => {
     it('should call logEvent for this competency', () => {
       // ARRANGE
@@ -170,6 +312,70 @@ describe('Test Report Analytics Effects', () => {
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions.next(new testDataActions.ControlledStopAddDrivingFault());
+      // ASSERT
+      effects.controlledStopAddDrivingFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('controlledStopAddSeriousFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.ControlledStopAddSeriousFault());
+      // ASSERT
+      effects.controlledStopAddSeriousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_SERIOUS_FAULT,
+          fullCompetencyLabels['outcomeControlledStop'],
+          1,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.ControlledStopAddSeriousFault());
+      // ASSERT
+      effects.controlledStopAddSeriousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('controlledStopAddDangerousFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.ControlledStopAddDangerousFault());
+      // ASSERT
+      effects.controlledStopAddDrivingFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DANGEROUS_FAULT,
+          fullCompetencyLabels['outcomeControlledStop'],
+          1,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.ControlledStopAddDangerousFault());
       // ASSERT
       effects.controlledStopAddDrivingFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -210,6 +416,70 @@ describe('Test Report Analytics Effects', () => {
     });
   });
 
+  describe('showMeQuestionSeriousFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.ShowMeQuestionSeriousFault());
+      // ASSERT
+      effects.showMeQuestionSeriousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_SERIOUS_FAULT,
+          fullCompetencyLabels['showMeQuestion'],
+          1,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.ShowMeQuestionSeriousFault());
+      // ASSERT
+      effects.showMeQuestionSeriousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('showMeQuestionDangerousFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.ShowMeQuestionDangerousFault());
+      // ASSERT
+      effects.showMeQuestionDangerousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DANGEROUS_FAULT,
+          fullCompetencyLabels['showMeQuestion'],
+          1,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.ShowMeQuestionDangerousFault());
+      // ASSERT
+      effects.showMeQuestionDangerousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('removeDrivingFault', () => {
     it('should call logEvent for this competency', () => {
       // ARRANGE
@@ -218,7 +488,7 @@ describe('Test Report Analytics Effects', () => {
       // ACT
       actions.next(new testDataActions.RemoveDrivingFault({
         competency: Competencies.controlsGears,
-        newFaultCount: 1,
+        newFaultCount: 0,
       }));
       // ASSERT
       effects.removeDrivingFault$.subscribe((result) => {
@@ -227,6 +497,7 @@ describe('Test Report Analytics Effects', () => {
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_DRIVING_FAULT,
           fullCompetencyLabels[Competencies.controlsGears],
+          0,
         );
       });
     });
@@ -241,6 +512,70 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.removeDrivingFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('removeSeriousFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.RemoveSeriousFault(Competencies.controlsGears));
+      // ASSERT
+      effects.removeSeriousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.REMOVE_SERIOUS_FAULT,
+          fullCompetencyLabels[Competencies.controlsGears],
+          0,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.RemoveSeriousFault(Competencies.controlsGears));
+      // ASSERT
+      effects.removeSeriousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('removeDangerousFault', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testDataActions.RemoveDangerousFault(Competencies.controlsGears));
+      // ASSERT
+      effects.removeDangerousFault$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.REMOVE_DANGEROUS_FAULT,
+          fullCompetencyLabels[Competencies.controlsGears],
+          0,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testDataActions.RemoveDangerousFault(Competencies.controlsGears));
+      // ASSERT
+      effects.removeDangerousFault$.subscribe((result) => {
         expect(result).toEqual({});
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });

--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -69,6 +69,96 @@ describe('Test Report Analytics Effects', () => {
     });
   });
 
+  describe('toggleRemoveFaultMode', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testReportActions.ToggleRemoveFaultMode());
+      // ASSERT
+      effects.toggleRemoveFaultMode$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.SELECT_REMOVE_MODE,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testReportActions.ToggleRemoveFaultMode());
+      // ASSERT
+      effects.toggleRemoveFaultMode$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('toggleSeriousFaultMode', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testReportActions.ToggleSeriousFaultMode());
+      // ASSERT
+      effects.toggleSeriousFaultMode$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.SELECT_SERIOUS_MODE,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testReportActions.ToggleSeriousFaultMode());
+      // ASSERT
+      effects.toggleSeriousFaultMode$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('toggleDangerousFaultMode', () => {
+    it('should call logEvent for this competency', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions.next(new testReportActions.ToggleDangerousFaultMode());
+      // ASSERT
+      effects.toggleDangerousFaultMode$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.SELECT_DANGEROUS_MODE,
+        );
+      });
+    });
+    it('should not call logEvent for this competency when it is a practice test', () => {
+      // ARRANGE
+      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions.next(new testReportActions.ToggleDangerousFaultMode());
+      // ASSERT
+      effects.toggleDangerousFaultMode$.subscribe((result) => {
+        expect(result).toEqual({});
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('addDrivingFault', () => {
     it('should call logEvent for this competency', () => {
       // ARRANGE

--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -27,6 +27,7 @@ import {
   manoeuvreTypeLabels,
   manoeuvreCompetencyLabels,
 } from '../components/manoeuvre-competency/manoeuvre-competency.constants';
+import { AnalyticRecorded, AnalyticNotRecorded } from '../../../providers/analytics/analytics.actions';
 
 describe('Test Report Analytics Effects', () => {
 
@@ -63,7 +64,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testReportActions.TestReportViewDidEnter());
       // ASSERT
       effects.testReportViewDidEnter$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.setCurrentPage).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
       });
     });
@@ -78,7 +79,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testReportActions.ToggleRemoveFaultMode());
       // ASSERT
       effects.toggleRemoveFaultMode$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_REMOVE_MODE,
@@ -93,7 +94,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testReportActions.ToggleRemoveFaultMode());
       // ASSERT
       effects.toggleRemoveFaultMode$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -108,7 +109,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testReportActions.ToggleSeriousFaultMode());
       // ASSERT
       effects.toggleSeriousFaultMode$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_SERIOUS_MODE,
@@ -123,7 +124,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testReportActions.ToggleSeriousFaultMode());
       // ASSERT
       effects.toggleSeriousFaultMode$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -138,7 +139,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testReportActions.ToggleDangerousFaultMode());
       // ASSERT
       effects.toggleDangerousFaultMode$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_DANGEROUS_MODE,
@@ -153,7 +154,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testReportActions.ToggleDangerousFaultMode());
       // ASSERT
       effects.toggleDangerousFaultMode$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -171,7 +172,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addDrivingFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
@@ -191,7 +192,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addDrivingFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -206,7 +207,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.AddSeriousFault(Competencies.controlsGears));
       // ASSERT
       effects.addSeriousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_SERIOUS_FAULT,
@@ -223,7 +224,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.AddSeriousFault(Competencies.controlsGears));
       // ASSERT
       effects.addSeriousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -238,7 +239,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.AddDangerousFault(Competencies.controlsGears));
       // ASSERT
       effects.addDangerousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DANGEROUS_FAULT,
@@ -255,7 +256,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.AddDangerousFault(Competencies.controlsGears));
       // ASSERT
       effects.addDangerousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -273,7 +274,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addManoeuvreDrivingFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
@@ -294,7 +295,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addManoeuvreDrivingFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -312,7 +313,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addManoeuvreSeriousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_SERIOUS_FAULT,
@@ -333,7 +334,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addManoeuvreSeriousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -351,7 +352,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addManoeuvreDangerousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DANGEROUS_FAULT,
@@ -372,7 +373,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addManoeuvreDangerousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -387,7 +388,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ControlledStopAddDrivingFault());
       // ASSERT
       effects.controlledStopAddDrivingFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
@@ -404,7 +405,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ControlledStopAddDrivingFault());
       // ASSERT
       effects.controlledStopAddDrivingFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -419,7 +420,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ControlledStopAddSeriousFault());
       // ASSERT
       effects.controlledStopAddSeriousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_SERIOUS_FAULT,
@@ -436,7 +437,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ControlledStopAddSeriousFault());
       // ASSERT
       effects.controlledStopAddSeriousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -451,7 +452,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ControlledStopAddDangerousFault());
       // ASSERT
       effects.controlledStopAddDrivingFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DANGEROUS_FAULT,
@@ -468,7 +469,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ControlledStopAddDangerousFault());
       // ASSERT
       effects.controlledStopAddDrivingFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -483,7 +484,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ShowMeQuestionDrivingFault());
       // ASSERT
       effects.showMeQuestionDrivingFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
@@ -500,7 +501,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ShowMeQuestionDrivingFault());
       // ASSERT
       effects.showMeQuestionDrivingFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -515,7 +516,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ShowMeQuestionSeriousFault());
       // ASSERT
       effects.showMeQuestionSeriousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_SERIOUS_FAULT,
@@ -532,7 +533,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ShowMeQuestionSeriousFault());
       // ASSERT
       effects.showMeQuestionSeriousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -547,7 +548,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ShowMeQuestionDangerousFault());
       // ASSERT
       effects.showMeQuestionDangerousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DANGEROUS_FAULT,
@@ -564,7 +565,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ShowMeQuestionDangerousFault());
       // ASSERT
       effects.showMeQuestionDangerousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -582,7 +583,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.removeDrivingFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_DRIVING_FAULT,
@@ -602,7 +603,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.removeDrivingFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -617,7 +618,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.RemoveSeriousFault(Competencies.controlsGears));
       // ASSERT
       effects.removeSeriousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_SERIOUS_FAULT,
@@ -634,7 +635,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.RemoveSeriousFault(Competencies.controlsGears));
       // ASSERT
       effects.removeSeriousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -649,7 +650,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.RemoveDangerousFault(Competencies.controlsGears));
       // ASSERT
       effects.removeDangerousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_DANGEROUS_FAULT,
@@ -666,7 +667,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.RemoveDangerousFault(Competencies.controlsGears));
       // ASSERT
       effects.removeDangerousFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -684,7 +685,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.removeManoeuvreFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_DRIVING_FAULT,
@@ -704,7 +705,7 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.removeManoeuvreFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -719,7 +720,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ControlledStopRemoveFault());
       // ASSERT
       effects.controlledStopRemoveFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_FAULT,
@@ -735,7 +736,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ControlledStopRemoveFault());
       // ASSERT
       effects.controlledStopRemoveFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });
@@ -750,7 +751,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ShowMeQuestionRemoveFault());
       // ASSERT
       effects.showMeQuestionRemoveFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_FAULT,
@@ -766,7 +767,7 @@ describe('Test Report Analytics Effects', () => {
       actions$.next(new testDataActions.ShowMeQuestionRemoveFault());
       // ASSERT
       effects.showMeQuestionRemoveFault$.subscribe((result) => {
-        expect(result).toEqual({});
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
         expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
       });
     });

--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -31,12 +31,12 @@ import {
 describe('Test Report Analytics Effects', () => {
 
   let effects: TestReportAnalyticsEffects;
-  let actions: ReplaySubject<any>;
+  let actions$: ReplaySubject<any>;
   let analyticsProviderMock;
   let store$: Store<StoreModel>;
 
   beforeEach(() => {
-    actions = new ReplaySubject(1);
+    actions$ = new ReplaySubject(1);
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -45,7 +45,7 @@ describe('Test Report Analytics Effects', () => {
       ],
       providers: [
         TestReportAnalyticsEffects,
-        provideMockActions(() => actions),
+        provideMockActions(() => actions$),
         { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
         Store,
       ],
@@ -60,7 +60,7 @@ describe('Test Report Analytics Effects', () => {
       // ARRANGE
       spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
       // ACT
-      actions.next(new testReportActions.TestReportViewDidEnter());
+      actions$.next(new testReportActions.TestReportViewDidEnter());
       // ASSERT
       effects.testReportViewDidEnter$.subscribe((result) => {
         expect(result).toEqual({});
@@ -75,7 +75,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testReportActions.ToggleRemoveFaultMode());
+      actions$.next(new testReportActions.ToggleRemoveFaultMode());
       // ASSERT
       effects.toggleRemoveFaultMode$.subscribe((result) => {
         expect(result).toEqual({});
@@ -90,7 +90,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testReportActions.ToggleRemoveFaultMode());
+      actions$.next(new testReportActions.ToggleRemoveFaultMode());
       // ASSERT
       effects.toggleRemoveFaultMode$.subscribe((result) => {
         expect(result).toEqual({});
@@ -105,7 +105,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testReportActions.ToggleSeriousFaultMode());
+      actions$.next(new testReportActions.ToggleSeriousFaultMode());
       // ASSERT
       effects.toggleSeriousFaultMode$.subscribe((result) => {
         expect(result).toEqual({});
@@ -120,7 +120,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testReportActions.ToggleSeriousFaultMode());
+      actions$.next(new testReportActions.ToggleSeriousFaultMode());
       // ASSERT
       effects.toggleSeriousFaultMode$.subscribe((result) => {
         expect(result).toEqual({});
@@ -135,7 +135,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testReportActions.ToggleDangerousFaultMode());
+      actions$.next(new testReportActions.ToggleDangerousFaultMode());
       // ASSERT
       effects.toggleDangerousFaultMode$.subscribe((result) => {
         expect(result).toEqual({});
@@ -150,7 +150,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testReportActions.ToggleDangerousFaultMode());
+      actions$.next(new testReportActions.ToggleDangerousFaultMode());
       // ASSERT
       effects.toggleDangerousFaultMode$.subscribe((result) => {
         expect(result).toEqual({});
@@ -165,7 +165,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.AddDrivingFault({
+      actions$.next(new testDataActions.AddDrivingFault({
         competency: Competencies.controlsGears,
         newFaultCount: 1,
       }));
@@ -185,7 +185,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.AddDrivingFault({
+      actions$.next(new testDataActions.AddDrivingFault({
         competency: Competencies.controlsGears,
         newFaultCount: 1,
       }));
@@ -203,7 +203,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.AddSeriousFault(Competencies.controlsGears));
+      actions$.next(new testDataActions.AddSeriousFault(Competencies.controlsGears));
       // ASSERT
       effects.addSeriousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -220,7 +220,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.AddSeriousFault(Competencies.controlsGears));
+      actions$.next(new testDataActions.AddSeriousFault(Competencies.controlsGears));
       // ASSERT
       effects.addSeriousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -235,7 +235,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.AddDangerousFault(Competencies.controlsGears));
+      actions$.next(new testDataActions.AddDangerousFault(Competencies.controlsGears));
       // ASSERT
       effects.addDangerousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -252,7 +252,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.AddDangerousFault(Competencies.controlsGears));
+      actions$.next(new testDataActions.AddDangerousFault(Competencies.controlsGears));
       // ASSERT
       effects.addDangerousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -267,7 +267,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.AddManoeuvreDrivingFault({
+      actions$.next(new testDataActions.AddManoeuvreDrivingFault({
         manoeuvre: ManoeuvreTypes.reverseRight,
         competency: ManoeuvreCompetencies.controlFault,
       }));
@@ -288,7 +288,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.AddManoeuvreDrivingFault({
+      actions$.next(new testDataActions.AddManoeuvreDrivingFault({
         manoeuvre: ManoeuvreTypes.reverseRight,
         competency: ManoeuvreCompetencies.controlFault,
       }));
@@ -306,7 +306,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.AddManoeuvreSeriousFault({
+      actions$.next(new testDataActions.AddManoeuvreSeriousFault({
         manoeuvre: ManoeuvreTypes.reverseRight,
         competency: ManoeuvreCompetencies.controlFault,
       }));
@@ -327,7 +327,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.AddManoeuvreSeriousFault({
+      actions$.next(new testDataActions.AddManoeuvreSeriousFault({
         manoeuvre: ManoeuvreTypes.reverseRight,
         competency: ManoeuvreCompetencies.controlFault,
       }));
@@ -345,7 +345,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.AddManoeuvreDangerousFault({
+      actions$.next(new testDataActions.AddManoeuvreDangerousFault({
         manoeuvre: ManoeuvreTypes.reverseRight,
         competency: ManoeuvreCompetencies.controlFault,
       }));
@@ -366,7 +366,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.AddManoeuvreDangerousFault({
+      actions$.next(new testDataActions.AddManoeuvreDangerousFault({
         manoeuvre: ManoeuvreTypes.reverseRight,
         competency: ManoeuvreCompetencies.controlFault,
       }));
@@ -384,7 +384,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.ControlledStopAddDrivingFault());
+      actions$.next(new testDataActions.ControlledStopAddDrivingFault());
       // ASSERT
       effects.controlledStopAddDrivingFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -401,7 +401,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.ControlledStopAddDrivingFault());
+      actions$.next(new testDataActions.ControlledStopAddDrivingFault());
       // ASSERT
       effects.controlledStopAddDrivingFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -416,7 +416,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.ControlledStopAddSeriousFault());
+      actions$.next(new testDataActions.ControlledStopAddSeriousFault());
       // ASSERT
       effects.controlledStopAddSeriousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -433,7 +433,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.ControlledStopAddSeriousFault());
+      actions$.next(new testDataActions.ControlledStopAddSeriousFault());
       // ASSERT
       effects.controlledStopAddSeriousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -448,7 +448,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.ControlledStopAddDangerousFault());
+      actions$.next(new testDataActions.ControlledStopAddDangerousFault());
       // ASSERT
       effects.controlledStopAddDrivingFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -465,7 +465,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.ControlledStopAddDangerousFault());
+      actions$.next(new testDataActions.ControlledStopAddDangerousFault());
       // ASSERT
       effects.controlledStopAddDrivingFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -480,7 +480,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.ShowMeQuestionDrivingFault());
+      actions$.next(new testDataActions.ShowMeQuestionDrivingFault());
       // ASSERT
       effects.showMeQuestionDrivingFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -497,7 +497,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.ShowMeQuestionDrivingFault());
+      actions$.next(new testDataActions.ShowMeQuestionDrivingFault());
       // ASSERT
       effects.showMeQuestionDrivingFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -512,7 +512,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.ShowMeQuestionSeriousFault());
+      actions$.next(new testDataActions.ShowMeQuestionSeriousFault());
       // ASSERT
       effects.showMeQuestionSeriousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -529,7 +529,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.ShowMeQuestionSeriousFault());
+      actions$.next(new testDataActions.ShowMeQuestionSeriousFault());
       // ASSERT
       effects.showMeQuestionSeriousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -544,7 +544,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.ShowMeQuestionDangerousFault());
+      actions$.next(new testDataActions.ShowMeQuestionDangerousFault());
       // ASSERT
       effects.showMeQuestionDangerousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -561,7 +561,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.ShowMeQuestionDangerousFault());
+      actions$.next(new testDataActions.ShowMeQuestionDangerousFault());
       // ASSERT
       effects.showMeQuestionDangerousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -576,7 +576,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.RemoveDrivingFault({
+      actions$.next(new testDataActions.RemoveDrivingFault({
         competency: Competencies.controlsGears,
         newFaultCount: 0,
       }));
@@ -596,7 +596,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.RemoveDrivingFault({
+      actions$.next(new testDataActions.RemoveDrivingFault({
         competency: Competencies.controlsGears,
         newFaultCount: 1,
       }));
@@ -614,7 +614,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.RemoveSeriousFault(Competencies.controlsGears));
+      actions$.next(new testDataActions.RemoveSeriousFault(Competencies.controlsGears));
       // ASSERT
       effects.removeSeriousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -631,7 +631,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.RemoveSeriousFault(Competencies.controlsGears));
+      actions$.next(new testDataActions.RemoveSeriousFault(Competencies.controlsGears));
       // ASSERT
       effects.removeSeriousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -646,7 +646,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.RemoveDangerousFault(Competencies.controlsGears));
+      actions$.next(new testDataActions.RemoveDangerousFault(Competencies.controlsGears));
       // ASSERT
       effects.removeDangerousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -663,7 +663,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.RemoveDangerousFault(Competencies.controlsGears));
+      actions$.next(new testDataActions.RemoveDangerousFault(Competencies.controlsGears));
       // ASSERT
       effects.removeDangerousFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -678,7 +678,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.RemoveManoeuvreFault({
+      actions$.next(new testDataActions.RemoveManoeuvreFault({
         manoeuvre: ManoeuvreTypes.reverseRight,
         competency: ManoeuvreCompetencies.controlFault,
       }));
@@ -698,7 +698,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.RemoveManoeuvreFault({
+      actions$.next(new testDataActions.RemoveManoeuvreFault({
         manoeuvre: ManoeuvreTypes.reverseRight,
         competency: ManoeuvreCompetencies.controlFault,
       }));
@@ -716,7 +716,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.ControlledStopRemoveFault());
+      actions$.next(new testDataActions.ControlledStopRemoveFault());
       // ASSERT
       effects.controlledStopRemoveFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -732,7 +732,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.ControlledStopRemoveFault());
+      actions$.next(new testDataActions.ControlledStopRemoveFault());
       // ASSERT
       effects.controlledStopRemoveFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -747,7 +747,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
-      actions.next(new testDataActions.ShowMeQuestionRemoveFault());
+      actions$.next(new testDataActions.ShowMeQuestionRemoveFault());
       // ASSERT
       effects.showMeQuestionRemoveFault$.subscribe((result) => {
         expect(result).toEqual({});
@@ -763,7 +763,7 @@ describe('Test Report Analytics Effects', () => {
       spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions.next(new testDataActions.ShowMeQuestionRemoveFault());
+      actions$.next(new testDataActions.ShowMeQuestionRemoveFault());
       // ASSERT
       effects.showMeQuestionRemoveFault$.subscribe((result) => {
         expect(result).toEqual({});

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -11,7 +11,7 @@ import {
 import * as testReportActions from '../../pages/test-report/test-report.actions';
 import * as testDataActions from '../../modules/tests/test-data/test-data.actions';
 import { getTests } from '../../modules/tests/tests.reducer';
-import { isTestReportPracticeTest } from '../../modules/tests/tests.selector';
+import { isPracticeMode } from '../../modules/tests/tests.selector';
 import { fullCompetencyLabels } from '../../shared/constants/competencies/catb-competencies';
 import {
   manoeuvreCompetencyLabels,
@@ -50,11 +50,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testReportActions.ToggleRemoveFaultMode, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testReportActions.ToggleRemoveFaultMode, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_REMOVE_MODE,
@@ -71,11 +71,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testReportActions.ToggleSeriousFaultMode, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testReportActions.ToggleSeriousFaultMode, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_SERIOUS_MODE,
@@ -92,11 +92,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testReportActions.ToggleDangerousFaultMode, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testReportActions.ToggleDangerousFaultMode, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_DANGEROUS_MODE,
@@ -115,11 +115,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.AddDrivingFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.AddDrivingFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
@@ -140,11 +140,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.AddSeriousFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.AddSeriousFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_SERIOUS_FAULT,
@@ -165,11 +165,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.AddDangerousFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.AddDangerousFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DANGEROUS_FAULT,
@@ -190,11 +190,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.AddManoeuvreDrivingFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.AddManoeuvreDrivingFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
@@ -215,11 +215,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.AddManoeuvreSeriousFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.AddManoeuvreSeriousFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_SERIOUS_FAULT,
@@ -240,11 +240,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.AddManoeuvreDangerousFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.AddManoeuvreDangerousFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DANGEROUS_FAULT,
@@ -265,11 +265,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ControlledStopAddDrivingFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.ControlledStopAddDrivingFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
@@ -290,11 +290,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ControlledStopAddSeriousFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.ControlledStopAddSeriousFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_SERIOUS_FAULT,
@@ -315,11 +315,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ControlledStopAddDangerousFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.ControlledStopAddDangerousFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DANGEROUS_FAULT,
@@ -340,11 +340,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ShowMeQuestionDrivingFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.ShowMeQuestionDrivingFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
@@ -365,11 +365,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ShowMeQuestionSeriousFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.ShowMeQuestionSeriousFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_SERIOUS_FAULT,
@@ -390,11 +390,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ShowMeQuestionDangerousFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.ShowMeQuestionDangerousFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DANGEROUS_FAULT,
@@ -415,11 +415,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.RemoveDrivingFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.RemoveDrivingFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_DRIVING_FAULT,
@@ -440,11 +440,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.RemoveSeriousFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.RemoveSeriousFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_SERIOUS_FAULT,
@@ -465,11 +465,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.RemoveDangerousFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.RemoveDangerousFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_DANGEROUS_FAULT,
@@ -490,11 +490,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.RemoveManoeuvreFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.RemoveManoeuvreFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_DRIVING_FAULT,
@@ -514,11 +514,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ControlledStopRemoveFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.ControlledStopRemoveFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_FAULT,
@@ -538,11 +538,11 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isTestReportPracticeTest),
+        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ShowMeQuestionRemoveFault, boolean]) => {
-      if (!isTestReportPracticeTest) {
+    concatMap(([action, isPracticeMode]: [testDataActions.ShowMeQuestionRemoveFault, boolean]) => {
+      if (!isPracticeMode) {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_FAULT,

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -17,6 +17,7 @@ import {
   manoeuvreCompetencyLabels,
   manoeuvreTypeLabels,
 } from './components/manoeuvre-competency/manoeuvre-competency.constants';
+import { AnalyticRecorded, AnalyticNotRecorded } from '../../providers/analytics/analytics.actions';
 
 @Injectable()
 export class TestReportAnalyticsEffects {
@@ -39,7 +40,7 @@ export class TestReportAnalyticsEffects {
     ofType(testReportActions.TEST_REPORT_VIEW_DID_ENTER),
     switchMap((action: testReportActions.TestReportViewDidEnter) => {
       this.analytics.setCurrentPage(AnalyticsScreenNames.TEST);
-      return of({});
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -58,8 +59,9 @@ export class TestReportAnalyticsEffects {
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_REMOVE_MODE,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -78,8 +80,9 @@ export class TestReportAnalyticsEffects {
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_SERIOUS_MODE,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -98,8 +101,9 @@ export class TestReportAnalyticsEffects {
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_DANGEROUS_MODE,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -122,8 +126,9 @@ export class TestReportAnalyticsEffects {
           fullCompetencyLabels[action.payload.competency],
           action.payload.newFaultCount,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -146,8 +151,9 @@ export class TestReportAnalyticsEffects {
           fullCompetencyLabels[action.payload],
           1,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -170,8 +176,9 @@ export class TestReportAnalyticsEffects {
           fullCompetencyLabels[action.payload],
           1,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -194,8 +201,9 @@ export class TestReportAnalyticsEffects {
           `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
           1,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -218,8 +226,9 @@ export class TestReportAnalyticsEffects {
           `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
           1,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -242,8 +251,9 @@ export class TestReportAnalyticsEffects {
           `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
           1,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -266,8 +276,9 @@ export class TestReportAnalyticsEffects {
           fullCompetencyLabels['outcomeControlledStop'],
           1,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -290,8 +301,9 @@ export class TestReportAnalyticsEffects {
           fullCompetencyLabels['outcomeControlledStop'],
           1,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -314,8 +326,9 @@ export class TestReportAnalyticsEffects {
           fullCompetencyLabels['outcomeControlledStop'],
           1,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -338,8 +351,9 @@ export class TestReportAnalyticsEffects {
           fullCompetencyLabels['showMeQuestion'],
           1,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -362,8 +376,9 @@ export class TestReportAnalyticsEffects {
           fullCompetencyLabels['showMeQuestion'],
           1,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -386,8 +401,9 @@ export class TestReportAnalyticsEffects {
           fullCompetencyLabels['showMeQuestion'],
           1,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -410,8 +426,9 @@ export class TestReportAnalyticsEffects {
           fullCompetencyLabels[action.payload.competency],
           action.payload.newFaultCount,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -434,8 +451,9 @@ export class TestReportAnalyticsEffects {
           fullCompetencyLabels[action.payload],
           0,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -458,8 +476,9 @@ export class TestReportAnalyticsEffects {
           fullCompetencyLabels[action.payload],
           0,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -481,8 +500,9 @@ export class TestReportAnalyticsEffects {
           AnalyticsEvents.REMOVE_DRIVING_FAULT,
           `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -504,8 +524,9 @@ export class TestReportAnalyticsEffects {
           AnalyticsEvents.REMOVE_FAULT,
           fullCompetencyLabels['outcomeControlledStop'],
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 
@@ -527,8 +548,9 @@ export class TestReportAnalyticsEffects {
           AnalyticsEvents.REMOVE_FAULT,
           fullCompetencyLabels['showMeQuestion'],
         );
+        return of(new AnalyticRecorded());
       }
-      return of({});
+      return of(new AnalyticNotRecorded());
     }),
   );
 

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -8,11 +8,8 @@ import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import {
   AnalyticsScreenNames, AnalyticsEventCategories, AnalyticsEvents,
 } from '../../providers/analytics/analytics.model';
-import {
-  TEST_REPORT_VIEW_DID_ENTER,
-  TestReportViewDidEnter,
-} from '../../pages/test-report/test-report.actions';
-import * as  testDataActions from '../../modules/tests/test-data/test-data.actions';
+import * as testReportActions from '../../pages/test-report/test-report.actions';
+import * as testDataActions from '../../modules/tests/test-data/test-data.actions';
 import { getTests } from '../../modules/tests/tests.reducer';
 import { isTestReportPracticeTest } from '../../modules/tests/tests.selector';
 import { fullCompetencyLabels } from '../../shared/constants/competencies/catb-competencies';
@@ -39,9 +36,69 @@ export class TestReportAnalyticsEffects {
 
   @Effect()
   testReportViewDidEnter$ = this.actions$.pipe(
-    ofType(TEST_REPORT_VIEW_DID_ENTER),
-    switchMap((action: TestReportViewDidEnter) => {
+    ofType(testReportActions.TEST_REPORT_VIEW_DID_ENTER),
+    switchMap((action: testReportActions.TestReportViewDidEnter) => {
       this.analytics.setCurrentPage(AnalyticsScreenNames.TEST);
+      return of({});
+    }),
+  );
+
+  @Effect()
+  toggleRemoveFaultMode$ = this.actions$.pipe(
+    ofType(testReportActions.TOGGLE_REMOVE_FAULT_MODE),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testReportActions.ToggleRemoveFaultMode, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.SELECT_REMOVE_MODE,
+        );
+      }
+      return of({});
+    }),
+  );
+
+  @Effect()
+  toggleSeriousFaultMode$ = this.actions$.pipe(
+    ofType(testReportActions.TOGGLE_SERIOUS_FAULT_MODE),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testReportActions.ToggleSeriousFaultMode, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.SELECT_SERIOUS_MODE,
+        );
+      }
+      return of({});
+    }),
+  );
+
+  @Effect()
+  toggleDangerousFaultMode$ = this.actions$.pipe(
+    ofType(testReportActions.TOGGLE_DANGEROUS_FAULT_MODE),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testReportActions.ToggleDangerousFaultMode, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.SELECT_DANGEROUS_MODE,
+        );
+      }
       return of({});
     }),
   );

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -71,6 +71,54 @@ export class TestReportAnalyticsEffects {
   );
 
   @Effect()
+  addSeriousFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.ADD_SERIOUS_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.AddSeriousFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_SERIOUS_FAULT,
+          fullCompetencyLabels[action.payload],
+          1,
+        );
+      }
+      return of({});
+    }),
+  );
+
+  @Effect()
+  addDangerousFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.ADD_DANGEROUS_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.AddDangerousFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DANGEROUS_FAULT,
+          fullCompetencyLabels[action.payload],
+          1,
+        );
+      }
+      return of({});
+    }),
+  );
+
+  @Effect()
   addManoeuvreDrivingFault$ = this.actions$.pipe(
     ofType(
       testDataActions.ADD_MANOEUVRE_DRIVING_FAULT,
@@ -86,6 +134,54 @@ export class TestReportAnalyticsEffects {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
+          `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
+          1,
+        );
+      }
+      return of({});
+    }),
+  );
+
+  @Effect()
+  addManoeuvreSeriousFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.ADD_MANOEUVRE_SERIOUS_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.AddManoeuvreSeriousFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_SERIOUS_FAULT,
+          `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
+          1,
+        );
+      }
+      return of({});
+    }),
+  );
+
+  @Effect()
+  addManoeuvreDangerousFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.ADD_MANOEUVRE_DANGEROUS_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.AddManoeuvreDangerousFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DANGEROUS_FAULT,
           `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
           1,
         );
@@ -119,6 +215,54 @@ export class TestReportAnalyticsEffects {
   );
 
   @Effect()
+  controlledStopAddSeriousFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.CONTROLLED_STOP_ADD_SERIOUS_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ControlledStopAddSeriousFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_SERIOUS_FAULT,
+          fullCompetencyLabels['outcomeControlledStop'],
+          1,
+        );
+      }
+      return of({});
+    }),
+  );
+
+  @Effect()
+  controlledStopAddDangerousFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.CONTROLLED_STOP_ADD_DANGEROUS_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ControlledStopAddDangerousFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DANGEROUS_FAULT,
+          fullCompetencyLabels['outcomeControlledStop'],
+          1,
+        );
+      }
+      return of({});
+    }),
+  );
+
+  @Effect()
   showMeQuestionDrivingFault$ = this.actions$.pipe(
     ofType(
       testDataActions.SHOW_ME_QUESTION_DRIVING_FAULT,
@@ -134,6 +278,54 @@ export class TestReportAnalyticsEffects {
         this.analytics.logEvent(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
+          fullCompetencyLabels['showMeQuestion'],
+          1,
+        );
+      }
+      return of({});
+    }),
+  );
+
+  @Effect()
+  showMeQuestionSeriousFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.SHOW_ME_QUESTION_SERIOUS_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ShowMeQuestionSeriousFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_SERIOUS_FAULT,
+          fullCompetencyLabels['showMeQuestion'],
+          1,
+        );
+      }
+      return of({});
+    }),
+  );
+
+  @Effect()
+  showMeQuestionDangerousFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.SHOW_ME_QUESTION_DANGEROUS_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.ShowMeQuestionDangerousFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DANGEROUS_FAULT,
           fullCompetencyLabels['showMeQuestion'],
           1,
         );
@@ -159,6 +351,55 @@ export class TestReportAnalyticsEffects {
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_DRIVING_FAULT,
           fullCompetencyLabels[action.payload.competency],
+          action.payload.newFaultCount,
+        );
+      }
+      return of({});
+    }),
+  );
+
+  @Effect()
+  removeSeriousFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.REMOVE_SERIOUS_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.RemoveSeriousFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.REMOVE_SERIOUS_FAULT,
+          fullCompetencyLabels[action.payload],
+          0,
+        );
+      }
+      return of({});
+    }),
+  );
+
+  @Effect()
+  removeDangerousFault$ = this.actions$.pipe(
+    ofType(
+      testDataActions.REMOVE_DANGEROUS_FAULT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+        map(isTestReportPracticeTest),
+      ),
+    ),
+    concatMap(([action, isTestReportPracticeTest]: [testDataActions.RemoveDangerousFault, boolean]) => {
+      if (!isTestReportPracticeTest) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.REMOVE_DANGEROUS_FAULT,
+          fullCompetencyLabels[action.payload],
+          0,
         );
       }
       return of({});

--- a/src/providers/analytics/analytics.actions.ts
+++ b/src/providers/analytics/analytics.actions.ts
@@ -1,0 +1,16 @@
+import { Action } from '@ngrx/store';
+
+export const ANALYTIC_RECORDED = '[Analytics] Analytic Recorded';
+export const ANALYTIC_NOT_RECORDED = '[Analytics] Analytic Recorded';
+
+export class AnalyticRecorded implements Action {
+  readonly type = ANALYTIC_RECORDED;
+}
+
+export class AnalyticNotRecorded implements Action {
+  readonly type = ANALYTIC_NOT_RECORDED;
+}
+
+export type Types =
+  | AnalyticRecorded
+  | AnalyticNotRecorded;


### PR DESCRIPTION
## Description and relevant Jira numbers
- Add effects for serious and dangerous faults
- Ensure the analytics effects return a type because as I now understand, returning `of({})` will produce an error `actions must have a type property`... and this breaks the test report 😞  So they now return an action of `AnalyticRecorded or `AnalyticNotRecorded` instead - which is effectively a dummy / void action. But this does mean that tests can now check to see the correct action was returned.

A future PR will need to look at Logs and other Analytics to fix similar issues.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing (AND WORKS ON DEVICE!)
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
