### PR TITLE
MES-2948: fix pass cert length

### DIFF
--- a/src/pages/pass-finalisation/__tests__/pass-finalisation.spec.ts
+++ b/src/pages/pass-finalisation/__tests__/pass-finalisation.spec.ts
@@ -44,17 +44,39 @@ describe('PassFinalisationPage', () => {
       });
   }));
 
-  describe('Class', () => {
-    describe('onSubmit', () => {
-      // Unit tests for the components TypeScript class
-      it('should dispatch the PersistTests action', () => {
-        const form = component.form;
-        form.get('provisionalLicenseProvidedCtrl').setValue(true);
-        form.get('passCertificateNumberCtrl').setValue(true);
-        form.get('transmissionCtrl').setValue('Manual');
-        component.onSubmit();
-        expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
-      });
+  describe('onSubmit', () => {
+    // Unit tests for the components TypeScript class
+    it('should dispatch the PersistTests action', () => {
+      const form = component.form;
+      form.get('provisionalLicenseProvidedCtrl').setValue(true);
+      form.get('passCertificateNumberCtrl').setValue('A123456*');
+      form.get('transmissionCtrl').setValue('Manual');
+      component.onSubmit();
+      expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
+    });
+  });
+  describe('formControls', () => {
+    it('should contain a maxlength validation error when passCertificateNumberCtrl fails to meet maxlength', () => {
+      const formCtrl = component.form.controls['passCertificateNumberCtrl'];
+      formCtrl.setValue('A123456B1');
+      expect(formCtrl.hasError('maxlength')).toBe(true);
+    });
+    it('should contain no validation errors when passCertificateNumberCtrl ends with digit', () => {
+      const formCtrl = component.form.controls['passCertificateNumberCtrl'];
+      formCtrl.setValue('A1234567');
+      expect(formCtrl.hasError('maxlength')).toBe(false);
+    });
+    it('should contain no validation errors when passCertificateNumberCtrl ends with underscore', () => {
+      const formCtrl = component.form.controls['passCertificateNumberCtrl'];
+      formCtrl.setValue('A123456_');
+      expect(formCtrl.hasError('pattern')).toBe(false);
+      expect(formCtrl.hasError('maxlength')).toBe(false);
+    });
+    it('should contain no validation errors when passCertificateNumberCtrl ends with letter', () => {
+      const formCtrl = component.form.controls['passCertificateNumberCtrl'];
+      formCtrl.setValue('A123456B');
+      expect(formCtrl.hasError('pattern')).toBe(false);
+      expect(formCtrl.hasError('maxlength')).toBe(false);
     });
   });
 });

--- a/src/pages/pass-finalisation/pass-finalisation.html
+++ b/src/pages/pass-finalisation/pass-finalisation.html
@@ -92,7 +92,8 @@
         </ion-row>
 
         <ion-row class="mes-validated-row mes-row-separator" id="provisional-license-card">
-          <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('passCertificateNumberCtrl')"></div>
+          <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('passCertificateNumberCtrl') ||
+          passCertificateValidation()"></div>
           <ion-col class="component-label" col-36 align-self-center>
             <label>Pass certificate number</label>
           </ion-col>
@@ -101,15 +102,18 @@
             <ion-row>
               <ion-col>
                 <input #passCertificateNumberInput formControlName="passCertificateNumberCtrl"
-                  [class.ng-invalid]="isCtrlDirtyAndInvalid('passCertificateNumberCtrl')" type="text"
+                  [class.ng-invalid]="isCtrlDirtyAndInvalid('passCertificateNumberCtrl') ||
+                  passCertificateValidation()"
+                  type="text"
                   value="{{pageState.passCertificateNumber$ | async}}" id="pass-certificate-number"
                   class="pass-cert-input">
               </ion-col>
             </ion-row>
             <ion-row class="validation-message-row" align-items-center>
-              <div class="validation-text" [class.ng-invalid]="isCtrlDirtyAndInvalid('passCertificateNumberCtrl')"
+              <div class="validation-text" [class.ng-invalid]="isCtrlDirtyAndInvalid('passCertificateNumberCtrl') ||
+                passCertificateValidation()"
                 id="pass-finalisation-certificate-number-validation-text">
-                Enter a certificate number
+                Enter a valid certificate number (max 8 characters)
               </div>
             </ion-row>
           </ion-col>

--- a/src/pages/pass-finalisation/pass-finalisation.ts
+++ b/src/pages/pass-finalisation/pass-finalisation.ts
@@ -65,7 +65,7 @@ interface PassFinalisationPageState {
 })
 export class PassFinalisationPage extends PracticeableBasePageComponent {
   pageState: PassFinalisationPageState;
-
+  passCertificateCtrl: string = 'passCertificateNumberCtrl';
   @ViewChild('passCertificateNumberInput')
   passCertificateNumberInput: ElementRef;
 
@@ -189,12 +189,20 @@ export class PassFinalisationPage extends PracticeableBasePageComponent {
   getFormValidation(): { [key: string]: FormControl } {
     return {
       provisionalLicenseProvidedCtrl: new FormControl(null, [Validators.required]),
-      passCertificateNumberCtrl: new FormControl(null, [Validators.required]),
+      passCertificateNumberCtrl: new FormControl(null, [
+        Validators.required,
+        Validators.maxLength(8),
+      ]),
       transmissionCtrl: new FormControl(null, [Validators.required]),
     };
   }
   isCtrlDirtyAndInvalid(controlName: string): boolean {
     return !this.form.value[controlName] && this.form.get(controlName).dirty;
+  }
+
+  passCertificateValidation() {
+    const ctrlHasErrors = this.form.get(this.passCertificateCtrl).errors ? true : false;
+    return ctrlHasErrors && this.form.get(this.passCertificateCtrl).dirty;
   }
 
   /**

--- a/test/e2e/features/06-debrief.feature
+++ b/test/e2e/features/06-debrief.feature
@@ -66,7 +66,7 @@ Feature: Debrief including Health Declaration
       Then I should see the "Test debrief - Ali Campbell" page
       And the health declaration candidate name should be "Mr Ali Campbell"
       And the health declaration candidate driver number should be "CAMPB 805220 A89HC"
-      And the pass certificate number should be "123456789"
+      And the pass certificate number should be "A123456&"
       And validation item "pass-certificate-receipt-validation-text" should not be visible
       And validation item "health-declaration-signature-validation-text" should not be visible
       When I try to confirm the health declaration

--- a/test/e2e/step-definitions/debrief-steps.ts
+++ b/test/e2e/step-definitions/debrief-steps.ts
@@ -14,7 +14,7 @@ When('I end the debrief', () => {
 
 When('I complete the pass details', () => {
   const passCertificateNumberField = getElement(by.id('pass-certificate-number'));
-  passCertificateNumberField.sendKeys('123456789');
+  passCertificateNumberField.sendKeys('A123456&');
   const licenceRecievedRadio = getElement(by.id('license-received'));
   clickElement(licenceRecievedRadio);
   continuePassFinalisation();


### PR DESCRIPTION
## Description and relevant Jira numbers
- update `pass-finalisation` validation to enforce a max length of 8 chars for `pass-certificate-numbers`

<img width="495" alt="Screenshot 2019-07-19 at 12 09 32" src="https://user-images.githubusercontent.com/30832405/61531255-32d3e880-aa1e-11e9-86a3-a2c20f7447b8.png">
<img width="495" alt="Screenshot 2019-07-19 at 12 09 43" src="https://user-images.githubusercontent.com/30832405/61531256-336c7f00-aa1e-11e9-84a6-fa2ef37e7f94.png">


## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
