### PR TITLE
Making tests more Truthy

### DIFF
--- a/src/modules/logs/__tests__/logs.effects.spec.ts
+++ b/src/modules/logs/__tests__/logs.effects.spec.ts
@@ -67,10 +67,6 @@ describe('Logs Effects', () => {
     dataStoreMock = TestBed.get(DataStoreProvider);
   });
 
-  it('should create the logs effects', () => {
-    expect(effects).toBeTruthy();
-  });
-
   it('should dispatch the persist logs action when the logs post successfully', (done) => {
     // ARRANGE
     const timeStamps: number[] = [12345678];

--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -118,8 +118,8 @@ describe('testsReducer', () => {
     expect(output.startedTests[testReportPracticeSlotId].testData.vehicleChecks.tellMeQuestion.outcome)
       .toBeUndefined();
 
-    expect(output.startedTests[1].testData.seriousFaults.signalsTimed).toBeTruthy();
-    expect(output.startedTests[1].testData.drivingFaults.clearance).toBeTruthy();
+    expect(output.startedTests[1].testData.seriousFaults.signalsTimed).toEqual(true);
+    expect(output.startedTests[1].testData.drivingFaults.clearance).toEqual(1);
     expect(output.startedTests[1].testData.vehicleChecks.tellMeQuestion.outcome).toEqual(CompetencyOutcome.DF);
     expect(output.startedTests[1].testData.vehicleChecks.showMeQuestion.outcome).toEqual(CompetencyOutcome.S);
   });

--- a/src/modules/tests/__tests__/tests.selector.spec.ts
+++ b/src/modules/tests/__tests__/tests.selector.spec.ts
@@ -168,17 +168,17 @@ describe('testsSelector', () => {
     };
     it('should return true for a passed activity code', () => {
       const result = isPassed(testState);
-      expect(result).toBeTruthy();
+      expect(result).toEqual(true);
     });
     it('should return false for a failed activity code', () => {
       testState.activityCode = ActivityCodes.FAIL;
       const result = isPassed(testState);
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
     it('should return false for a terminated activity code', () => {
       testState.activityCode = ActivityCodes.MECHANICAL_FAILURE;
       const result = isPassed(testState);
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
   });
 
@@ -223,19 +223,19 @@ describe('testsSelector', () => {
 
     it('should return false when no tests started', () => {
       const result = isTestReportPracticeTest(testState);
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
 
     it('should return false when slot id is numeric', () => {
       testState.currentTest.slotId = '1';
       const result = isTestReportPracticeTest(testState);
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
 
     it('should return true when slot id starts with practice', () => {
       testState.currentTest.slotId = testReportPracticeSlotId;
       const result = isTestReportPracticeTest(testState);
-      expect(result).toBeTruthy();
+      expect(result).toEqual(true);
     });
   });
 
@@ -248,19 +248,19 @@ describe('testsSelector', () => {
 
     it('should return false when no tests started', () => {
       const result = isEndToEndPracticeTest(testState);
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
 
     it('should return false when slot id is numeric', () => {
       testState.currentTest.slotId = '1';
       const result = isEndToEndPracticeTest(testState);
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
 
     it('should return true when slot id starts with practice', () => {
       testState.currentTest.slotId = end2endPracticeSlotId;
       const result = isEndToEndPracticeTest(testState);
-      expect(result).toBeTruthy();
+      expect(result).toEqual(true);
     });
   });
 

--- a/src/modules/tests/eyesight-test-result/__tests__/eyesight-test-result.selector.spec.ts
+++ b/src/modules/tests/eyesight-test-result/__tests__/eyesight-test-result.selector.spec.ts
@@ -3,16 +3,16 @@ import { isFailed, isPassed } from '../eyesight-test-result.selector';
 describe('eyesight test result selector', () => {
   describe('isFailed', () => {
     it('should return true if the eyesight result is a failure, false otherwise', () => {
-      expect(isFailed('F')).toBeTruthy();
-      expect(isFailed('P')).toBeFalsy();
-      expect(isFailed(null)).toBeFalsy();
+      expect(isFailed('F')).toEqual(true);
+      expect(isFailed('P')).toEqual(false);
+      expect(isFailed(null)).toEqual(false);
     });
   });
   describe('isPassed', () => {
     it('should return true if the eyesight result is a pass, false otherwise', () => {
-      expect(isPassed('P')).toBeTruthy();
-      expect(isPassed('F')).toBeFalsy();
-      expect(isPassed(null)).toBeFalsy();
+      expect(isPassed('P')).toEqual(true);
+      expect(isPassed('F')).toEqual(false);
+      expect(isPassed(null)).toEqual(false);
     });
   });
 });

--- a/src/modules/tests/test-data/__tests__/test-data.reducer.spec.ts
+++ b/src/modules/tests/test-data/__tests__/test-data.reducer.spec.ts
@@ -74,7 +74,7 @@ describe('TestDataReducer reducer', () => {
   describe('ADD SERIOUS FAULT', () => {
     it('should add a serious fault when none exist', () => {
       const result = testDataReducer(initialState, new AddSeriousFault(Competencies.followingDistance));
-      expect(result.seriousFaults.followingDistance).toBeTruthy();
+      expect(result.seriousFaults.followingDistance).toEqual(true);
     });
     it('should update serious fault which already exists', () => {
       const state: TestData = {
@@ -84,7 +84,7 @@ describe('TestDataReducer reducer', () => {
       };
 
       const result = testDataReducer(state, new AddSeriousFault(Competencies.followingDistance));
-      expect(result.seriousFaults.followingDistance).toBeTruthy();
+      expect(result.seriousFaults.followingDistance).toEqual(true);
     });
     it('should not remove an existing serious fault when a new one is added', () => {
       const state: TestData = {
@@ -94,8 +94,8 @@ describe('TestDataReducer reducer', () => {
       };
 
       const result = testDataReducer(state, new AddSeriousFault(Competencies.judgementCrossing));
-      expect(result.seriousFaults.followingDistance).toBeTruthy();
-      expect(result.seriousFaults.judgementCrossing).toBeTruthy();
+      expect(result.seriousFaults.followingDistance).toEqual(true);
+      expect(result.seriousFaults.judgementCrossing).toEqual(true);
     });
   });
 
@@ -209,7 +209,7 @@ describe('TestDataReducer reducer', () => {
   describe('ADD_DANGEROUS_FAULT', () => {
     it('should add a dangerous fault when none exists', () => {
       const result = testDataReducer(initialState, new AddDangerousFault(Competencies.followingDistance));
-      expect(result.dangerousFaults.followingDistance).toBeTruthy();
+      expect(result.dangerousFaults.followingDistance).toEqual(true);
     });
 
     it('should update dangerous fault which already exists', () => {
@@ -220,7 +220,7 @@ describe('TestDataReducer reducer', () => {
       };
 
       const result = testDataReducer(state, new AddDangerousFault(Competencies.followingDistance));
-      expect(result.dangerousFaults.followingDistance).toBeTruthy();
+      expect(result.dangerousFaults.followingDistance).toEqual(true);
     });
 
     it('should not remove an existing dangerous fault when a new one is added', () => {
@@ -231,8 +231,8 @@ describe('TestDataReducer reducer', () => {
       };
 
       const result = testDataReducer(state, new AddDangerousFault(Competencies.judgementCrossing));
-      expect(result.dangerousFaults.followingDistance).toBeTruthy();
-      expect(result.dangerousFaults.judgementCrossing).toBeTruthy();
+      expect(result.dangerousFaults.followingDistance).toEqual(true);
+      expect(result.dangerousFaults.judgementCrossing).toEqual(true);
     });
   });
 
@@ -244,7 +244,7 @@ describe('TestDataReducer reducer', () => {
 
       const result = testDataReducer(state, new ToggleLegalRequirement(LegalRequirements.normalStart1));
 
-      expect(result.testRequirements.normalStart1).toBeTruthy();
+      expect(result.testRequirements.normalStart1).toEqual(true);
     });
 
     it('should toggle normal start 1 to incomplete (false) when dispatched second time', () => {
@@ -255,7 +255,7 @@ describe('TestDataReducer reducer', () => {
       const modifiedState = testDataReducer(state, new ToggleLegalRequirement(LegalRequirements.normalStart1));
       const result = testDataReducer(modifiedState, new ToggleLegalRequirement(LegalRequirements.normalStart1));
 
-      expect(result.testRequirements.normalStart1).toBeFalsy();
+      expect(result.testRequirements.normalStart1).toEqual(false);
     });
   });
 
@@ -267,7 +267,7 @@ describe('TestDataReducer reducer', () => {
 
       const result = testDataReducer(state, new ToggleLegalRequirement(LegalRequirements.normalStart2));
 
-      expect(result.testRequirements.normalStart2).toBeTruthy();
+      expect(result.testRequirements.normalStart2).toEqual(true);
     });
 
     it('should toggle normal start 2 to incomplete (false) when dispatched second time', () => {
@@ -278,7 +278,7 @@ describe('TestDataReducer reducer', () => {
       const modifiedState = testDataReducer(state, new ToggleLegalRequirement(LegalRequirements.normalStart2));
       const result = testDataReducer(modifiedState, new ToggleLegalRequirement(LegalRequirements.normalStart2));
 
-      expect(result.testRequirements.normalStart2).toBeFalsy();
+      expect(result.testRequirements.normalStart2).toEqual(false);
     });
   });
 
@@ -290,7 +290,7 @@ describe('TestDataReducer reducer', () => {
 
       const result = testDataReducer(state, new ToggleLegalRequirement(LegalRequirements.angledStart));
 
-      expect(result.testRequirements.angledStart).toBeTruthy();
+      expect(result.testRequirements.angledStart).toEqual(true);
     });
 
     it('should toggle angled start to incomplete (false) when dispatched second time', () => {
@@ -301,7 +301,7 @@ describe('TestDataReducer reducer', () => {
       const modifiedState = testDataReducer(state, new ToggleLegalRequirement(LegalRequirements.angledStart));
       const result = testDataReducer(modifiedState, new ToggleLegalRequirement(LegalRequirements.angledStart));
 
-      expect(result.testRequirements.angledStart).toBeFalsy();
+      expect(result.testRequirements.angledStart).toEqual(false);
     });
   });
 
@@ -313,7 +313,7 @@ describe('TestDataReducer reducer', () => {
 
       const result = testDataReducer(state, new ToggleLegalRequirement(LegalRequirements.hillStart));
 
-      expect(result.testRequirements.hillStart).toBeTruthy();
+      expect(result.testRequirements.hillStart).toEqual(true);
     });
 
     it('should toggle hill start to incomplete (false) when dispatched second time', () => {
@@ -324,7 +324,7 @@ describe('TestDataReducer reducer', () => {
       const modifiedState = testDataReducer(state, new ToggleLegalRequirement(LegalRequirements.hillStart));
       const result = testDataReducer(modifiedState, new ToggleLegalRequirement(LegalRequirements.hillStart));
 
-      expect(result.testRequirements.hillStart).toBeFalsy();
+      expect(result.testRequirements.hillStart).toEqual(false);
 
     });
   });
@@ -335,7 +335,7 @@ describe('TestDataReducer reducer', () => {
         eco: {},
       };
       const result = testDataReducer(state, new ToggleEco());
-      expect(result.eco.completed).toBeTruthy();
+      expect(result.eco.completed).toEqual(true);
     });
 
     it('should toggle eco (false when dispatched second time)', () => {
@@ -344,7 +344,7 @@ describe('TestDataReducer reducer', () => {
       };
       const modifiedState = testDataReducer(state, new ToggleEco());
       const result = testDataReducer(modifiedState, new ToggleEco());
-      expect(result.eco.completed).toBeFalsy();
+      expect(result.eco.completed).toEqual(false);
     });
   });
   describe('TOGGLE_CONTROL_ECO', () => {
@@ -353,8 +353,8 @@ describe('TestDataReducer reducer', () => {
         eco: {},
       };
       const result = testDataReducer(state, new ToggleControlEco());
-      expect(result.eco.adviceGivenControl).toBeTruthy();
-      expect(result.eco.completed).toBeTruthy();
+      expect(result.eco.adviceGivenControl).toEqual(true);
+      expect(result.eco.completed).toEqual(true);
     });
 
     it('should toggle control eco fault (false when dispatched second time) and leave eco as completed', () => {
@@ -363,8 +363,8 @@ describe('TestDataReducer reducer', () => {
       };
       const modifiedState = testDataReducer(state, new ToggleControlEco());
       const result = testDataReducer(modifiedState, new ToggleControlEco());
-      expect(result.eco.adviceGivenControl).toBeFalsy();
-      expect(result.eco.completed).toBeTruthy();
+      expect(result.eco.adviceGivenControl).toEqual(false);
+      expect(result.eco.completed).toEqual(true);
     });
   });
 
@@ -374,8 +374,8 @@ describe('TestDataReducer reducer', () => {
         eco: {},
       };
       const result = testDataReducer(state, new TogglePlanningEco());
-      expect(result.eco.adviceGivenPlanning).toBeTruthy();
-      expect(result.eco.completed).toBeTruthy();
+      expect(result.eco.adviceGivenPlanning).toEqual(true);
+      expect(result.eco.completed).toEqual(true);
     });
 
     it('should toggle planning eco fault (false when dispatched second time) and leave eco as completed', () => {
@@ -384,8 +384,8 @@ describe('TestDataReducer reducer', () => {
       };
       const modifiedState = testDataReducer(state, new TogglePlanningEco());
       const result = testDataReducer(modifiedState, new TogglePlanningEco());
-      expect(result.eco.adviceGivenPlanning).toBeFalsy();
-      expect(result.eco.completed).toBeTruthy();
+      expect(result.eco.adviceGivenPlanning).toEqual(false);
+      expect(result.eco.completed).toEqual(true);
     });
   });
   describe('TOGGLE_CONTROLLED_STOP', () => {
@@ -394,7 +394,7 @@ describe('TestDataReducer reducer', () => {
         controlledStop: {},
       };
       const result = testDataReducer(state, new ToggleControlledStop());
-      expect(result.controlledStop.selected).toBeTruthy();
+      expect(result.controlledStop.selected).toEqual(true);
     });
 
     it('should remove the controlled stop property when dispatched second time', () => {
@@ -417,7 +417,7 @@ describe('TestDataReducer reducer', () => {
 
       const result = testDataReducer(state, new ToggleETA(ExaminerActions.verbal));
 
-      expect(result.ETA.verbal).toBeTruthy();
+      expect(result.ETA.verbal).toEqual(true);
     });
 
     it('should toggle ETA verbal to false when dispatched second time', () => {
@@ -428,7 +428,7 @@ describe('TestDataReducer reducer', () => {
       const modifiedState = testDataReducer(state, new ToggleETA(ExaminerActions.verbal));
       const result = testDataReducer(modifiedState, new ToggleETA(ExaminerActions.verbal));
 
-      expect(result.ETA.verbal).toBeFalsy();
+      expect(result.ETA.verbal).toEqual(false);
     });
   });
 
@@ -440,7 +440,7 @@ describe('TestDataReducer reducer', () => {
 
       const result = testDataReducer(state, new ToggleETA(ExaminerActions.physical));
 
-      expect(result.ETA.physical).toBeTruthy();
+      expect(result.ETA.physical).toBe(true);
     });
 
     it('should toggle ETA physical to false when dispatched second time', () => {
@@ -451,7 +451,7 @@ describe('TestDataReducer reducer', () => {
       const modifiedState = testDataReducer(state, new ToggleETA(ExaminerActions.physical));
       const result = testDataReducer(modifiedState, new ToggleETA(ExaminerActions.physical));
 
-      expect(result.ETA.physical).toBeFalsy();
+      expect(result.ETA.physical).toEqual(false);
     });
   });
 

--- a/src/modules/tests/test-data/__tests__/test-data.selector.spec.ts
+++ b/src/modules/tests/test-data/__tests__/test-data.selector.spec.ts
@@ -182,7 +182,7 @@ describe('TestDataSelectors', () => {
 
   describe('hasSeriousFault', () => {
     it('should return true if a competency has a serious fault', () => {
-      expect(hasSeriousFault(state, Competencies.awarenessPlanning)).toBeTruthy();
+      expect(hasSeriousFault(state, Competencies.awarenessPlanning)).toEqual(true);
     });
     it('should return false if a competency does not have a serious fault', () => {
       expect(hasSeriousFault(state, Competencies.controlsClutch)).toBeFalsy();
@@ -191,7 +191,7 @@ describe('TestDataSelectors', () => {
 
   describe('hasDangerousFault', () => {
     it('should return true if a competency has a dangerous fault', () => {
-      expect(hasDangerousFault(state, Competencies.useOfSpeed)).toBeTruthy();
+      expect(hasDangerousFault(state, Competencies.useOfSpeed)).toEqual(true);
     });
     it('should return false if a competency does not have a dangerous fault', () => {
       expect(hasDangerousFault(state, Competencies.useOfMirrorsSignalling)).toBeFalsy();
@@ -202,10 +202,10 @@ describe('TestDataSelectors', () => {
     it('should return all the properties of testRequirements', () => {
       const result = getTestRequirements(state);
 
-      expect(result.normalStart1).toBeTruthy();
-      expect(result.normalStart2).toBeTruthy();
-      expect(result.angledStart).toBeTruthy();
-      expect(result.hillStart).toBeTruthy();
+      expect(result.normalStart1).toEqual(true);
+      expect(result.normalStart2).toEqual(true);
+      expect(result.angledStart).toEqual(true);
+      expect(result.hillStart).toEqual(true);
     });
   });
 
@@ -279,7 +279,7 @@ describe('TestDataSelectors', () => {
           forwardPark: { selected: true },
         },
       };
-      expect(hasManoeuvreBeenCompleted(state)).toBeTruthy();
+      expect(hasManoeuvreBeenCompleted(state)).toEqual(true);
     });
   });
 
@@ -357,7 +357,7 @@ describe('TestDataSelectors', () => {
           },
         } as TestData;
 
-        expect(hasVehicleChecksBeenCompleted(state)).toBeTruthy();
+        expect(hasVehicleChecksBeenCompleted(state)).toEqual(true);
       });
       it('should return true if vehicle checks have been completed with a driving fault', () => {
         const state = {
@@ -371,7 +371,7 @@ describe('TestDataSelectors', () => {
           },
         } as TestData;
 
-        expect(hasVehicleChecksBeenCompleted(state)).toBeTruthy();
+        expect(hasVehicleChecksBeenCompleted(state)).toEqual(true);
       });
       it('should return true if vehicle checks have been completed with a serious fault', () => {
         const state = {
@@ -385,7 +385,7 @@ describe('TestDataSelectors', () => {
           },
         } as TestData;
 
-        expect(hasVehicleChecksBeenCompleted(state)).toBeTruthy();
+        expect(hasVehicleChecksBeenCompleted(state)).toEqual(true);
       });
       it('should return true if vehicle checks have been completed with a dangerous fault', () => {
         const state = {
@@ -399,7 +399,7 @@ describe('TestDataSelectors', () => {
           },
         } as TestData;
 
-        expect(hasVehicleChecksBeenCompleted(state)).toBeTruthy();
+        expect(hasVehicleChecksBeenCompleted(state)).toEqual(true);
       });
       it('should return false if show me question outcome is not defined', () => {
         const state = {
@@ -412,7 +412,7 @@ describe('TestDataSelectors', () => {
           },
         } as TestData;
 
-        expect(hasVehicleChecksBeenCompleted(state)).toBeFalsy();
+        expect(hasVehicleChecksBeenCompleted(state)).toEqual(false);
       });
     });
     describe('getCatBLegalRequirements', () => {

--- a/src/modules/tests/test-slot-attributes/__tests__/test-slot-attributes.selector.spec.ts
+++ b/src/modules/tests/test-slot-attributes/__tests__/test-slot-attributes.selector.spec.ts
@@ -29,13 +29,13 @@ describe('testSlotAttributes selector', () => {
 
   describe('isExtendedTest', () => {
     it('should return true if test is an extended test', () => {
-      expect(isExtendedTest(testSlotAttributes)).toBeTruthy();
+      expect(isExtendedTest(testSlotAttributes)).toEqual(true);
     });
   });
 
   describe('isSpecialNeeds', () => {
     it('should return true if special needs', () => {
-      expect(isSpecialNeeds(testSlotAttributes)).toBeTruthy();
+      expect(isSpecialNeeds(testSlotAttributes)).toEqual(true);
     });
   });
 
@@ -47,7 +47,7 @@ describe('testSlotAttributes selector', () => {
 
   describe('isWelshTest', () => {
     it('should return if the test is welsh', () => {
-      expect(isWelshTest(testSlotAttributes)).toBeTruthy();
+      expect(isWelshTest(testSlotAttributes)).toEqual(true);
     });
   });
 

--- a/src/pages/candidate-details/__tests__/candidate-details.selector.spec.ts
+++ b/src/pages/candidate-details/__tests__/candidate-details.selector.spec.ts
@@ -245,7 +245,7 @@ describe('Candidate Details Selector', () => {
         },
       };
       const result = isCandidateSpecialNeeds(slot);
-      expect(result).toBeTruthy();
+      expect(result).toEqual(true);
     });
   });
 
@@ -396,13 +396,13 @@ describe('Candidate Details Selector', () => {
       const slot = {
         booking: {
           application: {
-            entitlementCheck: 'true',
+            entitlementCheck: true,
           },
           previousCancellation: [],
         },
       };
       const result = isCandidateCheckNeeded(slot);
-      expect(result).toBeTruthy();
+      expect(result).toEqual(true);
     });
   });
 
@@ -412,13 +412,13 @@ describe('Candidate Details Selector', () => {
         hasSlotChanged: true,
         booking: {
           application: {
-            entitlementCheck: 'true',
+            entitlementCheck: true,
           },
           previousCancellation: [],
         },
       };
       const result = getSlotChanged(slot);
-      expect(result).toBeTruthy();
+      expect(result).toEqual(true);
     });
   });
 
@@ -479,7 +479,7 @@ describe('Candidate Details Selector', () => {
         hasSlotChanged: true,
         booking: {
           application: {
-            entitlementCheck: 'true',
+            entitlementCheck: true,
           },
           previousCancellation: [],
           business: mockBusiness,

--- a/src/pages/debrief/__tests__/debrief.selector.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.selector.spec.ts
@@ -85,7 +85,7 @@ describe('debriefSelector', () => {
         drivingFaults: localDrivingFaults,
       };
       const result = displayDrivingFaultComments(testData);
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
 
     it('should return true if there are more than 15 driving faults and no serious or dangerous faults', () => {
@@ -104,7 +104,7 @@ describe('debriefSelector', () => {
         drivingFaults: localDrivingFaults,
       };
       const result = displayDrivingFaultComments(testData);
-      expect(result).toBeTruthy();
+      expect(result).toEqual(true);
     });
 
     it('should return false if there are more than 15 driving faults and a serious fault', () => {
@@ -126,7 +126,7 @@ describe('debriefSelector', () => {
         drivingFaults: localDrivingFaults,
       };
       const result = displayDrivingFaultComments(testData);
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
 
     it('should return false if there are more than 15 driving faults and a dangerous fault', () => {
@@ -148,7 +148,7 @@ describe('debriefSelector', () => {
         drivingFaults: localDrivingFaults,
       };
       const result = displayDrivingFaultComments(testData);
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
 
     });
 

--- a/src/pages/fake-journal/__tests__/fake-journal.effects.spec.ts
+++ b/src/pages/fake-journal/__tests__/fake-journal.effects.spec.ts
@@ -40,10 +40,6 @@ describe('Fake Journal Effects', () => {
     store$ = TestBed.get(Store);
   });
 
-  it('should create the fake journal effects', () => {
-    expect(effects).toBeTruthy();
-  });
-
   describe('startE2EPracticeTestEffect', () => {
     const testId = `${end2endPracticeSlotId}_1`;
     beforeEach(() => {

--- a/src/pages/health-declaration/__tests__/health-declaration.spec.ts
+++ b/src/pages/health-declaration/__tests__/health-declaration.spec.ts
@@ -208,8 +208,8 @@ describe('HealthDeclarationPage', () => {
       component.rehydrateFields();
       fixture.detectChanges();
 
-      expect(form.get('healthCheckboxCtrl').value).toBeTruthy();
-      expect(form.get('receiptCheckboxCtrl').value).toBeTruthy();
+      expect(form.get('healthCheckboxCtrl').value).toEqual(true);
+      expect(form.get('receiptCheckboxCtrl').value).toEqual(true);
       expect(form.get('signatureAreaCtrl').value).toEqual('abc123');
     });
   });

--- a/src/pages/journal/__tests__/journal.effects.spec.ts
+++ b/src/pages/journal/__tests__/journal.effects.spec.ts
@@ -81,10 +81,6 @@ describe('Journal Effects', () => {
     appConfigProvider = TestBed.get(AppConfigProvider);
   });
 
-  it('should create the journal effects', () => {
-    expect(effects).toBeTruthy();
-  });
-
   it('should dispatch the success action when the journal loads successfully', (done) => {
     // ARRANGE
     spyOn(journalProvider, 'getJournal').and.callThrough();
@@ -146,9 +142,9 @@ describe('Journal Effects', () => {
       expect(slotProvider.getRelevantSlots).toHaveBeenCalledTimes(0);
 
       if (result instanceof journalActions.JournalRefreshError) {
-        expect(result instanceof journalActions.JournalRefreshError).toBeTruthy();
+        expect(result instanceof journalActions.JournalRefreshError).toEqual(true);
       } else if (result instanceof journalActions.LoadJournalFailure) {
-        expect(result instanceof journalActions.LoadJournalFailure).toBeTruthy();
+        expect(result instanceof journalActions.LoadJournalFailure).toEqual(true);
       } else {
         fail('Unknown Action Sent');
       }

--- a/src/pages/journal/__tests__/journal.reducer.spec.ts
+++ b/src/pages/journal/__tests__/journal.reducer.spec.ts
@@ -115,7 +115,7 @@ describe('Journal Reducer', () => {
       };
       const action = new ClearChangedSlot(1234);
       const result = journalReducer(stateWithChangedSlot, action);
-      expect(result.slots[slotDate][0].hasSlotChanged).toBeFalsy();
+      expect(result.slots[slotDate][0].hasSlotChanged).toEqual(false);
 
     });
   });

--- a/src/pages/journal/__tests__/journal.selector.spec.ts
+++ b/src/pages/journal/__tests__/journal.selector.spec.ts
@@ -31,7 +31,7 @@ describe('JournalSelector', () => {
 
   describe('getIsLoading', () => {
     it('should fetch the loading status from the state', () => {
-      expect(getIsLoading(state)).toBeTruthy();
+      expect(getIsLoading(state)).toEqual(true);
     });
   });
 

--- a/src/pages/journal/__tests__/journal.spec.ts
+++ b/src/pages/journal/__tests__/journal.spec.ts
@@ -130,7 +130,7 @@ describe('JournalPage', () => {
       component.pageState.slots$.subscribe(slots => noOfSlotsReturned = slots.length);
 
       expect(slotsList.children.length).toBe(noOfSlotsReturned);
-      expect(slotsList.children.every(child => child.name === 'test-slot')).toBeTruthy();
+      expect(slotsList.children.every(child => child.name === 'test-slot')).toEqual(true);
     });
 
     describe('test report practice mode', () => {

--- a/src/pages/journal/components/submission-status/__tests__/submission-status.spec.ts
+++ b/src/pages/journal/components/submission-status/__tests__/submission-status.spec.ts
@@ -33,23 +33,23 @@ describe('PracticeTestModal', () => {
     describe('showBanner', () => {
       it('should show banner if test status is completed', () => {
         component.testStatus = TestStatus.Completed;
-        expect(component.showBanner()).toBeTruthy();
+        expect(component.showBanner()).toEqual(true);
       });
       it('should not show banner if test status is booked', () => {
         component.testStatus = TestStatus.Booked;
-        expect(component.showBanner()).toBeFalsy();
+        expect(component.showBanner()).toEqual(false);
       });
       it('should not show banner if test status is decided', () => {
         component.testStatus = TestStatus.Decided;
-        expect(component.showBanner()).toBeFalsy();
+        expect(component.showBanner()).toEqual(false);
       });
       it('should not show banner if test status is started', () => {
         component.testStatus = TestStatus.Started;
-        expect(component.showBanner()).toBeFalsy();
+        expect(component.showBanner()).toEqual(false);
       });
       it('should not show banner if test status is submitted', () => {
         component.testStatus = TestStatus.Submitted;
-        expect(component.showBanner()).toBeFalsy();
+        expect(component.showBanner()).toEqual(false);
       });
     });
   });

--- a/src/pages/journal/components/test-slot/__tests__/test-slot.spec.ts
+++ b/src/pages/journal/components/test-slot/__tests__/test-slot.spec.ts
@@ -180,47 +180,47 @@ describe('TestSlotComponent', () => {
 
       it('should return correct value for showing vehicle details', () => {
         component.slot.booking.application.testCategory = 'A';
-        expect(component.showVehicleDetails()).toBeFalsy();
+        expect(component.showVehicleDetails()).toEqual(false);
         component.slot.booking.application.testCategory = 'A1';
-        expect(component.showVehicleDetails()).toBeFalsy();
+        expect(component.showVehicleDetails()).toEqual(false);
         component.slot.booking.application.testCategory = 'A2';
-        expect(component.showVehicleDetails()).toBeFalsy();
+        expect(component.showVehicleDetails()).toEqual(false);
         component.slot.booking.application.testCategory = 'AM';
-        expect(component.showVehicleDetails()).toBeFalsy();
+        expect(component.showVehicleDetails()).toEqual(false);
         component.slot.booking.application.testCategory = 'B';
-        expect(component.showVehicleDetails()).toBeFalsy();
+        expect(component.showVehicleDetails()).toEqual(false);
         component.slot.booking.application.testCategory = 'B1';
-        expect(component.showVehicleDetails()).toBeFalsy();
+        expect(component.showVehicleDetails()).toEqual(false);
         component.slot.booking.application.testCategory = 'B+E';
-        expect(component.showVehicleDetails()).toBeFalsy();
+        expect(component.showVehicleDetails()).toEqual(false);
         component.slot.booking.application.testCategory = 'C';
-        expect(component.showVehicleDetails()).toBeTruthy();
+        expect(component.showVehicleDetails()).toEqual(true);
         component.slot.booking.application.testCategory = 'C1';
-        expect(component.showVehicleDetails()).toBeTruthy();
+        expect(component.showVehicleDetails()).toEqual(true);
         component.slot.booking.application.testCategory = 'C1+E';
-        expect(component.showVehicleDetails()).toBeTruthy();
+        expect(component.showVehicleDetails()).toEqual(true);
         component.slot.booking.application.testCategory = 'C+E';
-        expect(component.showVehicleDetails()).toBeTruthy();
+        expect(component.showVehicleDetails()).toEqual(true);
         component.slot.booking.application.testCategory = 'D';
-        expect(component.showVehicleDetails()).toBeTruthy();
+        expect(component.showVehicleDetails()).toEqual(true);
         component.slot.booking.application.testCategory = 'D1';
-        expect(component.showVehicleDetails()).toBeTruthy();
+        expect(component.showVehicleDetails()).toEqual(true);
         component.slot.booking.application.testCategory = 'D+E';
-        expect(component.showVehicleDetails()).toBeTruthy();
+        expect(component.showVehicleDetails()).toEqual(true);
         component.slot.booking.application.testCategory = 'D1+E';
-        expect(component.showVehicleDetails()).toBeTruthy();
+        expect(component.showVehicleDetails()).toEqual(true);
       });
       it('should return true for isPortrait() if device is portrait', () => {
         component.screenOrientation.type = component.screenOrientation.ORIENTATIONS.PORTRAIT_PRIMARY;
-        expect(component.isPortrait()).toBeTruthy();
+        expect(component.isPortrait()).toEqual(true);
         component.screenOrientation.type = component.screenOrientation.ORIENTATIONS.PORTRAIT;
-        expect(component.isPortrait()).toBeTruthy();
+        expect(component.isPortrait()).toEqual(true);
       });
       it('should return false for isPortrait() if device is landscape', () => {
         component.screenOrientation.type = component.screenOrientation.ORIENTATIONS.LANDSCAPE_PRIMARY;
-        expect(component.isPortrait()).toBeFalsy();
+        expect(component.isPortrait()).toEqual(false);
         component.screenOrientation.type = component.screenOrientation.ORIENTATIONS.LANDSCAPE;
-        expect(component.isPortrait()).toBeFalsy();
+        expect(component.isPortrait()).toEqual(false);
       });
     });
 
@@ -326,7 +326,7 @@ describe('TestSlotComponent', () => {
         });
         component.slot.slotDetail.start =
           DateTime.at(startTime).add(1, Duration.DAY).format('YYYY-MM-DDTHH:mm:ss+00:00');
-        expect(component.canStartTest()).toBeFalsy();
+        expect(component.canStartTest()).toEqual(false);
       });
     });
 
@@ -355,7 +355,7 @@ describe('TestSlotComponent', () => {
         const indicatorComponent = fixture.debugElement.query(
           By.directive(MockComponent(IndicatorsComponent))).componentInstance;
         expect(indicatorComponent).toBeDefined();
-        expect(indicatorComponent.showExclamationIndicator).toBeFalsy();
+        expect(indicatorComponent.showExclamationIndicator).toEqual(false);
       });
 
       it('should pass something to sub-component time input', () => {
@@ -371,7 +371,7 @@ describe('TestSlotComponent', () => {
         expect(subByDirective.name.title).toBe('Miss');
         expect(subByDirective.name.firstName).toBe('Florence');
         expect(subByDirective.name.lastName).toBe('Pearson');
-        expect(subByDirective.isPortrait).toBeFalsy();
+        expect(subByDirective.isPortrait).toEqual(false);
       });
 
       it('should pass something to sub-component test-category input', () => {
@@ -423,7 +423,7 @@ describe('TestSlotComponent', () => {
         fixture.detectChanges();
         const subByDirective = fixture.debugElement.query(
           By.directive(MockComponent(LanguageComponent))).componentInstance;
-        expect(subByDirective.welshLanguage).toBeFalsy();
+        expect(subByDirective.welshLanguage).toEqual(false);
       });
 
       it('should pass something to sub-component location input', () => {

--- a/src/pages/journal/components/time/__tests__/time.spec.ts
+++ b/src/pages/journal/components/time/__tests__/time.spec.ts
@@ -48,7 +48,7 @@ describe('TimeComponent', () => {
       it('should be time-test-complete-text', () => {
         fixture.detectChanges();
         const timeSpan: any = componentEl.query(By.css('h2'));
-        expect(timeSpan.classes['time-test-complete-text']).toBeTruthy();
+        expect(timeSpan.classes['time-test-complete-text']).not.toBeNull();
       });
     });
   });

--- a/src/pages/login/__tests__/login.spec.ts
+++ b/src/pages/login/__tests__/login.spec.ts
@@ -112,7 +112,7 @@ describe('LoginPage', () => {
       expect(component.initialisePersistentStorage).toHaveBeenCalled();
       expect(appConfigProvider.loadRemoteConfig).toHaveBeenCalled();
       expect(navController.setRoot).toHaveBeenCalledWith(JOURNAL_PAGE);
-      expect(component.hasUserLoggedOut).toBeFalsy();
+      expect(component.hasUserLoggedOut).toEqual(false);
       expect(splashScreen.hide).toHaveBeenCalled();
     }));
 
@@ -128,7 +128,7 @@ describe('LoginPage', () => {
       tick();
       expect(component.handleLoadingUI).toHaveBeenCalledWith(false);
       expect(component.appInitError === AuthenticationError.NO_INTERNET);
-      expect(component.hasUserLoggedOut).toBeFalsy();
+      expect(component.hasUserLoggedOut).toEqual(false);
       expect(splashScreen.hide).toHaveBeenCalled();
     }));
 
@@ -145,7 +145,7 @@ describe('LoginPage', () => {
       component.login();
       tick();
       expect(appConfigProvider.loadRemoteConfig).toHaveBeenCalled();
-      expect(component.hasUserLoggedOut).toBeFalsy();
+      expect(component.hasUserLoggedOut).toEqual(false);
       expect(component.appInitError === AuthenticationError.USER_NOT_AUTHORISED);
       expect(store$.dispatch).toHaveBeenCalledWith(new StartSendingLogs());
 
@@ -156,64 +156,64 @@ describe('LoginPage', () => {
       component.appInitError = AuthenticationError.NO_INTERNET;
       component.hasUserLoggedOut = false;
 
-      expect(component.isInternetConnectionError()).toBeTruthy();
+      expect(component.isInternetConnectionError()).toEqual(true);
     });
 
     it('should return false for isInternetConnectError when criteria is not met', () => {
       component.appInitError = AuthenticationError.NO_INTERNET;
       component.hasUserLoggedOut = true;
 
-      expect(component.isInternetConnectionError()).toBeFalsy();
+      expect(component.isInternetConnectionError()).toEqual(false);
 
       component.appInitError = undefined;
       component.hasUserLoggedOut = false;
 
-      expect(component.isInternetConnectionError()).toBeFalsy();
+      expect(component.isInternetConnectionError()).toEqual(false);
     });
 
     it('should return true for isUserCancelledError when criteria is met', () => {
       component.appInitError = AuthenticationError.USER_CANCELLED;
       component.hasUserLoggedOut = false;
 
-      expect(component.isUserCancelledError()).toBeTruthy();
+      expect(component.isUserCancelledError()).toEqual(true);
     });
 
     it('should return false for isUserCancelledError when criteria is not met', () => {
       component.appInitError = AuthenticationError.USER_CANCELLED;
       component.hasUserLoggedOut = true;
 
-      expect(component.isUserCancelledError()).toBeFalsy();
+      expect(component.isUserCancelledError()).toEqual(false);
 
       component.appInitError = undefined;
       component.hasUserLoggedOut = false;
 
-      expect(component.isUserCancelledError()).toBeFalsy();
+      expect(component.isUserCancelledError()).toEqual(false);
     });
 
     it('should return true for isUnknownError when criteria is met', () => {
       component.appInitError = AuthenticationError.NO_RESPONSE;
       component.hasUserLoggedOut = false;
 
-      expect(component.isUnknownError()).toBeTruthy();
+      expect(component.isUnknownError()).toEqual(true);
     });
 
     it('should return false for isUnknownError when criteria is not met', () => {
       component.appInitError = AuthenticationError.USER_CANCELLED;
       component.hasUserLoggedOut = false;
 
-      expect(component.isUnknownError()).toBeFalsy();
+      expect(component.isUnknownError()).toEqual(false);
 
       component.appInitError = undefined;
       component.hasUserLoggedOut = true;
 
-      expect(component.isUnknownError()).toBeFalsy();
+      expect(component.isUnknownError()).toEqual(false);
     });
 
     it('should return true for isUserNotAuthorised when criteria is met', () => {
       component.appInitError = AuthenticationError.USER_NOT_AUTHORISED;
       component.hasUserLoggedOut = false;
 
-      expect(component.isUserNotAuthorised()).toBeTruthy();
+      expect(component.isUserNotAuthorised()).toEqual(true);
     });
 
     it('should dispatch LOAD_LOG, START_SENDING_LOGS, START_SENDING_COMPLETED_LOGS action', fakeAsync(() => {

--- a/src/pages/test-report/__tests__/test-report.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.effects.spec.ts
@@ -58,10 +58,6 @@ describe('Test Report Effects', () => {
     store$ = TestBed.get(Store);
   });
 
-  it('should create the test report effects', () => {
-    expect(effects).toBeTruthy();
-  });
-
   describe('validateCatBLegalRequirements', () => {
 
     beforeEach(() => {

--- a/src/pages/test-report/__tests__/test-report.reducer.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.reducer.spec.ts
@@ -9,7 +9,7 @@ describe('TestReportReducer reducer', () => {
   describe('TOGGLE_SERIOUS_FAULT_MODE', () => {
     it('should enable serious fault mode', () => {
       const result = testReportReducer(initialState, new ToggleSeriousFaultMode());
-      expect(result.seriousMode).toBeTruthy();
+      expect(result.seriousMode).toEqual(true);
     });
     it('should disable serious fault mode', () => {
       const state = {
@@ -17,13 +17,13 @@ describe('TestReportReducer reducer', () => {
         seriousMode: true,
       };
       const result = testReportReducer(state, new ToggleSeriousFaultMode());
-      expect(result.seriousMode).toBeFalsy();
+      expect(result.seriousMode).toEqual(false);
     });
   });
   describe('TOGGLE_DANGEROUS_FAULT_MODE', () => {
     it('should enable dangerous fault mode', () => {
       const result = testReportReducer(initialState, new ToggleDangerousFaultMode());
-      expect(result.dangerousMode).toBeTruthy();
+      expect(result.dangerousMode).toEqual(true);
     });
     it('should disable dangerous fault mode', () => {
       const state = {
@@ -31,19 +31,19 @@ describe('TestReportReducer reducer', () => {
         dangerousMode: true,
       };
       const result = testReportReducer(state, new ToggleDangerousFaultMode());
-      expect(result.dangerousMode).toBeFalsy();
+      expect(result.dangerousMode).toEqual(false);
     });
   });
   describe('VALIDATE_TEST', () => {
     it('should update isLegalRequirementsValid based on the value of a ValidateLegalRequirements payload', () => {
       const result = testReportReducer(initialState, new ValidateLegalRequirements(true));
-      expect(result.isLegalRequirementsValid).toBeTruthy();
+      expect(result.isLegalRequirementsValid).toEqual(true);
     });
   });
   describe('VALIDATE_ETA', () => {
     it('should update isEtaValid based on the value of a ValidateEta payload', () => {
       const result = testReportReducer(initialState, new ValidateEta(true));
-      expect(result.isEtaValid).toBe(true);
+      expect(result.isEtaValid).toEqual(true);
     });
   });
 });

--- a/src/pages/test-report/__tests__/test-report.selector.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.selector.spec.ts
@@ -12,22 +12,22 @@ describe('TestReportSelectors', () => {
 
   describe('isSeriousMode', () => {
     it('should return true if the test report is in serious mode', () => {
-      expect(isSeriousMode(state)).toBeTruthy();
+      expect(isSeriousMode(state)).toEqual(true);
     });
   });
   describe('isDangerousMode', () => {
     it('should return true if the test report is in dangerous mode', () => {
-      expect(isDangerousMode(state)).toBeTruthy();
+      expect(isDangerousMode(state)).toEqual(true);
     });
   });
   describe('isLegalRequirementsValid', () => {
     it('should return true if the legal requirements are valid', () => {
-      expect(isLegalRequirementsValid(state)).toBeTruthy();
+      expect(isLegalRequirementsValid(state)).toEqual(true);
     });
   });
   describe('isEtaValid', () => {
     it('should return true if the eta conditions are valid', () => {
-      expect(isEtaValid(state)).toBe(true);
+      expect(isEtaValid(state)).toEqual(true);
     });
   });
 });

--- a/src/pages/test-report/components/competency-button/__tests__/competency-button.spec.ts
+++ b/src/pages/test-report/components/competency-button/__tests__/competency-button.spec.ts
@@ -67,7 +67,7 @@ describe('CompetencyButtonComponent', () => {
 
         expect(button).toBeDefined();
         expect(button.nativeElement.className).toContain('activated');
-        expect(component.touchState).toBeTruthy();
+        expect(component.touchState).toEqual(true);
       });
 
       it('should remove the activated class after a specified delay when the button is not pressed', (done) => {
@@ -80,7 +80,7 @@ describe('CompetencyButtonComponent', () => {
 
             expect(button).toBeDefined();
             expect(button.nativeElement.className).not.toContain('activated');
-            expect(component.touchState).toBeFalsy();
+            expect(component.touchState).toEqual(false);
             done();
           },
           component.touchStateDelay);

--- a/src/pages/test-report/components/competency/__tests__/competency.spec.ts
+++ b/src/pages/test-report/components/competency/__tests__/competency.spec.ts
@@ -432,7 +432,7 @@ describe('CompetencyComponent', () => {
       component.hasDangerousFault = true;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeTruthy();
+      expect(component.allowRipple).toEqual(true);
     });
 
     it('should not allow ripple when in remove dangerous mode and there is not a dangerous fault', () => {
@@ -441,7 +441,7 @@ describe('CompetencyComponent', () => {
       component.hasDangerousFault = false;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeFalsy();
+      expect(component.allowRipple).toEqual(false);
     });
 
     it('should allow ripple when in remove serious mode and there is a serious fault', () => {
@@ -450,7 +450,7 @@ describe('CompetencyComponent', () => {
       component.hasSeriousFault = true;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeTruthy();
+      expect(component.allowRipple).toEqual(true);
     });
 
     it('should not allow ripple when in remove serious mode and there is not a serious fault', () => {
@@ -459,7 +459,7 @@ describe('CompetencyComponent', () => {
       component.hasSeriousFault = false;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeFalsy();
+      expect(component.allowRipple).toEqual(false);
     });
 
     it('should allow ripple when in remove fault mode and there is a driving fault', () => {
@@ -467,7 +467,7 @@ describe('CompetencyComponent', () => {
       component.faultCount = 1;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeTruthy();
+      expect(component.allowRipple).toEqual(true);
     });
 
     it('should not allow ripple when in remove fault mode and there is not a driving fault', () => {
@@ -475,14 +475,14 @@ describe('CompetencyComponent', () => {
       component.faultCount = 0;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeFalsy();
+      expect(component.allowRipple).toEqual(false);
     });
 
     it('should not allow ripple when in remove fault mode and driving fault is undefined', () => {
       component.isRemoveFaultMode = true;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeFalsy();
+      expect(component.allowRipple).toEqual(false);
     });
 
     it('should not allow ripple when in add dangerous mode and there is a dangerous fault', () => {
@@ -491,7 +491,7 @@ describe('CompetencyComponent', () => {
       component.hasDangerousFault = true;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeFalsy();
+      expect(component.allowRipple).toEqual(false);
     });
 
     it('should allow ripple when in add dangerous mode and there is not a dangerous fault', () => {
@@ -500,7 +500,7 @@ describe('CompetencyComponent', () => {
       component.hasDangerousFault = false;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeTruthy();
+      expect(component.allowRipple).toEqual(true);
     });
 
     it('should not allow ripple when in add serious mode and there is a serious fault', () => {
@@ -509,7 +509,7 @@ describe('CompetencyComponent', () => {
       component.hasSeriousFault = true;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeFalsy();
+      expect(component.allowRipple).toEqual(false);
     });
 
     it('should allow ripple when in add serious mode and there is not a serious fault', () => {
@@ -518,7 +518,7 @@ describe('CompetencyComponent', () => {
       component.hasSeriousFault = false;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeTruthy();
+      expect(component.allowRipple).toEqual(true);
     });
 
     it('should allow ripple when in add fault mode and there is a driving fault', () => {
@@ -526,7 +526,7 @@ describe('CompetencyComponent', () => {
       component.faultCount = 1;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeTruthy();
+      expect(component.allowRipple).toEqual(true);
     });
 
     it('should allow ripple when in add fault mode and there is not a driving fault', () => {
@@ -534,14 +534,14 @@ describe('CompetencyComponent', () => {
       component.faultCount = 0;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeTruthy();
+      expect(component.allowRipple).toEqual(true);
     });
 
     it('should allow ripple when in add fault mode and driving fault is undefined', () => {
       component.isRemoveFaultMode = false;
 
       component.canButtonRipple();
-      expect(component.allowRipple).toBeTruthy();
+      expect(component.allowRipple).toEqual(true);
     });
   });
 

--- a/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
+++ b/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
@@ -195,7 +195,7 @@ describe('ControlledStopComponent', () => {
         .componentInstance as CompetencyButtonComponent;
 
       fixture.detectChanges();
-      expect(competencyButton.ripple).toBeFalsy();
+      expect(competencyButton.ripple).toEqual(false);
     });
 
     describe('Tick button effects', () => {

--- a/src/pages/test-report/components/manoeuvres-popover/__tests__/manoeuvres-popover.spec.ts
+++ b/src/pages/test-report/components/manoeuvres-popover/__tests__/manoeuvres-popover.spec.ts
@@ -54,8 +54,8 @@ describe('ManoeuvresPopoverComponent', () => {
     it('should display the correct competencies against each manoeuvre', () => {
       component.recordManoeuvreSelection(ManoeuvreTypes.reverseParkRoad);
       fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('#reverseParkRoad-controlFault'))).toBeTruthy();
-      expect(fixture.debugElement.query(By.css('#reverseParkRoad-observationFault'))).toBeTruthy();
+      expect(fixture.debugElement.query(By.css('#reverseParkRoad-controlFault'))).not.toBeNull();
+      expect(fixture.debugElement.query(By.css('#reverseParkRoad-observationFault'))).not.toBeNull();
       expect(fixture.debugElement.query(By.css('#reverseRight-controlFault'))).toBeNull();
       expect(fixture.debugElement.query(By.css('#reverseRight-observationFault'))).toBeNull();
       expect(fixture.debugElement.query(By.css('#reverseParkCarpark-controlFault'))).toBeNull();

--- a/src/pages/test-report/components/toolbar/__tests__/toolbar.spec.ts
+++ b/src/pages/test-report/components/toolbar/__tests__/toolbar.spec.ts
@@ -88,8 +88,8 @@ describe('ToolbarComponent', () => {
     it('should not show any tooltips in default mode', () => {
 
       fixture.detectChanges();
-      expect(component.isSeriousMode).toBeFalsy();
-      expect(component.isDangerousMode).toBeFalsy();
+      expect(component.isSeriousMode).toEqual(false);
+      expect(component.isDangerousMode).toEqual(false);
 
       expect(fixture.debugElement.query(By.css('#serious-button'))).toBeDefined();
       expect(fixture.debugElement.query(By.css('#dangerous-button'))).toBeDefined();
@@ -106,9 +106,9 @@ describe('ToolbarComponent', () => {
 
       fixture.detectChanges();
 
-      expect(component.isSeriousMode).toBeTruthy();
-      expect(component.isDangerousMode).toBeFalsy();
-      expect(component.isRemoveFaultMode).toBeFalsy();
+      expect(component.isSeriousMode).toEqual(true);
+      expect(component.isDangerousMode).toEqual(false);
+      expect(component.isRemoveFaultMode).toEqual(false);
 
       expect(fixture.debugElement.query(By.css('#serious-button'))).toBeDefined();
       expect(fixture.debugElement.query(By.css('serious-tooltip'))).toBeDefined();
@@ -124,9 +124,9 @@ describe('ToolbarComponent', () => {
       component.isDangerousMode = true;
 
       fixture.detectChanges();
-      expect(component.isRemoveFaultMode).toBeFalsy();
-      expect(component.isSeriousMode).toBeFalsy();
-      expect(component.isDangerousMode).toBeTruthy();
+      expect(component.isRemoveFaultMode).toEqual(false);
+      expect(component.isSeriousMode).toEqual(false);
+      expect(component.isDangerousMode).toEqual(true);
 
       expect(fixture.debugElement.query(By.css('#serious-button'))).toBeDefined();
       expect(fixture.debugElement.query(By.css('#dangerous-button'))).toBeDefined();

--- a/src/pages/view-test-result/__tests__/view-test-result.spec.ts
+++ b/src/pages/view-test-result/__tests__/view-test-result.spec.ts
@@ -88,7 +88,7 @@ describe('ViewTestResultPage', () => {
       it('should setup a loading spinner when isLoading is set to true', () => {
         component.handleLoadingUI(true);
 
-        expect(component.isLoading).toBeTruthy();
+        expect(component.isLoading).toEqual(true);
         expect(component.loadingSpinner).not.toBeNull;
       });
       it('should remove the loading spinner when isLoading is set to false', () => {
@@ -96,7 +96,7 @@ describe('ViewTestResultPage', () => {
 
         component.handleLoadingUI(false);
 
-        expect(component.isLoading).toBeFalsy();
+        expect(component.isLoading).toEqual(false);
         expect(component.loadingSpinner).toBeNull();
       });
     });
@@ -151,7 +151,7 @@ describe('ViewTestResultPage', () => {
       it('should return the correct data', () => {
         component.testResult = categoryBTestResultMock;
         const result: TestSummaryCardModel = component.getTestSummary();
-        expect(result.D255).toBeFalsy();
+        expect(result.D255).toEqual(false);
         expect(result.accompaniment).toEqual(['ADI', 'Interpreter']);
         expect(result.candidateDescription).toBe('mock-candidate-description');
         expect(result.debriefWitnessed).toBe(true);

--- a/src/pages/view-test-result/components/test-summary-card/__tests__/test-summary-card.spec.ts
+++ b/src/pages/view-test-result/components/test-summary-card/__tests__/test-summary-card.spec.ts
@@ -31,11 +31,11 @@ describe('TestSummaryCardComponent', () => {
     describe('shouldHideCard', () => {
       it('should return true if there is no data', () => {
         component.data = {};
-        expect(component.shouldHideCard()).toBeTruthy();
+        expect(component.shouldHideCard()).toEqual(true);
       });
       it('should return false if there is data', () => {
         component.data = { routeNumber: 12345 };
-        expect(component.shouldHideCard()).toBeFalsy();
+        expect(component.shouldHideCard()).toEqual(false);
       });
     });
   });

--- a/src/pages/view-test-result/components/vehicle-details-card/__tests__/vehicle-details-card.spec.ts
+++ b/src/pages/view-test-result/components/vehicle-details-card/__tests__/vehicle-details-card.spec.ts
@@ -36,7 +36,7 @@ describe('VehicleDetailsCardComponent', () => {
           transmission: undefined,
         };
 
-        expect(component.shouldHideCard).toBeTruthy();
+        expect(component.shouldHideCard()).toEqual(true);
       });
     });
   });

--- a/src/pages/view-test-result/view-test-result.scss
+++ b/src/pages/view-test-result/view-test-result.scss
@@ -7,4 +7,10 @@ page-view-test-result {
     width: auto;
     margin-left: 5px;
   }
+  .card-content-ios{
+    padding: 0;
+  }
+  .grid{
+    padding: 0;
+  }
 }

--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.spec.ts
@@ -149,8 +149,8 @@ describe('WaitingRoomToCarPage', () => {
         fixture.detectChanges();
         const eyesightFailureConfirmation = fixture.debugElement.query(By.css('eyesight-failure-confirmation'));
         const formAfterEyesight = fixture.debugElement.query(By.css('#post-eyesight-form-content'));
-        expect(eyesightFailureConfirmation).toBeTruthy();
-        expect(formAfterEyesight.nativeElement.hidden).toBeTruthy();
+        expect(eyesightFailureConfirmation).not.toBeNull();
+        expect(formAfterEyesight.nativeElement.hidden).toEqual(true);
       });
       // tslint:disable-next-line:max-line-length
       it('should show the rest of the form and not render eyesight failure confirmation when page state indicates pass is selected', () => {
@@ -160,7 +160,7 @@ describe('WaitingRoomToCarPage', () => {
         const eyesightFailureConfirmation = fixture.debugElement.query(By.css('eyesight-failure-confirmation'));
         const formAfterEyesight = fixture.debugElement.query(By.css('#post-eyesight-form-content'));
         expect(eyesightFailureConfirmation).toBeNull();
-        expect(formAfterEyesight.nativeElement.hidden).toBeFalsy();
+        expect(formAfterEyesight.nativeElement.hidden).toEqual(false);
       });
       it('should dispatch an EyesightResultReset action when the when the method is called', () => {
         component.eyesightFailCancelled();

--- a/src/pages/waiting-room/__tests__/waiting-room.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.spec.ts
@@ -207,8 +207,8 @@ describe('WaitingRoomPage', () => {
       component.rehydrateFields();
       fixture.detectChanges();
 
-      expect(form.get('insuranceCheckboxCtrl').value).toBeTruthy();
-      expect(form.get('residencyCheckboxCtrl').value).toBeTruthy();
+      expect(form.get('insuranceCheckboxCtrl').value).toEqual(true);
+      expect(form.get('residencyCheckboxCtrl').value).toEqual(true);
       expect(form.get('signatureAreaCtrl').value).toEqual('abc123');
     });
   });

--- a/src/providers/authentication/__tests__/interceptor.spec.ts
+++ b/src/providers/authentication/__tests__/interceptor.spec.ts
@@ -80,7 +80,7 @@ describe('Authentication interceptor', () => {
       platform.is = jasmine.createSpy('platform.is').and.returnValue(true);
       const next: any = {
         handle: (request: HttpRequest<any>) => {
-          expect(request.headers.has('Authorization')).toBeTruthy();
+          expect(request.headers.has('Authorization')).toEqual(true);
           expect(request.headers.get('Authorization')).toEqual('token');
           return of({});
         },

--- a/src/providers/device/__tests__/device.spec.ts
+++ b/src/providers/device/__tests__/device.spec.ts
@@ -33,7 +33,7 @@ describe('Device Provider', () => {
     it('should return true if the device in supported devices list', () => {
       spyOn(deviceProvider, 'getDeviceType').and.returnValue('iPad7,4');
       const deviceValid = deviceProvider.validDeviceType();
-      expect(deviceValid).toBeTruthy();
+      expect(deviceValid).toEqual(true);
     });
   });
 
@@ -41,7 +41,7 @@ describe('Device Provider', () => {
     it('should return false if the device is not in supported devices list', () => {
       spyOn(deviceProvider, 'getDeviceType').and.returnValue('nonIpad7,4');
       const deviceValid = deviceProvider.validDeviceType();
-      expect(deviceValid).toBeFalsy();
+      expect(deviceValid).toEqual(false);
     });
   });
 

--- a/src/providers/outcome-behaviour-map/__tests__/outcome-behaviour-map.spec.ts
+++ b/src/providers/outcome-behaviour-map/__tests__/outcome-behaviour-map.spec.ts
@@ -65,49 +65,49 @@ describe('OutcomeBehaviourMapProvider', () => {
   describe('isVisible', () => {
     it(`should return true for an outcome and field that has display Y`, () => {
       const result = outcomeBehaviourMapProvider.isVisible('1', 'routeNumber', 'x');
-      expect(result).toBeTruthy();
+      expect(result).toEqual(true);
     });
     it(`should return false for an outcome and field that has display N`, () => {
       const result = outcomeBehaviourMapProvider.isVisible('3', 'routeNumber', 'x');
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
     it(`should return true for an outcome and field that has display A and has a value`, () => {
       const result = outcomeBehaviourMapProvider.isVisible('4', 'faultComment', 'x');
-      expect(result).toBeTruthy();
+      expect(result).toEqual(true);
     });
     it(`should return false for an outcome and field that has display A and has no value`, () => {
       const result = outcomeBehaviourMapProvider.isVisible('4', 'faultComment', null);
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
 
     it(`should return true for a non-existant outcome`, () => {
       const result = outcomeBehaviourMapProvider.isVisible('40', 'faultComment', 'x');
-      expect(result).toBeTruthy();
+      expect(result).toEqual(true);
     });
     it(`should return false for a non-existant field`, () => {
       const result = outcomeBehaviourMapProvider.isVisible('4', 'fakefield', 'x');
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
   });
 
   describe('hasDefault', () => {
     it(`should return false if defaultValue field is not present`, () => {
       const result = outcomeBehaviourMapProvider.hasDefault('1', 'independentDriving');
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
 
     it(`should return false if defaultValue field is present but is null`, () => {
       const result = outcomeBehaviourMapProvider.hasDefault('1', 'routeNumber');
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
     it(`should return false if defaultValue field is present but is empty string`, () => {
       const result = outcomeBehaviourMapProvider.hasDefault('1', 'routeNumber');
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
 
     it(`should return true if defaultValue field is present and non null`, () => {
       const result = outcomeBehaviourMapProvider.hasDefault('3', 'routeNumber');
-      expect(result).toBeTruthy();
+      expect(result).toEqual(true);
     });
 
   });
@@ -137,26 +137,26 @@ describe('OutcomeBehaviourMapProvider', () => {
   describe('showNotApplicable', () => {
     it(`should return false if showNotApplicable is false`, () => {
       const result = outcomeBehaviourMapProvider.showNotApplicable('1', 'independentDriving');
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
 
     it(`should return false if showNotApplicable field is missing`, () => {
       const result = outcomeBehaviourMapProvider.showNotApplicable('1', 'routeNumber');
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
 
     it(`should return false if showNotApplicable field is true`, () => {
       const result = outcomeBehaviourMapProvider.showNotApplicable('4', 'independentDriving');
-      expect(result).toBeTruthy();
+      expect(result).toEqual(true);
     });
     it(`should return false if called with non existant outcome`, () => {
       const result = outcomeBehaviourMapProvider.showNotApplicable('x', 'routeNumber');
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
 
     it(`should return false if called with non existant field`, () => {
       const result = outcomeBehaviourMapProvider.showNotApplicable('4', 'fakeroute');
-      expect(result).toBeFalsy();
+      expect(result).toEqual(false);
     });
   });
 
@@ -297,8 +297,8 @@ describe('OutcomeBehaviourMapProvider', () => {
         const independent = outcomeBehaviourMapProvider.showNotApplicable('4', 'independentDriving');
         const showMe = outcomeBehaviourMapProvider.showNotApplicable('4', 'showMeQuestion');
 
-        expect(independent).toBeTruthy();
-        expect(showMe).toBeTruthy();
+        expect(independent).toEqual(true);
+        expect(showMe).toEqual(true);
       });
     });
     describe('outcome 11', () => {
@@ -344,8 +344,8 @@ describe('OutcomeBehaviourMapProvider', () => {
         const independent = outcomeBehaviourMapProvider.showNotApplicable('11', 'independentDriving');
         const showMe = outcomeBehaviourMapProvider.showNotApplicable('11', 'showMeQuestion');
 
-        expect(independent).toBeTruthy();
-        expect(showMe).toBeTruthy();
+        expect(independent).toEqual(true);
+        expect(showMe).toEqual(true);
       });
     });
     describe('outcome 20', () => {
@@ -437,8 +437,8 @@ describe('OutcomeBehaviourMapProvider', () => {
         outcomeBehaviourMapProvider.setBehaviourMap(behaviourMap);
         const independent = outcomeBehaviourMapProvider.showNotApplicable('22', 'independentDriving');
         const showMe = outcomeBehaviourMapProvider.showNotApplicable('22', 'showMeQuestion');
-        expect(independent).toBeTruthy();
-        expect(showMe).toBeTruthy();
+        expect(independent).toEqual(true);
+        expect(showMe).toEqual(true);
       });
 
       it(`should return visibility A for tellMeQuestion`, () => {
@@ -487,7 +487,7 @@ describe('OutcomeBehaviourMapProvider', () => {
       it(`should return showNotApplicable true for independent driving`, () => {
         outcomeBehaviourMapProvider.setBehaviourMap(behaviourMap);
         const independent = outcomeBehaviourMapProvider.showNotApplicable('23', 'independentDriving');
-        expect(independent).toBeTruthy();
+        expect(independent).toEqual(true);
       });
 
       it(`should return visibility N for eta, eco and faultComment fields`, () => {

--- a/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
+++ b/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
@@ -30,7 +30,7 @@ describe('TestReportValidator', () => {
       };
       // ASSERT
       testReportValidatorProvider.validateCatBLegalRequirements(testResult).subscribe((result) => {
-        expect(result).toBeTruthy();
+        expect(result).toEqual(true);
         done();
       });
     });
@@ -47,7 +47,7 @@ describe('TestReportValidator', () => {
       };
       // ASSERT
       testReportValidatorProvider.validateCatBLegalRequirements(testResult).subscribe((result) => {
-        expect(result).toBeFalsy();
+        expect(result).toEqual(false);
         done();
       });
     });


### PR DESCRIPTION
## Description and relevant Jira numbers

I learnt last sprint that using tobeTruthy() and tobeFalsy() isn't technically correct when testing for boolean. 

This PR updates tests to be more explicit.

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
