### PR TITLE
Update test report analytics effects and tests to cater for practice mode

### DIFF
--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -19,7 +19,6 @@ import {
   AnalyticsScreenNames,
   AnalyticsEventCategories,
   AnalyticsEvents,
-  AnalyticsLabels,
 } from '../../../providers/analytics/analytics.model';
 import { fullCompetencyLabels } from '../../../shared/constants/competencies/catb-competencies';
 import { testsReducer } from '../../../modules/tests/tests.reducer';
@@ -28,7 +27,7 @@ import {
   manoeuvreTypeLabels,
   manoeuvreCompetencyLabels,
 } from '../components/manoeuvre-competency/manoeuvre-competency.constants';
-import { AnalyticRecorded, AnalyticNotRecorded } from '../../../providers/analytics/analytics.actions';
+import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
 
 describe('Test Report Analytics Effects', () => {
 
@@ -55,10 +54,11 @@ describe('Test Report Analytics Effects', () => {
     effects = TestBed.get(TestReportAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     store$ = TestBed.get(Store);
+    spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
   });
 
   describe('testReportViewDidEnter', () => {
-    it('should call setCurrentPage and addCustomDimension', () => {
+    it('should call setCurrentPage and addCustomDimension', (done) => {
       // ARRANGE
       spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
       // ACT
@@ -66,105 +66,121 @@ describe('Test Report Analytics Effects', () => {
       // ASSERT
       effects.testReportViewDidEnter$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.setCurrentPage).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.setCurrentPage).toHaveBeenCalledWith(AnalyticsScreenNames.TEST);
+        done();
       });
     });
   });
 
   describe('toggleRemoveFaultMode', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testReportActions.ToggleRemoveFaultMode());
       // ASSERT
       effects.toggleRemoveFaultMode$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_REMOVE_MODE,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testReportActions.ToggleRemoveFaultMode());
       // ASSERT
       effects.toggleRemoveFaultMode$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.SELECT_REMOVE_MODE}`,
+        );
+        done();
       });
     });
   });
 
   describe('toggleSeriousFaultMode', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testReportActions.ToggleSeriousFaultMode());
       // ASSERT
       effects.toggleSeriousFaultMode$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_SERIOUS_MODE,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testReportActions.ToggleSeriousFaultMode());
       // ASSERT
       effects.toggleSeriousFaultMode$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.SELECT_SERIOUS_MODE}`,
+        );
+        done();
       });
     });
   });
 
   describe('toggleDangerousFaultMode', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testReportActions.ToggleDangerousFaultMode());
       // ASSERT
       effects.toggleDangerousFaultMode$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_DANGEROUS_MODE,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testReportActions.ToggleDangerousFaultMode());
       // ASSERT
       effects.toggleDangerousFaultMode$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.SELECT_DANGEROUS_MODE}`,
+        );
+        done();
       });
     });
   });
 
   describe('addDrivingFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.AddDrivingFault({
@@ -174,17 +190,18 @@ describe('Test Report Analytics Effects', () => {
       // ASSERT
       effects.addDrivingFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
           fullCompetencyLabels[Competencies.controlsGears],
           1,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.AddDrivingFault({
@@ -193,80 +210,100 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addDrivingFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_DRIVING_FAULT}`,
+          fullCompetencyLabels[Competencies.controlsGears],
+          1,
+        );
+        done();
       });
     });
   });
 
   describe('addSeriousFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.AddSeriousFault(Competencies.controlsGears));
       // ASSERT
       effects.addSeriousFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_SERIOUS_FAULT,
           fullCompetencyLabels[Competencies.controlsGears],
           1,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.AddSeriousFault(Competencies.controlsGears));
       // ASSERT
       effects.addSeriousFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_SERIOUS_FAULT}`,
+          fullCompetencyLabels[Competencies.controlsGears],
+          1,
+        );
+        done();
       });
     });
   });
 
   describe('addDangerousFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.AddDangerousFault(Competencies.controlsGears));
       // ASSERT
       effects.addDangerousFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DANGEROUS_FAULT,
           fullCompetencyLabels[Competencies.controlsGears],
           1,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.AddDangerousFault(Competencies.controlsGears));
       // ASSERT
       effects.addDangerousFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_DANGEROUS_FAULT}`,
