### PR TITLE
BUGFIX - Nest error message container styling

### DIFF
--- a/src/components/error-message/error-message.scss
+++ b/src/components/error-message/error-message.scss
@@ -1,25 +1,27 @@
-.container {
-  margin: 0px auto;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+error-message {
+  .container {
+    margin: 0px auto;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
 
-  & div {
-    text-align: center;
+    & div {
+      text-align: center;
+    }
   }
-}
 
-.link {
-  text-decoration: underline;
-  color: map-get($colors-gds, 'gds-blue');
-}
+  .link {
+    text-decoration: underline;
+    color: map-get($colors-gds, 'gds-blue');
+  }
 
-.error-details-link,
-.error-details {
-  display: inline-block;
-  font-size: 14px;
-  padding-top: 5px;
+  .error-details-link,
+  .error-details {
+    display: inline-block;
+    font-size: 14px;
+    padding-top: 5px;
+  }
 }


### PR DESCRIPTION
Fix a bug introduced in [PR 613](https://github.com/dvsa/mes-mobile-app/pull/613) that caused various UI problems because the styling for error message `.container` was not nested underneath the error message component.