### PR TITLE
MES-2566: Fixed size and position of slot time on candidate details page

### DIFF
--- a/src/pages/candidate-details/candidate-details.html
+++ b/src/pages/candidate-details/candidate-details.html
@@ -10,12 +10,20 @@
 </ion-header>
 
 <ion-content padding>
-  <h2>
-    {{ pageState.name$ | async }}
-    <span class="test-start-time">
-      {{ pageState.time$ | async | date: "HH:mm" }}
-    </span>
-  </h2>
+  <ion-grid>
+    <ion-row>
+      <ion-col>
+        <h2>
+          {{ pageState.name$ | async }}
+        </h2>
+      </ion-col>
+      <ion-col col-12>
+        <h2 class="test-start-time">
+          {{ pageState.time$ | async | date: "HH:mm" }}
+        </h2>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
 
   <ion-card>
     <ion-card-header>

--- a/src/pages/fake-candidate-details/fake-candidate-details.html
+++ b/src/pages/fake-candidate-details/fake-candidate-details.html
@@ -10,12 +10,20 @@
   </ion-header>
 
   <ion-content padding>
-    <h2>
-      {{ name }}
-      <span class="test-start-time">
-        {{ time | date: "HH:mm" }}
-      </span>
-    </h2>
+    <ion-grid>
+      <ion-row>
+        <ion-col>
+          <h2>
+           {{ name }}
+          </h2>
+        </ion-col>
+        <ion-col col-12>
+          <h2 class="test-start-time">
+            {{ time | date: "HH:mm" }}
+          </h2>
+        </ion-col>
+      </ion-row>
+    </ion-grid>
 
     <ion-card>
       <ion-card-header>


### PR DESCRIPTION
## Description and relevant Jira numbers
![IMG_EDF77A47C0C5-1](https://user-images.githubusercontent.com/41190821/62478225-7bbbc900-b7a2-11e9-93ff-21ce49f8dc98.jpeg)
An Ionic grid element has been added to contain the name and time heading of the candidate details page. They now display in line with each other and are the same size.

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