+          fullCompetencyLabels[Competencies.controlsGears],
+          1,
+        );
+        done();
       });
     });
   });
 
   describe('addManoeuvreDrivingFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.AddManoeuvreDrivingFault({
@@ -276,6 +313,7 @@ describe('Test Report Analytics Effects', () => {
       // ASSERT
       effects.addManoeuvreDrivingFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
@@ -283,11 +321,11 @@ describe('Test Report Analytics Effects', () => {
           `${manoeuvreTypeLabels[ManoeuvreTypes.reverseRight]} - ${manoeuvreCompetencyLabels[ManoeuvreCompetencies.controlFault]}`,
           1,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.AddManoeuvreDrivingFault({
@@ -296,16 +334,23 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addManoeuvreDrivingFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_DRIVING_FAULT}`,
+          // tslint:disable-next-line:max-line-length
+          `${manoeuvreTypeLabels[ManoeuvreTypes.reverseRight]} - ${manoeuvreCompetencyLabels[ManoeuvreCompetencies.controlFault]}`,
+          1,
+        );
+        done();
       });
     });
   });
 
   describe('addManoeuvreSeriousFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.AddManoeuvreSeriousFault({
@@ -315,6 +360,7 @@ describe('Test Report Analytics Effects', () => {
       // ASSERT
       effects.addManoeuvreSeriousFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_SERIOUS_FAULT,
@@ -322,11 +368,11 @@ describe('Test Report Analytics Effects', () => {
           `${manoeuvreTypeLabels[ManoeuvreTypes.reverseRight]} - ${manoeuvreCompetencyLabels[ManoeuvreCompetencies.controlFault]}`,
           1,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.AddManoeuvreSeriousFault({
@@ -335,16 +381,23 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addManoeuvreSeriousFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_SERIOUS_FAULT}`,
+          // tslint:disable-next-line:max-line-length
+          `${manoeuvreTypeLabels[ManoeuvreTypes.reverseRight]} - ${manoeuvreCompetencyLabels[ManoeuvreCompetencies.controlFault]}`,
+          1,
+        );
+        done();
       });
     });
   });
 
   describe('addManoeuvreDangerousFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.AddManoeuvreDangerousFault({
@@ -354,6 +407,7 @@ describe('Test Report Analytics Effects', () => {
       // ASSERT
       effects.addManoeuvreDangerousFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DANGEROUS_FAULT,
@@ -361,11 +415,11 @@ describe('Test Report Analytics Effects', () => {
           `${manoeuvreTypeLabels[ManoeuvreTypes.reverseRight]} - ${manoeuvreCompetencyLabels[ManoeuvreCompetencies.controlFault]}`,
           1,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.AddManoeuvreDangerousFault({
@@ -374,208 +428,257 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.addManoeuvreDangerousFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_DANGEROUS_FAULT}`,
+          // tslint:disable-next-line:max-line-length
+          `${manoeuvreTypeLabels[ManoeuvreTypes.reverseRight]} - ${manoeuvreCompetencyLabels[ManoeuvreCompetencies.controlFault]}`,
+          1,
+        );
+        done();
       });
     });
   });
 
   describe('controlledStopAddDrivingFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.ControlledStopAddDrivingFault());
       // ASSERT
       effects.controlledStopAddDrivingFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
           fullCompetencyLabels['outcomeControlledStop'],
           1,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.ControlledStopAddDrivingFault());
       // ASSERT
       effects.controlledStopAddDrivingFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_DRIVING_FAULT}`,
+          fullCompetencyLabels['outcomeControlledStop'],
+          1,
+        );
+        done();
       });
     });
   });
 
   describe('controlledStopAddSeriousFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.ControlledStopAddSeriousFault());
       // ASSERT
       effects.controlledStopAddSeriousFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_SERIOUS_FAULT,
           fullCompetencyLabels['outcomeControlledStop'],
           1,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.ControlledStopAddSeriousFault());
       // ASSERT
       effects.controlledStopAddSeriousFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_SERIOUS_FAULT}`,
+          fullCompetencyLabels['outcomeControlledStop'],
+          1,
+        );
+        done();
       });
     });
   });
 
   describe('controlledStopAddDangerousFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.ControlledStopAddDangerousFault());
       // ASSERT
-      effects.controlledStopAddDrivingFault$.subscribe((result) => {
+      effects.controlledStopAddDangerousFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DANGEROUS_FAULT,
           fullCompetencyLabels['outcomeControlledStop'],
           1,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.ControlledStopAddDangerousFault());
       // ASSERT
-      effects.controlledStopAddDrivingFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+      effects.controlledStopAddDangerousFault$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_DANGEROUS_FAULT}`,
+          fullCompetencyLabels['outcomeControlledStop'],
+          1,
+        );
+        done();
       });
     });
   });
 
   describe('showMeQuestionDrivingFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.ShowMeQuestionDrivingFault());
       // ASSERT
       effects.showMeQuestionDrivingFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DRIVING_FAULT,
           fullCompetencyLabels['showMeQuestion'],
           1,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.ShowMeQuestionDrivingFault());
       // ASSERT
       effects.showMeQuestionDrivingFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_DRIVING_FAULT}`,
+          fullCompetencyLabels['showMeQuestion'],
+          1,
+        );
+        done();
       });
     });
   });
 
   describe('showMeQuestionSeriousFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.ShowMeQuestionSeriousFault());
       // ASSERT
       effects.showMeQuestionSeriousFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_SERIOUS_FAULT,
           fullCompetencyLabels['showMeQuestion'],
           1,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.ShowMeQuestionSeriousFault());
       // ASSERT
       effects.showMeQuestionSeriousFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_SERIOUS_FAULT}`,
