### PR TITLE
Mes 2003 - Prevent adding of multiple driving faults simultaneously

### DIFF
--- a/src/modules/tests/test-data/__tests__/test-data.effects.spec.ts
+++ b/src/modules/tests/test-data/__tests__/test-data.effects.spec.ts
@@ -7,6 +7,8 @@ import * as journalActions from '../../../../pages/journal/journal.actions';
 import { testsReducer } from '../../tests.reducer';
 import { Store, StoreModule } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
+import { Competencies } from '../test-data.constants';
+import { FaultPayload } from '../test-data.models';
 
 describe('Test Data Effects', () => {
 
@@ -30,6 +32,26 @@ describe('Test Data Effects', () => {
     });
     effects = TestBed.get(TestDataEffects);
     store$ = TestBed.get(Store);
+  });
+
+  describe('throttleAddDrivingFaultEffect', () => {
+    it('should dispatch an action to add driving fault', (done) => {
+      const faultPayload: FaultPayload = {
+        competency: Competencies.ancillaryControls,
+        newFaultCount: 1,
+      };
+      const throttleAddDrivingFault = new testDataActions.ThrottleAddDrivingFault(faultPayload);
+      // ARRANGE - setup the store
+      store$.dispatch(new journalActions.StartTest(123456));
+      store$.dispatch(throttleAddDrivingFault);
+      // ACT - replay the action for the effect
+      actions$.next(throttleAddDrivingFault);
+      // ASSERT
+      effects.throttleAddDrivingFaultEffect$.subscribe((result) => {
+        expect(result).toEqual(new testDataActions.AddDrivingFault(faultPayload));
+        done();
+      });
+    });
   });
 
   describe('setEcoControlCompletedEffect', () => {

--- a/src/modules/tests/test-data/test-data.actions.ts
+++ b/src/modules/tests/test-data/test-data.actions.ts
@@ -18,6 +18,7 @@ export const ADD_MANOEUVRE_DANGEROUS_FAULT = '[Manoeuvres] Add Manoeuvre Dangero
 export const ADD_MANOEUVRE_COMMENT = '[Manoeuvres] Add Manoeuvre Comment';
 export const REMOVE_MANOEUVRE_FAULT = '[Manoeuvres] Remove Manoeuvre Fault';
 export const ADD_DRIVING_FAULT = '[Competency] Add Driving Fault';
+export const THROTTLE_ADD_DRIVING_FAULT = '[Competency] Debounce Add Driving Fault';
 export const ADD_SERIOUS_FAULT = '[Competency] Add Serious Fault';
 export const ADD_SERIOUS_FAULT_COMMENT = '[Office] Add Serious Fault Comment';
 export const ADD_DANGEROUS_FAULT = '[Competency] Add Dangerous Fault';
@@ -137,6 +138,10 @@ export class AddDrivingFault implements Action {
   constructor(public payload: FaultPayload) { }
   readonly type = ADD_DRIVING_FAULT;
 }
+export class ThrottleAddDrivingFault implements Action {
+  constructor(public payload: FaultPayload) { }
+  readonly type = THROTTLE_ADD_DRIVING_FAULT;
+}
 export class AddSeriousFault implements Action {
   constructor(public payload: Competencies) { }
   readonly type = ADD_SERIOUS_FAULT;
@@ -252,6 +257,7 @@ export type Types =
   | AddManoeuvreComment
   | RemoveManoeuvreFault
   | AddDrivingFault
+  | ThrottleAddDrivingFault
   | AddDrivingFaultComment
   | AddSeriousFault
   | AddSeriousFaultComment

--- a/src/modules/tests/test-data/test-data.effects.ts
+++ b/src/modules/tests/test-data/test-data.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { withLatestFrom, concatMap, switchMap } from 'rxjs/operators';
+import { withLatestFrom, concatMap, switchMap, throttleTime } from 'rxjs/operators';
 import * as testDataActions from './../test-data/test-data.actions';
 import { of } from 'rxjs/observable/of';
 import { StoreModel } from '../../../shared/models/store.model';
@@ -17,6 +17,17 @@ export class TestDataEffects {
     private actions$: Actions,
     private store$: Store<StoreModel>,
   ) {}
+
+  @Effect()
+  throttleAddDrivingFaultEffect$ = this.actions$.pipe(
+    ofType(
+      testDataActions.THROTTLE_ADD_DRIVING_FAULT,
+    ),
+    throttleTime(250),
+    concatMap((action: testDataActions.ThrottleAddDrivingFault) => {
+      return of(new testDataActions.AddDrivingFault(action.payload));
+    }),
+  );
 
   @Effect()
   setEcoControlCompletedEffect$ = this.actions$.pipe(

--- a/src/pages/test-report/components/competency/__tests__/competency.spec.ts
+++ b/src/pages/test-report/components/competency/__tests__/competency.spec.ts
@@ -12,6 +12,7 @@ import {
   RemoveDrivingFault,
   RemoveDangerousFault,
   RemoveSeriousFault,
+  ThrottleAddDrivingFault,
 } from '../../../../../modules/tests/test-data/test-data.actions';
 import { MockComponent } from 'ng-mocks';
 import { CompetencyButtonComponent } from '../../../components/competency-button/competency-button';
@@ -72,13 +73,13 @@ describe('CompetencyComponent', () => {
     });
 
     describe('addDrivingFault', () => {
-      it('should dispatch an ADD_DRIVING_FAULT action for press', () => {
+      it('should dispatch a THROTTLE_ADD_DRIVING_FAULT action for press', () => {
         component.competency = Competencies.controlsSteering;
 
         const storeDispatchSpy = spyOn(store$, 'dispatch');
         component.addOrRemoveFault(true);
 
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new AddDrivingFault({
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ThrottleAddDrivingFault({
           competency: component.competency,
           newFaultCount: 1,
         }));

--- a/src/pages/test-report/components/competency/competency.ts
+++ b/src/pages/test-report/components/competency/competency.ts
@@ -7,7 +7,7 @@ import { map, tap } from 'rxjs/operators';
 
 import { StoreModel } from '../../../../shared/models/store.model';
 import {
-  AddDrivingFault,
+  ThrottleAddDrivingFault,
   AddSeriousFault,
   AddDangerousFault,
   RemoveDrivingFault,
@@ -200,7 +200,7 @@ export class CompetencyComponent {
 
     if (wasPress) {
       const competency = this.competency;
-      return this.store$.dispatch(new AddDrivingFault({
+      return this.store$.dispatch(new ThrottleAddDrivingFault({
         competency,
         newFaultCount: this.faultCount ? this.faultCount + 1 : 1,
       }));


### PR DESCRIPTION
## Description and relevant Jira numbers
Link to story - https://jira.dvsacloud.uk/browse/MES-2003

Branch is wrongly prefixed mes-2001, should be mes-2003.

Leverages the `throttleTime` rxjs operator to prevent immediate subsequent dispatches of the add driving fault action therefore preventing adding of multiple driving faults simultaneously.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
