### PR TITLE
MES-2966 record if in practice mode during analytics on comms and pass page

### DIFF
--- a/src/modules/tests/candidate/candidate.reducer.ts
+++ b/src/modules/tests/candidate/candidate.reducer.ts
@@ -2,7 +2,21 @@ import { Candidate } from '@dvsa/mes-test-schema/categories/B';
 import { createFeatureSelector } from '@ngrx/store';
 import * as candidateActions from './candidate.actions';
 
-export const initialState = null;
+export const initialState: Candidate = {
+  candidateId: null,
+  candidateName: {},
+  driverNumber: '',
+  dateOfBirth: '',
+  gender: null,
+  candidateAddress: {},
+  primaryTelephone: '',
+  secondaryTelephone: '',
+  mobileTelephone: '',
+  emailAddress: '',
+  prn: null,
+  previousADITests: null,
+  ethnicityCode: '',
+};
 
 export function candidateReducer(
   state = initialState,

--- a/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
@@ -27,7 +27,7 @@ describe('Communication Analytics Effects', () => {
   let actions$: any;
   let store$: Store<StoreModel>;
   const screenName = AnalyticsScreenNames.COMMUNICATION;
-  const screenNamePracticeTest = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.COMMUNICATION}`;
+  const screenNamePracticeMode = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.COMMUNICATION}`;
   const mockCandidate: Candidate = {
     candidateId: 1001,
   };
@@ -88,7 +88,7 @@ describe('Communication Analytics Effects', () => {
         expect(analyticsProviderMock.addCustomDimension)
           .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, end2endPracticeSlotId);
         expect(analyticsProviderMock.setCurrentPage)
-          .toHaveBeenCalledWith(screenNamePracticeTest);
+          .toHaveBeenCalledWith(screenNamePracticeMode);
         done();
       });
     });

