### PR TITLE
Rectifying Imported Code from develop on R2 branch

### DIFF
--- a/src/pages/pass-finalisation/pass-finalisation.ts
+++ b/src/pages/pass-finalisation/pass-finalisation.ts
@@ -45,12 +45,6 @@ import { GearboxCategory } from '@dvsa/mes-test-schema/categories/B';
 import { GearboxCategoryChanged } from '../../modules/tests/vehicle-details/vehicle-details.actions';
 import { HEALTH_DECLARATION_PAGE } from '../page-names.constants';
 import {
-  D255Yes,
-  D255No,
-  DebriefWitnessed,
-  DebriefUnwitnessed,
-} from '../../modules/tests/test-summary/test-summary.actions';
-import {
   CandidateChoseToProceedWithTestInWelsh,
   CandidateChoseToProceedWithTestInEnglish,
 } from '../../modules/tests/communication-preferences/communication-preferences.actions';
@@ -237,14 +231,6 @@ export class PassFinalisationPage extends PracticeableBasePageComponent {
     const subscription = changeStream$
       .subscribe((newVal: string) => this.store$.dispatch(new actionType(newVal)));
     return subscription;
-  }
-
-  d255Changed(d255: boolean): void {
-    this.store$.dispatch(d255 ? new D255Yes() : new D255No());
-  }
-
-  debriefWitnessedChanged(debriefWitnessed: boolean) {
-    this.store$.dispatch(debriefWitnessed ? new DebriefWitnessed() : new DebriefUnwitnessed());
   }
 
   isWelshChanged(isWelsh: boolean) {


### PR DESCRIPTION
## Description and relevant Jira numbers

- Removed d255 and debreifWitnessed imports and functions from passFinalisationPage that had sneaked into the cherry-pick merge conflicts on release-2.0 

cherry-pick branch - https://github.com/dvsa/mes-mobile-app/pull/669
original branch - https://github.com/dvsa/mes-mobile-app/pull/666