### PR TITLE
MES-2860: Hide advanced search for non-LDTMs (DEs)

### DIFF
--- a/src/pages/test-results-search/__tests__/test-results-search.spec.ts
+++ b/src/pages/test-results-search/__tests__/test-results-search.spec.ts
@@ -8,10 +8,15 @@ import { AuthenticationProviderMock } from '../../../providers/authentication/__
 import { TestResultsSearchComponentsModule } from '../components/test-results-search-components.module';
 import { SearchProvider } from '../../../providers/search/search';
 import { SearchProviderMock } from '../../../providers/search/__mocks__/search.mock';
+import { By } from '@angular/platform-browser';
+import { AppConfigProvider } from '../../../providers/app-config/app-config';
+import { AppConfigProviderMock } from '../../../providers/app-config/__mocks__/app-config.mock';
+import { ExaminerRole } from '../../../providers/app-config/constants/examiner-role.constants';
 
 describe('TestResultsSearchPage', () => {
   let fixture: ComponentFixture<TestResultsSearchPage>;
   let component: TestResultsSearchPage;
+  let appConfigProviderMock: AppConfigProvider;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -29,11 +34,13 @@ describe('TestResultsSearchPage', () => {
         { provide: Platform, useFactory: () => PlatformMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
         { provide: SearchProvider, useClass: SearchProviderMock },
+        { provide: AppConfigProvider, useClass: AppConfigProviderMock },
       ],
     })
       .compileComponents()
       .then(() => {
         fixture = TestBed.createComponent(TestResultsSearchPage);
+        appConfigProviderMock = TestBed.get(AppConfigProvider);
         component = fixture.componentInstance;
       });
   }));
@@ -47,5 +54,34 @@ describe('TestResultsSearchPage', () => {
   });
 
   describe('DOM', () => {
+  });
+
+  describe('advanced search', () => {
+    describe('when the user is an LDTM', () => {
+      beforeEach(() => {
+        spyOn(appConfigProviderMock, 'getAppConfig').and.returnValue({
+          role: ExaminerRole.LDTM,
+        });
+        fixture.detectChanges();
+      });
+
+      it('displays the advanced search', () => {
+        expect(fixture.debugElement.query(By.css('#tab-search-advanced'))).not.toBeNull();
+      });
+    });
+
+    describe('when the user is a DE', () => {
+      beforeEach(() => {
+        spyOn(appConfigProviderMock, 'getAppConfig').and.returnValue({
+          role: ExaminerRole.DE,
+        });
+        fixture.detectChanges();
+      });
+
+      it('only displays the candidate search', () => {
+        expect(fixture.debugElement.query(By.css('#tab-search-candidate-details'))).not.toBeNull();
+        expect(fixture.debugElement.query(By.css('#tab-search-advanced'))).toBeNull();
+      });
+    });
   });
 });

