### PR TITLE
MES-2507 make pass fail and terminate colours consistent

### DIFF
--- a/src/pages/debrief/debrief.scss
+++ b/src/pages/debrief/debrief.scss
@@ -17,7 +17,7 @@ page-debrief > * {
     }
   }
   .passed {
-    border: 8px solid map-get($colors-gds, "gds-turquoise");
+    border: 8px solid map-get($colors-gds, "gds-dark-green-3");
   }
   .failed {
     border: 8px solid map-get($colors-gds, "gds-red");

--- a/src/pages/office/office.html
+++ b/src/pages/office/office.html
@@ -16,9 +16,18 @@
     </ion-col>
     <ion-col col-36 class="align-col-right">
       <h2>{{pageState.startTime$ | async}}</h2>
-      <h3>test outcome:
-        <span id="office-page-test-outcome" [ngClass]="(pageState.isPassed$ | async) ? 'mes-green' : 'mes-red'">{{pageState.testOutcomeText$
-          | async}}</span>
+      <h3>test outcome: 
+        <div id="test-outcome-text" class="inline-mode" [ngSwitch]="(pageState.testOutcomeText$ | async)">
+          <span class="pass" *ngSwitchCase="'Passed'">
+            {{pageState.testOutcomeText$ | async}}
+          </span>
+          <span class="fail" *ngSwitchCase="'Unsuccessful'">
+            {{pageState.testOutcomeText$ | async}}
+          </span>
+          <span class="terminated" *ngSwitchCase="'Terminated'">
+            {{pageState.testOutcomeText$ | async}}
+          </span>
+        </div>
       </h3>
     </ion-col>
   </ion-row>

--- a/src/pages/office/office.scss
+++ b/src/pages/office/office.scss
@@ -59,8 +59,16 @@ page-office {
           padding-right: 48px;
         }
       }
-      .unsuccessful {
-        color: map-get($colors, "mes-red");
+      #test-outcome-text {
+        .pass {
+          color: map-get($colors-gds, 'gds-dark-green-3');
+        }
+        .fail {
+          color: map-get($colors-gds, 'gds-red');
+        }
+        .terminated {
+          color: map-get($colors-gds, "gds-grey-1");
+        }
       }
       .inline-mode {
         display: inline;

--- a/src/pages/test-finalisation/components/finalisation-header/finalisation-header.html
+++ b/src/pages/test-finalisation/components/finalisation-header/finalisation-header.html
@@ -8,7 +8,7 @@
     <ion-col>
       <h3 id="candidate-driver-number">{{candidateDriverNumber}}</h3>
     </ion-col>
-    <ion-col col-36 class="align-col-right">
+    <ion-col col-40 class="align-col-right">
       <h3>test outcome: 
         <div id="test-outcome-text" [ngSwitch]="outcomeText">
           <div class="pass" *ngSwitchCase="'Passed'">

--- a/src/pages/test-finalisation/components/finalisation-header/finalisation-header.scss
+++ b/src/pages/test-finalisation/components/finalisation-header/finalisation-header.scss
@@ -1,12 +1,13 @@
 finalisation-header {
   .header-card {
-    margin-left: 32px;
+    padding-left: 32px;
+    padding-right: 32px;
   }
   .top-row {
-    margin-top: 24px;
+    padding-top: 24px;
   }
   .bottom-row {
-    margin-bottom: 24px;
+    padding-bottom: 24px;
   }
   .pass {
     color: map-get($colors-gds, 'gds-dark-green-3');
@@ -19,5 +20,8 @@ finalisation-header {
   }
   div {
     display:inline;
+  }
+  .align-col-right {
+    text-align: right;
   }
 }

--- a/src/pages/test-finalisation/components/finalisation-header/finalisation-header.scss
+++ b/src/pages/test-finalisation/components/finalisation-header/finalisation-header.scss
@@ -9,7 +9,7 @@ finalisation-header {
     margin-bottom: 24px;
   }
   .pass {
-    color: map-get($colors-gds, 'gds-green');
+    color: map-get($colors-gds, 'gds-dark-green-3');
   }
   .fail {
     color: map-get($colors-gds, 'gds-red');

--- a/src/pages/test-finalisation/non-pass-finalisation/non-pass-finalisation.scss
+++ b/src/pages/test-finalisation/non-pass-finalisation/non-pass-finalisation.scss
@@ -33,15 +33,7 @@ non-pass-finalisation {
       margin-top: 11px;
     }
   }
-  .header-card {
-    margin-left: 32px;
-  }
-  .top-row {
-    margin-top: 24px;
-  }
-  .bottom-row {
-    margin-bottom: 24px;
-  }
+
   #test-outcome {
     color: map-get($colors, "mes-red") !important;
     

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -55,6 +55,7 @@ $colors-gds: (
   gds-green: #006435,
   gds-dark-green: #00823b,
   gds-dark-green-2: #006f4b,
+  gds-dark-green-3: #00703c,
   gds-turquoise: #28a197,
   gds-light-blue: #2b8cc4,
   gds-blue: #005ea5,


### PR DESCRIPTION
## Description and relevant Jira numbers
Ensure the colours for pass, fail and terminate text and the border box are all consistent.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

## Pass
![IMG_0124](https://user-images.githubusercontent.com/8069071/63777791-a5689b80-c8db-11e9-81b1-bf4c3f25f728.PNG) 

![IMG_0125](https://user-images.githubusercontent.com/8069071/63777804-ab5e7c80-c8db-11e9-9c9b-dcb4ecf59051.PNG)

![IMG_0126](https://user-images.githubusercontent.com/8069071/63777844-be714c80-c8db-11e9-86c5-9273d81bc88f.PNG)

## Fail
![IMG_0127](https://user-images.githubusercontent.com/8069071/63777860-c16c3d00-c8db-11e9-8d58-c6506821c3ce.PNG)

![IMG_0128](https://user-images.githubusercontent.com/8069071/63777866-c4672d80-c8db-11e9-95a3-47c8e08425d2.PNG)

![IMG_0129](https://user-images.githubusercontent.com/8069071/63777875-c6c98780-c8db-11e9-98b2-ab2cfa5fab58.PNG)

## Terminate
![IMG_0130](https://user-images.githubusercontent.com/8069071/63777880-c92be180-c8db-11e9-935c-656a86687824.PNG)

![IMG_0131](https://user-images.githubusercontent.com/8069071/63777887-cc26d200-c8db-11e9-8b2a-e07c4cfefa4e.PNG)

![IMG_0132](https://user-images.githubusercontent.com/8069071/63777891-cdf09580-c8db-11e9-8c5d-a6485110438d.PNG)



