### PR TITLE
MES-2990 Improve ngrx performance

### DIFF
--- a/src/modules/logs/logs.effects.ts
+++ b/src/modules/logs/logs.effects.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Effect, Actions, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 
-import { switchMap, map, catchError, withLatestFrom } from 'rxjs/operators';
+import { switchMap, map, catchError, withLatestFrom, concatMap } from 'rxjs/operators';
 import { of } from 'rxjs/observable/of';
 import { interval } from 'rxjs/observable/interval';
 
@@ -50,11 +50,13 @@ export class LogsEffects {
   @Effect()
   persistLogEffect$ = this.actions$.pipe(
     ofType(logsActions.PERSIST_LOG),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getLogsState),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getLogsState),
+        ),
       ),
-    ),
+    )),
     switchMap(([action, logs]) => {
       this.saveLogs(logs);
       return of();
@@ -90,11 +92,13 @@ export class LogsEffects {
   @Effect()
   sendLogsEffect$ = this.actions$.pipe(
     ofType(logsActions.SEND_LOGS),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getLogsState),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getLogsState),
+        ),
       ),
-    ),
+    )),
     switchMap(([action, logs]) => {
       if (this.networkStateProvider.getNetworkState() === ConnectionStatus.OFFLINE) {
         return of();

--- a/src/modules/tests/tests.analytics.effects.ts
+++ b/src/modules/tests/tests.analytics.effects.ts
@@ -34,11 +34,13 @@ export class TestsAnalyticsEffects {
   @Effect()
   setTestStatusSubmittedEffect$ = this.actions$.pipe(
     ofType(SET_TEST_STATUS_SUBMITTED),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [SetTestStatusSubmitted, TestsModel]) => {
       const test = getTestById(tests, action.slotId);
       const isTestPassed = isPassed(test);

--- a/src/pages/candidate-details/candidate-details.analytics.effects.ts
+++ b/src/pages/candidate-details/candidate-details.analytics.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
-import { switchMap, map, withLatestFrom } from 'rxjs/operators';
+import { switchMap, map, withLatestFrom, concatMap } from 'rxjs/operators';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { getJournalState } from '../journal/journal.reducer';
@@ -47,12 +47,14 @@ export class CandidateDetailsAnalyticsEffects {
   @Effect()
     candidateView$ = this.actions$.pipe(
       ofType(CANDIDATE_DETAILS_VIEW_DID_ENTER),
-      withLatestFrom(
-        this.store$.pipe(
-          select(getJournalState),
-          map(getSlots),
+      concatMap(action => of(action).pipe(
+        withLatestFrom(
+          this.store$.pipe(
+            select(getJournalState),
+            map(getSlots),
+          ),
         ),
-      ),
+      )),
       switchMap(([action, slots]: [CandidateDetailsViewDidEnter, any[]]) => {
         const slot = getSlotById(slots, action.slotId);
         const specNeeds = isCandidateSpecialNeeds(slot);

--- a/src/pages/debrief/debrief.analytics.effects.ts
+++ b/src/pages/debrief/debrief.analytics.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
-import { switchMap, withLatestFrom } from 'rxjs/operators';
+import { switchMap, withLatestFrom, concatMap } from 'rxjs/operators';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import {
   AnalyticsScreenNames,
@@ -33,13 +33,15 @@ export class DebriefAnalyticsEffects {
   @Effect()
   debriefViewDidEnter$ = this.actions$.pipe(
     ofType(DEBRIEF_VIEW_DID_ENTER),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
-        select(isPassed),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(isPassed),
+        ),
       ),
-    ),
+    )),
     switchMap(([action, isPassed]: [DebriefViewDidEnter, boolean]) => {
       if (isPassed) {
         this.analytics.setCurrentPage(AnalyticsScreenNames.PASS_DEBRIEF);

--- a/src/pages/health-declaration/health-declaration.effects.ts
+++ b/src/pages/health-declaration/health-declaration.effects.ts
@@ -9,6 +9,7 @@ import { Store, select } from '@ngrx/store';
 import { getTests } from '../../modules/tests/tests.reducer';
 import { getCurrentTestSlotId } from '../../modules/tests/tests.selector';
 import { CONTINUE_FROM_DECLARATION } from './health-declaration.actions';
+import { of } from 'rxjs/observable/of';
 
 @Injectable()
 export class HealthDeclarationEffects {
@@ -20,12 +21,14 @@ export class HealthDeclarationEffects {
   @Effect()
   endHealthDeclarationEffect$ = this.actions$.pipe(
     ofType(CONTINUE_FROM_DECLARATION),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
-        select(getCurrentTestSlotId),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTestSlotId),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, slotId]) => {
       return [
         new testStatusActions.SetTestStatusWriteUp(slotId),

--- a/src/pages/journal/journal.analytics.effects.ts
+++ b/src/pages/journal/journal.analytics.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
-import { switchMap, withLatestFrom } from 'rxjs/operators';
+import { switchMap, withLatestFrom, concatMap } from 'rxjs/operators';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import {
   JOURNAL_VIEW_DID_ENTER,
@@ -126,11 +126,13 @@ export class JournalAnalyticsEffects {
   @Effect()
   resumingWriteUpEffect$ = this.actions$.pipe(
     ofType(RESUMING_WRITE_UP),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     switchMap(([action, tests]) => {
       const setTestStatusSubmittedAction = action as ResumingWriteUp;
       const test = getTestById(tests, setTestStatusSubmittedAction.slotId);

--- a/src/pages/office/office.analytics.effects.ts
+++ b/src/pages/office/office.analytics.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { withLatestFrom, switchMap } from 'rxjs/operators';
+import { withLatestFrom, switchMap, concatMap } from 'rxjs/operators';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import {
   AnalyticsScreenNames, AnalyticsDimensionIndices, AnalyticsEventCategories, AnalyticsEvents, AnalyticsErrorTypes,
@@ -38,13 +38,15 @@ export class OfficeAnalyticsEffects {
   @Effect()
   officeViewDidEnter$ = this.actions$.pipe(
     ofType(OFFICE_VIEW_DID_ENTER),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
-        select(isPassed),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(isPassed),
+        ),
       ),
-    ),
+    )),
     switchMap(([action, isPassed]: [OfficeViewDidEnter, boolean]) => {
       if (isPassed) {
         this.analytics.setCurrentPage(AnalyticsScreenNames.PASS_TEST_SUMMARY);
@@ -59,18 +61,20 @@ export class OfficeAnalyticsEffects {
   @Effect()
   savingWriteUpForLaterEffect$ = this.actions$.pipe(
     ofType(SAVING_WRITE_UP_FOR_LATER),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
-        select(isPassed),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(isPassed),
+        ),
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getJournalData),
+        ),
       ),
-      this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
-        select(getJournalData),
-      ),
-    ),
+    )),
     switchMap(([action, isPassed, journalDataOfTest]: [SavingWriteUpForLater, boolean, JournalData]) => {
       this.analytics.logEvent(
         AnalyticsEventCategories.POST_TEST,
@@ -90,13 +94,15 @@ export class OfficeAnalyticsEffects {
   @Effect()
   validationErrorEffect$ = this.actions$.pipe(
     ofType(VALIDATION_ERROR),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
-        select(isPassed),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(isPassed),
+        ),
       ),
-    ),
+    )),
     switchMap(([action, isPassed]: [ValidationError, boolean]) => {
       const screenName = isPassed ? AnalyticsScreenNames.PASS_TEST_SUMMARY : AnalyticsScreenNames.FAIL_TEST_SUMMARY;
       this.analytics.logError(

--- a/src/pages/office/office.effects.ts
+++ b/src/pages/office/office.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Effect, Actions, ofType } from '@ngrx/effects';
-import { map, switchMap, withLatestFrom } from 'rxjs/operators';
+import { map, switchMap, withLatestFrom, concatMap } from 'rxjs/operators';
 
 import * as testDataActions from '../../modules/tests/test-data/test-data.actions';
 import * as testSummaryActions from '../../modules/tests/test-summary/test-summary.actions';
@@ -11,6 +11,7 @@ import { StoreModel } from '../../shared/models/store.model';
 import { Store, select } from '@ngrx/store';
 import { getTests } from '../../modules/tests/tests.reducer';
 import { getCurrentTestSlotId } from '../../modules/tests/tests.selector';
+import { of } from 'rxjs/observable/of';
 
 @Injectable()
 export class OfficeEffects {
@@ -42,12 +43,14 @@ export class OfficeEffects {
   @Effect()
   completeTestEffect$ = this.actions$.pipe(
     ofType(officeActions.COMPLETE_TEST),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
-        select(getCurrentTestSlotId),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTestSlotId),
+        ),
       ),
-    ),
+    )),
     switchMap(([action, slotId]) => {
       return [
         new testStatusActions.SetTestStatusCompleted(slotId),

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -43,11 +43,13 @@ export class TestReportAnalyticsEffects {
   @Effect()
   toggleRemoveFaultMode$ = this.actions$.pipe(
     ofType(testReportActions.TOGGLE_REMOVE_FAULT_MODE),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testReportActions.ToggleRemoveFaultMode, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -60,11 +62,13 @@ export class TestReportAnalyticsEffects {
   @Effect()
   toggleSeriousFaultMode$ = this.actions$.pipe(
     ofType(testReportActions.TOGGLE_SERIOUS_FAULT_MODE),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testReportActions.ToggleSeriousFaultMode, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -77,11 +81,13 @@ export class TestReportAnalyticsEffects {
   @Effect()
   toggleDangerousFaultMode$ = this.actions$.pipe(
     ofType(testReportActions.TOGGLE_DANGEROUS_FAULT_MODE),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testReportActions.ToggleDangerousFaultMode, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -96,11 +102,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.ADD_DRIVING_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.AddDrivingFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -117,11 +125,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.ADD_SERIOUS_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.AddSeriousFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -138,11 +148,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.ADD_DANGEROUS_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.AddDangerousFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -159,11 +171,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.ADD_MANOEUVRE_DRIVING_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.AddManoeuvreDrivingFault, TestsModel]) => {
       this.analytics.logEvent(
           formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -180,11 +194,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.ADD_MANOEUVRE_SERIOUS_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.AddManoeuvreSeriousFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -201,11 +217,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.ADD_MANOEUVRE_DANGEROUS_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.AddManoeuvreDangerousFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -222,11 +240,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.CONTROLLED_STOP_ADD_DRIVING_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.ControlledStopAddDrivingFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -243,11 +263,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.CONTROLLED_STOP_ADD_SERIOUS_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.ControlledStopAddSeriousFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -264,11 +286,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.CONTROLLED_STOP_ADD_DANGEROUS_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.ControlledStopAddDangerousFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -285,11 +309,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.SHOW_ME_QUESTION_DRIVING_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.ShowMeQuestionDrivingFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -306,11 +332,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.SHOW_ME_QUESTION_SERIOUS_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.ShowMeQuestionSeriousFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -327,11 +355,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.SHOW_ME_QUESTION_DANGEROUS_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.ShowMeQuestionDangerousFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -348,11 +378,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.REMOVE_DRIVING_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.RemoveDrivingFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -369,11 +401,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.REMOVE_SERIOUS_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.RemoveSeriousFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -390,11 +424,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.REMOVE_DANGEROUS_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.RemoveDangerousFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -411,11 +447,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.REMOVE_MANOEUVRE_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.RemoveManoeuvreFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -431,11 +469,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.CONTROLLED_STOP_REMOVE_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.ControlledStopRemoveFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -451,11 +491,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testDataActions.SHOW_ME_QUESTION_REMOVE_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testDataActions.ShowMeQuestionRemoveFault, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
@@ -471,11 +513,13 @@ export class TestReportAnalyticsEffects {
     ofType(
       testReportActions.TERMINATE_TEST_FROM_TEST_REPORT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, tests]: [testReportActions.TerminateTestFromTestReport, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TERMINATION, tests),

--- a/src/pages/test-report/test-report.effects.ts
+++ b/src/pages/test-report/test-report.effects.ts
@@ -13,6 +13,7 @@ import * as testsActions from '../../modules/tests/tests.actions';
 import * as  testDataActions from '../../modules/tests/test-data/test-data.actions';
 import { TestResultProvider } from '../../providers/test-result/test-result';
 import { ActivityCode } from '@dvsa/mes-test-schema/categories/B';
+import { of } from 'rxjs/observable/of';
 
 @Injectable()
 export class TestReportEffects {
@@ -39,14 +40,16 @@ export class TestReportEffects {
       testDataActions.SHOW_ME_QUESTION_SERIOUS_FAULT,
       testDataActions.SHOW_ME_QUESTION_DANGEROUS_FAULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
-        select(getTestData),
-        map(getCatBLegalRequirements),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getTestData),
+          map(getCatBLegalRequirements),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, catBLegalRequirements]) => {
       return this.testReportValidator.validateCatBLegalRequirements(catBLegalRequirements)
         .pipe(
@@ -64,13 +67,15 @@ export class TestReportEffects {
       testDataActions.REMOVE_SERIOUS_FAULT,
       testDataActions.TOGGLE_ETA,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
-        select(getTestData),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getTestData),
+        ),
       ),
-    ),
+    )),
     concatMap(([action, testData]) => {
       return this.testReportValidator.validateCatBEta(testData)
         .pipe(
@@ -84,12 +89,14 @@ export class TestReportEffects {
     ofType(
       testReportActions.CALCULATE_TEST_RESULT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
-        map(getCurrentTest),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+          map(getCurrentTest),
+        ),
       ),
-    ),
+    )),
     switchMap(([action, currentTest]) => {
       return this.testResultProvider.calculateCatBTestResult(currentTest.testData)
         .pipe(
@@ -128,12 +135,14 @@ export class TestReportEffects {
       testDataActions.TOGGLE_ETA,
       testDataActions.TOGGLE_LEGAL_REQUIREMENT,
     ),
-    withLatestFrom(
-      this.store$.pipe(
-        select(getTests),
-        map(isTestReportPracticeTest),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+          map(isTestReportPracticeTest),
+        ),
       ),
-    ),
+    )),
     filter(([action, isTestReportPracticeTest]) => !isTestReportPracticeTest),
     delay(1000), // Added a 1 second delay to allow other action to complete/effects to fire
     map(() => new testsActions.PersistTests()),


### PR DESCRIPTION
## Description and relevant Jira numbers
This PR stops selectors in effects from firing outside of the intended action by wrapping them with concatMap. Currently the selectors fire whenever the store is updated - which is a lot. 

This will impact performance and also can result in unintended errors if the state does not contain the correct properties at the time the selector fires.

A note on https://ngrx.io/guide/effects clarifies this:

<img width="575" alt="Screenshot 2019-07-18 at 10 02 23" src="https://user-images.githubusercontent.com/8069071/61444367-2cbd0980-a943-11e9-9c16-228b6a45ec18.png">

WR and WRTC effects are being updated in a separate PR.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
