### PR TITLE
MES-3111 - Fixes issue with default form values not being preselected on Communications page

### DIFF
--- a/src/pages/communication-page/__tests__/communication.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.spec.ts
@@ -98,8 +98,8 @@ describe('CommunicationPage', () => {
                 },
                 communicationPreferences: {
                   updatedEmail: '',
-                  communicationMethod: 'Post',
-                  conductedLanguage: 'Cymraeg',
+                  communicationMethod: 'Not provided',
+                  conductedLanguage: 'Not provided',
                 },
               },
             },
@@ -278,11 +278,18 @@ describe('CommunicationPage', () => {
         expect(returnValue).toBe(false);
       });
 
-      it('should return true for shouldPreselectADefaultValue() if communication type is null', () => {
-        component.communicationType = null;
+      it('should return true for shouldPreselectADefaultValue() if communication type is \'Not provided\'', () => {
+        component.communicationType = 'Not provided';
         const returnValue = component.shouldPreselectADefaultValue();
         expect(returnValue).toBe(true);
       });
+
+      it('should return false for shouldPreselectADefaultValue() if communication type is null', () => {
+        component.communicationType = null;
+        const returnValue = component.shouldPreselectADefaultValue();
+        expect(returnValue).toBe(false);
+      });
+
     });
     describe('clickBack', () => {
       it('should should trigger the lock screen', () => {
@@ -290,6 +297,7 @@ describe('CommunicationPage', () => {
         expect(deviceAuthenticationProvider.triggerLockScreen).toHaveBeenCalled();
       });
     });
+
   });
 
   describe('DOM', () => {

--- a/src/pages/communication-page/communication.ts
+++ b/src/pages/communication-page/communication.ts
@@ -67,6 +67,7 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
   static readonly updatedEmail: string = 'Updated';
   static readonly email: CommunicationMethod = 'Email';
   static readonly post: CommunicationMethod = 'Post';
+  static readonly notProvided: CommunicationMethod = 'Not provided';
   static readonly welshLanguage: ConductedLanguage = 'Cymraeg';
   static readonly englishLanguage: ConductedLanguage = 'English';
 
@@ -79,10 +80,10 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
   pageState: CommunicationPageState;
   candidateProvidedEmail: string;
   communicationEmail: string;
-  communicationType: string;
+  communicationType: CommunicationMethod;
   selectProvidedEmail: boolean;
   selectNewEmail: boolean;
-  conductedLanguage: string;
+  conductedLanguage: ConductedLanguage;
   isBookedInWelsh: boolean;
   merged$: Observable<string | boolean>;
 
@@ -195,9 +196,9 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
     this.merged$ = merge(
       candidateProvidedEmail$.pipe(map(value => this.candidateProvidedEmail = value)),
       communicationEmail$.pipe(map(value => this.communicationEmail = value)),
-      communicationType$.pipe(map(value => this.communicationType = value)),
+      communicationType$.pipe(map(value => this.communicationType = value as CommunicationMethod)),
       welshTest$.pipe(map(isWelsh => this.isBookedInWelsh = isWelsh)),
-      conductedLanguage$.pipe(map(value => this.conductedLanguage = value)),
+      conductedLanguage$.pipe(map(value => this.conductedLanguage = value as ConductedLanguage)),
     );
 
     this.subscription = this.merged$.subscribe();
@@ -262,7 +263,7 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
     );
   }
 
-  setCommunicationType(communicationChoice: string, emailType: string = null) {
+  setCommunicationType(communicationChoice: CommunicationMethod, emailType: string = null) {
     this.communicationType = communicationChoice;
     this.emailType = emailType;
     this.verifyNewEmailFormControl(communicationChoice);
@@ -380,8 +381,8 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
     }
   }
 
-  shouldPreselectADefaultValue() {
-    return this.communicationType === null;
+  shouldPreselectADefaultValue(): boolean {
+    return this.communicationType === CommunicationPage.notProvided;
   }
 
   /**


### PR DESCRIPTION
#  Description and relevant Jira numbers
Linked to https://jira.dvsacloud.uk/browse/MES-3111

Changing the default values of email and conducted language to 'Not provided' had the side effect of preventing default values from being preselected.
This fix ensures form values are preselected when email / conducted language are 'Not provided'. 

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [ ] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
