### PR TITLE
mes-2989 Clean up calls to .unsubscribe from observable subscriptions

### DIFF
--- a/src/pages/candidate-details/candidate-details.ts
+++ b/src/pages/candidate-details/candidate-details.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { IonicPage, NavController, NavParams, Platform } from 'ionic-angular';
 import { Observable } from 'rxjs/Observable';
@@ -43,7 +43,7 @@ interface CandidateDetailsPageState {
   selector: 'page-candidate-details',
   templateUrl: 'candidate-details.html',
 })
-export class CandidateDetailsPage extends BasePageComponent implements OnInit, OnDestroy {
+export class CandidateDetailsPage extends BasePageComponent implements OnInit {
   pageState: CandidateDetailsPageState;
   subscription: Subscription;
   slotId: number;
@@ -108,6 +108,7 @@ export class CandidateDetailsPage extends BasePageComponent implements OnInit, O
     );
 
     this.subscription = merged$.subscribe();
+
     if (this.slotChanged) {
       this.store$.dispatch(new CandidateDetailsSlotChangeViewed(this.slotId));
     }
@@ -119,10 +120,12 @@ export class CandidateDetailsPage extends BasePageComponent implements OnInit, O
         }
       },
     );
-
   }
-  ngOnDestroy(): void {
-    this.subscription.unsubscribe();
+
+  ionViewDidLeave(): void {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 
   ionViewDidEnter(): void {

--- a/src/pages/communication-page/communication.ts
+++ b/src/pages/communication-page/communication.ts
@@ -1,5 +1,5 @@
 import { IonicPage, Navbar, Platform, NavController } from 'ionic-angular';
-import { Component, ViewChild, OnInit, OnDestroy } from '@angular/core';
+import { Component, ViewChild, OnInit } from '@angular/core';
 import { PracticeableBasePageComponent } from '../../shared/classes/practiceable-base-page';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
@@ -62,7 +62,7 @@ interface CommunicationPageState {
   selector: 'communication',
   templateUrl: 'communication.html',
 })
-export class CommunicationPage extends PracticeableBasePageComponent implements OnInit, OnDestroy {
+export class CommunicationPage extends PracticeableBasePageComponent implements OnInit {
 
   static readonly providedEmail: string = 'Provided';
   static readonly updatedEmail: string = 'Updated';
@@ -86,6 +86,7 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
   selectNewEmail: boolean;
   conductedLanguage: string;
   isBookedInWelsh: boolean;
+  merged$: Observable<string | boolean>;
 
   constructor(
     store$: Store<StoreModel>,
@@ -193,14 +194,13 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
       conductedLanguage$,
     } = this.pageState;
 
-    const merged$ = merge(
+    this.merged$ = merge(
       candidateProvidedEmail$.pipe(map(value => this.candidateProvidedEmail = value)),
       communicationEmail$.pipe(map(value => this.communicationEmail = value)),
       communicationType$.pipe(map(value => this.communicationType = value)),
       welshTest$.pipe(map(isWelsh => this.isBookedInWelsh = isWelsh)),
       conductedLanguage$.pipe(map(value => this.conductedLanguage = value)),
     );
-    this.subscription = merged$.subscribe();
 
     if (this.shouldPreselectADefaultValue()) {
       this.initialiseDefaultSelections();
@@ -211,9 +211,19 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
     this.restoreRadioValidators();
   }
 
-  ngOnDestroy(): void {
-    super.ngOnDestroy();
-    this.subscription.unsubscribe();
+  ionViewWillEnter(): boolean {
+    if (this.merged$) {
+      this.subscription = this.merged$.subscribe();
+    }
+
+    return true;
+  }
+
+  ionViewDidLeave(): void {
+    super.ionViewDidLeave();
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 
   configureI18N(isWelsh: boolean): void {

--- a/src/pages/debrief/components/vehicle-checks-card/vehicle-checks-card.ts
+++ b/src/pages/debrief/components/vehicle-checks-card/vehicle-checks-card.ts
@@ -63,6 +63,7 @@ export class VehicleChecksCardComponent implements OnInit, OnDestroy {
       hasVehicleChecksFault$.pipe(map(val => this.hasFault = val)),
       showMeQuestionOutcome$.pipe(map(val => this.hasShowMeFault = val !== CompetencyOutcome.P)),
     ).subscribe();
+
   }
 
   ngOnDestroy(): void {

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -182,7 +182,7 @@ export class DebriefPage extends PracticeableBasePageComponent {
 
     const { testResult$, welshTest$, etaFaults$, ecoFaults$, conductedLanguage$ } = this.pageState;
 
-    const merged$ = merge(
+    this.subscription = merge(
       testResult$.pipe(map(result => this.outcome = result)),
       welshTest$.pipe(map(isWelsh => this.isBookedInWelsh = isWelsh)),
       etaFaults$.pipe(
@@ -198,9 +198,9 @@ export class DebriefPage extends PracticeableBasePageComponent {
         }),
       ),
       conductedLanguage$.pipe(map(language => this.conductedLanguage = language)),
-    );
+    ).subscribe();
+
     this.configureI18N(this.conductedLanguage === DebriefPage.welshLanguage);
-    this.subscription = merged$.subscribe();
   }
 
   configureI18N(isWelsh: boolean): void {
@@ -209,23 +209,22 @@ export class DebriefPage extends PracticeableBasePageComponent {
     }
   }
 
-  ngOnDestroy(): void {
-    super.ngOnDestroy();
-    if (this.subscription) {
-      this.subscription.unsubscribe();
-    }
-  }
-
   ionViewDidEnter(): void {
     this.store$.dispatch(new DebriefViewDidEnter());
   }
 
   ionViewDidLeave(): void {
+    super.ionViewDidLeave();
     if (this.isTestReportPracticeMode) {
       if (super.isIos()) {
         this.screenOrientation.unlock();
         this.insomnia.allowSleepAgain();
       }
+    }
+
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+
     }
   }
 

--- a/src/pages/journal/components/test-outcome/test-outcome.ts
+++ b/src/pages/journal/components/test-outcome/test-outcome.ts
@@ -1,3 +1,4 @@
+import { Subscription } from 'rxjs/Subscription';
 import { Component, Input, OnInit } from '@angular/core';
 import { NavController, ModalController, Modal } from 'ionic-angular';
 import { Store, select } from '@ngrx/store';
@@ -20,6 +21,7 @@ import { ActivityCode } from '@dvsa/mes-test-schema/categories/B';
 import { getCheckComplete } from '../../journal.selector';
 import { getJournalState } from '../../journal.reducer';
 import { map } from 'rxjs/operators';
+import { Observable } from 'rxjs/Observable';
 
 @Component({
   selector: 'test-outcome',
@@ -46,6 +48,8 @@ export class TestOutcomeComponent implements OnInit {
   isRekey: boolean = false;
 
   candidateDetailsViewed: boolean;
+  subscription: Subscription;
+  seenCandidateDetails$: Observable<boolean>;
 
   constructor(
     private store$: Store<StoreModel>,
@@ -58,10 +62,17 @@ export class TestOutcomeComponent implements OnInit {
       select(getJournalState),
       map(journalData => getCheckComplete(journalData, this.slotDetail.slotId)),
     );
-    seenCandidateDetails$.subscribe(
-      (candidateDetails) => {
+
+    this.subscription = seenCandidateDetails$.subscribe(
+      (candidateDetails: boolean) => {
         this.candidateDetailsViewed = candidateDetails;
       });
+  }
+
+  ionViewDidLeave(): void {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 
   showOutcome(): boolean {

--- a/src/pages/pass-finalisation/pass-finalisation.ts
+++ b/src/pages/pass-finalisation/pass-finalisation.ts
@@ -151,15 +151,22 @@ export class PassFinalisationPage extends PracticeableBasePageComponent {
         }),
       ),
     };
-    this.inputSubscriptions = [
-      this.inputChangeSubscriptionDispatchingAction(this.passCertificateNumberInput, PassCertificateNumberChanged),
-    ];
     this.store$.dispatch(new PopulatePassCompletion());
   }
 
-  ngOnDestroy(): void {
-    super.ngOnDestroy();
-    this.inputSubscriptions.forEach(sub => sub.unsubscribe());
+  ionViewWillEnter(): boolean {
+    this.inputSubscriptions = [
+      this.inputChangeSubscriptionDispatchingAction(this.passCertificateNumberInput, PassCertificateNumberChanged),
+    ];
+
+    return true;
+  }
+
+  ionViewDidLeave(): void {
+    super.ionViewDidLeave();
+    if (this.inputSubscriptions) {
+      this.inputSubscriptions.forEach(sub => sub.unsubscribe());
+    }
   }
 
   ionViewDidEnter(): void {

--- a/src/pages/test-report/components/competency/competency.ts
+++ b/src/pages/test-report/components/competency/competency.ts
@@ -106,10 +106,10 @@ export class CompetencyComponent {
       hasSeriousFault$.pipe(map(toggle => this.hasSeriousFault = toggle)),
       isDangerousMode$.pipe(map(toggle => this.isDangerousMode = toggle)),
       hasDangerousFault$.pipe(map(toggle => this.hasDangerousFault = toggle)),
-    )
-    .pipe(tap(this.canButtonRipple));
+    ).pipe(tap(this.canButtonRipple));
 
     this.subscription = merged$.subscribe();
+
   }
 
   ngOnDestroy(): void {

--- a/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
+++ b/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
@@ -36,7 +36,7 @@ describe('ControlledStopComponent', () => {
       ],
       imports: [
         IonicModule,
-        StoreModule.forRoot({ tests: testsReducer, testReport : testReportReducer }),
+        StoreModule.forRoot({ tests: testsReducer, testReport: testReportReducer }),
       ],
     })
       .compileComponents()

--- a/src/pages/test-report/components/controlled-stop/controlled-stop.ts
+++ b/src/pages/test-report/components/controlled-stop/controlled-stop.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { merge } from 'rxjs/observable/merge';
@@ -38,7 +38,7 @@ interface ControlledStopComponentState {
   selector: 'controlled-stop',
   templateUrl: 'controlled-stop.html',
 })
-export class ControlledStopComponent implements OnInit {
+export class ControlledStopComponent implements OnInit, OnDestroy {
 
   componentState: ControlledStopComponentState;
   subscription: Subscription;
@@ -49,8 +49,9 @@ export class ControlledStopComponent implements OnInit {
 
   selectedControlledStop: boolean = false;
   controlledStopOutcome: CompetencyOutcome;
+  merged$: Observable<boolean | CompetencyOutcome>;
 
-  constructor(private store$: Store<StoreModel>) {}
+  constructor(private store$: Store<StoreModel>) { }
 
   ngOnInit(): void {
     const currentTest$ = this.store$.pipe(
@@ -86,15 +87,13 @@ export class ControlledStopComponent implements OnInit {
       controlledStopOutcome$,
     } = this.componentState;
 
-    const merged$ = merge(
+    this.subscription = merge(
       isRemoveFaultMode$.pipe(map(toggle => this.isRemoveFaultMode = toggle)),
       isSeriousMode$.pipe(map(toggle => this.isSeriousMode = toggle)),
       isDangerousMode$.pipe(map(toggle => this.isDangerousMode = toggle)),
       selectedControlledStop$.pipe(map(value => this.selectedControlledStop = value)),
       controlledStopOutcome$.pipe(map(outcome => this.controlledStopOutcome = outcome)),
-    );
-
-    this.subscription = merged$.subscribe();
+    ).subscribe();
 
   }
 

--- a/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.ts
+++ b/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
@@ -16,13 +16,13 @@ interface DrivingFaultSummaryState {
   selector: 'driving-fault-summary',
   templateUrl: 'driving-fault-summary.html',
 })
-export class DrivingFaultSummaryComponent implements OnInit, OnDestroy {
+export class DrivingFaultSummaryComponent implements OnInit {
 
   componentState: DrivingFaultSummaryState;
   subscription: Subscription;
 
   constructor(
-    private store$: Store<StoreModel>) {}
+    private store$: Store<StoreModel>) { }
 
   ngOnInit(): void {
     this.componentState = {
@@ -33,14 +33,18 @@ export class DrivingFaultSummaryComponent implements OnInit, OnDestroy {
         select(getDrivingFaultSummaryCount),
       ),
     };
-
-    const { count$ } = this.componentState;
-
-    this.subscription = count$.subscribe();
   }
 
-  ngOnDestroy(): void {
-    this.subscription.unsubscribe();
+  ionViewWillEnter(): void {
+    if (this.componentState && this.componentState.count$) {
+      this.subscription = this.componentState.count$.subscribe();
+    }
+  }
+
+  ionViewDidLeave(): void {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 
 }

--- a/src/pages/test-report/components/eco/eco.ts
+++ b/src/pages/test-report/components/eco/eco.ts
@@ -32,10 +32,11 @@ export class EcoComponent implements OnInit {
   adviceGivenPlanning: boolean = false;
   adviceGivenControl: boolean = false;
   componentState: EcoComponentState;
+  merged$: Observable<boolean>;
 
   constructor(
     private store$: Store<StoreModel>,
-  ) {}
+  ) { }
 
   ngOnInit(): void {
 

--- a/src/pages/test-report/components/manoeuvre-competency/manoeuvre-competency.ts
+++ b/src/pages/test-report/components/manoeuvre-competency/manoeuvre-competency.ts
@@ -15,7 +15,7 @@ import { getTestReportState } from '../../test-report.reducer';
 import { isRemoveFaultMode, isSeriousMode, isDangerousMode } from '../../test-report.selector';
 import { manoeuvreCompetencyLabels } from './manoeuvre-competency.constants';
 import { CompetencyOutcome } from '../../../../shared/models/competency-outcome';
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Subscription } from 'rxjs/Subscription';
 import { merge } from 'rxjs/observable/merge';
@@ -34,7 +34,7 @@ interface ManoeuvreCompetencyComponentState {
   selector: 'manoeuvre-competency',
   templateUrl: 'manoeuvre-competency.html',
 })
-export class ManoeuvreCompetencyComponent implements OnInit {
+export class ManoeuvreCompetencyComponent implements OnInit, OnDestroy {
 
   @Input()
   competency: ManoeuvreCompetencies;

--- a/src/pages/test-report/components/manoeuvre-competency/manoeuvre-competency.ts
+++ b/src/pages/test-report/components/manoeuvre-competency/manoeuvre-competency.ts
@@ -12,10 +12,10 @@ import { getTestData } from '../../../../modules/tests/test-data/test-data.reduc
 import { getTests } from '../../../../modules/tests/tests.reducer';
 import { getManoeuvres } from '../../../../modules/tests/test-data/test-data.selector';
 import { getTestReportState } from '../../test-report.reducer';
-import { isRemoveFaultMode, isSeriousMode, isDangerousMode  } from '../../test-report.selector';
+import { isRemoveFaultMode, isSeriousMode, isDangerousMode } from '../../test-report.selector';
 import { manoeuvreCompetencyLabels } from './manoeuvre-competency.constants';
 import { CompetencyOutcome } from '../../../../shared/models/competency-outcome';
-import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Subscription } from 'rxjs/Subscription';
 import { merge } from 'rxjs/observable/merge';
@@ -34,7 +34,7 @@ interface ManoeuvreCompetencyComponentState {
   selector: 'manoeuvre-competency',
   templateUrl: 'manoeuvre-competency.html',
 })
-export class ManoeuvreCompetencyComponent implements OnInit, OnDestroy {
+export class ManoeuvreCompetencyComponent implements OnInit {
 
   @Input()
   competency: ManoeuvreCompetencies;
@@ -107,6 +107,7 @@ export class ManoeuvreCompetencyComponent implements OnInit, OnDestroy {
     );
 
     this.subscription = merged$.subscribe();
+
   }
 
   ngOnDestroy(): void {
@@ -217,12 +218,12 @@ export class ManoeuvreCompetencyComponent implements OnInit, OnDestroy {
     clearTimeout(this.rippleTimeout);
   }
 
-  onTouchStart():void {
+  onTouchStart(): void {
     clearTimeout(this.touchTimeout);
     this.touchState = true;
   }
 
-  onTouchEnd():void {
+  onTouchEnd(): void {
     // defer the removal of the touch state to allow the page to render
     this.touchTimeout = setTimeout(() => this.touchState = false, this.touchStateDelay);
   }

--- a/src/pages/test-report/components/manoeuvres/manoeuvres.ts
+++ b/src/pages/test-report/components/manoeuvres/manoeuvres.ts
@@ -1,3 +1,4 @@
+import { Manoeuvres } from '@dvsa/mes-test-schema/categories/B';
 import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { OverlayCallback } from '../../test-report';
 import { StoreModel } from '../../../../shared/models/store.model';
@@ -7,6 +8,7 @@ import { getManoeuvres, sumManoeuvreFaults } from '../../../../modules/tests/tes
 import { getCurrentTest } from '../../../../modules/tests/tests.selector';
 import { getTests } from '../../../../modules/tests/tests.reducer';
 import { Subscription } from 'rxjs/Subscription';
+import { Observable } from 'rxjs/Observable';
 import { CompetencyOutcome } from '../../../../shared/models/competency-outcome';
 
 @Component({
@@ -30,20 +32,21 @@ export class ManoeuvresComponent implements OnInit, OnDestroy {
   subscription: Subscription;
 
   displayPopover: boolean;
+  manoeuvres$: Observable<Manoeuvres>;
 
   constructor(private store$: Store<StoreModel>) {
     this.displayPopover = false;
   }
 
   ngOnInit(): void {
-    const manoeuvres$ = this.store$.pipe(
+    this.manoeuvres$ = this.store$.pipe(
       select(getTests),
       select(getCurrentTest),
       select(getTestData),
       select(getManoeuvres),
     );
 
-    this.subscription = manoeuvres$.subscribe((manoeuvres) => {
+    this.subscription = this.manoeuvres$.subscribe((manoeuvres: Manoeuvres) => {
       this.drivingFaults = sumManoeuvreFaults(manoeuvres, CompetencyOutcome.DF);
       this.hasSeriousFault = sumManoeuvreFaults(manoeuvres, CompetencyOutcome.S) > 0;
       this.hasDangerousFault = sumManoeuvreFaults(manoeuvres, CompetencyOutcome.D) > 0;

--- a/src/pages/test-report/components/toolbar/toolbar.ts
+++ b/src/pages/test-report/components/toolbar/toolbar.ts
@@ -62,6 +62,7 @@ export class ToolbarComponent {
       this.subscription.unsubscribe();
     }
   }
+
   toggleRemoveFaultMode(): void {
     this.store$.dispatch(new ToggleRemoveFaultMode());
   }

--- a/src/pages/test-report/components/vehicle-check/vehicle-check.ts
+++ b/src/pages/test-report/components/vehicle-check/vehicle-check.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
 import { getTests } from '../../../../modules/tests/tests.reducer';
@@ -21,12 +21,13 @@ import { isSeriousMode, isDangerousMode, isRemoveFaultMode } from '../../test-re
 import { map } from 'rxjs/operators';
 import { merge } from 'rxjs/observable/merge';
 import { isEmpty } from 'lodash';
+import { Observable } from 'rxjs/Observable';
 
 @Component({
   selector: 'vehicle-check',
   templateUrl: 'vehicle-check.html',
 })
-export class VehicleCheckComponent implements OnInit {
+export class VehicleCheckComponent implements OnInit, OnDestroy {
 
   selectedShowMeQuestion: boolean = false;
 
@@ -37,9 +38,11 @@ export class VehicleCheckComponent implements OnInit {
   isSeriousMode: boolean = false;
   isDangerousMode: boolean = false;
 
+  merged$: Observable<void | boolean>;
+
   subscription: Subscription;
 
-  constructor(private store$: Store<StoreModel>) {}
+  constructor(private store$: Store<StoreModel>) { }
 
   ngOnInit(): void {
 
@@ -65,7 +68,7 @@ export class VehicleCheckComponent implements OnInit {
       select(isRemoveFaultMode),
     );
 
-    const merged$ = merge(
+    this.subscription = merge(
       vehicleChecks$.pipe(map((vehicleChecks: VehicleChecks) => {
         this.tellMeQuestionFault = vehicleChecks.tellMeQuestion.outcome;
         this.showMeQuestionFault = vehicleChecks.showMeQuestion.outcome;
@@ -75,9 +78,8 @@ export class VehicleCheckComponent implements OnInit {
       isSeriousMode$.pipe(map(toggle => this.isSeriousMode = toggle)),
       isDangerousMode$.pipe(map(toggle => this.isDangerousMode = toggle)),
       isRemoveFaultMode$.pipe(map(toggle => this.isRemoveFaultMode = toggle)),
-    );
+    ).subscribe();
 
-    this.subscription = merged$.subscribe();
   }
 
   ngOnDestroy(): void {

--- a/src/pages/test-report/test-report.ts
+++ b/src/pages/test-report/test-report.ts
@@ -166,7 +166,7 @@ export class TestReportPage extends PracticeableBasePageComponent {
       catBLegalRequirements$,
     } = this.pageState;
 
-    const merged$ = merge(
+    this.subscription = merge(
       candidateUntitledName$,
       isRemoveFaultMode$.pipe(map(result => (this.isRemoveFaultMode = result))),
       isSeriousMode$.pipe(map(result => (this.isSeriousMode = result))),
@@ -179,11 +179,10 @@ export class TestReportPage extends PracticeableBasePageComponent {
       catBLegalRequirements$.pipe(
         map(result => (this.catBLegalRequirements = result)),
       ),
-    );
-    this.subscription = merged$.subscribe();
+    ).subscribe();
   }
 
-  ionViewWillEnter() {
+  ionViewWillEnter(): boolean {
     // ionViewWillEnter lifecylce event used to ensure screen orientation is correct before page transition
     if (super.isIos() && this.isPracticeMode) {
       this.screenOrientation.lock(
@@ -192,6 +191,7 @@ export class TestReportPage extends PracticeableBasePageComponent {
       this.insomnia.keepAwake();
       this.statusBar.hide();
     }
+
     return true;
   }
 
@@ -209,8 +209,8 @@ export class TestReportPage extends PracticeableBasePageComponent {
     this.displayOverlay = !this.displayOverlay;
   }
 
-  ngOnDestroy(): void {
-    super.ngOnDestroy();
+  ionViewDidLeave(): void {
+    super.ionViewDidLeave();
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
@@ -239,10 +239,10 @@ export class TestReportPage extends PracticeableBasePageComponent {
     return this.isRemoveFaultMode
       ? 'remove-mode'
       : this.isSeriousMode
-      ? 'serious-mode'
-      : this.isDangerousMode
-      ? 'dangerous-mode'
-      : '';
+        ? 'serious-mode'
+        : this.isDangerousMode
+          ? 'dangerous-mode'
+          : '';
   }
 
   onModalDismiss = (event: ModalEvent): void => {

--- a/src/pages/test-results-search/test-results-search.ts
+++ b/src/pages/test-results-search/test-results-search.ts
@@ -35,7 +35,7 @@ export class TestResultsSearchPage extends BasePageComponent {
   hasSearched: boolean = false;
   showSearchSpinner: boolean = false;
   showAdvancedSearchSpinner: boolean = false;
-  subscription: Subscription;
+  subscription: Subscription = Subscription.EMPTY;
 
   constructor(
     public navController: NavController,
@@ -67,6 +67,7 @@ export class TestResultsSearchPage extends BasePageComponent {
 
   searchTests() {
     if (this.searchBy === SearchBy.DriverNumber) {
+      this.subscription.unsubscribe();
       this.store$.dispatch(new PerformDriverNumberSearch());
       this.showSearchSpinner = true;
       this.subscription = this.searchProvider.driverNumberSearch(this.candidateInfo)
@@ -86,6 +87,7 @@ export class TestResultsSearchPage extends BasePageComponent {
     }
 
     if (this.searchBy === SearchBy.ApplicationReferenece) {
+      this.subscription.unsubscribe();
       this.store$.dispatch(new PerformApplicationReferenceSearch());
       this.showSearchSpinner = true;
       this.subscription = this.searchProvider.applicationReferenceSearch(this.candidateInfo)
@@ -106,6 +108,7 @@ export class TestResultsSearchPage extends BasePageComponent {
   }
 
   advancedSearch(advancedSearchParams: AdvancedSearchParams): void {
+    this.subscription.unsubscribe();
     this.store$.dispatch(new PerformLDTMSearch());
     this.showAdvancedSearchSpinner = true;
     this.subscription = this.searchProvider.advancedSearch(advancedSearchParams)
@@ -122,7 +125,6 @@ export class TestResultsSearchPage extends BasePageComponent {
         }),
       )
       .subscribe();
-    // TODO - Need to Unsubscribe
   }
 
   myHeaderFn(record: any, recordIndex: any): string {

--- a/src/pages/test-results-search/test-results-search.ts
+++ b/src/pages/test-results-search/test-results-search.ts
@@ -1,3 +1,4 @@
+import { Subscription } from 'rxjs/Subscription';
 import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams, Platform } from 'ionic-angular';
 import { BasePageComponent } from '../../shared/classes/base-page';
@@ -34,6 +35,7 @@ export class TestResultsSearchPage extends BasePageComponent {
   hasSearched: boolean = false;
   showSearchSpinner: boolean = false;
   showAdvancedSearchSpinner: boolean = false;
+  subscription: Subscription;
 
   constructor(
     public navController: NavController,
@@ -67,7 +69,7 @@ export class TestResultsSearchPage extends BasePageComponent {
     if (this.searchBy === SearchBy.DriverNumber) {
       this.store$.dispatch(new PerformDriverNumberSearch());
       this.showSearchSpinner = true;
-      this.searchProvider.driverNumberSearch(this.candidateInfo)
+      this.subscription = this.searchProvider.driverNumberSearch(this.candidateInfo)
         .pipe(
           tap(() => this.hasSearched = true),
           map((results) => {
@@ -81,13 +83,12 @@ export class TestResultsSearchPage extends BasePageComponent {
           }),
         )
         .subscribe();
-      // TODO - Need to Unsubscribe
     }
 
     if (this.searchBy === SearchBy.ApplicationReferenece) {
       this.store$.dispatch(new PerformApplicationReferenceSearch());
       this.showSearchSpinner = true;
-      this.searchProvider.applicationReferenceSearch(this.candidateInfo)
+      this.subscription = this.searchProvider.applicationReferenceSearch(this.candidateInfo)
         .pipe(
           tap(() => this.hasSearched = true),
           map((results) => {
@@ -101,14 +102,13 @@ export class TestResultsSearchPage extends BasePageComponent {
           }),
         )
         .subscribe();
-      // TODO - Need to unsubscribe
     }
   }
 
   advancedSearch(advancedSearchParams: AdvancedSearchParams): void {
     this.store$.dispatch(new PerformLDTMSearch());
     this.showAdvancedSearchSpinner = true;
-    this.searchProvider.advancedSearch(advancedSearchParams)
+    this.subscription = this.searchProvider.advancedSearch(advancedSearchParams)
       .pipe(
         tap(() => this.hasSearched = true),
         map((results) => {
@@ -130,6 +130,12 @@ export class TestResultsSearchPage extends BasePageComponent {
       return '';
     }
     return null;
+  }
+
+  ionViewDidLeave(): void {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 
 }

--- a/src/pages/view-test-result/__tests__/view-test-result.spec.ts
+++ b/src/pages/view-test-result/__tests__/view-test-result.spec.ts
@@ -393,6 +393,7 @@ describe('ViewTestResultPage', () => {
         fixture.debugElement.query(By.css('test-summary-card')),
       ).toBeNull();
     });
+
     it('should show the cards when the data is not loading and there is no error', () => {
       component.isLoading = false;
       component.showErrorMessage = false;

--- a/src/pages/view-test-result/view-test-result.ts
+++ b/src/pages/view-test-result/view-test-result.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { IonicPage, NavController, NavParams, Platform, Loading, LoadingController } from 'ionic-angular';
 import { BasePageComponent } from '../../shared/classes/base-page';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
@@ -8,6 +8,7 @@ import { tap, catchError, map } from 'rxjs/operators';
 import { of } from 'rxjs/observable/of';
 import { TestDetailsModel } from './components/test-details-card/test-details-card.model';
 import { Subscription } from 'rxjs/Subscription';
+import { Observable } from 'rxjs/Observable';
 import { DateTime } from '../../shared/helpers/date-time';
 import { ExaminerDetailsModel } from './components/examiner-details-card/examiner-details-card.model';
 import { VehicleDetailsModel } from './components/vehicle-details-card/vehicle-details-card.model';
@@ -46,7 +47,7 @@ import { ViewTestResultViewDidEnter } from './view-test-result.actions';
   selector: 'page-view-test-result',
   templateUrl: 'view-test-result.html',
 })
-export class ViewTestResultPage extends BasePageComponent implements OnInit, OnDestroy {
+export class ViewTestResultPage extends BasePageComponent implements OnInit {
 
   applicationReference: string = '';
 
@@ -56,6 +57,7 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit, OnD
   loadingSpinner: Loading;
   subscription: Subscription;
   showErrorMessage: boolean = false;
+  testResult$ = new Observable<object | StandardCarTestCATBSchema>();
 
   constructor(
     public navController: NavController,
@@ -90,7 +92,7 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit, OnD
       ).subscribe();
   }
 
-  ngOnDestroy(): void {
+  ionViewDidLeave(): void {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }

--- a/src/pages/view-test-result/view-test-result.ts
+++ b/src/pages/view-test-result/view-test-result.ts
@@ -8,7 +8,6 @@ import { tap, catchError, map } from 'rxjs/operators';
 import { of } from 'rxjs/observable/of';
 import { TestDetailsModel } from './components/test-details-card/test-details-card.model';
 import { Subscription } from 'rxjs/Subscription';
-import { Observable } from 'rxjs/Observable';
 import { DateTime } from '../../shared/helpers/date-time';
 import { ExaminerDetailsModel } from './components/examiner-details-card/examiner-details-card.model';
 import { VehicleDetailsModel } from './components/vehicle-details-card/vehicle-details-card.model';
@@ -57,7 +56,6 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit {
   loadingSpinner: Loading;
   subscription: Subscription;
   showErrorMessage: boolean = false;
-  testResult$ = new Observable<object | StandardCarTestCATBSchema>();
 
   constructor(
     public navController: NavController,

--- a/src/shared/classes/practiceable-base-page.ts
+++ b/src/shared/classes/practiceable-base-page.ts
@@ -10,7 +10,7 @@ import { AuthenticationProvider } from '../../providers/authentication/authentic
 import { StoreModel } from '../models/store.model';
 import { getTests } from '../../modules/tests/tests.reducer';
 import { isPracticeMode, isTestReportPracticeTest, isEndToEndPracticeTest } from '../../modules/tests/tests.selector';
-import { OnInit, OnDestroy } from '@angular/core';
+import { OnInit } from '@angular/core';
 import { FakeJournalPage } from '../../pages/fake-journal/fake-journal';
 
 interface PracticeableBasePageState {
@@ -19,7 +19,7 @@ interface PracticeableBasePageState {
   isEndToEndPracticeMode$: Observable<boolean>;
 }
 
-export abstract class PracticeableBasePageComponent extends BasePageComponent implements OnInit, OnDestroy {
+export abstract class PracticeableBasePageComponent extends BasePageComponent implements OnInit {
 
   public isPracticeMode: boolean;
   public isTestReportPracticeMode: boolean;
@@ -65,10 +65,11 @@ export abstract class PracticeableBasePageComponent extends BasePageComponent im
       isTestReportPracticeMode$.pipe(map(value => this.isTestReportPracticeMode = value)),
       isEndToEndPracticeMode$.pipe(map(value => this.isEndToEndPracticeMode = value)),
     );
+
     this.practiceableBasePageSubscription = merged$.subscribe();
   }
 
-  ngOnDestroy(): void {
+  ionViewDidLeave(): void {
     if (this.practiceableBasePageSubscription) {
       this.practiceableBasePageSubscription.unsubscribe();
     }


### PR DESCRIPTION
## Description and relevant Jira numbers
Refactor subscribe and unsubscribe on observables to clean up on ionViewDidLeave and to subscribe on ionViewWillEnter. If ngOnInit is fired on each page request, the subscribe has been left as is.
[https://jira.i-env.net/browse/MES-2989](https://jira.i-env.net/browse/MES-2989)

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
