### PR TITLE
MES-3402 - Test Termination Activity Code Bug

### DIFF
--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -33,7 +33,7 @@
       <ion-card-content class="card-content-ios" no-bounce>
         <ion-grid class="grid">
           <activity-code id="activity-code-card" [formGroup]="form" [activityCodeModel]="pageState.activityCode$ | async"
-            [activityCodeOptions]="activityCodeOptions" (activityCodeChange)="activityCodeChanged($event)" [disabled]="true"></activity-code>
+            [activityCodeOptions]="activityCodeOptions" (activityCodeChange)="activityCodeChanged($event)" [disabled]="pageState.disableActivityCode$ | async"></activity-code>
 
           <div no-padding [hidden]="!(pageState.isTestOutcomeSet$ | async)">
             <route-number [display]="pageState.displayRouteNumber$ | async" [routeNumber]="pageState.routeNumber$ | async"

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -116,6 +116,7 @@ import { REKEY_REASON_PAGE, JOURNAL_PAGE } from '../page-names.constants';
 
 interface OfficePageState {
   activityCode$: Observable<ActivityCodeModel>;
+  disableActivityCode$: Observable<boolean>;
   startTime$: Observable<string>;
   testOutcome$: Observable<string>;
   testOutcomeText$: Observable<string>;
@@ -207,6 +208,10 @@ export class OfficePage extends PracticeableBasePageComponent {
     this.pageState = {
       activityCode$: currentTest$.pipe(
         select(getActivityCode),
+      ),
+      disableActivityCode$: currentTest$.pipe(
+        select(getActivityCode),
+        select(activityCodeModel => this.activityCodeDisabled(activityCodeModel)),
       ),
       isRekey$: currentTest$.pipe(
         select(getRekeyIndicator),
@@ -640,4 +645,8 @@ export class OfficePage extends PracticeableBasePageComponent {
       source: result.source,
       comment: result.comment,
     })
+
+  activityCodeDisabled(activityCodeModel: ActivityCodeModel): boolean {
+    return activityCodeModel ? true : false;
+  }
 }


### PR DESCRIPTION
## Description and relevant Jira numbers

- This fixes a bug where force closing before activity code was selected displayed an empty but disabled ion-select on the office page preventing you from continuing.
- Changed `ActivityCode` ion-select on the office page from always being disabled to only being disabled if an activity code has been selected. 

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
