### PR TITLE
MES-1827 display personal commitments

### DIFF
--- a/mock/generate-local-journal.ts
+++ b/mock/generate-local-journal.ts
@@ -16,6 +16,7 @@ const localJournal: ExaminerWorkSchedule = {
     individualId: 9000000,
   },
   nonTestActivities: [],
+  personalCommitments: [],
   testSlots: [
     {
       booking: {

--- a/src/pages/journal/components/journal-components.module.ts
+++ b/src/pages/journal/components/journal-components.module.ts
@@ -10,6 +10,7 @@ import { PracticeEndToEndCardComponent } from './practice-end-to-end-card/practi
 import { TestResultsSearchCardComponent } from './test-results-search-card/test-results-search-card';
 import { RekeySearchCardComponent } from './rekey-search-card/rekey-search-card';
 import { TestSlotComponentsModule } from '../../../components/test-slot/test-slot-components.module';
+import { PersonalCommitmentSlotComponent } from '../personal-commitment/personal-commitment';
 
 @NgModule({
   declarations: [
@@ -20,12 +21,16 @@ import { TestSlotComponentsModule } from '../../../components/test-slot/test-slo
     PracticeEndToEndCardComponent,
     TestResultsSearchCardComponent,
     RekeySearchCardComponent,
+    PersonalCommitmentSlotComponent,
   ],
   imports: [
     CommonModule,
     IonicModule,
     PracticeTestModalModule,
     TestSlotComponentsModule,
+  ],
+  entryComponents: [
+    PersonalCommitmentSlotComponent,
   ],
   exports: [
     ActivitySlotComponent,
@@ -35,6 +40,7 @@ import { TestSlotComponentsModule } from '../../../components/test-slot/test-slo
     PracticeEndToEndCardComponent,
     TestResultsSearchCardComponent,
     RekeySearchCardComponent,
+    PersonalCommitmentSlotComponent,
   ],
 })
 export class JournalComponentsModule { }

--- a/src/pages/journal/journal.ts
+++ b/src/pages/journal/journal.ts
@@ -31,6 +31,7 @@ import { IncompleteTestsProvider } from '../../providers/incomplete-tests/incomp
 import { ERROR_PAGE } from '../page-names.constants';
 import { App } from './../../app/app.component';
 import { ErrorTypes } from '../../shared/models/error-message';
+import { PersonalCommitmentSlotComponent } from './personal-commitment/personal-commitment';
 
 interface JournalPageState {
   selectedDate$: Observable<string>;
@@ -216,6 +217,10 @@ export class JournalPage extends BasePageComponent implements OnInit {
       (<SlotComponent>componentRef.instance).hasSlotChanged = slot.hasSlotChanged;
       (<SlotComponent>componentRef.instance).showLocation = (slot.slotData.testCentre.centreName !== lastLocation);
       lastLocation = slot.slotData.testCentre.centreName;
+
+      // if this is a personal commitment assign it to the component
+      (<PersonalCommitmentSlotComponent>componentRef.instance).personalCommitments =
+        slot.personalCommitment;
     }
   }
 

--- a/src/pages/journal/personal-commitment/personal-commitment.html
+++ b/src/pages/journal/personal-commitment/personal-commitment.html
@@ -1,0 +1,16 @@
+<ion-card class="personal-commitment personal-commitment-card">
+  <ion-row class="slot-row" *ngFor="let commitment of personalCommitments; let i = index;" align-items-center nowrap>
+    <ion-col class="time-column">
+      <div>
+        <time [time]="transformSlotTime(commitment, i)" [testComplete]="false">
+        </time>
+      </div>
+    </ion-col>
+    <ion-col class="title-column">
+      <h3 class="title">{{ commitment.activityDescription }}</h3>
+    </ion-col>
+    <ion-col class="activity-code-column ">
+      <h2 float-right class="activity-code">{{ formatActivityCode(commitment.activityCode) }}</h2>
+    </ion-col>
+  </ion-row>
+</ion-card>

--- a/src/pages/journal/personal-commitment/personal-commitment.scss
+++ b/src/pages/journal/personal-commitment/personal-commitment.scss
@@ -1,0 +1,39 @@
+personal-commitment {
+  ion-card {
+      border: 1px solid map-get($colors-gds, 'gds-grey-2');
+
+    .slot-row {
+        padding: 0.5em 0;
+        height: 50px;
+        background: map-get($colors-gds, 'gds-grey-5');
+        min-height: 108px;
+        position: relative;
+      }
+       &.test-slot-portrait-mode {
+         min-height: 108px;
+       }
+       .inflate-row {
+         min-height: 108px;
+         border-top: none;
+         border-bottom: none;
+       }
+  }
+  .time-column {
+    max-width: 192px;
+    padding-left: 55px;
+  }
+
+  .title-column {
+    display: flex;
+    justify-content: center;
+  }
+
+  .activity-code-column {
+    max-width: 192px;
+    padding-right: 55px;
+
+    .activity-code {
+      float: right;
+    }
+  }
+}

--- a/src/pages/journal/personal-commitment/personal-commitment.spec.ts
+++ b/src/pages/journal/personal-commitment/personal-commitment.spec.ts
@@ -1,0 +1,57 @@
+import { PersonalCommitmentSlotComponent } from './personal-commitment';
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { PersonalCommitment } from '@dvsa/mes-journal-schema';
+import { AppConfigProvider } from '../../../providers/app-config/app-config';
+import { AppConfigProviderMock } from '../../../providers/app-config/__mocks__/app-config.mock';
+import { Config, IonicModule } from 'ionic-angular';
+import { ConfigMock } from 'ionic-mocks';
+import { MockComponent } from 'ng-mocks';
+import { TimeComponent } from '../../../components/test-slot/time/time';
+import { LocationComponent } from '../../../components/test-slot/location/location';
+
+describe('PersonalCommitmentSlotComponent', () => {
+  let fixture: ComponentFixture<PersonalCommitmentSlotComponent>;
+  let component: PersonalCommitmentSlotComponent;
+  const mockCommitment: PersonalCommitment = {
+    commitmentId: 12345,
+    slotId: 1001,
+    startDate: null,
+    startTime: null,
+    endDate: null,
+    endTime: null,
+    activityCode: '091',
+    activityDescription: 'Annual Leave',
+  };
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        PersonalCommitmentSlotComponent,
+        MockComponent(TimeComponent),
+        MockComponent(LocationComponent),
+      ],
+      providers: [
+        { provide: AppConfigProvider, useClass: AppConfigProviderMock },
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+      ],
+      imports: [IonicModule],
+    }).compileComponents().then(() => {
+      fixture = TestBed.createComponent(PersonalCommitmentSlotComponent);
+      component = fixture.componentInstance;
+    });
+  }));
+
+  describe('Class', () => {
+    describe('formatActivityCode', () => {
+      it('should strip leading zeros from activityCode', () => {
+        const activityCodeWithZeroRemoved = '91';
+        expect(component.formatActivityCode(mockCommitment.activityCode)).toBe(activityCodeWithZeroRemoved);
+      });
+      it('should return 0 if activityCode is null', () => {
+        const zeroActivityCode = '0';
+        const nullActivityCode = null;
+        expect(component.formatActivityCode(nullActivityCode)).toBe(zeroActivityCode);
+      });
+    });
+  });
+});