+          fullCompetencyLabels['showMeQuestion'],
+          1,
+        );
+        done();
       });
     });
   });
 
   describe('showMeQuestionDangerousFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.ShowMeQuestionDangerousFault());
       // ASSERT
       effects.showMeQuestionDangerousFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.ADD_DANGEROUS_FAULT,
           fullCompetencyLabels['showMeQuestion'],
           1,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.ShowMeQuestionDangerousFault());
       // ASSERT
       effects.showMeQuestionDangerousFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_DANGEROUS_FAULT}`,
+          fullCompetencyLabels['showMeQuestion'],
+          1,
+        );
+        done();
       });
     });
   });
 
   describe('removeDrivingFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.RemoveDrivingFault({
@@ -585,99 +688,120 @@ describe('Test Report Analytics Effects', () => {
       // ASSERT
       effects.removeDrivingFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_DRIVING_FAULT,
           fullCompetencyLabels[Competencies.controlsGears],
           0,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.RemoveDrivingFault({
         competency: Competencies.controlsGears,
-        newFaultCount: 1,
+        newFaultCount: 0,
       }));
       // ASSERT
       effects.removeDrivingFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REMOVE_DRIVING_FAULT}`,
+          fullCompetencyLabels[Competencies.controlsGears],
+          0,
+        );
+        done();
       });
     });
   });
 
   describe('removeSeriousFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.RemoveSeriousFault(Competencies.controlsGears));
       // ASSERT
       effects.removeSeriousFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_SERIOUS_FAULT,
           fullCompetencyLabels[Competencies.controlsGears],
           0,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.RemoveSeriousFault(Competencies.controlsGears));
       // ASSERT
       effects.removeSeriousFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REMOVE_SERIOUS_FAULT}`,
+          fullCompetencyLabels[Competencies.controlsGears],
+          0,
+        );
+        done();
       });
     });
   });
 
   describe('removeDangerousFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.RemoveDangerousFault(Competencies.controlsGears));
       // ASSERT
       effects.removeDangerousFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_DANGEROUS_FAULT,
           fullCompetencyLabels[Competencies.controlsGears],
           0,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.RemoveDangerousFault(Competencies.controlsGears));
       // ASSERT
       effects.removeDangerousFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REMOVE_DANGEROUS_FAULT}`,
