### PR TITLE
MES-2388 make route number field two digits

### DIFF
--- a/src/pages/office/components/route-number/__tests__/route-number.spec.ts
+++ b/src/pages/office/components/route-number/__tests__/route-number.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { RouteNumberComponent } from '../route-number';
+import { IonicModule } from 'ionic-angular';
+import { AppModule } from '../../../../../app/app.module';
+import { OutcomeBehaviourMapProvider } from '../../../../../providers/outcome-behaviour-map/outcome-behaviour-map';
+import { behaviourMap } from '../../../../../pages/office/office-behaviour-map';
+
+describe('RouteNumberComponent', () => {
+  let fixture: ComponentFixture<RouteNumberComponent>;
+  let component: RouteNumberComponent;
+  let behaviourMapProvider: OutcomeBehaviourMapProvider;
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        RouteNumberComponent,
+      ],
+      imports: [
+        IonicModule,
+        AppModule,
+      ],
+      providers: [
+        { provide: OutcomeBehaviourMapProvider, useClass: OutcomeBehaviourMapProvider },
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(RouteNumberComponent);
+        behaviourMapProvider = TestBed.get(OutcomeBehaviourMapProvider);
+        behaviourMapProvider.setBehaviourMap(behaviourMap);
+        component = fixture.componentInstance;
+      });
+  }));
+
+  describe('class', () => {
+    it('should emit route number if 1 character', () => {
+      spyOn(component.routeNumberChange, 'emit');
+      const routeNumber = '7';
+      component.routeNumberChanged(routeNumber);
+      expect(component.routeNumberChange.emit).toHaveBeenCalledWith(Number.parseInt(routeNumber, 10));
+    });
+
+    it('should emit route number if 2 characters', () => {
+      spyOn(component.routeNumberChange, 'emit');
+      const routeNumber = '44';
+      component.routeNumberChanged(routeNumber);
+      expect(component.routeNumberChange.emit).toHaveBeenCalledWith(Number.parseInt(routeNumber, 10));
+    });
+
+    it('should emit no route number if not numeric', () => {
+      spyOn(component.routeNumberChange, 'emit');
+      const routeNumber = 'ABC123';
+      component.routeNumberChanged(routeNumber);
+      expect(component.routeNumberChange.emit).toHaveBeenCalledWith(null);
+    });
+  });
+});

--- a/src/pages/office/components/route-number/route-number.html
+++ b/src/pages/office/components/route-number/route-number.html
@@ -6,8 +6,8 @@
   <ion-col align-self-center>
     <ion-row class="spacing-row"></ion-row>
     <ion-row>
-      <ion-col col-32>
-        <input type="text" id="route" class="vehicle-reg-input mes-data" numberonly formControlName="routeNumber"
+      <ion-col col-12>
+        <input type="number" id="route" class="vehicle-reg-input mes-data" numbersOnly formControlName="routeNumber"
           (change)="routeNumberChanged($event.target.value)">
       </ion-col>
     </ion-row>

--- a/src/pages/office/components/route-number/route-number.html
+++ b/src/pages/office/components/route-number/route-number.html
@@ -7,13 +7,13 @@
     <ion-row class="spacing-row"></ion-row>
     <ion-row>
       <ion-col col-12>
-        <input type="number" id="route" class="vehicle-reg-input mes-data" numbersOnly formControlName="routeNumber"
-          (change)="routeNumberChanged($event.target.value)">
+        <input type="number" id="route" class="vehicle-reg-input mes-data" numbersOnly inputmode="numeric" pattern="[0-9]*"
+        formControlName="routeNumber" (change)="routeNumberChanged($event.target.value)">
       </ion-col>
     </ion-row>
     <ion-row class="validation-message-row" align-items-center>
       <div class="validation-text" [class.ng-invalid]="invalid" id="office-route-number-validation-text">