--- a/src/pages/journal/personal-commitment/personal-commitment.ts
+++ b/src/pages/journal/personal-commitment/personal-commitment.ts
@@ -1,0 +1,35 @@
+import { Component, Input } from '@angular/core';
+import { isNil } from 'lodash';
+import { SlotItem } from '../../../providers/slot-selector/slot-item';
+import { PersonalCommitment } from '@dvsa/mes-journal-schema';
+import { SlotComponent } from '../../../components/test-slot/slot/slot';
+
+@Component({
+  selector: 'personal-commitment',
+  templateUrl: 'personal-commitment.html',
+})
+export class PersonalCommitmentSlotComponent implements SlotComponent {
+  @Input()
+  slot: SlotItem;
+
+  @Input()
+  hasSlotChanged: boolean;
+
+  @Input()
+  showLocation: boolean;
+
+  @Input()
+  personalCommitments: PersonalCommitment[];
+
+  formatActivityCode(activityCode: any): string {
+    if (isNil(activityCode)) {
+      return '0';
+    }
+    // Remove leading zeros (e.g. 089 -> 89)
+    return activityCode.toString().replace(/^0+(?!$)/, '');
+  }
+
+  transformSlotTime(commitment: PersonalCommitment, index: number) {
+    return index === 0 ? `${commitment.startDate}T${commitment.startTime}` : null;
+  }
+}

