### PR TITLE
MES-3266 bug fix to ensure single app mode is disabled on journal screen

### DIFF
--- a/src/pages/journal/__tests__/journal.spec.ts
+++ b/src/pages/journal/__tests__/journal.spec.ts
@@ -36,11 +36,20 @@ import { IncompleteTestsProvider } from '../../../providers/incomplete-tests/inc
 import { IncompleteTestsMock } from '../../../providers/incomplete-tests/__mocks__/incomplete-tests.mock';
 import { of } from 'rxjs/observable/of';
 import { TestSlotComponentsModule } from '../../../components/test-slot/test-slot-components.module';
+import { ScreenOrientation } from '@ionic-native/screen-orientation';
+import { ScreenOrientationMock } from '../../../shared/mocks/screen-orientation.mock';
+import { DeviceProvider } from '../../../providers/device/device';
+import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
+import { Insomnia } from '@ionic-native/insomnia';
+import { InsomniaMock } from '../../../shared/mocks/insomnia.mock';
 
 describe('JournalPage', () => {
   let fixture: ComponentFixture<JournalPage>;
   let component: JournalPage;
   let store$: Store<StoreModel>;
+  let screenOrientation: ScreenOrientation;
+  let insomnia: Insomnia;
+  let deviceProvider: DeviceProvider;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -69,6 +78,9 @@ describe('JournalPage', () => {
         { provide: AppConfigProvider, useClass: AppConfigProviderMock },
         { provide: IncompleteTestsProvider, useClass: IncompleteTestsMock },
         { provide: App, useClass: MockAppComponent },
+        { provide: DeviceProvider, useClass: DeviceProviderMock },
+        { provide: ScreenOrientation, useClass: ScreenOrientationMock },
+        { provide: Insomnia, useClass: InsomniaMock },
       ],
     })
       .compileComponents()
@@ -76,10 +88,13 @@ describe('JournalPage', () => {
         fixture = TestBed.createComponent(JournalPage);
         component = fixture.componentInstance;
         component.subscription = new Subscription();
+        screenOrientation = TestBed.get(ScreenOrientation);
+        insomnia = TestBed.get(Insomnia);
+        deviceProvider = TestBed.get(DeviceProvider);
+        store$ = TestBed.get(Store);
+        spyOn(store$, 'dispatch');
       });
 
-    store$ = TestBed.get(Store);
-    spyOn(store$, 'dispatch');
   }));
 
   describe('Class', () => {
@@ -96,6 +111,15 @@ describe('JournalPage', () => {
       it('should dispatch a LoadJournal action', () => {
         component.loadJournalManually();
         expect(store$.dispatch).toHaveBeenCalledWith(new LoadJournal());
+      });
+    });
+
+    describe('ionViewDidEnter', () => {
+      it('should disable test inhibitions', () => {
+        component.ionViewDidEnter();
+        expect(deviceProvider.disableSingleAppMode).toHaveBeenCalled();
+        expect(screenOrientation.unlock).toHaveBeenCalled();
+        expect(insomnia.allowSleepAgain).toHaveBeenCalled();
       });
     });
   });

--- a/src/pages/journal/journal.ts
+++ b/src/pages/journal/journal.ts
@@ -31,6 +31,7 @@ import { IncompleteTestsProvider } from '../../providers/incomplete-tests/incomp
 import { ERROR_PAGE } from '../page-names.constants';
 import { App } from './../../app/app.component';
 import { ErrorTypes } from '../../shared/models/error-message';
+import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { DeviceProvider } from '../../providers/device/device';
 import { Insomnia } from '@ionic-native/insomnia';
 

--- a/src/pages/journal/journal.ts
+++ b/src/pages/journal/journal.ts
@@ -31,6 +31,8 @@ import { IncompleteTestsProvider } from '../../providers/incomplete-tests/incomp
 import { ERROR_PAGE } from '../page-names.constants';
 import { App } from './../../app/app.component';
 import { ErrorTypes } from '../../shared/models/error-message';
+import { DeviceProvider } from '../../providers/device/device';
+import { Insomnia } from '@ionic-native/insomnia';
 
 interface JournalPageState {
   selectedDate$: Observable<string>;
@@ -77,6 +79,10 @@ export class JournalPage extends BasePageComponent implements OnInit {
     public appConfigProvider: AppConfigProvider,
     public incompleteTestsProvider: IncompleteTestsProvider,
     private app: App,
+    private deviceProvider: DeviceProvider,
+    public screenOrientation: ScreenOrientation,
+    public insomnia: Insomnia,
+
   ) {
     super(platform, navController, authenticationProvider);
     this.analytics.initialiseAnalytics().then(() => console.log('journal analytics initialised'));
@@ -156,6 +162,12 @@ export class JournalPage extends BasePageComponent implements OnInit {
 
   ionViewDidEnter(): void {
     this.store$.dispatch(new journalActions.JournalViewDidEnter());
+
+    if (super.isIos()) {
+      this.screenOrientation.unlock();
+      this.insomnia.allowSleepAgain();
+      this.deviceProvider.disableSingleAppMode();
+    }
   }
 
   loadJournalManually() {


### PR DESCRIPTION
## Description and relevant Jira numbers
Disable single app mode when the journal page is active. This fixes a bug were navigating back from the communication page left the app in single app mode. It's also catches any other instances where single app mode hasn't been disabled because we can be certain that single app mode should be disabled on the journal page.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