-        Enter the route number
+        Enter the route number (max 2 digits)
       </div>
     </ion-row>
   </ion-col>

--- a/src/pages/office/components/route-number/route-number.html
+++ b/src/pages/office/components/route-number/route-number.html
@@ -7,7 +7,7 @@
     <ion-row class="spacing-row"></ion-row>
     <ion-row>
       <ion-col col-12>
-        <input type="number" id="route" class="vehicle-reg-input mes-data" numbersOnly inputmode="numeric" pattern="[0-9]*"
+        <input type="number" id="route" class="vehicle-reg-input mes-data" numbersOnly
         formControlName="routeNumber" (change)="routeNumberChanged($event.target.value)">
       </ion-col>
     </ion-row>

--- a/src/pages/office/components/route-number/route-number.ts
+++ b/src/pages/office/components/route-number/route-number.ts
@@ -4,7 +4,6 @@ import {
   OutcomeBehaviourMapProvider,
   VisibilityType,
 } from '../../../../providers/outcome-behaviour-map/outcome-behaviour-map';
-import { StringType } from '../../../../shared/helpers/string-type';
 
 @Component({
   selector: 'route-number',
@@ -51,11 +50,7 @@ export class RouteNumberComponent implements OnChanges {
   }
 
   routeNumberChanged(routeNumber: string): void {
-    if (this.formControl.valid) {
-      if (StringType.isNumeric(routeNumber)) {
-        this.routeNumberChange.emit(Number.parseInt(routeNumber, 10));
-      }
-    }
+    this.routeNumberChange.emit(Number.parseInt(routeNumber, 10) || null);
   }
 
   get invalid(): boolean {

--- a/src/pages/office/components/route-number/route-number.ts
+++ b/src/pages/office/components/route-number/route-number.ts
@@ -44,7 +44,8 @@ export class RouteNumberComponent implements OnChanges {
     if (visibilityType === VisibilityType.NotVisible) {
       this.formGroup.get(RouteNumberComponent.fieldName).clearValidators();
     } else {
-      this.formGroup.get(RouteNumberComponent.fieldName).setValidators([Validators.required]);
+      this.formGroup.get(RouteNumberComponent.fieldName).setValidators([
+        Validators.required, Validators.min(1), Validators.max(99), Validators.pattern(/^[0-9]*$/)]);
     }
     this.formControl.patchValue(this.routeNumber);
   }

--- a/src/pages/office/office.module.ts
+++ b/src/pages/office/office.module.ts
@@ -7,10 +7,12 @@ import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import { ComponentsModule } from '../../components/components.module';
 import { OfficeComponentsModule } from './components/office.components.module';
 import { OfficeEffects } from './office.effects';
+import { InputRestrictionNumbersDirective } from '../../directives/input-restriction-numbers.directive';
 
 @NgModule({
   declarations: [
     OfficePage,
+    InputRestrictionNumbersDirective,
   ],
   imports: [
     IonicPageModule.forChild(OfficePage),

--- a/src/pages/office/office.scss
+++ b/src/pages/office/office.scss
@@ -16,6 +16,9 @@ page-office {
         ion-select{
           width: 452px;
         }
+        input.vehicle-reg-input {
+          width: 66px;
+        }
         .mes-full-width-card {
           height: 120px;
           #continue-to-test-report {


### PR DESCRIPTION
## Description and relevant Jira numbers
- Shortened the route number field to match the maximum length of 2 digits
- Restricted the input to only allow numbers
- Added validation to ensure field is a number between 1 and 99, but whilst also allowing a blank value to be saved when pressing "Save and continue later"

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

![IMG_0011](https://user-images.githubusercontent.com/8069071/62143314-b4adf680-b2e7-11e9-8cc0-c887c4b40b27.PNG)

![IMG_0012](https://user-images.githubusercontent.com/8069071/62143320-b7105080-b2e7-11e9-89b1-0ccd0d73d3bc.PNG)
