### PR TITLE
MES-2995 update analytics to show practice mode on post test screens

### DIFF
--- a/src/pages/back-to-office/__tests__/back-to-office.analytics.effects.spec.ts
+++ b/src/pages/back-to-office/__tests__/back-to-office.analytics.effects.spec.ts
@@ -1,0 +1,188 @@
+import { BackToOfficeAnalyticsEffects } from '../back-to-office.analytics.effects';
+import { TestBed } from '@angular/core/testing';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { StoreModule, Store } from '@ngrx/store';
+import { provideMockActions } from '@ngrx/effects/testing';
+import * as backToOfficeActions from '../back-to-office.actions';
+import { AnalyticsProvider } from '../../../providers/analytics/analytics';
+import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
+import {
+  AnalyticsScreenNames,
+  AnalyticsEventCategories,
+  AnalyticsDimensionIndices,
+  AnalyticsEvents,
+} from '../../../providers/analytics/analytics.model';
+import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
+import { StoreModel } from '../../../shared/models/store.model';
+import * as journalActions from '../../journal/journal.actions';
+import * as fakeJournalActions from '../../fake-journal/fake-journal.actions';
+import * as testsActions from '../../../modules/tests/tests.actions';
+import { testsReducer } from '../../../modules/tests/tests.reducer';
+import { PopulateCandidateDetails } from '../../../modules/tests/candidate/candidate.actions';
+import { Candidate } from '@dvsa/mes-journal-schema';
+import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
+import { ActivityCodes } from '../../../shared/models/activity-codes';
+
+describe('Back To Office Analytics Effects', () => {
+
+  let effects: BackToOfficeAnalyticsEffects;
+  let analyticsProviderMock;
+  let actions$: any;
+  let store$: Store<StoreModel>;
+  const screenName = AnalyticsScreenNames.BACK_TO_OFFICE;
+  const screenNamePracticeMode = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.BACK_TO_OFFICE}`;
+  const mockCandidate: Candidate = {
+    candidateId: 1001,
+  };
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: testsReducer,
+        }),
+      ],
+      providers: [
+        BackToOfficeAnalyticsEffects,
+        { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
+        provideMockActions(() => actions$),
+        Store,
+      ],
+    });
+    effects = TestBed.get(BackToOfficeAnalyticsEffects);
+    analyticsProviderMock = TestBed.get(AnalyticsProvider);
+    store$ = TestBed.get(Store);
+    spyOn(analyticsProviderMock, 'addCustomDimension').and.callThrough();
+    spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
+    spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+  });
+
+  describe('backToOfficeViewDidEnter', () => {
+    it('should call setCurrentPage', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new backToOfficeActions.BackToOfficeViewDidEnter());
+      // ASSERT
+      effects.backToOfficeViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenName);
+        done();
+      });
+    });
+    it('should call setCurrentPage with practice mode prefix', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new backToOfficeActions.BackToOfficeViewDidEnter());
+      // ASSERT
+      effects.backToOfficeViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNamePracticeMode);
+        done();
+      });
+    });
+
+  });
+
+  describe('deferWriteUpEffect', () => {
+    it('should call logEvent with pass page and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new backToOfficeActions.DeferWriteUp());
+      // ASSERT
+      effects.deferWriteUpEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, '123');
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.BACK_TO_OFFICE,
+            AnalyticsEvents.DEFER_WRITE_UP,
+            'pass',
+          );
+        done();
+      });
+    });
+    it('should call logEvent with fail page and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.FAIL));
+      // ACT
+      actions$.next(new backToOfficeActions.DeferWriteUp());
+      // ASSERT
+      effects.deferWriteUpEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, '123');
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.BACK_TO_OFFICE,
+            AnalyticsEvents.DEFER_WRITE_UP,
+            'fail',
+          );
+        done();
+      });
+    });
+    it('should call logEvent with pass page, practice mode prefix and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new backToOfficeActions.DeferWriteUp());
+      // ASSERT
+      effects.deferWriteUpEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, end2endPracticeSlotId);
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsEventCategories.BACK_TO_OFFICE}`,
+            `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsEvents.DEFER_WRITE_UP}`,
+            'pass',
+          );
+        done();
+      });
+    });
+    it('should call logEvent with fail page, practice mode prefix and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.FAIL));
+      // ACT
+      actions$.next(new backToOfficeActions.DeferWriteUp());
+      // ASSERT
+      effects.deferWriteUpEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, end2endPracticeSlotId);
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsEventCategories.BACK_TO_OFFICE}`,
+            `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsEvents.DEFER_WRITE_UP}`,
+            'fail',
+          );
+        done();
+      });
+    });
+  });
+
+});

--- a/src/pages/debrief/__tests__/debrief.analytics.effects.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.analytics.effects.spec.ts
@@ -1,0 +1,114 @@
+import { DebriefAnalyticsEffects } from '../debrief.analytics.effects';
+import { TestBed } from '@angular/core/testing';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { StoreModule, Store } from '@ngrx/store';
+import { provideMockActions } from '@ngrx/effects/testing';
+import * as debriefActions from '../debrief.actions';
+import { AnalyticsProvider } from '../../../providers/analytics/analytics';
+import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
+import {
+  AnalyticsScreenNames,
+  AnalyticsEventCategories,
+} from '../../../providers/analytics/analytics.model';
+import { StoreModel } from '../../../shared/models/store.model';
+import { testsReducer } from '../../../modules/tests/tests.reducer';
+import * as journalActions from '../../journal/journal.actions';
+import * as fakeJournalActions from '../../fake-journal/fake-journal.actions';
+import * as testsActions from '../../../modules/tests/tests.actions';
+import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
+import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
+import { ActivityCodes } from '../../../shared/models/activity-codes';
+
+describe('Debrief Analytics Effects', () => {
+
+  let effects: DebriefAnalyticsEffects;
+  let analyticsProviderMock;
+  let actions$: any;
+  let store$: Store<StoreModel>;
+  const screenNamePass = AnalyticsScreenNames.PASS_DEBRIEF;
+  const screenNameFail = AnalyticsScreenNames.FAIL_DEBRIEF;
+  const screenNamePracticeModePass = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.PASS_DEBRIEF}`;
+  const screenNamePracticeModeFail = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.FAIL_DEBRIEF}`;
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: testsReducer,
+        }),
+      ],
+      providers: [
+        DebriefAnalyticsEffects,
+        { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
+        provideMockActions(() => actions$),
+        Store,
+      ],
+    });
+    effects = TestBed.get(DebriefAnalyticsEffects);
+    analyticsProviderMock = TestBed.get(AnalyticsProvider);
+    store$ = TestBed.get(Store);
+    spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
+  });
+
+  describe('debriefViewDidEnter', () => {
+    it('should call setCurrentPage with pass page', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new debriefActions.DebriefViewDidEnter());
+      // ASSERT
+      effects.debriefViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNamePass);
+        done();
+      });
+    });
+    it('should call setCurrentPage with fail page', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.FAIL));
+      // ACT
+      actions$.next(new debriefActions.DebriefViewDidEnter());
+      // ASSERT
+      effects.debriefViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNameFail);
+        done();
+      });
+    });
+    it('should call setCurrentPage with pass and practice mode prefix', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new debriefActions.DebriefViewDidEnter());
+      // ASSERT
+      effects.debriefViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNamePracticeModePass);
+        done();
+      });
+    });
+    it('should call setCurrentPage with fail and practice mode prefix', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.FAIL));
+      // ACT
+      actions$.next(new debriefActions.DebriefViewDidEnter());
+      // ASSERT
+      effects.debriefViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNamePracticeModeFail);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/src/pages/health-declaration/__tests__/health-declaration.analytics.effects.spec.ts
+++ b/src/pages/health-declaration/__tests__/health-declaration.analytics.effects.spec.ts
@@ -1,0 +1,88 @@
+import { HealthDeclarationAnalyticsEffects } from '../health-declaration.analytics.effects';
+import { TestBed } from '@angular/core/testing';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { StoreModule, Store } from '@ngrx/store';
+import { provideMockActions } from '@ngrx/effects/testing';
+import * as healthDeclarationActions from '../health-declaration.actions';
+import { AnalyticsProvider } from '../../../providers/analytics/analytics';
+import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
+import {
+  AnalyticsScreenNames,
+  AnalyticsEventCategories,
+} from '../../../providers/analytics/analytics.model';
+import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
+import { StoreModel } from '../../../shared/models/store.model';
+import * as journalActions from '../../journal/journal.actions';
+import * as fakeJournalActions from '../../fake-journal/fake-journal.actions';
+import { testsReducer } from '../../../modules/tests/tests.reducer';
+import { PopulateCandidateDetails } from '../../../modules/tests/candidate/candidate.actions';
+import { Candidate } from '@dvsa/mes-journal-schema';
+import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
+
+describe('Health Declaration Analytics Effects', () => {
+
+  let effects: HealthDeclarationAnalyticsEffects;
+  let analyticsProviderMock;
+  let actions$: any;
+  let store$: Store<StoreModel>;
+  const screenName = AnalyticsScreenNames.HEALTH_DECLARATION;
+  // tslint:disable-next-line:max-line-length
+  const screenNamePracticeMode = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.HEALTH_DECLARATION}`;
+  const mockCandidate: Candidate = {
+    candidateId: 1001,
+  };
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: testsReducer,
+        }),
+      ],
+      providers: [
+        HealthDeclarationAnalyticsEffects,
+        { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
+        provideMockActions(() => actions$),
+        Store,
+      ],
+    });
+    effects = TestBed.get(HealthDeclarationAnalyticsEffects);
+    analyticsProviderMock = TestBed.get(AnalyticsProvider);
+    store$ = TestBed.get(Store);
+    spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
+  });
+
+  describe('healthDeclarationViewDidEnter', () => {
+    it('should call setCurrentPage', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new healthDeclarationActions.HealthDeclarationViewDidEnter());
+      // ASSERT
+      effects.healthDeclarationViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenName);
+        done();
+      });
+    });
+    it('should call setCurrentPage with practice mode prefix', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      // ACT
+      actions$.next(new healthDeclarationActions.HealthDeclarationViewDidEnter());
+      // ASSERT
+      effects.healthDeclarationViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNamePracticeMode);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/src/pages/office/__tests__/office.analytics.effects.spec.ts
+++ b/src/pages/office/__tests__/office.analytics.effects.spec.ts
@@ -1,0 +1,309 @@
+import { OfficeAnalyticsEffects } from '../office.analytics.effects';
+import { TestBed } from '@angular/core/testing';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { StoreModule, Store } from '@ngrx/store';
+import { provideMockActions } from '@ngrx/effects/testing';
+import * as officeActions from '../office.actions';
+import { AnalyticsProvider } from '../../../providers/analytics/analytics';
+import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
+import {
+  AnalyticsDimensionIndices,
+  AnalyticsScreenNames,
+  AnalyticsEventCategories,
+  AnalyticsEvents,
+  AnalyticsErrorTypes,
+} from '../../../providers/analytics/analytics.model';
+import { StoreModel } from '../../../shared/models/store.model';
+import { Candidate } from '@dvsa/mes-journal-schema';
+import { testsReducer } from '../../../modules/tests/tests.reducer';
+import * as journalActions from '../../journal/journal.actions';
+import * as fakeJournalActions from '../../fake-journal/fake-journal.actions';
+import * as testsActions from '../../../modules/tests/tests.actions';
+import { PopulateCandidateDetails } from '../../../modules/tests/candidate/candidate.actions';
+import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
+import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
+import { ActivityCodes } from '../../../shared/models/activity-codes';
+
+describe('Office Analytics Effects', () => {
+
+  let effects: OfficeAnalyticsEffects;
+  let analyticsProviderMock;
+  let actions$: any;
+  let store$: Store<StoreModel>;
+  const screenNamePass = AnalyticsScreenNames.PASS_TEST_SUMMARY;
+  const screenNameFail = AnalyticsScreenNames.FAIL_TEST_SUMMARY;
+  // tslint:disable-next-line:max-line-length
+  const screenNamePracticeModePass = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.PASS_TEST_SUMMARY}`;
+  // tslint:disable-next-line:max-line-length
+  const screenNamePracticeModeFail = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.FAIL_TEST_SUMMARY}`;
+  const mockCandidate: Candidate = {
+    candidateId: 1001,
+  };
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: testsReducer,
+        }),
+      ],
+      providers: [
+        OfficeAnalyticsEffects,
+        { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
+        provideMockActions(() => actions$),
+        Store,
+      ],
+    });
+    effects = TestBed.get(OfficeAnalyticsEffects);
+    analyticsProviderMock = TestBed.get(AnalyticsProvider);
+    store$ = TestBed.get(Store);
+    spyOn(analyticsProviderMock, 'addCustomDimension').and.callThrough();
+    spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
+    spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
+    spyOn(analyticsProviderMock, 'logError').and.callThrough();
+  });
+
+  describe('officeViewDidEnter', () => {
+    it('should call setCurrentPage with pass page and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new officeActions.OfficeViewDidEnter());
+      // ASSERT
+      effects.officeViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, '123');
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNamePass);
+        done();
+      });
+    });
+    it('should call setCurrentPage with fail page and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.FAIL));
+      // ACT
+      actions$.next(new officeActions.OfficeViewDidEnter());
+      // ASSERT
+      effects.officeViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, '123');
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNameFail);
+        done();
+      });
+    });
+    it('should call setCurrentPage with pass page, practice mode prefix and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new officeActions.OfficeViewDidEnter());
+      // ASSERT
+      effects.officeViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, end2endPracticeSlotId);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNamePracticeModePass);
+        done();
+      });
+    });
+    it('should call setCurrentPage with fail page, practice mode prefix and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.FAIL));
+      // ACT
+      actions$.next(new officeActions.OfficeViewDidEnter());
+      // ASSERT
+      effects.officeViewDidEnter$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, end2endPracticeSlotId);
+        expect(analyticsProviderMock.setCurrentPage)
+          .toHaveBeenCalledWith(screenNamePracticeModeFail);
+        done();
+      });
+    });
+
+  });
+
+  describe('savingWriteUpForLaterEffect', () => {
+    it('should call logEvent with pass page and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new officeActions.SavingWriteUpForLater());
+      // ASSERT
+      effects.savingWriteUpForLaterEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, '123');
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.POST_TEST,
+            AnalyticsEvents.SAVE_WRITE_UP,
+            'pass',
+          );
+        done();
+      });
+    });
+    it('should call logEvent with fail page and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.FAIL));
+      // ACT
+      actions$.next(new officeActions.SavingWriteUpForLater());
+      // ASSERT
+      effects.savingWriteUpForLaterEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, '123');
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.POST_TEST,
+            AnalyticsEvents.SAVE_WRITE_UP,
+            'fail',
+          );
+        done();
+      });
+    });
+    it('should call logEvent with pass page, practice mode prefix and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new officeActions.SavingWriteUpForLater());
+      // ASSERT
+      effects.savingWriteUpForLaterEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, end2endPracticeSlotId);
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsEventCategories.POST_TEST}`,
+            `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsEvents.SAVE_WRITE_UP}`,
+            'pass',
+          );
+        done();
+      });
+    });
+    it('should call logEvent with fail page, practice mode prefix and addCustomDimension', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.FAIL));
+      // ACT
+      actions$.next(new officeActions.SavingWriteUpForLater());
+      // ASSERT
+      effects.savingWriteUpForLaterEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
+        expect(analyticsProviderMock.addCustomDimension)
+          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, end2endPracticeSlotId);
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsEventCategories.POST_TEST}`,
+            `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsEvents.SAVE_WRITE_UP}`,
+            'fail',
+          );
+        done();
+      });
+    });
+  });
+
+  describe('validationErrorEffect', () => {
+    it('should call logError with pass', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new officeActions.ValidationError('error message'));
+      // ASSERT
+      effects.validationErrorEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logError)
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenNamePass})`,
+          'error message');
+        done();
+      });
+    });
+    it('should call logError with fail', (done) => {
+      // ARRANGE
+      store$.dispatch(new journalActions.StartTest(123));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.FAIL));
+      // ACT
+      actions$.next(new officeActions.ValidationError('error message'));
+      // ASSERT
+      effects.validationErrorEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logError)
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenNameFail})`,
+          'error message');
+        done();
+      });
+    });
+    it('should call logError with pass, prefixed with practice mode', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new officeActions.ValidationError('error message'));
+      // ASSERT
+      effects.validationErrorEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logError)
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenNamePracticeModePass})`,
+          'error message');
+        done();
+      });
+    });
+    it('should call logError with fail, prefixed with practice mode', (done) => {
+      // ARRANGE
+      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
+      store$.dispatch(new PopulateCandidateDetails(mockCandidate));
+      store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.FAIL));
+      // ACT
+      actions$.next(new officeActions.ValidationError('error message'));
+      // ASSERT
+      effects.validationErrorEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logError)
+          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenNamePracticeModeFail})`,
+          'error message');
+        done();
+      });
+    });
+  });
+
+});

