### PR TITLE
fix for preselecting email radio btn

### DIFF
--- a/src/pages/communication-page/communication.ts
+++ b/src/pages/communication-page/communication.ts
@@ -200,6 +200,8 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
       conductedLanguage$.pipe(map(value => this.conductedLanguage = value)),
     );
 
+    this.subscription = this.merged$.subscribe();
+
     if (this.shouldPreselectADefaultValue()) {
       this.initialiseDefaultSelections();
     }
@@ -210,7 +212,7 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
   }
 
   ionViewWillEnter(): boolean {
-    if (this.merged$) {
+    if (this.subscription.closed && this.merged$) {
       this.subscription = this.merged$.subscribe();
     }
 


### PR DESCRIPTION
## Description and relevant Jira numbers
subscribe was not triggered soon enough on the communications page. It is required for ngOnInit and also ionViewWillEnter as ngOnInit is not called again after it's initial load. Hence the check in ionViewWillEnter to ensure the subscription has not already been set.


## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