--- a/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
@@ -1,0 +1,98 @@
+import { CommunicationAnalyticsEffects } from '../communication.analytics.effects';
+import { TestBed } from '@angular/core/testing';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { StoreModule, Store } from '@ngrx/store';
+import { provideMockActions } from '@ngrx/effects/testing';
+import * as communicationActions from '../communication.actions';
+import { AnalyticsProvider } from '../../../providers/analytics/analytics';
+import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
+import {
+  AnalyticsDimensionIndices,
+  AnalyticsScreenNames,
+  AnalyticsEventCategories,
+} from '../../../providers/analytics/analytics.model';
+import { StoreModel } from '../../../shared/models/store.model';
+import { Candidate } from '@dvsa/mes-journal-schema';
+import { testsReducer } from '../../../modules/tests/tests.reducer';
+import * as journalActions from '../../journal/journal.actions';
+import * as fakeJournalActions from '../../fake-journal/fake-journal.actions';
+import { PopulateCandidateDetails } from '../../../modules/tests/candidate/candidate.actions';
+import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
+import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
+
+fdescribe('Communication Analytics Effects', () => {
+
+  let effects: CommunicationAnalyticsEffects;
+  let analyticsProviderMock;
+  let actions$: any;
+  let store$: Store<StoreModel>;
+  const screenName = AnalyticsScreenNames.COMMUNICATION;
+  const screenNamePracticeTest = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.COMMUNICATION}`;
+  const mockCandidate: Candidate = {
+    candidateId: 1001,
+  };
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: testsReducer,
+        }),
+      ],
+      providers: [
+        CommunicationAnalyticsEffects,
+        { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
+        provideMockActions(() => actions$),
+        Store,
+      ],
+    });
+    effects = TestBed.get(CommunicationAnalyticsEffects);
+    analyticsProviderMock = TestBed.get(AnalyticsProvider);
+    store$ = TestBed.get(Store);
+    spyOn(analyticsProviderMock, 'addCustomDimension').and.callThrough();
+    spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
+    spyOn(analyticsProviderMock, 'logError').and.callThrough();
+  });
+
+  describe('communicationViewDidEnter', () => {
+    it('should call setCurrentPage and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new communicationActions.CommunicationViewDidEnter());
+      // ASSERT
+      effects.communicationViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, '123');
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenName);
+        done();
+      });
+    });
+    it('should call setCurrentPage with practice mode prefix and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new communicationActions.CommunicationViewDidEnter());
+      // ASSERT
+      effects.communicationViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, end2endPracticeSlotId);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNamePracticeTest);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
@@ -20,7 +20,7 @@ import { PopulateCandidateDetails } from '../../../modules/tests/candidate/candi
 import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
 import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
 
-fdescribe('Communication Analytics Effects', () => {
+describe('Communication Analytics Effects', () => {
 
   let effects: CommunicationAnalyticsEffects;
   let analyticsProviderMock;

--- a/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
@@ -10,6 +10,7 @@ import {
   AnalyticsDimensionIndices,
   AnalyticsScreenNames,
   AnalyticsEventCategories,
+  AnalyticsErrorTypes,
 } from '../../../providers/analytics/analytics.model';
 import { StoreModel } from '../../../shared/models/store.model';
 import { Candidate } from '@dvsa/mes-journal-schema';
@@ -89,6 +90,40 @@ describe('Communication Analytics Effects', () => {
           .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, end2endPracticeSlotId);
         expect(analyticsProviderMock.setCurrentPage)
           .toHaveBeenCalledWith(screenNamePracticeMode);
+        done();
+      });
+    });
+
+  });
+
+  describe('communicationValidationError', () => {
+    it('should call logError', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new communicationActions.CommunicationValidationError('formControl1'));
+      // ASSERT
+      effects.communicationValidationError$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logError)
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenName})`,
+          'formControl1');
+        done();
+      });
+    });
+    it('should call logError, prefixed with practice mode', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new communicationActions.CommunicationValidationError('formControl1'));
+      // ASSERT
+      effects.communicationValidationError$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logError)
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenNamePracticeMode})`,
+          'formControl1');
         done();
       });
     });

--- a/src/pages/communication-page/communication.actions.ts
+++ b/src/pages/communication-page/communication.actions.ts
@@ -6,6 +6,7 @@ export const COMMUNICATION_VIEW_CHOSE_EMAIL_PROVIDED_AT_BOOKING =
 export const COMMUNICATION_VIEW_CHOSE_NEW_EMAIL =
   '[CommunicationPage] Communication page chose new email';
 export const COMMUNICATION_VIEW_ADDED_NEW_CANDIDATE_EMAIL = '[CommunicationPage] Added new candidate email';
+export const COMMUNICATION_VALIDATION_ERROR = '[CommunicationPage] Communication page validation error';
 
 export class CommunicationViewDidEnter implements Action {
   readonly type = COMMUNICATION_VIEW_DID_ENTER;
@@ -22,6 +23,11 @@ export class CommunicationViewChoseNewEmail implements Action {
 export class CommunicationViewInputNewEmail implements Action {
   readonly type = COMMUNICATION_VIEW_ADDED_NEW_CANDIDATE_EMAIL;
   constructor(public payload: string) {}
+}
+
+export class CommunicationValidationError implements Action {
+  readonly type = COMMUNICATION_VALIDATION_ERROR;
+  constructor(public errorMessage: string) { }
 }
 
 export type Types =

--- a/src/pages/communication-page/communication.analytics.effects.ts
+++ b/src/pages/communication-page/communication.analytics.effects.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@angular/core';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { of } from 'rxjs/observable/of';
+import { switchMap, withLatestFrom } from 'rxjs/operators';
+import { AnalyticsProvider } from '../../providers/analytics/analytics';
+import {
+  AnalyticsScreenNames, AnalyticsDimensionIndices,
+} from '../../providers/analytics/analytics.model';
+import {
+  COMMUNICATION_VIEW_DID_ENTER,
+  CommunicationViewDidEnter,
+} from './communication.actions';
+import { TestsModel } from '../../modules/tests/tests.model';
+import { formatAnalyticsText } from '../../shared/helpers/format-analytics-text';
+import { AnalyticRecorded } from '../../providers/analytics/analytics.actions';
+import { StoreModel } from '../../shared/models/store.model';
+import { Store, select } from '@ngrx/store';
+import { getTests } from '../../modules/tests/tests.reducer';
+import { getCurrentTestSlotId, getCurrentTest, getJournalData } from '../../modules/tests/tests.selector';
+import { JournalData } from '@dvsa/mes-test-schema/categories/B';
+import { get } from 'lodash';
+
+@Injectable()
+export class CommunicationAnalyticsEffects {
+
+  constructor(
+    public analytics: AnalyticsProvider,
+    private actions$: Actions,
+    private store$: Store<StoreModel>,
+  ) {
+    this.analytics.initialiseAnalytics();
+  }
+
+  @Effect()
+  communicationViewDidEnter$ = this.actions$.pipe(
+    ofType(COMMUNICATION_VIEW_DID_ENTER),
+    withLatestFrom(
+      this.store$.pipe(
+        select(getTests),
+      ),
+      this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getJournalData),
+        ),
+    ),
+    switchMap(([action, tests, journalData]: [CommunicationViewDidEnter, TestsModel, JournalData]) => {
+      const slotId = getCurrentTestSlotId(tests);
+      const candidateId = get(journalData, 'candidate.candidateId', '');
+
+      this.analytics.addCustomDimension(AnalyticsDimensionIndices.CANDIDATE_ID, `${candidateId}`);
+      this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_ID, `${slotId}`);
+      this.analytics.setCurrentPage(
+        formatAnalyticsText(AnalyticsScreenNames.COMMUNICATION, tests),
+      );
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+}

--- a/src/pages/communication-page/communication.module.ts
+++ b/src/pages/communication-page/communication.module.ts
@@ -7,6 +7,8 @@ import { ProvidedEmailComponent } from './components/provided-email/provided-ema
 import { NewEmailComponent } from './components/new-email/new-email';
 import { PostalAddressComponent } from './components/postal-address/postal-address';
 import { TranslateModule } from 'ng2-translate';
+import { EffectsModule } from '@ngrx/effects';
+import { CommunicationAnalyticsEffects } from './communication.analytics.effects';
 
 @NgModule({
   declarations: [
@@ -17,6 +19,9 @@ import { TranslateModule } from 'ng2-translate';
   ],
   imports: [
     IonicPageModule.forChild(CommunicationPage),
+    EffectsModule.forFeature([
+      CommunicationAnalyticsEffects,
+    ]),
     ComponentsModule,
     TranslateModule,
   ],

--- a/src/pages/communication-page/communication.ts
+++ b/src/pages/communication-page/communication.ts
@@ -1,5 +1,5 @@
 import { IonicPage, Navbar, Platform, NavController } from 'ionic-angular';
-import { Component, ViewChild } from '@angular/core';
+import { Component, ViewChild, OnInit, OnDestroy } from '@angular/core';
 import { PracticeableBasePageComponent } from '../../shared/classes/practiceable-base-page';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
@@ -62,7 +62,7 @@ interface CommunicationPageState {
   selector: 'communication',
   templateUrl: 'communication.html',
 })
-export class CommunicationPage extends PracticeableBasePageComponent {
+export class CommunicationPage extends PracticeableBasePageComponent implements OnInit, OnDestroy {
 
   static readonly providedEmail: string = 'Provided';
   static readonly updatedEmail: string = 'Updated';

--- a/src/pages/communication-page/communication.ts
+++ b/src/pages/communication-page/communication.ts
@@ -22,7 +22,7 @@ import {
   getPostalAddress,
 } from '../../modules/tests/candidate/candidate.selector';
 import {
-  CommunicationViewDidEnter,
+  CommunicationViewDidEnter, CommunicationValidationError,
 } from './communication.actions';
 import { map, take } from 'rxjs/operators';
 import {
@@ -228,6 +228,12 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
       this.navController.push(WAITING_ROOM_PAGE);
+    } else {
+      Object.keys(this.form.controls).forEach((controlName) => {
+        if (this.form.controls[controlName].invalid) {
+          this.store$.dispatch(new CommunicationValidationError(`${controlName} is blank`));
+        }
+      });
     }
   }
 

--- a/src/pages/journal/journal.analytics.effects.ts
+++ b/src/pages/journal/journal.analytics.effects.ts
@@ -118,7 +118,7 @@ export class JournalAnalyticsEffects {
   testOutcomeStartTest$ = this.actions$.pipe(
     ofType(START_TEST),
     switchMap((action: StartTest) => {
-      this.analytics.logEvent(AnalyticsEventCategories.CLICK, AnalyticsEvents.START_TEST);
+      this.analytics.logEvent(AnalyticsEventCategories.JOURNAL, AnalyticsEvents.START_TEST, action.slotId.toString());
       return of();
     }),
   );

--- a/src/pages/pass-finalisation/__tests__/pass-finalisation.analytics.effects.spec.ts
+++ b/src/pages/pass-finalisation/__tests__/pass-finalisation.analytics.effects.spec.ts
@@ -1,0 +1,99 @@
+import { PassFinalisationAnalyticsEffects } from '../pass-finalisation.analytics.effects';
+import { TestBed } from '@angular/core/testing';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { StoreModule, Store } from '@ngrx/store';
+import { provideMockActions } from '@ngrx/effects/testing';
+import * as passFinalisationActions from '../pass-finalisation.actions';
+import { AnalyticsProvider } from '../../../providers/analytics/analytics';
+import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
+import {
+  AnalyticsDimensionIndices,
+  AnalyticsScreenNames,
+  AnalyticsEventCategories,
+} from '../../../providers/analytics/analytics.model';
+import { StoreModel } from '../../../shared/models/store.model';
+import { Candidate } from '@dvsa/mes-journal-schema';
+import { testsReducer } from '../../../modules/tests/tests.reducer';
+import * as journalActions from '../../journal/journal.actions';
+import * as fakeJournalActions from '../../fake-journal/fake-journal.actions';
+import { PopulateCandidateDetails } from '../../../modules/tests/candidate/candidate.actions';
+import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
+import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
+
+describe('Pass Finalisation Analytics Effects', () => {
+
+  let effects: PassFinalisationAnalyticsEffects;
+  let analyticsProviderMock;
+  let actions$: any;
+  let store$: Store<StoreModel>;
+  const screenName = AnalyticsScreenNames.PASS_FINALISATION;
+  // tslint:disable-next-line:max-line-length
+  const screenNamePracticeMode = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.PASS_FINALISATION}`;
+  const mockCandidate: Candidate = {
+    candidateId: 1001,
+  };
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: testsReducer,
+        }),
+      ],
+      providers: [
+        PassFinalisationAnalyticsEffects,
+        { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
+        provideMockActions(() => actions$),
+        Store,
+      ],
+    });
+    effects = TestBed.get(PassFinalisationAnalyticsEffects);
+    analyticsProviderMock = TestBed.get(AnalyticsProvider);
+    store$ = TestBed.get(Store);
+    spyOn(analyticsProviderMock, 'addCustomDimension').and.callThrough();
+    spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
+    spyOn(analyticsProviderMock, 'logError').and.callThrough();
+  });
+
+  describe('passFinalisationViewDidEnter', () => {
+    it('should call setCurrentPage and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new passFinalisationActions.PassFinalisationViewDidEnter());
+      // ASSERT
+      effects.passFinalisationViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, '123');
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenName);
+        done();
+      });
+    });
+    it('should call setCurrentPage with practice mode prefix and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new passFinalisationActions.PassFinalisationViewDidEnter());
+      // ASSERT
+      effects.passFinalisationViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, end2endPracticeSlotId);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNamePracticeMode);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/src/pages/pass-finalisation/pass-finalisation.analytics.effects.ts
+++ b/src/pages/pass-finalisation/pass-finalisation.analytics.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs/observable/of';
-import { switchMap } from 'rxjs/operators';
+import { switchMap, concatMap, withLatestFrom } from 'rxjs/operators';
 import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import {
   AnalyticsScreenNames,
@@ -10,6 +10,12 @@ import {
   PASS_FINALISTATION_VIEW_DID_ENTER,
   PassFinalisationViewDidEnter,
 } from '../../pages/pass-finalisation/pass-finalisation.actions';
+import { TestsModel } from '../../modules/tests/tests.model';
+import { StoreModel } from '../../shared/models/store.model';
+import { Store, select } from '@ngrx/store';
+import { getTests } from '../../modules/tests/tests.reducer';
+import { formatAnalyticsText } from '../../shared/helpers/format-analytics-text';
+import { AnalyticRecorded } from '../../providers/analytics/analytics.actions';
 
 @Injectable()
 export class PassFinalisationAnalyticsEffects {
@@ -17,21 +23,26 @@ export class PassFinalisationAnalyticsEffects {
   constructor(
     public analytics: AnalyticsProvider,
     private actions$: Actions,
+    private store$: Store<StoreModel>,
   ) {
-    this.analytics.initialiseAnalytics()
-          .then(() => {})
-          .catch(() => {
-            console.log('error initialising analytics');
-          },
-    );
+    this.analytics.initialiseAnalytics();
   }
 
   @Effect()
   passFinalisationViewDidEnter$ = this.actions$.pipe(
     ofType(PASS_FINALISTATION_VIEW_DID_ENTER),
-    switchMap((action: PassFinalisationViewDidEnter) => {
-      this.analytics.setCurrentPage(AnalyticsScreenNames.PASS_FINALISATION);
-      return of();
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      )),
+    ),
+    switchMap(([action, tests]: [PassFinalisationViewDidEnter, TestsModel]) => {
+      this.analytics.setCurrentPage(
+        formatAnalyticsText(AnalyticsScreenNames.PASS_FINALISATION, tests),
+      );
+      return of(new AnalyticRecorded());
     }),
   );
 }

--- a/src/providers/analytics/analytics.ts
+++ b/src/providers/analytics/analytics.ts
@@ -52,7 +52,6 @@ export class AnalyticsProvider implements IAnalyticsProvider {
       this.ga
         .startTrackerWithId(this.googleAnalyticsKey)
         .then(() => {
-          this.addCustomDimension(AnalyticsDimensionIndices.DEVICE_ID, this.uniqueDeviceId);
           this.ga.trackView(name)
             .then((resp) => { })
             .catch(pageError => console.log('Error setting page', pageError));


### PR DESCRIPTION
## Description and relevant Jira numbers
- Update the analytics on the communication and pass finalisation page to record if this is practice mode
- Ensure the Candidate initial state is always set
- Remove unnecessary call to set device ID when setting the current page

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
