### PR TITLE
MES-3102 - Saving shortName as the tellMeQuestion description

### DIFF
--- a/src/modules/tests/test-data/__tests__/test-data.reducer.spec.ts
+++ b/src/modules/tests/test-data/__tests__/test-data.reducer.spec.ts
@@ -533,7 +533,7 @@ describe('TestDataReducer reducer', () => {
       };
       const result = testDataReducer(oldState, new TellMeQuestionSelected(newQuestionPayload));
       expect(result.vehicleChecks.tellMeQuestion.code).toBe('T1');
-      expect(result.vehicleChecks.tellMeQuestion.description).toBe('desc');
+      expect(result.vehicleChecks.tellMeQuestion.description).toBe('name');
       expect(result.vehicleChecks.tellMeQuestion.outcome).toBeUndefined();
     });
 

--- a/src/modules/tests/test-data/__tests__/test-data.reducer.spec.ts
+++ b/src/modules/tests/test-data/__tests__/test-data.reducer.spec.ts
@@ -556,7 +556,7 @@ describe('TestDataReducer reducer', () => {
 
       const result = testDataReducer({}, new ShowMeQuestionSelected(newQuestionPayload));
       expect(result.vehicleChecks.showMeQuestion.code).toBe('S1');
-      expect(result.vehicleChecks.showMeQuestion.description).toBe('desc');
+      expect(result.vehicleChecks.showMeQuestion.description).toBe('name');
     });
 
     it('should update the show me question details', () => {
@@ -577,7 +577,7 @@ describe('TestDataReducer reducer', () => {
 
       const result = testDataReducer(oldState, new ShowMeQuestionSelected(newQuestionPayload));
       expect(result.vehicleChecks.showMeQuestion.code).toBe('S1');
-      expect(result.vehicleChecks.showMeQuestion.description).toBe('desc');
+      expect(result.vehicleChecks.showMeQuestion.description).toBe('name');
     });
   });
 

--- a/src/modules/tests/test-data/test-data.reducer.ts
+++ b/src/modules/tests/test-data/test-data.reducer.ts
@@ -338,7 +338,7 @@ export function testDataReducer(
           ...state.vehicleChecks,
           showMeQuestion: {
             code: action.showMeQuestion.code as string,
-            description: action.showMeQuestion.description as string,
+            description: action.showMeQuestion.shortName as string,
           },
         },
       };

--- a/src/modules/tests/test-data/test-data.reducer.ts
+++ b/src/modules/tests/test-data/test-data.reducer.ts
@@ -297,7 +297,7 @@ export function testDataReducer(
           ...state.vehicleChecks,
           tellMeQuestion: {
             code: action.tellMeQuestion.code as string,
-            description: action.tellMeQuestion.description as string,
+            description: action.tellMeQuestion.shortName as string,
           },
         },
       };


### PR DESCRIPTION
> ## Description and relevant Jira numbers

- RSIS was complaining that the `tellMeQuestion.description` within the test submission was over 100 characters, so the description is now set as the `tellMeQuestion.shortName` 
https://jira.dvsacloud.uk/browse/MES-3102

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
