### PR TITLE
MES-2202 - Populate new examiner fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -548,9 +548,9 @@
       "dev": true
     },
     "@dvsa/mes-test-schema": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-1.0.33.tgz",
-      "integrity": "sha512-SgQ9xlhm2WIMJxMHP2wuoewDHwxuMtiRfYoNCAY5AzqxbpHHwMx3pedui5sKD5T0fHYFMdMO4zNUSgQEe97Q4A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-2.0.1.tgz",
+      "integrity": "sha512-3FOCE6pfE5Mh3+kFlqBC1u25+xCuqPotyiLMnOq/bRAaq0X9+OIdLJVENHy1GYkI9g1ECqi8/gcnhTq6FjhcSw==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@angular/compiler-cli": "^5.2.11",
     "@dvsa/mes-journal-schema": "1.1.0",
     "@dvsa/mes-search-schema": "1.0.3",
-    "@dvsa/mes-test-schema": "1.0.33",
+    "@dvsa/mes-test-schema": "2.0.1",
     "@hapi/joi": "^15.1.0",
     "@ionic-native-mocks/device": "^2.0.12",
     "@ionic-native-mocks/secure-storage": "^2.0.12",

--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -77,6 +77,10 @@ describe('testsReducer', () => {
           journalData: null,
           activityCode: null,
           rekey: false,
+          changeMarker: false,
+          examinerBooked: 1,
+          examinerConducted: 1,
+          examinerKeyed: 1,
         },
         [testReportPracticeSlotId]: {
           testData: {
@@ -103,6 +107,10 @@ describe('testsReducer', () => {
           journalData: null,
           activityCode: null,
           rekey: false,
+          changeMarker: false,
+          examinerBooked: 1,
+          examinerConducted: 1,
+          examinerKeyed: 1,
         },
       },
       testStatus: {},

--- a/src/modules/tests/__tests__/tests.selector.spec.ts
+++ b/src/modules/tests/__tests__/tests.selector.spec.ts
@@ -52,6 +52,10 @@ describe('testsSelector', () => {
         },
         activityCode: ActivityCodes.PASS,
         rekey: false,
+        changeMarker: false,
+        examinerBooked: 1,
+        examinerConducted: 1,
+        examinerKeyed: 1,
       };
       const journal: JournalModel = {
         isLoading: false,
@@ -125,6 +129,10 @@ describe('testsSelector', () => {
         },
       },
       rekey: false,
+      changeMarker: false,
+      examinerBooked: 1,
+      examinerConducted: 1,
+      examinerKeyed: 1,
     };
     it('should retrieve a passed result for a pass activity code', () => {
       const result = getTestOutcomeText(testState);
@@ -166,6 +174,10 @@ describe('testsSelector', () => {
         },
       },
       rekey: false,
+      changeMarker: false,
+      examinerBooked: 1,
+      examinerConducted: 1,
+      examinerKeyed: 1,
     };
     it('should return true for a passed activity code', () => {
       const result = isPassed(testState);
@@ -207,6 +219,10 @@ describe('testsSelector', () => {
         },
       },
       rekey: false,
+      changeMarker: false,
+      examinerBooked: 1,
+      examinerConducted: 1,
+      examinerKeyed: 1,
     };
     it('should return the DVSA_RADIO_FAILURE ActivityCode', () => {
       const activityCode = getActivityCode(testState);
@@ -275,6 +291,10 @@ describe('testsSelector', () => {
             activityCode: ActivityCodes.ACCIDENT,
             journalData: null,
             rekey: false,
+            changeMarker: false,
+            examinerBooked: 1,
+            examinerConducted: 1,
+            examinerKeyed: 1,
           },
         },
         testStatus: {},

--- a/src/modules/tests/change-marker/__tests__/change-marker.reducer.spec.ts
+++ b/src/modules/tests/change-marker/__tests__/change-marker.reducer.spec.ts
@@ -2,10 +2,6 @@ import { changeMarkerReducer } from '../change-marker';
 import { SetChangeMarker } from '../change-marker.actions';
 
 describe('changeMarkerReducer', () => {
-  it('should default to false ', () => {
-    const result = changeMarkerReducer(null, null);
-    expect(result).toBe(false);
-  });
   it('should return the correct value ', () => {
     const result = changeMarkerReducer(null, new SetChangeMarker(true));
     expect(result).toBe(true);

--- a/src/modules/tests/change-marker/__tests__/examiner-keyed.reducer.spec.ts
+++ b/src/modules/tests/change-marker/__tests__/examiner-keyed.reducer.spec.ts
@@ -1,0 +1,13 @@
+import { changeMarkerReducer } from '../change-marker';
+import { SetChangeMarker } from '../change-marker.actions';
+
+describe('changeMarkerReducer', () => {
+  it('should default to false ', () => {
+    const result = changeMarkerReducer(null, null);
+    expect(result).toBe(false);
+  });
+  it('should return the correct value ', () => {
+    const result = changeMarkerReducer(null, new SetChangeMarker(true));
+    expect(result).toBe(true);
+  });
+});

--- a/src/modules/tests/change-marker/change-marker.actions.ts
+++ b/src/modules/tests/change-marker/change-marker.actions.ts
@@ -1,0 +1,11 @@
+import { Action } from '@ngrx/store';
+
+export const SET_CHANGE_MARKER = '[Test Actions] Set the change marker for the test';
+
+export class SetChangeMarker implements Action {
+  readonly type = SET_CHANGE_MARKER;
+
+  constructor(public changeMarker: boolean) {}
+}
+
+export type Types = SetChangeMarker;

--- a/src/modules/tests/change-marker/change-marker.ts
+++ b/src/modules/tests/change-marker/change-marker.ts
@@ -1,0 +1,18 @@
+import  * as changeMarkerActions from './change-marker.actions';
+import { createFeatureSelector } from '@ngrx/store';
+
+export const initialState: boolean = false;
+
+export const changeMarkerReducer = (
+  state = initialState,
+  action: changeMarkerActions.Types,
+): boolean => {
+  switch (action.type) {
+    case changeMarkerActions.SET_CHANGE_MARKER:
+      return action.changeMarker;
+    default:
+      return state;
+  }
+};
+
+export const getChangeMarker = createFeatureSelector<boolean>('changeMarker');

--- a/src/modules/tests/examiner-booked/__tests__/examiner-booked.reducer.spec.ts
+++ b/src/modules/tests/examiner-booked/__tests__/examiner-booked.reducer.spec.ts
@@ -1,0 +1,13 @@
+import { examinerBookedReducer } from '../examiner-booked.reducer';
+import { SetExaminerBooked } from '../examiner-booked.actions';
+
+describe('examinerBookedReducer', () => {
+  it('should default to null ', () => {
+    const result = examinerBookedReducer(null, null);
+    expect(result).toBe(null);
+  });
+  it('should return the correct value ', () => {
+    const result = examinerBookedReducer(null, new SetExaminerBooked(123456));
+    expect(result).toBe(123456);
+  });
+});

--- a/src/modules/tests/examiner-booked/__tests__/examiner-booked.reducer.spec.ts
+++ b/src/modules/tests/examiner-booked/__tests__/examiner-booked.reducer.spec.ts
@@ -2,10 +2,6 @@ import { examinerBookedReducer } from '../examiner-booked.reducer';
 import { SetExaminerBooked } from '../examiner-booked.actions';
 
 describe('examinerBookedReducer', () => {
-  it('should default to null ', () => {
-    const result = examinerBookedReducer(null, null);
-    expect(result).toBe(null);
-  });
   it('should return the correct value ', () => {
     const result = examinerBookedReducer(null, new SetExaminerBooked(123456));
     expect(result).toBe(123456);

--- a/src/modules/tests/examiner-booked/examiner-booked.actions.ts
+++ b/src/modules/tests/examiner-booked/examiner-booked.actions.ts
@@ -1,0 +1,11 @@
+import { Action } from '@ngrx/store';
+
+export const SET_EXAMINER_BOOKED = '[Test Actions] Set the examiner the test was booked against';
+
+export class SetExaminerBooked implements Action {
+  readonly type = SET_EXAMINER_BOOKED;
+
+  constructor(public examinerBooked: number) {}
+}
+
+export type Types = SetExaminerBooked;

--- a/src/modules/tests/examiner-booked/examiner-booked.reducer.ts
+++ b/src/modules/tests/examiner-booked/examiner-booked.reducer.ts
@@ -1,0 +1,18 @@
+import  * as examinerBookedActions from './examiner-booked.actions';
+import { createFeatureSelector } from '@ngrx/store';
+
+export const initialState: number = null;
+
+export const examinerBookedReducer = (
+  state = initialState,
+  action: examinerBookedActions.Types,
+): number => {
+  switch (action.type) {
+    case examinerBookedActions.SET_EXAMINER_BOOKED:
+      return action.examinerBooked;
+    default:
+      return state;
+  }
+};
+
+export const getExaminerBooked = createFeatureSelector<number>('examinerBooked');

--- a/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.reducer.spec.ts
+++ b/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.reducer.spec.ts
@@ -2,10 +2,6 @@ import { examinerConductedReducer } from '../examiner-conducted.reducer';
 import { SetExaminerConducted } from '../examiner-conducted.actions';
 
 describe('examinerConductedReducer', () => {
-  it('should default to null ', () => {
-    const result = examinerConductedReducer(null, null);
-    expect(result).toBe(null);
-  });
   it('should return the correct value ', () => {
     const result = examinerConductedReducer(null, new SetExaminerConducted(123456));
     expect(result).toBe(123456);

--- a/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.reducer.spec.ts
+++ b/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.reducer.spec.ts
@@ -1,0 +1,13 @@
+import { examinerConductedReducer } from '../examiner-conducted.reducer';
+import { SetExaminerConducted } from '../examiner-conducted.actions';
+
+describe('examinerConductedReducer', () => {
+  it('should default to null ', () => {
+    const result = examinerConductedReducer(null, null);
+    expect(result).toBe(null);
+  });
+  it('should return the correct value ', () => {
+    const result = examinerConductedReducer(null, new SetExaminerConducted(123456));
+    expect(result).toBe(123456);
+  });
+});

--- a/src/modules/tests/examiner-conducted/examiner-conducted.actions.ts
+++ b/src/modules/tests/examiner-conducted/examiner-conducted.actions.ts
@@ -1,0 +1,11 @@
+import { Action } from '@ngrx/store';
+
+export const SET_EXAMINER_CONDUCTED = '[Test Actions] Set the examiner the test was conducted by';
+
+export class SetExaminerConducted implements Action {
+  readonly type = SET_EXAMINER_CONDUCTED;
+
+  constructor(public examinerConducted: number) {}
+}
+
+export type Types = SetExaminerConducted;

--- a/src/modules/tests/examiner-conducted/examiner-conducted.reducer.ts
+++ b/src/modules/tests/examiner-conducted/examiner-conducted.reducer.ts
@@ -1,0 +1,18 @@
+import  * as examinerConductedActions from './examiner-conducted.actions';
+import { createFeatureSelector } from '@ngrx/store';
+
+export const initialState: number = null;
+
+export const examinerConductedReducer = (
+  state = initialState,
+  action: examinerConductedActions.Types,
+): number => {
+  switch (action.type) {
+    case examinerConductedActions.SET_EXAMINER_CONDUCTED:
+      return action.examinerConducted;
+    default:
+      return state;
+  }
+};
+
+export const getExaminerConducted = createFeatureSelector<number>('examinerConducted');

--- a/src/modules/tests/examiner-keyed/__tests__/examiner-keyed.reducer.spec.ts
+++ b/src/modules/tests/examiner-keyed/__tests__/examiner-keyed.reducer.spec.ts
@@ -2,10 +2,6 @@ import { examinerKeyedReducer } from '../examiner-keyed.reducer';
 import { SetExaminerKeyed } from '../examiner-keyed.actions';
 
 describe('examinerKeyedReducer', () => {
-  it('should default to null ', () => {
-    const result = examinerKeyedReducer(null, null);
-    expect(result).toBe(null);
-  });
   it('should return the correct value ', () => {
     const result = examinerKeyedReducer(null, new SetExaminerKeyed(123456));
     expect(result).toBe(123456);

--- a/src/modules/tests/examiner-keyed/__tests__/examiner-keyed.reducer.spec.ts
+++ b/src/modules/tests/examiner-keyed/__tests__/examiner-keyed.reducer.spec.ts
@@ -1,0 +1,13 @@
+import { examinerKeyedReducer } from '../examiner-keyed.reducer';
+import { SetExaminerKeyed } from '../examiner-keyed.actions';
+
+describe('examinerKeyedReducer', () => {
+  it('should default to null ', () => {
+    const result = examinerKeyedReducer(null, null);
+    expect(result).toBe(null);
+  });
+  it('should return the correct value ', () => {
+    const result = examinerKeyedReducer(null, new SetExaminerKeyed(123456));
+    expect(result).toBe(123456);
+  });
+});

--- a/src/modules/tests/examiner-keyed/examiner-keyed.actions.ts
+++ b/src/modules/tests/examiner-keyed/examiner-keyed.actions.ts
@@ -1,0 +1,11 @@
+import { Action } from '@ngrx/store';
+
+export const SET_EXAMINER_KEYED = '[Test Actions] Set the examiner the test was keyed by';
+
+export class SetExaminerKeyed implements Action {
+  readonly type = SET_EXAMINER_KEYED;
+
+  constructor(public examinerKeyed: number) {}
+}
+
+export type Types = SetExaminerKeyed;

--- a/src/modules/tests/examiner-keyed/examiner-keyed.reducer.ts
+++ b/src/modules/tests/examiner-keyed/examiner-keyed.reducer.ts
@@ -1,0 +1,18 @@
+import  * as examinerKeyedActions from './examiner-keyed.actions';
+import { createFeatureSelector } from '@ngrx/store';
+
+export const initialState: number = null;
+
+export const examinerKeyedReducer = (
+  state = initialState,
+  action: examinerKeyedActions.Types,
+): number => {
+  switch (action.type) {
+    case examinerKeyedActions.SET_EXAMINER_KEYED:
+      return action.examinerKeyed;
+    default:
+      return state;
+  }
+};
+
+export const getExaminerKeyed = createFeatureSelector<number>('examinerKeyed');

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -26,6 +26,10 @@ import * as fakeJournalActions from '../../pages/fake-journal/fake-journal.actio
 import { testReportPracticeSlotId } from '../../shared/mocks/test-slot-ids.mock';
 import { categoryReducer } from './category/category.reducer';
 import { rekeyReducer } from './rekey/rekey.reducer';
+import { examinerBookedReducer } from './examiner-booked/examiner-booked.reducer';
+import { examinerConductedReducer } from './examiner-conducted/examiner-conducted.reducer';
+import { examinerKeyedReducer } from './examiner-keyed/examiner-keyed.reducer';
+import { changeMarkerReducer } from './change-marker/change-marker';
 
 export const initialState: TestsModel = {
   currentTest: { slotId: null },
@@ -112,6 +116,10 @@ const createStateObject = (state: TestsModel, action: Action, slotId: string) =>
             testSummary: testSummaryReducer,
             communicationPreferences: communicationPreferencesReducer,
             rekey: rekeyReducer,
+            examinerBooked: examinerBookedReducer,
+            examinerConducted: examinerConductedReducer,
+            examinerKeyed: examinerKeyedReducer,
+            changeMarker: changeMarkerReducer,
           }, combineReducers,
         )(
           // The redux pattern necessitates that the state tree be initialised

--- a/src/pages/journal/journal.effects.ts
+++ b/src/pages/journal/journal.effects.ts
@@ -45,6 +45,9 @@ import { SaveLog } from '../../modules/logs/logs.actions';
 import { LogHelper } from '../../providers/logs/logsHelper';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
+import { SetExaminerBooked } from '../../modules/tests/examiner-booked/examiner-booked.actions';
+import { SetExaminerConducted } from '../../modules/tests/examiner-conducted/examiner-conducted.actions';
+import { SetExaminerKeyed } from '../../modules/tests/examiner-keyed/examiner-keyed.actions';
 
 @Injectable()
 export class JournalEffects {
@@ -220,6 +223,9 @@ export class JournalEffects {
         new PopulateTestCentre(this.extractTestCentre(slot)),
         new SetTestStatusBooked(startTestAction.slotId.toString()),
         new PopulateTestCategory(slot.booking.application.testCategory),
+        new SetExaminerBooked(parseInt(staffNumber, 10)),
+        new SetExaminerConducted(parseInt(staffNumber, 10)),
+        new SetExaminerKeyed(parseInt(staffNumber, 10)),
       ];
 
       if (startTestAction.rekey) {

--- a/src/providers/test-persistence/__tests__/test-persistence.spec.ts
+++ b/src/providers/test-persistence/__tests__/test-persistence.spec.ts
@@ -21,6 +21,10 @@ describe('TestPersistenceProvider', () => {
       startedTests: {
         12345678: {
           rekey: false,
+          changeMarker: false,
+          examinerBooked: 1,
+          examinerConducted: 1,
+          examinerKeyed: 1,
           category: 'B',
           activityCode: '1',
           journalData: {
@@ -49,6 +53,10 @@ describe('TestPersistenceProvider', () => {
         },
         23456789: {
           rekey: false,
+          changeMarker: false,
+          examinerBooked: 1,
+          examinerConducted: 1,
+          examinerKeyed: 1,
           category: 'B',
           activityCode: '1',
           journalData: {

--- a/src/shared/mocks/cat-b-test-result.mock.ts
+++ b/src/shared/mocks/cat-b-test-result.mock.ts
@@ -4,6 +4,10 @@ export const categoryBTestResultMock : StandardCarTestCATBSchema = {
   category: 'B',
   activityCode: '2',
   rekey: false,
+  changeMarker: false,
+  examinerBooked: 1,
+  examinerConducted: 1,
+  examinerKeyed: 1,
   journalData: {
     applicationReference: {
       applicationId: 1,


### PR DESCRIPTION
## Description and relevant Jira numbers

- Updated test result schema to 2.0.1
- Added new reducers and actions for examinerBooked, examinerConducted, examinerKeyed and changeMarker
- Updated Start Test effect to populate these (all with the same value currently)

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
