### PR TITLE
MES-3402 - Fixed bug with test termination

### DIFF
--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -13,6 +13,7 @@ import {
   OFFICE_PAGE,
   PASS_FINALISATION_PAGE,
   JOURNAL_FORCE_CHECK_MODAL,
+  NON_PASS_FINALISATION_PAGE,
 } from '../../../pages/page-names.constants';
 import { ModalEvent } from '../../../pages/journal/journal-rekey-modal/journal-rekey-modal.constants';
 import { DateTime, Duration } from '../../../shared/helpers/date-time';
@@ -26,6 +27,7 @@ import { StoreModel } from '../../../shared/models/store.model';
 import { getRekeySearchState } from '../../../pages/rekey-search/rekey-search.reducer';
 import { getBookedTestSlot } from '../../../pages/rekey-search/rekey-search.selector';
 import { merge } from 'rxjs/observable/merge';
+import { ActivityCodes } from '../../../shared/models/activity-codes';
 
 @Component({
   selector: 'test-outcome',
@@ -128,7 +130,11 @@ export class TestOutcomeComponent implements OnInit {
 
   debriefTest() {
     this.store$.dispatch(new ActivateTest(this.slotDetail.slotId));
-    this.navController.push(PASS_FINALISATION_PAGE);
+    if (this.activityCode === ActivityCodes.PASS) {
+      this.navController.push(PASS_FINALISATION_PAGE);
+    } else {
+      this.navController.push(NON_PASS_FINALISATION_PAGE);
+    }
   }
 
   resumeTest() {

--- a/src/pages/debrief/__tests__/debrief.effects.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.effects.spec.ts
@@ -57,7 +57,7 @@ describe('Debrief Effects', () => {
       });
     });
 
-    it('should return SET_TEST_STATUS_WRITE_UP & PERSIST_TESTS actions when failed test', (done) => {
+    it('should return SET_TEST_STATUS_DECIDED & PERSIST_TESTS actions when failed test', (done) => {
       // Set activity code as failed
       store$.dispatch(new testsActions.StartTest(1234));
       store$.dispatch(new testsActions.SetActivityCode(ActivityCodes.FAIL));
@@ -67,7 +67,7 @@ describe('Debrief Effects', () => {
       effects.endDebriefEffect$.subscribe((result) => {
         if (result instanceof testStatusActions.SetTestStatusWriteUp ||
           result instanceof testStatusActions.SetTestStatusDecided) {
-          expect(result).toEqual(new testStatusActions.SetTestStatusWriteUp(currentSlotId));
+          expect(result).toEqual(new testStatusActions.SetTestStatusDecided(currentSlotId));
         }
         if (result instanceof testsActions.PersistTests) {
           expect(result).toEqual(new testsActions.PersistTests());

--- a/src/pages/debrief/debrief.effects.ts
+++ b/src/pages/debrief/debrief.effects.ts
@@ -8,8 +8,7 @@ import * as testsActions from '../../modules/tests/tests.actions';
 import { StoreModel } from '../../shared/models/store.model';
 import { Store, select } from '@ngrx/store';
 import { getTests } from '../../modules/tests/tests.reducer';
-import { getCurrentTestSlotId, getCurrentTest, getTestOutcomeText } from '../../modules/tests/tests.selector';
-import { TestOutcome } from '../../modules/tests/tests.constants';
+import { getCurrentTestSlotId } from '../../modules/tests/tests.selector';
 import { of } from 'rxjs/observable/of';
 
 @Injectable()
@@ -28,20 +27,11 @@ export class DebriefEffects {
           select(getTests),
           select(getCurrentTestSlotId),
         ),
-        this.store$.pipe(
-          select(getTests),
-          select(getCurrentTest),
-          select(getTestOutcomeText),
-        ),
       ),
     )),
-    switchMap(([action, slotId, testOutcome]) => {
-      // Passed test flow goes through additional pages before write up
-      const testStatusAction = testOutcome === TestOutcome.Passed ?
-        new testStatusActions.SetTestStatusDecided(slotId)
-        : new testStatusActions.SetTestStatusWriteUp(slotId);
+    switchMap(([action, slotId]) => {
       return [
-        testStatusAction,
+        new testStatusActions.SetTestStatusDecided(slotId),
         new testsActions.PersistTests(),
       ];
     }),

--- a/src/pages/page-names.constants.ts
+++ b/src/pages/page-names.constants.ts
@@ -20,3 +20,4 @@ export const ERROR_PAGE = 'ErrorPage';
 export const POST_DEBRIEF_HOLDING_PAGE = 'PostDebriefHoldingPage';
 export const REKEY_REASON_PAGE = 'RekeyReasonPage';
 export const REKEY_UPLOAD_OUTCOME_PAGE = 'RekeyUploadOutcomePage';
+export const NON_PASS_FINALISATION_PAGE = 'NonPassFinalisationPage';


### PR DESCRIPTION
## Description and relevant Jira numbers
Fixed bug where if you crashed the app after state=decided on the non-pass journey, it would skip the non-pass finalisation pages and go straight to write-up on resume

**This was achieved by:**
- Modifying the debrief effect to set the state to decided for all cases instead of write-up for non-pass journey
- Adding conditional logic to the resume test button for both pass and non-pass journeys.

JIRA: https://jira.dvsacloud.uk/browse/MES-3402

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