--- a/src/providers/slot-selector/slot-item.ts
+++ b/src/providers/slot-selector/slot-item.ts
@@ -1,6 +1,6 @@
 import { Type } from '@angular/core';
+import { TestSlot, NonTestActivity, PersonalCommitment } from '@dvsa/mes-journal-schema';
 import { SlotComponent } from '../../components/test-slot/slot/slot';
-import { TestSlot, NonTestActivity } from '@dvsa/mes-journal-schema';
 
 export class SlotItem {
   constructor(
@@ -8,5 +8,6 @@ export class SlotItem {
     public hasSlotChanged: boolean,
     public component?: Type<SlotComponent>,
     public activityCode?: string,
+    public personalCommitment?: PersonalCommitment[],
   ) { }
 }

--- a/src/providers/slot-selector/slot-selector.ts
+++ b/src/providers/slot-selector/slot-selector.ts
@@ -6,6 +6,8 @@ import { ActivitySlotComponent } from '../../pages/journal/components/activity-s
 import { EmptySlotComponent } from '../../pages/journal/components/empty-slot/empty-slot';
 import { has, isEmpty, forOwn, isNil, isObject } from 'lodash';
 import { TestSlot } from '@dvsa/mes-journal-schema';
+import { PersonalCommitmentSlotComponent } from '../../pages/journal/personal-commitment/personal-commitment';
+
 @Injectable()
 export class SlotSelectorProvider {
 
@@ -63,7 +65,11 @@ export class SlotSelectorProvider {
   public isTestSlot = (slot: Slot) => has(slot, 'vehicleTypeCode');
 
   private resolveComponentName = (slot: SlotItem) => {
-    const { slotData } = slot;
+    const { slotData, personalCommitment } = slot;
+
+    if (!isEmpty(personalCommitment)) {
+      return PersonalCommitmentSlotComponent;
+    }
 
     if (has(slotData, 'activityCode')) {
       return ActivitySlotComponent;

--- a/src/providers/slot/__tests__/slot.spec.ts
+++ b/src/providers/slot/__tests__/slot.spec.ts
@@ -183,6 +183,7 @@ describe('SlotProvider', () => {
       },
       testSlots: cloneDeep(oldSlots['2019-01-21'].map(slot => slot.slotData)),
       nonTestActivities: cloneDeep(oldNonTestActivities),
+      personalCommitments: [],
     };
 
     describe('when there are no slots in the new journal', () => {

--- a/src/providers/slot/slot.ts
+++ b/src/providers/slot/slot.ts
@@ -44,7 +44,12 @@ export class SlotProvider {
         }
       }
 
-      return new SlotItem(newSlot, differenceFound);
+      const personalCommitment =
+        newJournal.personalCommitments.filter(commitment => commitment.slotId === newSlot.slotDetail.slotId);
+
+      // add personalCommitment information to SlotItem, component and activityCode set to null
+      // as they are not constructed at this stage.
+      return new SlotItem(newSlot, differenceFound, null, null, personalCommitment);
     });
   }
 


### PR DESCRIPTION
## Description and relevant Jira numbers
- Creating `PersonalCommitment` component to display DE personal commitments on the journal

<img width="546" alt="Screenshot 2019-08-12 at 15 45 00" src="https://user-images.githubusercontent.com/30832405/62874000-5554db00-bd18-11e9-8c01-34f3a939803a.png">
<img width="546" alt="Screenshot 2019-08-12 at 15 45 08" src="https://user-images.githubusercontent.com/30832405/62874006-5980f880-bd18-11e9-944f-b0c5d0f48c43.png">

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
