### PR TITLE
Devtools disable in prod fix

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -46,7 +46,7 @@ export function createTranslateLoader(http: Http) {
   return new TranslateStaticLoader(http, 'assets/i18n', '.json');
 }
 
-const enableDevTools = (environment && environment.enableDevTools) === true;
+const enableDevTools = (environment && environment.enableDevTools);
 
 @NgModule({
   declarations: [App],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -46,7 +46,7 @@ export function createTranslateLoader(http: Http) {
   return new TranslateStaticLoader(http, 'assets/i18n', '.json');
 }
 
-const enableDevTools = (environment && environment.enableDevTools);
+const enableDevTools = environment && environment.enableDevTools;
 
 @NgModule({
   declarations: [App],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -46,7 +46,7 @@ export function createTranslateLoader(http: Http) {
   return new TranslateStaticLoader(http, 'assets/i18n', '.json');
 }
 
-const enableDevTools = environment.enableDevTools;
+const enableDevTools = (environment && environment.enableDevTools) === true;
 
 @NgModule({
   declarations: [App],


### PR DESCRIPTION
## Description and relevant Jira numbers

In prod, environment will be undefined. Default `enableDevTools` to `false` in this case.