### PR TITLE
MES-3278 Config update to show dimensions for B+E category 

### DIFF
--- a/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
+++ b/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
@@ -192,7 +192,7 @@ describe('TestSlotComponent', () => {
         component.slot.booking.application.testCategory = 'B1';
         expect(component.showVehicleDetails()).toEqual(false);
         component.slot.booking.application.testCategory = 'B+E';
-        expect(component.showVehicleDetails()).toEqual(false);
+        expect(component.showVehicleDetails()).toEqual(true);
         component.slot.booking.application.testCategory = 'C';
         expect(component.showVehicleDetails()).toEqual(true);
         component.slot.booking.application.testCategory = 'C1';

--- a/src/components/test-slot/test-slot/test-slot.constants.ts
+++ b/src/components/test-slot/test-slot/test-slot.constants.ts
@@ -9,7 +9,7 @@ export const vehicleDetails = {
   [TestCategory.AM]: false,
   [TestCategory.B]: false,
   [TestCategory.B1]: false,
-  [TestCategory.BE]: false,
+  [TestCategory.BE]: true,
   [TestCategory.C]: true,
   [TestCategory.C1]: true,
   [TestCategory.C1E]: true,


### PR DESCRIPTION
Updated the config within the application which controls if vehicle dimensions are show for the category B+E.