### PR TITLE
Passing slot instead of the slotId to to fakeTestSlot

### DIFF
--- a/src/pages/fake-journal/components/fake-test-slot/fake-test-slot.html
+++ b/src/pages/fake-journal/components/fake-test-slot/fake-test-slot.html
@@ -32,7 +32,7 @@
           <ion-grid no-padding>
             <ion-row align-items-center>
               <ion-col col-64>
-                <candidate-link [slotId]="slot.slotDetail.slotId" [slotChanged]="hasSlotChanged"
+                <candidate-link [slot]="slot" [slotChanged]="hasSlotChanged"
                   [name]="slot.booking.candidate.candidateName" [isPortrait]="isPortrait()">
                 </candidate-link>
               </ion-col>


### PR DESCRIPTION
Bug fix for passing the right properties to the candidate link from fake test slot.