### PR TITLE
Analytics for WRTC screen

### DIFF
--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
@@ -16,10 +16,10 @@ import { StoreModel } from '../../../shared/models/store.model';
 import { Candidate } from '@dvsa/mes-journal-schema';
 import { testsReducer } from '../../../modules/tests/tests.reducer';
 import * as journalActions from '../../journal/journal.actions';
-import * as testsActions from '../../../modules/tests/tests.actions';
+import * as fakeJournalActions from '../../fake-journal/fake-journal.actions';
 import { PopulateCandidateDetails } from '../../../modules/tests/candidate/candidate.actions';
-import { testReportPracticeModeSlot } from '../../../modules/tests/__mocks__/tests.mock';
 import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
+import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
 
 describe('Waiting Room To Car Analytics Effects', () => {
 
@@ -29,7 +29,7 @@ describe('Waiting Room To Car Analytics Effects', () => {
   let store$: Store<StoreModel>;
   const screenName = AnalyticsScreenNames.WAITING_ROOM_TO_CAR;
   // tslint:disable-next-line:max-line-length
-  const screenNamePracticeTest = `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsScreenNames.WAITING_ROOM_TO_CAR}`;
+  const screenNamePracticeMode = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.WAITING_ROOM_TO_CAR}`;
   const mockCandidate: Candidate = {
     candidateId: 1001,
   };
@@ -78,7 +78,7 @@ describe('Waiting Room To Car Analytics Effects', () => {
     });
     it('should call setCurrentPage with practice mode prefix and addCustomDimension', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
       store$.dispatch(new PopulateCandidateDetails(mockCandidate));
       // ACT
       actions$.next(new waitingRoomToCarActions.WaitingRoomToCarViewDidEnter());
@@ -88,9 +88,9 @@ describe('Waiting Room To Car Analytics Effects', () => {
         expect(analyticsProviderMock.addCustomDimension)
           .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
         expect(analyticsProviderMock.addCustomDimension)
-          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, testReportPracticeModeSlot.slotDetail.slotId);
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, end2endPracticeSlotId);
         expect(analyticsProviderMock.setCurrentPage)
-          .toHaveBeenCalledWith(screenNamePracticeTest);
+          .toHaveBeenCalledWith(screenNamePracticeMode);
         done();
       });
     });
@@ -116,7 +116,7 @@ describe('Waiting Room To Car Analytics Effects', () => {
     });
     it('should call logError, prefixed with practice mode', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
       store$.dispatch(new PopulateCandidateDetails(mockCandidate));
       // ACT
       actions$.next(new waitingRoomToCarActions.WaitingRoomToCarError('error 123'));
@@ -124,7 +124,7 @@ describe('Waiting Room To Car Analytics Effects', () => {
       effects.waitingRoomToCarError$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logError)
-          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${screenNamePracticeTest})`,
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${screenNamePracticeMode})`,
           'error 123');
         done();
       });
@@ -150,7 +150,7 @@ describe('Waiting Room To Car Analytics Effects', () => {
     });
     it('should call logError, prefixed with practice mode', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
       store$.dispatch(new PopulateCandidateDetails(mockCandidate));
       // ACT
       actions$.next(new waitingRoomToCarActions.WaitingRoomToCarValidationError('formControl1'));
@@ -158,7 +158,7 @@ describe('Waiting Room To Car Analytics Effects', () => {
       effects.waitingRoomToCarValidationError$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.logError)
-          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenNamePracticeTest})`,
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenNamePracticeMode})`,
           'formControl1');
         done();
       });

--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
@@ -1,47 +1,45 @@
 import { WaitingRoomToCarAnalyticsEffects } from '../waiting-room-to-car.analytics.effects';
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { StoreModule, Store } from '@ngrx/store';
 import { provideMockActions } from '@ngrx/effects/testing';
 import * as waitingRoomToCarActions from '../waiting-room-to-car.actions';
 import { AnalyticsProvider } from '../../../providers/analytics/analytics';
 import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
-import { of } from 'rxjs/observable/of';
 import {
   AnalyticsDimensionIndices,
   AnalyticsScreenNames,
   AnalyticsErrorTypes,
+  AnalyticsEventCategories,
 } from '../../../providers/analytics/analytics.model';
+import { StoreModel } from '../../../shared/models/store.model';
+import { Candidate } from '@dvsa/mes-journal-schema';
+import { testsReducer } from '../../../modules/tests/tests.reducer';
+import * as journalActions from '../../journal/journal.actions';
+import * as testsActions from '../../../modules/tests/tests.actions';
+import { PopulateCandidateDetails } from '../../../modules/tests/candidate/candidate.actions';
+import { testReportPracticeModeSlot } from '../../../modules/tests/__mocks__/tests.mock';
+import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
 
 describe('Waiting Room To Car Analytics Effects', () => {
 
   let effects: WaitingRoomToCarAnalyticsEffects;
   let analyticsProviderMock;
   let actions$: any;
+  let store$: Store<StoreModel>;
+  const screenName = AnalyticsScreenNames.WAITING_ROOM_TO_CAR;
+  // tslint:disable-next-line:max-line-length
+  const screenNamePracticeTest = `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsScreenNames.WAITING_ROOM_TO_CAR}`;
+  const mockCandidate: Candidate = {
+    candidateId: 1001,
+  };
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
-          tests: () => ({
-            currentTest: {
-              slotId: '123',
-            },
-            testStatus: {},
-            startedTests: {
-              123: {
-                vehicleDetails: {},
-                accompaniment: {},
-                testData: {},
-                journalData: {
-                  candidate: {
-                    candidateId: 1001,
-                  },
-                },
-              },
-            },
-          }),
+          tests: testsReducer,
         }),
       ],
       providers: [
@@ -53,68 +51,118 @@ describe('Waiting Room To Car Analytics Effects', () => {
     });
     effects = TestBed.get(WaitingRoomToCarAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
+    store$ = TestBed.get(Store);
+    spyOn(analyticsProviderMock, 'addCustomDimension').and.callThrough();
+    spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
+    spyOn(analyticsProviderMock, 'logError').and.callThrough();
   });
 
   describe('waitingRoomToCarViewDidEnter', () => {
-    it('should call setCurrentPage and addCustomDimension', fakeAsync((done) => {
+    it('should call setCurrentPage and addCustomDimension', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'addCustomDimension').and.callThrough();
-      spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
       // ACT
       actions$.next(new waitingRoomToCarActions.WaitingRoomToCarViewDidEnter());
-      tick();
       // ASSERT
       effects.waitingRoomToCarViewDidEnter$.subscribe((result) => {
-        expect(result instanceof of).toBe(true);
-        expect(effects.analytics.addCustomDimension)
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
           .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
-        expect(effects.analytics.addCustomDimension)
+        expect(analyticsProviderMock.addCustomDimension)
           .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, '123');
-        expect(effects.analytics.setCurrentPage)
-          .toHaveBeenCalledWith(AnalyticsScreenNames.WAITING_ROOM_TO_CAR);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenName);
         done();
       });
-    }));
+    });
+    it('should call setCurrentPage with practice mode prefix and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new waitingRoomToCarActions.WaitingRoomToCarViewDidEnter());
+      // ASSERT
+      effects.waitingRoomToCarViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, testReportPracticeModeSlot.slotDetail.slotId);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNamePracticeTest);
+        done();
+      });
+    });
 
   });
 
   describe('waitingRoomToCarError', () => {
-    it('should call logError', fakeAsync((done) => {
+    it('should call logError', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logError').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
       // ACT
       actions$.next(new waitingRoomToCarActions.WaitingRoomToCarError('error 123'));
-      tick();
       // ASSERT
       effects.waitingRoomToCarError$.subscribe((result) => {
-        expect(result instanceof of).toBe(true);
-        expect(effects.analytics.logError)
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logError)
         // tslint:disable-next-line:max-line-length
-          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${AnalyticsScreenNames.WAITING_ROOM_TO_CAR})`,
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${screenName})`,
           'error 123');
         done();
       });
-    }));
+    });
+    it('should call logError, prefixed with practice mode', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new waitingRoomToCarActions.WaitingRoomToCarError('error 123'));
+      // ASSERT
+      effects.waitingRoomToCarError$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logError)
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${screenNamePracticeTest})`,
+          'error 123');
+        done();
+      });
+    });
 
   });
 
   describe('waitingRoomToCarValidationError', () => {
-    it('should call logError', fakeAsync((done) => {
+    it('should call logError', (done) => {
       // ARRANGE
-      spyOn(analyticsProviderMock, 'logError').and.callThrough();
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
       // ACT
       actions$.next(new waitingRoomToCarActions.WaitingRoomToCarValidationError('formControl1'));
-      tick();
       // ASSERT
       effects.waitingRoomToCarValidationError$.subscribe((result) => {
-        expect(result instanceof of).toBe(true);
-        expect(effects.analytics.logError)
-        // tslint:disable-next-line:max-line-length
-          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${AnalyticsScreenNames.WAITING_ROOM_TO_CAR})`,
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logError)
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenName})`,
           'formControl1');
         done();
       });
-    }));
+    });
+    it('should call logError, prefixed with practice mode', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new waitingRoomToCarActions.WaitingRoomToCarValidationError('formControl1'));
+      // ASSERT
+      effects.waitingRoomToCarValidationError$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logError)
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenNamePracticeTest})`,
+          'formControl1');
+        done();
+      });
+    });
 
   });
 

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.analytics.effects.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.analytics.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
-import { switchMap, withLatestFrom } from 'rxjs/operators';
+import { switchMap, withLatestFrom, concatMap } from 'rxjs/operators';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import {
   AnalyticsScreenNames,
@@ -40,22 +40,24 @@ export class WaitingRoomToCarAnalyticsEffects {
   @Effect()
   waitingRoomToCarViewDidEnter$ = this.actions$.pipe(
     ofType(WAITING_ROOM_TO_CAR_VIEW_DID_ENTER),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
-      ),
-      this.store$.pipe(
-        select(getTests),
-        select(getCurrentTestSlotId),
-      ),
-      this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
-        select(getJournalData),
-        select(getCandidate),
-        select(getCandidateId),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
         ),
-    ),
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTestSlotId),
+        ),
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getJournalData),
+          select(getCandidate),
+          select(getCandidateId),
+          ),
+      ),
+    )),
     switchMap(([action, tests, slotId, candidateId]: [WaitingRoomToCarViewDidEnter, TestsModel, string, number]) => {
       this.analytics.addCustomDimension(AnalyticsDimensionIndices.CANDIDATE_ID, `${candidateId}`);
       this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_ID, `${slotId}`);
@@ -69,11 +71,13 @@ export class WaitingRoomToCarAnalyticsEffects {
   @Effect()
   waitingRoomToCarError$ = this.actions$.pipe(
     ofType(WAITING_ROOM_TO_CAR_ERROR),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     switchMap(([action, tests]: [WaitingRoomToCarError, TestsModel]) => {
       const screenName = formatAnalyticsText(AnalyticsScreenNames.WAITING_ROOM_TO_CAR, tests);
       this.analytics.logError(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${screenName})`,
