### PR TITLE
Updating UI test to complete journal checks before starting tests

### DIFF
--- a/test/e2e/extended/cat-b-scenarios.feature
+++ b/test/e2e/extended/cat-b-scenarios.feature
@@ -39,7 +39,8 @@ Feature: Extended category B test scenarios
 
    Scenario: Candidate fails a test with a single dangerous fault
       Given I am logged in as "mobexaminer1" and I have a test for "Mr Ali Campbell"
-      When I start the test for "Mr Ali Campbell"
+      When I check candidate details for "Mr Ali Campbell"
+      And I start the test for "Mr Ali Campbell"
       And the candidate requests to receive results by post
       And the candidate confirms their communication preference
       Then I should see the "Declaration - Ali Campbell" page
@@ -67,7 +68,8 @@ Feature: Extended category B test scenarios
 
    Scenario: Candidate fails a test with a single serious fault
       Given I am logged in as "mobexaminer1" and I have a test for "Mrs Jane Doe"
-      When I start the test for "Mrs Jane Doe"
+      When I check candidate details for "Mrs Jane Doe"
+      And I start the test for "Mrs Jane Doe"
       And the candidate confirms their communication preference
       Then I should see the "Declaration - Jane Doe" page
       And the candidate completes the declaration page
@@ -92,7 +94,8 @@ Feature: Extended category B test scenarios
 
    Scenario: Examiner terminates the test in the interests of public safety
       Given I am logged in as "mobexaminer1" and I have a test for "Mr James Brown"
-      When I start the test for "Mr James Brown"
+      When I check candidate details for "Mr James Brown"
+      And I start the test for "Mr James Brown"
       And the candidate enters a new email address
       And the candidate confirms their communication preference
       Then I should see the "Declaration - James Brown" page
@@ -120,7 +123,8 @@ Feature: Extended category B test scenarios
 
    Scenario: Candidate passes a test with 15 driver faults
       Given I am logged in as "mobexaminer1" and I have a test for "Mrs Jane Doe"
-      When I start the test for "Mrs Jane Doe"
+      When I check candidate details for "Mrs Jane Doe"
+      And I start the test for "Mrs Jane Doe"
       And the candidate enters a new email address
       And the candidate confirms their communication preference
       Then I should see the "Declaration - Jane Doe" page
@@ -177,7 +181,8 @@ Feature: Extended category B test scenarios
 
    Scenario: Candidate fails a test with a dangerous and 16 driver faults
       Given I am logged in as "mobexaminer1" and I have a test for "Miss Theresa Shaw"
-      When I start the test for "Miss Theresa Shaw"
+      When I check candidate details for "Miss Theresa Shaw"
+      And I start the test for "Miss Theresa Shaw"
       Then I should see the "Declaration - Theresa Shaw" page
       And the candidate requests to receive results by post
       And the candidate confirms their communication preference

--- a/test/e2e/features/03-waitingroom.feature
+++ b/test/e2e/features/03-waitingroom.feature
@@ -2,14 +2,16 @@ Feature: Comms Capture and Waiting Room
 
    Scenario: Comms Capture screen populated for candidate
       Given I am logged in as "mobexaminer1" and I have a test for "Mrs Jane Doe"
-      When I start the test for "Mrs Jane Doe"
+      When I check candidate details for "Mrs Jane Doe"
+      And I start the test for "Mrs Jane Doe"
       Then the communication page candidate name should be "Mrs Jane Doe"
       And the communication page candidate driver number should be "DOEXX 625220 A99HC"
       And the email "jane.doe@example.com" has been provided and is preselected
 
    Scenario: Waiting room screen populated for candidate
       Given I am logged in as "mobexaminer1" and I have a test for "Miss Theresa Shaw"
-      When I start the test for "Miss Theresa Shaw"
+      When I check candidate details for "Miss Theresa Shaw"
+      And I start the test for "Miss Theresa Shaw"
       And the candidate enters a new email address
       And the candidate confirms their communication preference
       Then the waiting room candidate name should be "Miss Theresa Shaw"

--- a/test/e2e/features/04-waitingroomtocar.feature
+++ b/test/e2e/features/04-waitingroomtocar.feature
@@ -3,7 +3,8 @@ Feature: Waiting Room to Car
    @smoke
    Scenario: Waiting room to Car validation
       Given I am logged in as "mobexaminer1" and I have a test for "Miss Theresa Shaw"
-      When I start the test for "Miss Theresa Shaw"
+      When I check candidate details for "Miss Theresa Shaw"
+      And I start the test for "Miss Theresa Shaw"
       Then I should see the "Declaration - Theresa Shaw" page
       And the candidate enters a new email address
       And the candidate confirms their communication preference

--- a/test/e2e/features/06-debrief.feature
+++ b/test/e2e/features/06-debrief.feature
@@ -30,7 +30,8 @@ Feature: Debrief including Health Declaration
 
    Scenario: The transmission value from the WRTC is carried through to the pass test debrief
       Given I am logged in as "mobexaminer1" and I have a test for "Mrs Jane Doe"
-      When I start the test for "Mrs Jane Doe"
+      When I check candidate details for "Mrs Jane Doe"
+      And I start the test for "Mrs Jane Doe"
       And the candidate enters a new email address
       And the candidate confirms their communication preference
       Then I should see the "Declaration - Jane Doe" page
@@ -48,7 +49,8 @@ Feature: Debrief including Health Declaration
 
    Scenario: For a pass the health declaration shows the correct information and validation is enforced
       Given I am logged in as "mobexaminer1" and I have a test for "Mr Ali Campbell"
