### PR TITLE
MES-2269 bugfix: Prevent future tests from being started

### DIFF
--- a/src/pages/journal/components/test-slot/__tests__/test-slot.spec.ts
+++ b/src/pages/journal/components/test-slot/__tests__/test-slot.spec.ts
@@ -31,6 +31,7 @@ import { ProgressiveAccessComponent } from '../../progressive-access/progressive
 import { SpecialNeedsCode } from '../../../../candidate-details/candidate-details.constants';
 import { ActivityCodes } from '../../../../../shared/models/activity-codes';
 import { TestSlot } from '@dvsa/mes-journal-schema';
+import { DateTime, Duration } from '../../../../../shared/helpers/date-time';
 
 describe('TestSlotComponent', () => {
   let fixture: ComponentFixture<TestSlotComponent>;
@@ -314,6 +315,18 @@ describe('TestSlotComponent', () => {
           },
         });
         expect(component.canStartTest()).toBe(true);
+      });
+      it('should disallow starting of tests that arent today', () => {
+        getAppConfigSpy.and.returnValue({
+          journal: {
+            testPermissionPeriods: [
+              { testCategory: 'B', from: '2019-01-01', to: null },
+            ],
+          },
+        });
+        component.slot.slotDetail.start =
+          DateTime.at(startTime).add(1, Duration.DAY).format('YYYY-MM-DDTHH:mm:ss+00:00');
+        expect(component.canStartTest()).toBeFalsy();
       });
     });
 


### PR DESCRIPTION
## Description and relevant Jira numbers
* Fixing regression from #566 which allowed tests on future days to be started
* Migrate `canStartTest` method to use `DateTime` helper
* Preflight tests https://jenkins.mgmt.mes.dvsacloud.uk/job/mobile-app_build/642/console

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
