### PR TITLE
Mes 3159 disable local db save on rekey

### DIFF
--- a/src/modules/tests/__tests__/tests.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.effects.spec.ts
@@ -58,6 +58,7 @@ describe('Tests Effects', () => {
   describe('persistTestsEffect', () => {
     it('should respond to a PERSIST_TESTS action and delegate to the persistence provider', (done) => {
       // ARRANGE
+      store$.dispatch(new StartTest(12345));
       testPersistenceProviderMock.persistTests.and.returnValue(Promise.resolve());
       // ACT
       actions$.next(new testsActions.PersistTests());

--- a/src/modules/tests/__tests__/tests.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.effects.spec.ts
@@ -58,12 +58,12 @@ describe('Tests Effects', () => {
   describe('persistTestsEffect', () => {
     it('should respond to a PERSIST_TESTS action and delegate to the persistence provider', (done) => {
       // ARRANGE
-      testPersistenceProviderMock.persistAllTests.and.returnValue(Promise.resolve());
+      testPersistenceProviderMock.persistTests.and.returnValue(Promise.resolve());
       // ACT
       actions$.next(new testsActions.PersistTests());
       // ASSERT
       effects.persistTestsEffect$.subscribe(() => {
-        expect(testPersistenceProviderMock.persistAllTests).toHaveBeenCalled();
+        expect(testPersistenceProviderMock.persistTests).toHaveBeenCalled();
         done();
       });
     });

--- a/src/modules/tests/tests.effects.ts
+++ b/src/modules/tests/tests.effects.ts
@@ -61,9 +61,7 @@ export class TestsEffects {
     switchMap(([aciton, tests]) => {
       return this.testPersistenceProvider.persistTests(
         this.getSaveableTestsObject(tests),
-      )
-        .then(() => console.log('saved successfuly'))
-        .catch(err => console.log('error', err));
+      );
     }),
     catchError((err) => {
       console.log(`Error persisting tests: ${err}`);

--- a/src/modules/tests/tests.effects.ts
+++ b/src/modules/tests/tests.effects.ts
@@ -22,6 +22,8 @@ import { find, startsWith } from 'lodash';
 import { HttpResponse } from '@angular/common/http';
 import { HttpStatusCodes } from '../../shared/models/http-status-codes';
 import { TestStatus } from './test-status/test-status.model';
+import { getRekeyIndicator } from './rekey/rekey.reducer';
+import { isRekey } from './rekey/rekey.selector';
 
 @Injectable()
 export class TestsEffects {
@@ -43,9 +45,15 @@ export class TestsEffects {
           select(getTests),
           select(isPracticeMode),
         ),
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getRekeyIndicator),
+          map(isRekey),
+        ),
       ),
     )),
-    filter(([action, isPracticeMode]) => !isPracticeMode),
+    filter(([action, isPracticeMode, isRekey]) => !isPracticeMode && !isRekey),
     switchMap(() => this.testPersistenceProvider.persistAllTests()),
     catchError((err) => {
       console.log(`Error persisting tests: ${err}`);

--- a/src/modules/tests/tests.effects.ts
+++ b/src/modules/tests/tests.effects.ts
@@ -58,7 +58,7 @@ export class TestsEffects {
       ),
     )),
     filter(([action, tests, isPracticeMode, isRekey]) => !isPracticeMode && !isRekey),
-    switchMap(([aciton, tests]) => {
+    switchMap(([action, tests]) => {
       return this.testPersistenceProvider.persistTests(
         this.getSaveableTestsObject(tests),
       );

--- a/src/providers/test-persistence/__mocks__/test-persistence.mock.ts
+++ b/src/providers/test-persistence/__mocks__/test-persistence.mock.ts
@@ -1,5 +1,5 @@
 export class TestPersistenceProviderMock {
-  persistAllTests = jasmine.createSpy('persistAllTests');
+  persistTests = jasmine.createSpy('persistTests');
   loadPersistedTests = jasmine.createSpy('loadPersistedTests');
   clearPersistedTests = jasmine.createSpy('clearPersistedTests');
 }

--- a/src/providers/test-persistence/__tests__/test-persistence.spec.ts
+++ b/src/providers/test-persistence/__tests__/test-persistence.spec.ts
@@ -106,9 +106,9 @@ describe('TestPersistenceProvider', () => {
     dataStoreProvider = TestBed.get(DataStoreProvider);
   });
 
-  describe('persistAllTests', () => {
+  describe('persistTests', () => {
     it('should take the tests state slice and pass it to the data store provider stringified', async () => {
-      await testPersistenceProvider.persistAllTests();
+      await testPersistenceProvider.persistTests(testState);
 
       expect(dataStoreProvider.setItem).toHaveBeenCalledTimes(1);
       expect(dataStoreProvider.setItem.calls.first().args[0]).toBe('TESTS');

--- a/src/providers/test-persistence/test-persistence.ts
+++ b/src/providers/test-persistence/test-persistence.ts
@@ -1,8 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Store, select } from '@ngrx/store';
-import { StoreModel } from '../../shared/models/store.model';
-import { getTests } from '../../modules/tests/tests.reducer';
-import { switchMap, take, mapTo } from 'rxjs/operators';
 import { DataStoreProvider } from '../data-store/data-store';
 import { TestsModel } from '../../modules/tests/tests.model';
 import { DateTime } from '../../shared/helpers/date-time';
@@ -12,20 +8,14 @@ import { AppConfigProvider } from '../app-config/app-config';
 export class TestPersistenceProvider {
 
   constructor(
-    private store$: Store<StoreModel>,
     private dataStoreProvider: DataStoreProvider,
     private appConfigProvider: AppConfigProvider,
   ) {}
 
   private testKeychainKey = 'TESTS';
 
-  persistAllTests(): Promise<void> {
-    return this.store$.pipe(
-      select(getTests),
-      take(1),
-      switchMap(tests => this.dataStoreProvider.setItem(this.testKeychainKey, JSON.stringify(tests))),
-      mapTo(undefined),
-    ).toPromise();
+  persistTests(tests: TestsModel): Promise<string> {
+    return this.dataStoreProvider.setItem(this.testKeychainKey, JSON.stringify(tests));
   }
 
   async loadPersistedTests(): Promise<TestsModel | null> {


### PR DESCRIPTION
Removing both practice tests and all rekeyed tests from the tests object before persisting to local storage.