+          fullCompetencyLabels[Competencies.controlsGears],
+          0,
+        );
+        done();
       });
     });
   });
 
   describe('removeManoeuvreDrivingFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.RemoveManoeuvreFault({
@@ -687,17 +811,18 @@ describe('Test Report Analytics Effects', () => {
       // ASSERT
       effects.removeManoeuvreFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_DRIVING_FAULT,
           // tslint:disable-next-line:max-line-length
           `${manoeuvreTypeLabels[ManoeuvreTypes.reverseRight]} - ${manoeuvreCompetencyLabels[ManoeuvreCompetencies.controlFault]}`,
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.RemoveManoeuvreFault({
@@ -706,104 +831,91 @@ describe('Test Report Analytics Effects', () => {
       }));
       // ASSERT
       effects.removeManoeuvreFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REMOVE_DRIVING_FAULT}`,
+          // tslint:disable-next-line:max-line-length
+          `${manoeuvreTypeLabels[ManoeuvreTypes.reverseRight]} - ${manoeuvreCompetencyLabels[ManoeuvreCompetencies.controlFault]}`,
+        );
+        done();
       });
     });
   });
 
   describe('controlledStopRemoveFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.ControlledStopRemoveFault());
       // ASSERT
       effects.controlledStopRemoveFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_FAULT,
           fullCompetencyLabels['outcomeControlledStop'],
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.ControlledStopRemoveFault());
       // ASSERT
       effects.controlledStopRemoveFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REMOVE_FAULT}`,
+          fullCompetencyLabels['outcomeControlledStop'],
+        );
+        done();
       });
     });
   });
 
   describe('showMeQuestionRemoveFault', () => {
-    it('should call logEvent for this competency', () => {
+    it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new journalActions.StartTest(123456));
       // ACT
       actions$.next(new testDataActions.ShowMeQuestionRemoveFault());
       // ASSERT
       effects.showMeQuestionRemoveFault$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.REMOVE_FAULT,
           fullCompetencyLabels['showMeQuestion'],
         );
+        done();
       });
     });
