### PR TITLE
MES-2364 - prevent ion-select modals being closed on background tap

### DIFF
--- a/src/pages/office/components/activity-code/activity-code.html
+++ b/src/pages/office/components/activity-code/activity-code.html
@@ -7,7 +7,7 @@
       <ion-row class="spacing-row"></ion-row>
       <ion-row>
         <ion-select id="activity-code-selector" placeholder="Select an activity code" okText="Submit" cancelText="Cancel"
-          formControlName="activityCode" (ionChange)="activityCodeChanged($event)" [selectOptions]="{cssClass:'mes-select activity-code-select'}" [disabled]="isSelectDisabled()">
+          formControlName="activityCode" (ionChange)="activityCodeChanged($event)" [selectOptions]="{cssClass:'mes-select activity-code-select', enableBackdropDismiss:false}" [disabled]="isSelectDisabled()">
           <ion-option [value]="activityCode" [disabled]="isOptionDisabled(activityCode.activityCode)" *ngFor="let activityCode of activityCodeOptions">
             {{activityCode.activityCode}} - {{activityCode.description}}
           </ion-option>

--- a/src/pages/office/components/show-me-question/show-me-question.html
+++ b/src/pages/office/components/show-me-question/show-me-question.html
@@ -8,7 +8,7 @@
     <ion-row>
       <ion-select id="show-me-selector" placeholder="Select a question" okText="Submit" cancelText="Cancel"
         formControlName="showMeQuestion" (ionChange)="showMeQuestionChanged($event)"
-        [selectOptions]="{cssClass:'mes-select'}">
+        [selectOptions]="{cssClass:'mes-select', enableBackdropDismiss:false}">
         <ion-option [value]="showMeQuestion" *ngFor="let showMeQuestion of showMeQuestionOptions">
           {{showMeQuestion.code}} - {{showMeQuestion.shortName}}
         </ion-option>

--- a/src/pages/office/components/weather-conditions/weather-conditions.html
+++ b/src/pages/office/components/weather-conditions/weather-conditions.html
@@ -9,7 +9,7 @@
     <ion-row>
       <ion-select value="weather" multiple="true" okText="Submit" cancelText="Cancel"
         placeholder="Select weather conditions" formControlName="weatherConditions" [class.ng-invalid]="invalid"
-        (ionChange)="weatherConditionsChanged($event)" [selectOptions]="{cssClass:'mes-select'}">
+        (ionChange)="weatherConditionsChanged($event)" [selectOptions]="{cssClass:'mes-select', enableBackdropDismiss:false}">
         <ion-option [value]="weatherCondition.weatherConditionDescription"
           *ngFor="let weatherCondition of weatherConditionsOptions">
           {{weatherCondition.weatherConditionNumber}} - {{weatherCondition.weatherConditionDescription}}

--- a/src/pages/waiting-room-to-car/components/tell-me-question/tell-me-question.html
+++ b/src/pages/waiting-room-to-car/components/tell-me-question/tell-me-question.html
@@ -2,7 +2,7 @@
         <ion-col col-58>
           <ion-select value="tellMeQuestion" id="tell-me-selector" okText="Submit" cancelText="Cancel"
           placeholder="Select a question" (ionChange)="tellMeQuestionChanged($event)"
-            formControlName="tellMeQuestion" [selectOptions]="{cssClass:'mes-select'}">
+            formControlName="tellMeQuestion" [selectOptions]="{cssClass:'mes-select', enableBackdropDismiss:false}">
             <ion-option  
                 *ngFor="let currentTellMeQuestion of tellMeQuestions"
                 [value]="currentTellMeQuestion">


### PR DESCRIPTION
## Description and relevant Jira numbers
Super simple change to prevent ion-select modals from being closed by tapping on the modal background.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
