### PR TITLE
MES-2785 navigate to the journal instead of root

### DIFF
--- a/src/components/common/practice-mode-banner/__tests__/practice-mode-banner.spec.ts
+++ b/src/components/common/practice-mode-banner/__tests__/practice-mode-banner.spec.ts
@@ -28,7 +28,7 @@ describe('PracticeModeBanner', () => {
     describe('exitPracticeMode', () => {
       it('should take the user back to the root page', () => {
         component.exitPracticeMode();
-        expect(navController.popToRoot).toHaveBeenCalled();
+        expect(navController.popTo).toHaveBeenCalled();
       });
     });
   });

--- a/src/components/common/practice-mode-banner/practice-mode-banner.ts
+++ b/src/components/common/practice-mode-banner/practice-mode-banner.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { NavController } from 'ionic-angular';
+import { JOURNAL_PAGE } from '../../../pages/page-names.constants';
 
 @Component({
   selector: 'practice-mode-banner',
@@ -13,6 +14,7 @@ export class PracticeModeBanner {
   ) {}
 
   exitPracticeMode() {
-    this.navController.popToRoot({ animate: false });
+    const journalPage = this.navController.getViews().find(view => view.id === JOURNAL_PAGE);
+    this.navController.popTo(journalPage, { animate: false });
   }
 }

--- a/src/pages/back-to-office/__tests__/back-to-office.spec.ts
+++ b/src/pages/back-to-office/__tests__/back-to-office.spec.ts
@@ -83,9 +83,9 @@ describe('BackToOfficePage', () => {
   });
 
   describe('goToJournal', () => {
-    it('should call the popToRoot method in the navcontroller if not in practice mode', () => {
+    it('should call the popTo method in the navcontroller if not in practice mode', () => {
       component.goToJournal();
-      expect(navController.popToRoot).toHaveBeenCalled();
+      expect(navController.popTo).toHaveBeenCalled();
     });
     it('should call the popTo method in the navcontroller if in practice mode', () => {
       component.isPracticeMode = true;

--- a/src/pages/back-to-office/back-to-office.ts
+++ b/src/pages/back-to-office/back-to-office.ts
@@ -8,6 +8,7 @@ import { BackToOfficeViewDidEnter, DeferWriteUp } from './back-to-office.actions
 import { DeviceProvider } from '../../providers/device/device';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
+import { JOURNAL_PAGE } from '../page-names.constants';
 
 @IonicPage()
 @Component({
@@ -48,6 +49,7 @@ export class BackToOfficePage extends PracticeableBasePageComponent {
       return;
     }
     this.store$.dispatch(new DeferWriteUp());
-    this.navController.popToRoot();
+    const journalPage = this.navController.getViews().find(view => view.id === JOURNAL_PAGE);
+    this.navController.popTo(journalPage);
   }
 }

--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -367,7 +367,7 @@ describe('DebriefPage', () => {
       it('should navigate back to the root when this is a test report practice test', () => {
         component.isTestReportPracticeMode = true;
         component.endDebrief();
-        expect(navController.popToRoot).toHaveBeenCalled();
+        expect(navController.popTo).toHaveBeenCalled();
       });
     });
 

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -49,6 +49,7 @@ import {
   TEST_REPORT_PAGE,
   DEBRIEF_PAGE,
   POST_DEBRIEF_HOLDING_PAGE,
+  JOURNAL_PAGE,
 } from '../page-names.constants';
 
 interface DebriefPageState {
@@ -237,7 +238,8 @@ export class DebriefPage extends PracticeableBasePageComponent {
 
   endDebrief(): void {
     if (this.isTestReportPracticeMode) {
-      this.navController.popToRoot({ animate: false });
+      const journalPage = this.navController.getViews().find(view => view.id === JOURNAL_PAGE);
+      this.navController.popTo(journalPage, { animate: false });
       return;
     }
     this.store$.dispatch(new EndDebrief());

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -273,7 +273,7 @@ describe('OfficePage', () => {
         fixture.detectChanges();
 
         expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
-        expect(navController.popToRoot).toHaveBeenCalled();
+        expect(navController.popTo).toHaveBeenCalled();
       });
     });
 
@@ -340,9 +340,9 @@ describe('OfficePage', () => {
   });
 
   describe('popToRoot', () => {
-    it('should call the popToRoot method in the navcontroller if not in practice mode', () => {
+    it('should call the popTo method in the navcontroller if not in practice mode', () => {
       component.popToRoot();
-      expect(navController.popToRoot).toHaveBeenCalled();
+      expect(navController.popTo).toHaveBeenCalled();
     });
     it('should call the popTo method in the navcontroller if in practice mode.', () => {
       component.isPracticeMode = true;

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -112,7 +112,7 @@ import { CompetencyOutcome } from '../../shared/models/competency-outcome';
 import { startsWith } from 'lodash';
 import { getRekeyIndicator } from '../../modules/tests/rekey/rekey.reducer';
 import { isRekey } from '../../modules/tests/rekey/rekey.selector';
-import { REKEY_REASON_PAGE } from '../page-names.constants';
+import { REKEY_REASON_PAGE, JOURNAL_PAGE } from '../page-names.constants';
 
 interface OfficePageState {
   activityCode$: Observable<ActivityCodeModel>;
@@ -443,7 +443,8 @@ export class OfficePage extends PracticeableBasePageComponent {
       this.exitPracticeMode();
       return;
     }
-    this.navController.popToRoot();
+    const journalPage = this.navController.getViews().find(view => view.id === JOURNAL_PAGE);
+    this.navController.popTo(journalPage);
   }
 
   defer() {

--- a/src/pages/rekey-reason/rekey-reason.ts
+++ b/src/pages/rekey-reason/rekey-reason.ts
@@ -17,7 +17,7 @@ import {
   OtherReasonUpdated,
 } from '../../modules/tests/rekey-reason/rekey-reason.actions';
 import { Subscription } from 'rxjs/Subscription';
-import { REKEY_UPLOAD_OUTCOME_PAGE } from '../page-names.constants';
+import { REKEY_UPLOAD_OUTCOME_PAGE, REKEY_SEARCH_PAGE, JOURNAL_PAGE } from '../page-names.constants';
 import { getRekeyReasonState } from './rekey-reason.reducer';
 import { map } from 'rxjs/operators';
 import { merge } from 'rxjs/observable/merge';
@@ -221,7 +221,13 @@ export class RekeyReasonPage extends BasePageComponent {
 
   onExitRekey = (): void => {
     // TODO - modal confirmation
-    this.navController.popToRoot();
+    const rekeySearchPage = this.navController.getViews().find(view => view.id === REKEY_SEARCH_PAGE);
+    const journalPage = this.navController.getViews().find(view => view.id === JOURNAL_PAGE);
+    if (rekeySearchPage) {
+      this.navController.popTo(rekeySearchPage);
+    } else {
+      this.navController.popTo(journalPage);
+    }
     this.store$.dispatch(new EndRekey());
   }
 

--- a/src/pages/rekey-upload-outcome/__tests__/rekey-upload-outcome.spec.ts
+++ b/src/pages/rekey-upload-outcome/__tests__/rekey-upload-outcome.spec.ts
@@ -79,9 +79,9 @@ describe('RekeyUploadOutcomePage', () => {
     });
 
     describe('goToJournal', () => {
-      it('should call the popToRoot method in the navcontroller', () => {
+      it('should call the popTo method in the navcontroller', () => {
         component.goToJournal();
-        expect(navController.popToRoot).toHaveBeenCalled();
+        expect(navController.popTo).toHaveBeenCalled();
       });
     });
   });

--- a/src/pages/rekey-upload-outcome/rekey-upload-outcome.ts
+++ b/src/pages/rekey-upload-outcome/rekey-upload-outcome.ts
@@ -14,6 +14,7 @@ import { getRekeyReasonState } from './../rekey-reason/rekey-reason.reducer';
 import { map } from 'rxjs/operators';
 import { getUploadStatus } from './../rekey-reason/rekey-reason.selector';
 import { EndRekey } from '../../modules/tests/rekey/rekey.actions';
+import { REKEY_SEARCH_PAGE, JOURNAL_PAGE } from '../page-names.constants';
 
 interface RekeyUploadOutcomePageState {
   duplicateUpload$: Observable<boolean>;
@@ -63,7 +64,13 @@ export class RekeyUploadOutcomePage extends BasePageComponent {
   }
 
   goToJournal() {
-    this.navController.popToRoot();
+    const rekeySearchPage = this.navController.getViews().find(view => view.id === REKEY_SEARCH_PAGE);
+    const journalPage = this.navController.getViews().find(view => view.id === JOURNAL_PAGE);
+    if (rekeySearchPage) {
+      this.navController.popTo(rekeySearchPage);
+    } else {
+      this.navController.popTo(journalPage);
+    }
     this.store$.dispatch(new EndRekey());
   }
 }


### PR DESCRIPTION
## Description and relevant Jira numbers
Prep work for when the dashboard comes in as becomes the new root page. 

This work replaces instances of `popToRoot()` with `popTo()` ensuring that the journal page will be returned to in future rather than the dashboard.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
