### PR TITLE
MES-3063: Strip leading zeroes from staff number once JWT is obtained

### DIFF
--- a/src/providers/authentication/__tests__/authentication.spec.ts
+++ b/src/providers/authentication/__tests__/authentication.spec.ts
@@ -37,7 +37,7 @@ describe('Authentication', () => {
     testPersistenceProvider = TestBed.get(TestPersistenceProvider);
     authenticationProvider.initialiseAuthentication();
     authenticationProvider.jwtDecode = () => ({
-      'local-employeeIdKey': ['a'],
+      'local-employeeIdKey': ['12345678'],
     });
   }));
 
@@ -93,17 +93,27 @@ describe('Authentication', () => {
       await authenticationProvider.login();
 
       expect(authenticationProvider.isAuthenticated()).toEqual(true);
-      expect(authenticationProvider.getEmployeeId()).toEqual('a');
+      expect(authenticationProvider.getEmployeeId()).toEqual('12345678');
     });
 
     it('should set the correct employeeId when it is a string', async () => {
       authenticationProvider.jwtDecode = () => ({
-        'local-employeeIdKey': 'string',
+        'local-employeeIdKey': '12345678',
       });
       await authenticationProvider.login();
 
       expect(authenticationProvider.isAuthenticated()).toEqual(true);
-      expect(authenticationProvider.getEmployeeId()).toEqual('string');
+      expect(authenticationProvider.getEmployeeId()).toEqual('12345678');
+    });
+
+    it('should strip leading zeroes from the employeeId', async () => {
+      authenticationProvider.jwtDecode = () => ({
+        'local-employeeIdKey': '00123456',
+      });
+      await authenticationProvider.login();
+
+      expect(authenticationProvider.isAuthenticated()).toEqual(true);
+      expect(authenticationProvider.getEmployeeId()).toEqual('123456');
     });
 
     describe('logout', () => {

--- a/src/providers/authentication/authentication.ts
+++ b/src/providers/authentication/authentication.ts
@@ -27,7 +27,7 @@ export class AuthenticationProvider {
   ) {
   }
 
-  public initialiseAuthentication = ():void => {
+  public initialiseAuthentication = (): void => {
     this.authenticationSettings = this.appConfig.getAppConfig().authentication;
     this.employeeIdKey = this.appConfig.getAppConfig().authentication.employeeIdKey;
     this.jwtDecode = jwtDecode;
@@ -144,7 +144,9 @@ export class AuthenticationProvider {
   private successfulLogin = (authResponse: AuthenticationResult) => {
     const decodedToken = this.jwtDecode(authResponse.accessToken);
     const employeeId = decodedToken[this.employeeIdKey];
-    this.employeeId = Array.isArray(employeeId) ? employeeId[0] : employeeId;
+    const employeeIdClaim = Array.isArray(employeeId) ? employeeId[0] : employeeId;
+    const numericEmployeeId = Number.parseInt(employeeIdClaim, 10);
+    this.employeeId = numericEmployeeId.toString();
 
     this.isUserAuthenticated = true;
   }


### PR DESCRIPTION
## Description and relevant Jira numbers
* Ensure that any callers to `getEmployeeId` in the `AuthenticationProvider` receive the staff number with leading zeroes stripped.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