@@ -85,11 +89,13 @@ export class WaitingRoomToCarAnalyticsEffects {
   @Effect()
   waitingRoomToCarValidationError$ = this.actions$.pipe(
     ofType(WAITING_ROOM_TO_CAR_VALIDATION_ERROR),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     switchMap(([action, tests]: [WaitingRoomToCarValidationError, TestsModel]) => {
       const screenName = formatAnalyticsText(AnalyticsScreenNames.WAITING_ROOM_TO_CAR, tests);
       this.analytics.logError(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenName})`,

--- a/src/pages/waiting-room-to-car/waiting-room-to-car.analytics.effects.ts
+++ b/src/pages/waiting-room-to-car/waiting-room-to-car.analytics.effects.ts
@@ -22,6 +22,9 @@ import { getTests } from '../../modules/tests/tests.reducer';
 import { getCurrentTestSlotId, getCurrentTest, getJournalData } from '../../modules/tests/tests.selector';
 import { getCandidate } from '../../modules/tests/candidate/candidate.reducer';
 import { getCandidateId } from '../../modules/tests/candidate/candidate.selector';
+import { formatAnalyticsText } from '../../shared/helpers/format-analytics-text';
+import { AnalyticRecorded } from '../../providers/analytics/analytics.actions';
+import { TestsModel } from '../../modules/tests/tests.model';
 
 @Injectable()
 export class WaitingRoomToCarAnalyticsEffects {
@@ -31,18 +34,16 @@ export class WaitingRoomToCarAnalyticsEffects {
     private actions$: Actions,
     private store$: Store<StoreModel>,
   ) {
-    this.analytics.initialiseAnalytics()
-          .then(() => {})
-          .catch(() => {
-            console.log('error initialising analytics');
-          },
-    );
+    this.analytics.initialiseAnalytics();
   }
 
   @Effect()
   waitingRoomToCarViewDidEnter$ = this.actions$.pipe(
     ofType(WAITING_ROOM_TO_CAR_VIEW_DID_ENTER),
     withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+      ),
       this.store$.pipe(
         select(getTests),
         select(getCurrentTestSlotId),
@@ -55,31 +56,45 @@ export class WaitingRoomToCarAnalyticsEffects {
         select(getCandidateId),
         ),
     ),
-    switchMap(([action, slotId, candidateId]: [WaitingRoomToCarViewDidEnter, string, number]) => {
+    switchMap(([action, tests, slotId, candidateId]: [WaitingRoomToCarViewDidEnter, TestsModel, string, number]) => {
       this.analytics.addCustomDimension(AnalyticsDimensionIndices.CANDIDATE_ID, `${candidateId}`);
       this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_ID, `${slotId}`);
-      this.analytics.setCurrentPage(AnalyticsScreenNames.WAITING_ROOM_TO_CAR);
-      return of();
+      this.analytics.setCurrentPage(
+        formatAnalyticsText(AnalyticsScreenNames.WAITING_ROOM_TO_CAR, tests),
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 
   @Effect()
   waitingRoomToCarError$ = this.actions$.pipe(
     ofType(WAITING_ROOM_TO_CAR_ERROR),
-    switchMap((action: WaitingRoomToCarError) => {
-      this.analytics.logError(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${AnalyticsScreenNames.WAITING_ROOM_TO_CAR})`,
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+      ),
+    ),
+    switchMap(([action, tests]: [WaitingRoomToCarError, TestsModel]) => {
+      const screenName = formatAnalyticsText(AnalyticsScreenNames.WAITING_ROOM_TO_CAR, tests);
+      this.analytics.logError(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${screenName})`,
         action.errorMessage);
-      return of();
+      return of(new AnalyticRecorded());
     }),
   );
 
   @Effect()
   waitingRoomToCarValidationError$ = this.actions$.pipe(
     ofType(WAITING_ROOM_TO_CAR_VALIDATION_ERROR),
-    switchMap((action: WaitingRoomToCarValidationError) => {
-      this.analytics.logError(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${AnalyticsScreenNames.WAITING_ROOM_TO_CAR})`,
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+      ),
+    ),
+    switchMap(([action, tests]: [WaitingRoomToCarValidationError, TestsModel]) => {
+      const screenName = formatAnalyticsText(AnalyticsScreenNames.WAITING_ROOM_TO_CAR, tests);
+      this.analytics.logError(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenName})`,
         action.errorMessage);
-      return of();
+      return of(new AnalyticRecorded());
     }),
   );
 


### PR DESCRIPTION
## Description and relevant Jira numbers
Another PR to record analytics during practice mode.

Changed the analytics effects so that practice events are logged and prefixed with `"practice mode"`
Updated the tests so that they also fail if the effect does not emit a result.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