--- a/src/pages/pass-finalisation/__tests__/pass-finalisation.analytics.effects.spec.ts
+++ b/src/pages/pass-finalisation/__tests__/pass-finalisation.analytics.effects.spec.ts
@@ -7,7 +7,6 @@ import * as passFinalisationActions from '../pass-finalisation.actions';
 import { AnalyticsProvider } from '../../../providers/analytics/analytics';
 import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
 import {
-  AnalyticsDimensionIndices,
   AnalyticsScreenNames,
   AnalyticsEventCategories,
 } from '../../../providers/analytics/analytics.model';
@@ -51,9 +50,7 @@ describe('Pass Finalisation Analytics Effects', () => {
     effects = TestBed.get(PassFinalisationAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     store$ = TestBed.get(Store);
-    spyOn(analyticsProviderMock, 'addCustomDimension').and.callThrough();
     spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
-    spyOn(analyticsProviderMock, 'logError').and.callThrough();
   });
 
   describe('passFinalisationViewDidEnter', () => {
@@ -66,10 +63,6 @@ describe('Pass Finalisation Analytics Effects', () => {
       // ASSERT
       effects.passFinalisationViewDidEnter$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
-        expect(analyticsProviderMock.addCustomDimension)
-          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
-        expect(analyticsProviderMock.addCustomDimension)
-          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, '123');
         expect(analyticsProviderMock.setCurrentPage)
           .toHaveBeenCalledWith(screenName);
         done();
@@ -84,10 +77,6 @@ describe('Pass Finalisation Analytics Effects', () => {
       // ASSERT
       effects.passFinalisationViewDidEnter$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
-        expect(analyticsProviderMock.addCustomDimension)
-          .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1001');
-        expect(analyticsProviderMock.addCustomDimension)
-          .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_ID, end2endPracticeSlotId);
         expect(analyticsProviderMock.setCurrentPage)
           .toHaveBeenCalledWith(screenNamePracticeMode);
         done();


### PR DESCRIPTION
## Description and relevant Jira numbers
Update the analytics on the following pages so that practice mode can be distinguished
- debrief
- pass finalisation
- health declaration
- back to office

Added tests for all analytics effects

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