-    it('should not call logEvent for this competency when it is a practice test', () => {
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
       actions$.next(new testDataActions.ShowMeQuestionRemoveFault());
       // ASSERT
       effects.showMeQuestionRemoveFault$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('testTermination', () => {
-    it('should call logEvent for the termination event', (done) => {
-      // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-      store$.dispatch(new journalActions.StartTest(123456));
-      // ACT
-      actions$.next(new testReportActions.TerminateTestFromTestReport());
-      // ASSERT
-      effects.testTermination$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
-          AnalyticsEventCategories.TERMINATION,
-          AnalyticsEvents.END_TEST,
-          AnalyticsLabels.TERMINATE_TEST,
-        );
-        done();
-      });
-    });
-
-    it('should not call logEvent for termination when it is a practice test', (done) => {
-      // ARRANGE
-      spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
-      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
-      // ACT
-      actions$.next(new testReportActions.TerminateTestFromTestReport());
-      // ASSERT
-      effects.testTermination$.subscribe((result) => {
-        expect(result instanceof AnalyticNotRecorded).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REMOVE_FAULT}`,
+          fullCompetencyLabels['showMeQuestion'],
+          );
         done();
       });
     });
   });
+
 });

--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -19,6 +19,7 @@ import {
   AnalyticsScreenNames,
   AnalyticsEventCategories,
   AnalyticsEvents,
+  AnalyticsLabels,
 } from '../../../providers/analytics/analytics.model';
 import { fullCompetencyLabels } from '../../../shared/constants/competencies/catb-competencies';
 import { testsReducer } from '../../../modules/tests/tests.reducer';
@@ -912,6 +913,43 @@ describe('Test Report Analytics Effects', () => {
           `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
           `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REMOVE_FAULT}`,
           fullCompetencyLabels['showMeQuestion'],
+          );
+        done();
+      });
+    });
+  });
+
+  describe('testTermination', () => {
+    it('should call logEvent for termination event', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123456));
+      // ACT
+      actions$.next(new testReportActions.TerminateTestFromTestReport());
+      // ASSERT
+      effects.testTermination$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TERMINATION,
+          AnalyticsEvents.END_TEST,
+          AnalyticsLabels.TERMINATE_TEST,
+        );
+        done();
+      });
+    });
+    it('should call logEvent for termination event, prefixed with practice test', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions$.next(new testReportActions.TerminateTestFromTestReport());
+      // ASSERT
+      effects.testTermination$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TERMINATION}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.END_TEST}`,
+          AnalyticsLabels.TERMINATE_TEST,
           );
         done();
       });

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -6,7 +6,7 @@ import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import {
-  AnalyticsScreenNames, AnalyticsEventCategories, AnalyticsEvents,
+  AnalyticsScreenNames, AnalyticsEventCategories, AnalyticsEvents, AnalyticsLabels,
 } from '../../providers/analytics/analytics.model';
 import * as testReportActions from '../../pages/test-report/test-report.actions';
 import * as testDataActions from '../../modules/tests/test-data/test-data.actions';
@@ -461,6 +461,26 @@ export class TestReportAnalyticsEffects {
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
         formatAnalyticsText(AnalyticsEvents.REMOVE_FAULT, tests),
         fullCompetencyLabels['showMeQuestion'],
+      );
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  testTermination$ = this.actions$.pipe(
+    ofType(
+      testReportActions.TERMINATE_TEST_FROM_TEST_REPORT,
+    ),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+      ),
+    ),
+    concatMap(([action, tests]: [testReportActions.TerminateTestFromTestReport, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TERMINATION, tests),
+        formatAnalyticsText(AnalyticsEvents.END_TEST, tests),
+        AnalyticsLabels.TERMINATE_TEST,
       );
       return of(new AnalyticRecorded());
     }),

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -1,26 +1,24 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
-import { switchMap, concatMap, withLatestFrom, map } from 'rxjs/operators';
+import { switchMap, concatMap, withLatestFrom } from 'rxjs/operators';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import {
-  AnalyticsScreenNames,
-  AnalyticsEventCategories,
-  AnalyticsEvents,
-  AnalyticsLabels,
+  AnalyticsScreenNames, AnalyticsEventCategories, AnalyticsEvents,
 } from '../../providers/analytics/analytics.model';
 import * as testReportActions from '../../pages/test-report/test-report.actions';
 import * as testDataActions from '../../modules/tests/test-data/test-data.actions';
 import { getTests } from '../../modules/tests/tests.reducer';
-import { isPracticeMode } from '../../modules/tests/tests.selector';
 import { fullCompetencyLabels } from '../../shared/constants/competencies/catb-competencies';
 import {
   manoeuvreCompetencyLabels,
   manoeuvreTypeLabels,
 } from './components/manoeuvre-competency/manoeuvre-competency.constants';
-import { AnalyticRecorded, AnalyticNotRecorded } from '../../providers/analytics/analytics.actions';
+import { AnalyticRecorded } from '../../providers/analytics/analytics.actions';
+import { TestsModel } from '../../modules/tests/tests.model';
+import { formatAnalyticsText } from '../../shared/helpers/format-analytics-text';
 
 @Injectable()
 export class TestReportAnalyticsEffects {
@@ -30,12 +28,7 @@ export class TestReportAnalyticsEffects {
     private actions$: Actions,
     private store$: Store<StoreModel>,
   ) {
-    this.analytics.initialiseAnalytics()
-          .then(() => {})
-          .catch(() => {
-            console.log('error initialising analytics');
-          },
-    );
+    this.analytics.initialiseAnalytics();
   }
 
   @Effect()
@@ -53,18 +46,14 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testReportActions.ToggleRemoveFaultMode, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.SELECT_REMOVE_MODE,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testReportActions.ToggleRemoveFaultMode, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.SELECT_REMOVE_MODE, tests),
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -74,18 +63,14 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testReportActions.ToggleSeriousFaultMode, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.SELECT_SERIOUS_MODE,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testReportActions.ToggleSeriousFaultMode, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.SELECT_SERIOUS_MODE, tests),
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -95,18 +80,14 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testReportActions.ToggleDangerousFaultMode, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.SELECT_DANGEROUS_MODE,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testReportActions.ToggleDangerousFaultMode, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.SELECT_DANGEROUS_MODE, tests),
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -118,20 +99,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.AddDrivingFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.ADD_DRIVING_FAULT,
-          fullCompetencyLabels[action.payload.competency],
-          action.payload.newFaultCount,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.AddDrivingFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_DRIVING_FAULT, tests),
+        fullCompetencyLabels[action.payload.competency],
+        action.payload.newFaultCount,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -143,20 +120,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.AddSeriousFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.ADD_SERIOUS_FAULT,
-          fullCompetencyLabels[action.payload],
-          1,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.AddSeriousFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_SERIOUS_FAULT, tests),
+        fullCompetencyLabels[action.payload],
+        1,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -168,20 +141,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.AddDangerousFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.ADD_DANGEROUS_FAULT,
-          fullCompetencyLabels[action.payload],
-          1,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.AddDangerousFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_DANGEROUS_FAULT, tests),
+        fullCompetencyLabels[action.payload],
+        1,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -193,20 +162,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.AddManoeuvreDrivingFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.ADD_DRIVING_FAULT,
-          `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
-          1,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.AddManoeuvreDrivingFault, TestsModel]) => {
+      this.analytics.logEvent(
+          formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_DRIVING_FAULT, tests),
+        `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
+        1,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -218,20 +183,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.AddManoeuvreSeriousFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.ADD_SERIOUS_FAULT,
-          `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
-          1,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.AddManoeuvreSeriousFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_SERIOUS_FAULT, tests),
+        `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
+        1,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -243,20 +204,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.AddManoeuvreDangerousFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.ADD_DANGEROUS_FAULT,
-          `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
-          1,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.AddManoeuvreDangerousFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_DANGEROUS_FAULT, tests),
+        `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
+        1,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -268,20 +225,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.ControlledStopAddDrivingFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.ADD_DRIVING_FAULT,
-          fullCompetencyLabels['outcomeControlledStop'],
-          1,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.ControlledStopAddDrivingFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_DRIVING_FAULT, tests),
+        fullCompetencyLabels['outcomeControlledStop'],
+        1,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -293,20 +246,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.ControlledStopAddSeriousFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.ADD_SERIOUS_FAULT,
-          fullCompetencyLabels['outcomeControlledStop'],
-          1,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.ControlledStopAddSeriousFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_SERIOUS_FAULT, tests),
+        fullCompetencyLabels['outcomeControlledStop'],
+        1,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -318,20 +267,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.ControlledStopAddDangerousFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.ADD_DANGEROUS_FAULT,
-          fullCompetencyLabels['outcomeControlledStop'],
-          1,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.ControlledStopAddDangerousFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_DANGEROUS_FAULT, tests),
+        fullCompetencyLabels['outcomeControlledStop'],
+        1,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -343,20 +288,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.ShowMeQuestionDrivingFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.ADD_DRIVING_FAULT,
-          fullCompetencyLabels['showMeQuestion'],
-          1,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.ShowMeQuestionDrivingFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_DRIVING_FAULT, tests),
+        fullCompetencyLabels['showMeQuestion'],
+        1,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -368,20 +309,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.ShowMeQuestionSeriousFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.ADD_SERIOUS_FAULT,
-          fullCompetencyLabels['showMeQuestion'],
-          1,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.ShowMeQuestionSeriousFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_SERIOUS_FAULT, tests),
+        fullCompetencyLabels['showMeQuestion'],
+        1,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -393,20 +330,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.ShowMeQuestionDangerousFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.ADD_DANGEROUS_FAULT,
-          fullCompetencyLabels['showMeQuestion'],
-          1,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.ShowMeQuestionDangerousFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_DANGEROUS_FAULT, tests),
+        fullCompetencyLabels['showMeQuestion'],
+        1,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -418,20 +351,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.RemoveDrivingFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.REMOVE_DRIVING_FAULT,
-          fullCompetencyLabels[action.payload.competency],
-          action.payload.newFaultCount,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.RemoveDrivingFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.REMOVE_DRIVING_FAULT, tests),
+        fullCompetencyLabels[action.payload.competency],
+        action.payload.newFaultCount,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -443,20 +372,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.RemoveSeriousFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.REMOVE_SERIOUS_FAULT,
-          fullCompetencyLabels[action.payload],
-          0,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.RemoveSeriousFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.REMOVE_SERIOUS_FAULT, tests),
+        fullCompetencyLabels[action.payload],
+        0,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -468,20 +393,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.RemoveDangerousFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.REMOVE_DANGEROUS_FAULT,
-          fullCompetencyLabels[action.payload],
-          0,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.RemoveDangerousFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.REMOVE_DANGEROUS_FAULT, tests),
+        fullCompetencyLabels[action.payload],
+        0,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -493,19 +414,15 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.RemoveManoeuvreFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.REMOVE_DRIVING_FAULT,
-          `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.RemoveManoeuvreFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.REMOVE_DRIVING_FAULT, tests),
+        `${manoeuvreTypeLabels[action.payload.manoeuvre]} - ${manoeuvreCompetencyLabels[action.payload.competency]}`,
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -517,19 +434,15 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.ControlledStopRemoveFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.REMOVE_FAULT,
-          fullCompetencyLabels['outcomeControlledStop'],
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.ControlledStopRemoveFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.REMOVE_FAULT, tests),
+        fullCompetencyLabels['outcomeControlledStop'],
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
@@ -541,40 +454,16 @@ export class TestReportAnalyticsEffects {
     withLatestFrom(
       this.store$.pipe(
         select(getTests),
-        map(isPracticeMode),
       ),
     ),
-    concatMap(([action, isPracticeMode]: [testDataActions.ShowMeQuestionRemoveFault, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TEST_REPORT,
-          AnalyticsEvents.REMOVE_FAULT,
-          fullCompetencyLabels['showMeQuestion'],
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded());
+    concatMap(([action, tests]: [testDataActions.ShowMeQuestionRemoveFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.REMOVE_FAULT, tests),
+        fullCompetencyLabels['showMeQuestion'],
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
-  testTermination$ = this.actions$.pipe(
-    ofType(testReportActions.TERMINATE_TEST_FROM_TEST_REPORT),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
-        map(isPracticeMode),
-      ),
-    ),
-    concatMap(([action, isPracticeMode]: [testReportActions.TerminateTestFromTestReport, boolean]) => {
-      if (!isPracticeMode) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.TERMINATION,
-          AnalyticsEvents.END_TEST,
-          AnalyticsLabels.TERMINATE_TEST,
-        );
-        return of(new AnalyticRecorded());
-      }
-      return of(new AnalyticNotRecorded);
-    }),
-  );
 }

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -14,7 +14,7 @@ export interface IAnalyticsProvider {
 }
 
 export enum AnalyticsScreenNames {
-  CONTACT_DETAILS = 'contact details screen', // this may need removing as could be candidate details now
+  COMMUNICATION = 'communication screen',
   HEALTH_DECLARATION = 'health declaration screen',
   JOURNAL = 'journal screen',
   PASS_TEST_SUMMARY = 'pass test summary screen',
@@ -42,6 +42,8 @@ export enum AnalyticsEventCategories {
   POST_TEST = 'post-test',
   TEST_REPORT = 'test report',
   TERMINATION = 'test termination',
+  PRACTICE_TEST = 'practice test',
+  PRACTICE_MODE = 'practice mode',
 }
 
 export enum AnalyticsEvents {

--- a/src/providers/analytics/analytics.ts
+++ b/src/providers/analytics/analytics.ts
@@ -62,7 +62,6 @@ export class AnalyticsProvider implements IAnalyticsProvider {
   }
 
   logEvent(category: string, event: string, label?: string, value?: number): void {
-    console.log('logEvent', category, event, label), value;
     this.platform.ready().then(() => {
       this.ga
         .startTrackerWithId(this.googleAnalyticsKey)
@@ -76,7 +75,6 @@ export class AnalyticsProvider implements IAnalyticsProvider {
   }
 
   addCustomDimension(key: number, value: string): void {
-    console.log('addCustomDimension', key, value);
     this.ga
       .startTrackerWithId(this.googleAnalyticsKey)
       .then(() => {

--- a/src/shared/helpers/format-analytics-text.ts
+++ b/src/shared/helpers/format-analytics-text.ts
@@ -1,0 +1,13 @@
+import { TestsModel } from '../../modules/tests/tests.model';
+import { isEndToEndPracticeTest, isTestReportPracticeTest } from '../../modules/tests/tests.selector';
+import { AnalyticsEventCategories } from '../../providers/analytics/analytics.model';
+
+export function formatAnalyticsText(eventText: string, tests: TestsModel): string {
+  if (isEndToEndPracticeTest(tests)) {
+    return `${AnalyticsEventCategories.PRACTICE_MODE} - ${eventText}`;
+  }
+  if (isTestReportPracticeTest(tests)) {
+    return `${AnalyticsEventCategories.PRACTICE_TEST} - ${eventText}`;
+  }
+  return eventText;
+}


### PR DESCRIPTION
## Description and relevant Jira numbers
This is the first of many PRs for changes to analytics, all necessary to split out practice analytics from regular analytics during practice tests and end to end practice.

- Created a helper function to prefix analytics events with "practice mode", "practice test" or nothing depending on the test state.
- Changed the analytics effects so that practice events are logged, but now prefixed e.g. `category: "practice test - test report"` `event: "practice test - add driving fault"` `label: "Junctions - Approach speed"`.
- Updated the tests so that they are much better. Done is passed into the test and they now also fail if the effect does not emit a result.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