--- a/src/pages/test-results-search/components/advanced-search/advanced-search.ts
+++ b/src/pages/test-results-search/components/advanced-search/advanced-search.ts
@@ -44,7 +44,6 @@ export class AdvancedSearchComponent {
 
   searchTests() {
     const advancedSearchParams: AdvancedSearchParams = {
-      isLDTM: true,
       startDate: this.startDate,
       endDate: this.endDate,
       staffNumber: this.staffNumber,

--- a/src/pages/test-results-search/test-results-search.html
+++ b/src/pages/test-results-search/test-results-search.html
@@ -8,7 +8,7 @@
 <ion-content padding>
 
   <tabs>
-    <tab [tabTitle]="'Candidate details'">
+    <tab [tabTitle]="'Candidate details'" id="tab-search-candidate-details">
       <ion-grid>
         <ion-row align-self-center>
           <ion-col class="component-label" col-22>
@@ -61,7 +61,7 @@
         </ion-row>
       </ion-grid>
     </tab>
-    <tab [tabTitle]="'Advanced search'" *ngIf="displayAdvancedSearch">
+    <tab [tabTitle]="'Advanced search'" *ngIf="displayAdvancedSearch()" id="tab-search-advanced">
       <advanced-search (onSearchTests)="advancedSearch($event)" [showSpinner]="showAdvancedSearchSpinner"></advanced-search>
     </tab>
   </tabs>

--- a/src/pages/test-results-search/test-results-search.html
+++ b/src/pages/test-results-search/test-results-search.html
@@ -61,7 +61,7 @@
         </ion-row>
       </ion-grid>
     </tab>
-    <tab [tabTitle]="'Advanced search'">
+    <tab [tabTitle]="'Advanced search'" *ngIf="displayAdvancedSearch">
       <advanced-search (onSearchTests)="advancedSearch($event)" [showSpinner]="showAdvancedSearchSpinner"></advanced-search>
     </tab>
   </tabs>

--- a/src/pages/test-results-search/test-results-search.ts
+++ b/src/pages/test-results-search/test-results-search.ts
@@ -26,6 +26,8 @@ export class TestResultsSearchPage extends BasePageComponent {
   hasSearched: boolean = false;
   showSearchSpinner: boolean = false;
   showAdvancedSearchSpinner: boolean = false;
+  // TODO set `displayAdvancedSearch` based on examinerRole
+  displayAdvancedSearch: boolean = false;
 
   constructor(
     public navController: NavController,

--- a/src/pages/test-results-search/test-results-search.ts
+++ b/src/pages/test-results-search/test-results-search.ts
@@ -1,12 +1,14 @@
 import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams, Platform } from 'ionic-angular';
 import { BasePageComponent } from '../../shared/classes/base-page';
+import { AppConfigProvider } from '../../providers/app-config/app-config';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
 import { SearchProvider } from '../../providers/search/search';
 import { tap, catchError, map } from 'rxjs/operators';
 import { of } from 'rxjs/observable/of';
 import { SearchResultTestSchema } from '@dvsa/mes-search-schema';
 import { AdvancedSearchParams } from '../../providers/search/search.models';
+import { ExaminerRole } from '../../providers/app-config/constants/examiner-role.constants';
 
 enum SearchBy {
   DriverNumber = 'driverNumber',
@@ -26,8 +28,6 @@ export class TestResultsSearchPage extends BasePageComponent {
   hasSearched: boolean = false;
   showSearchSpinner: boolean = false;
   showAdvancedSearchSpinner: boolean = false;
-  // TODO set `displayAdvancedSearch` based on examinerRole
-  displayAdvancedSearch: boolean = false;
 
   constructor(
     public navController: NavController,
@@ -35,12 +35,17 @@ export class TestResultsSearchPage extends BasePageComponent {
     public navParams: NavParams,
     public authenticationProvider: AuthenticationProvider,
     public searchProvider: SearchProvider,
+    private appConfig: AppConfigProvider,
   ) {
     super(platform, navController, authenticationProvider);
   }
 
   searchByChanged(val: SearchBy) {
     this.searchBy = val;
+  }
+
+  displayAdvancedSearch() {
+    return this.appConfig.getAppConfig().role === ExaminerRole.LDTM;
   }
 
   candidateInfoChanged(val: string) {

--- a/src/providers/authentication/user-role.ts
+++ b/src/providers/authentication/user-role.ts
@@ -1,0 +1,4 @@
+export enum UserRole {
+  DE = 'DE',
+  LDTM = 'LDTM',
+}

--- a/src/providers/authentication/user-role.ts
+++ b/src/providers/authentication/user-role.ts
@@ -1,4 +1,0 @@
-export enum UserRole {
-  DE = 'DE',
-  LDTM = 'LDTM',
-}

--- a/src/providers/search/__tests__/search.spec.ts
+++ b/src/providers/search/__tests__/search.spec.ts
@@ -28,21 +28,20 @@ describe('SearchProvider', () => {
   describe('driverNumberSearch', () => {
     it('should call the search endpoint with the provided driver number', () => {
       searchProvider.driverNumberSearch('12345').subscribe();
-      httpMock.expectOne('https://www.example.com/api/v1/test-result?driverNumber=12345&isLDTM=false');
+      httpMock.expectOne('https://www.example.com/api/v1/test-result?driverNumber=12345');
     });
   });
 
   describe('applicationReferenceSearch', () => {
     it('should call the search endpoint with the provided application reference', () => {
       searchProvider.applicationReferenceSearch('12345').subscribe();
-      httpMock.expectOne('https://www.example.com/api/v1/test-result?applicationReference=12345&isLDTM=false');
+      httpMock.expectOne('https://www.example.com/api/v1/test-result?applicationReference=12345');
     });
   });
 
   describe('advancedSearch', () => {
     it('should call the search endpoint with the correct values for all parameters', () => {
       const params: AdvancedSearchParams = {
-        isLDTM: true,
         startDate: '12-12-12',
         endDate: '12-12-12',
         staffNumber: '12345',
@@ -53,17 +52,13 @@ describe('SearchProvider', () => {
 
       httpMock.expectOne(
         // tslint:disable-next-line:max-line-length
-        'https://www.example.com/api/v1/test-result?isLDTM=true&startDate=12-12-12&endDate=12-12-12&staffNumber=12345&dtcCode=abc',
+        'https://www.example.com/api/v1/test-result?startDate=12-12-12&endDate=12-12-12&staffNumber=12345&dtcCode=abc',
       );
     });
     it('should not add the paramters to the url if they are not provided', () => {
-      const params: AdvancedSearchParams = {
-        isLDTM: false,
-      };
-
-      searchProvider.advancedSearch(params).subscribe(() => {
+      searchProvider.advancedSearch({}).subscribe(() => {
         httpMock.expectOne(
-          'https://www.example.com/api/v1/test-result?isLDTM=false',
+          'https://www.example.com/api/v1/test-result',
         );
       });
     });

--- a/src/providers/search/search.models.ts
+++ b/src/providers/search/search.models.ts
@@ -1,5 +1,4 @@
 export interface AdvancedSearchParams {
-  isLDTM?: boolean;
   startDate?: string;
   endDate?: string;
   staffNumber?: string;

--- a/src/providers/search/search.ts
+++ b/src/providers/search/search.ts
@@ -18,7 +18,6 @@ export class SearchProvider {
       {
         params: {
           driverNumber,
-          isLDTM: 'false',
         },
       },
     );
@@ -30,7 +29,6 @@ export class SearchProvider {
       {
         params: {
           applicationReference,
-          isLDTM: 'false',
         },
       },
     );
@@ -41,8 +39,6 @@ export class SearchProvider {
       this.urlProvider.getTestResultServiceUrl(),
       {
         params: {
-          // TODO -  remove this when https://jira.i-env.net/browse/MES-2135 is implemented
-          isLDTM: advancedSearchParams.isLDTM ? 'true' : 'false',
           startDate: advancedSearchParams.startDate,
           endDate: advancedSearchParams.endDate,
           staffNumber: advancedSearchParams.staffNumber,


### PR DESCRIPTION
## Description and relevant Jira numbers

Hide advanced search when `role` is `'LDTM'`. Kept tab layout as per the design on Abstract.

<img width="648" alt="Screenshot 2019-07-15 at 17 32 38" src="https://user-images.githubusercontent.com/44976690/61232651-bcd23780-a726-11e9-814e-86e7631d3edc.png">

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [x] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