-      When I start the test for "Mr Ali Campbell"
+      When I check candidate details for "Mr Ali Campbell"
+      And I start the test for "Mr Ali Campbell"
       And the candidate requests to receive results by post
       And the candidate confirms their communication preference
       Then I should see the "Declaration - Ali Campbell" page

--- a/test/e2e/features/06-debrief.feature
+++ b/test/e2e/features/06-debrief.feature
@@ -25,7 +25,7 @@ Feature: Debrief including Health Declaration
       When I try to confirm the pass certificate details
       Then validation item "pass-finalisation-licence-received-validation-text" should be "Select a response"
       And validation item "pass-finalisation-licence-received-validation-text" should be visible
-      And validation item "pass-finalisation-certificate-number-validation-text" should be "Enter a certificate number"
+      And validation item "pass-finalisation-certificate-number-validation-text" should be "Enter a valid certificate number (max 8 characters)"
       And validation item "pass-finalisation-certificate-number-validation-text" should be visible
 
    Scenario: The transmission value from the WRTC is carried through to the pass test debrief

--- a/test/e2e/features/07-office.feature
+++ b/test/e2e/features/07-office.feature
@@ -41,7 +41,8 @@ Feature: Office page
 
    Scenario: Office page validation for fail
       Given I am logged in as "mobexaminer1" and I have a test for "Mrs Jane Doe"
-      When I start the test for "Mrs Jane Doe"
+      When I check candidate details for "Mrs Jane Doe"
+      And I start the test for "Mrs Jane Doe"
       And the candidate enters a new email address
       And the candidate confirms their communication preference
       Then I should see the "Declaration - Jane Doe" page

--- a/test/e2e/features/99-fulljourney.feature
+++ b/test/e2e/features/99-fulljourney.feature
@@ -29,8 +29,8 @@ Feature: Full end to end journey
 
    Scenario: Examiner completes a failed test with various faults
       Given I am logged in as "mobexaminer1" and I have a test for "Mrs Jane Doe"
-
-      When I start the test for "Mrs Jane Doe"
+      When I check candidate details for "Mrs Jane Doe"
+      And I start the test for "Mrs Jane Doe"
       And the candidate enters a new email address
       And the candidate confirms their communication preference
       Then I should see the "Declaration - Jane Doe" page
@@ -133,7 +133,8 @@ Feature: Full end to end journey
 
    Scenario: Examiner terminates test as candidate failed to attend (No mandatory office fields)
       Given I am logged in as "mobexaminer1" and I have a test for "Miss Theresa Shaw"
-      When I start the test for "Miss Theresa Shaw"
+      When I check candidate details for "Miss Theresa Shaw"
+      And I start the test for "Miss Theresa Shaw"
       Then I should see the "Declaration - Theresa Shaw" page
       And I terminate the test
       Then I should see the Debrief page with outcome "Terminated"
@@ -149,7 +150,8 @@ Feature: Full end to end journey
 
    Scenario: Examiner terminates test as candidate failed to present ID (Only physical description mandatory)
       Given I am logged in as "mobexaminer1" and I have a test for "Mr Ali Campbell"
-      When I start the test for "Mr Ali Campbell"
+      When I check candidate details for "Mr Ali Campbell"
+      And I start the test for "Mr Ali Campbell"
       And the candidate requests to receive results by post
       And the candidate confirms their communication preference
       Then I should see the "Declaration - Ali Campbell" page
@@ -171,7 +173,8 @@ Feature: Full end to end journey
 
    Scenario: Examiner terminates test as candidate failed eye sight test
       Given I am logged in as "mobexaminer1" and I have a test for "Mr James Brown"
-      When I start the test for "Mr James Brown"
+      When I check candidate details for "Mr James Brown"
+      And I start the test for "Mr James Brown"
       And the candidate requests to receive results by calling the support centre
       And the candidate confirms their communication preference
       Then I should see the "Declaration - James Brown" page

--- a/test/e2e/step-definitions/journal-steps.ts
+++ b/test/e2e/step-definitions/journal-steps.ts
@@ -20,8 +20,12 @@ Given('I am on the journal page as {string}', (username) => {
 });
 
 When('I view candidate details for {string}', (candidateName) => {
-  const buttonElement = getElement(by.xpath(`//h3[text()[normalize-space(.) = "${candidateName}"]]`));
-  return clickElement(buttonElement);
+  return viewCandidateDetails(candidateName);
+});
+
+When('I check candidate details for {string}', (candidateName) => {
+  viewCandidateDetails(candidateName);
+  closeCandidateDetailsDialog();
 });
 
 When('I start the test for {string}', (candidateName) => {
@@ -88,3 +92,14 @@ Then('the test result for {string} is {string}', (candidateName, testResult) => 
 
   return expect(testResultElement.getText()).to.eventually.equal(testResult);
 });
+
+const viewCandidateDetails = (candidateName) => {
+  const buttonElement = getElement(by.xpath(`//h3[text()[normalize-space(.) = "${candidateName}"]]`));
+  return clickElement(buttonElement);
+};
+
+const closeCandidateDetailsDialog = () => {
+  const closeCandidateDetailDialog = element(
+    by.xpath('//page-candidate-details//button/span[normalize-space(text()) = "Close"]'));
+  clickElement(closeCandidateDetailDialog);
+};


### PR DESCRIPTION
Since the introduction of MES-1397 the user is forced to view the candidate details before starting a test where there are checks against the slot.

This update performs the checks before starting test where relevant.