### PR TITLE
MES-3500 Swap the comms and waiting room page order

### DIFF
--- a/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
@@ -9,7 +9,7 @@ import { AnalyticsProviderMock } from '../../../../providers/analytics/__mocks__
 import { AnalyticsProvider } from '../../../../providers/analytics/analytics';
 import { StartTest, ActivateTest } from '../../../../modules/tests/tests.actions';
 import { TestStatus } from '../../../../modules/tests/test-status/test-status.model';
-import { OFFICE_PAGE, COMMUNICATION_PAGE } from '../../../../pages/page-names.constants';
+import { OFFICE_PAGE, WAITING_ROOM_PAGE } from '../../../../pages/page-names.constants';
 import { DateTime, Duration } from '../../../../shared/helpers/date-time';
 import { SlotDetail } from '@dvsa/mes-journal-schema/Journal';
 import { ActivityCodes } from '../../../../shared/models/activity-codes';
@@ -105,7 +105,7 @@ describe('Test Outcome', () => {
 
         expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId));
         const { calls } = navController.push as jasmine.Spy;
-        expect(calls.argsFor(0)[0]).toBe(COMMUNICATION_PAGE);
+        expect(calls.argsFor(0)[0]).toBe(WAITING_ROOM_PAGE);
       });
     });
   });

--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -9,7 +9,7 @@ import { StartE2EPracticeTest } from '../../../pages/fake-journal/fake-journal.a
 import { startsWith, isEmpty } from 'lodash';
 import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
 import {
-  COMMUNICATION_PAGE,
+  WAITING_ROOM_PAGE,
   OFFICE_PAGE,
   PASS_FINALISATION_PAGE,
   JOURNAL_FORCE_CHECK_MODAL,
@@ -139,7 +139,7 @@ export class TestOutcomeComponent implements OnInit {
 
   resumeTest() {
     this.store$.dispatch(new ActivateTest(this.slotDetail.slotId, this.isRekey));
-    this.navController.push(COMMUNICATION_PAGE);
+    this.navController.push(WAITING_ROOM_PAGE);
   }
 
   needsDebrief(): boolean {
@@ -156,7 +156,7 @@ export class TestOutcomeComponent implements OnInit {
     } else {
       this.store$.dispatch(new StartTest(this.slotDetail.slotId, this.isRekey));
     }
-    this.navController.push(COMMUNICATION_PAGE);
+    this.navController.push(WAITING_ROOM_PAGE);
   }
 
   rekeyTest() {

--- a/src/pages/communication-page/__tests__/communication.effects.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.effects.spec.ts
@@ -1,15 +1,15 @@
-import { WaitingRoomEffects } from '../waiting-room.effects';
+import { CommunicationEffects } from '../communication.effects';
 import { TestBed } from '@angular/core/testing';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { StoreModule, Store } from '@ngrx/store';
 import { provideMockActions } from '@ngrx/effects/testing';
-import * as waitingRoomActions from '../waiting-room.actions';
+import * as communicationActions from '../communication.actions';
 import * as testStatusActions from '../../../modules/tests/test-status/test-status.actions';
 import * as testsActions from '../../../modules/tests/tests.actions';
 
-describe('Waiting Room Effects', () => {
+describe('Communication Effects', () => {
 
-  let effects: WaitingRoomEffects;
+  let effects: CommunicationEffects;
   let actions$: any;
 
   const currentSlotId = '1234';
@@ -29,20 +29,20 @@ describe('Waiting Room Effects', () => {
         }),
       ],
       providers: [
-        WaitingRoomEffects,
+        CommunicationEffects,
         provideMockActions(() => actions$),
         Store,
       ],
     });
-    effects = TestBed.get(WaitingRoomEffects);
+    effects = TestBed.get(CommunicationEffects);
   });
 
-  describe('submitWaitingRoomInfoEffect', () => {
+  describe('submitCommunicationInfoEffect', () => {
 
     it('should return SET_STATUS_DECIDED & PERSIST_TESTS actions', (done) => {
-      actions$.next(new waitingRoomActions.SubmitWaitingRoomInfo());
+      actions$.next(new communicationActions.CommunicationSubmitInfo());
 
-      effects.submitWaitingRoomInfoEffect$.subscribe((result) => {
+      effects.communicationSubmitInfoEffect$.subscribe((result) => {
         if (result instanceof testStatusActions.SetTestStatusStarted) {
           expect(result).toEqual(new testStatusActions.SetTestStatusStarted(currentSlotId));
         }

--- a/src/pages/communication-page/__tests__/communication.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { ComponentFixture, async, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { CommunicationPage } from '../communication';
 import { Store, StoreModule } from '@ngrx/store';
 import { StoreModel } from '../../../shared/models/store.model';
@@ -35,6 +35,7 @@ import { TranslateService, TranslateModule } from 'ng2-translate';
 import { PopulateTestSlotAttributes } from '../../../modules/tests/test-slot-attributes/test-slot-attributes.actions';
 import * as welshTranslations from '../../../assets/i18n/cy.json';
 import { PrivacyNoticeComponent } from '../components/privacy-notice/privacy-notice';
+import { CommunicationSubmitInfo } from '../communication.actions';
 
 describe('CommunicationPage', () => {
   let fixture: ComponentFixture<CommunicationPage>;
@@ -179,7 +180,14 @@ describe('CommunicationPage', () => {
 
     });
 
-    describe('Communication validation', () => {
+    describe('Submit', () => {
+      it('should dispatch the SubmitCommunicationInfo action', fakeAsync(() => {
+        const form = component.form;
+        form.get('radioCtrl').setValue(true);
+        component.onSubmit();
+        tick();
+        expect(store$.dispatch).toHaveBeenCalledWith(new CommunicationSubmitInfo());
+      }));
       it('form should only be valid whenever all form controls are initialised', () => {
         const form = component.form;
         form.get('radioCtrl').setValue(true);
@@ -292,9 +300,9 @@ describe('CommunicationPage', () => {
 
     });
     describe('clickBack', () => {
-      it('should should trigger the lock screen', () => {
+      it('should not should trigger the lock screen', () => {
         component.clickBack();
-        expect(deviceAuthenticationProvider.triggerLockScreen).toHaveBeenCalled();
+        expect(deviceAuthenticationProvider.triggerLockScreen).not.toHaveBeenCalled();
       });
     });
 

--- a/src/pages/communication-page/communication.actions.ts
+++ b/src/pages/communication-page/communication.actions.ts
@@ -6,6 +6,8 @@ export const COMMUNICATION_VIEW_CHOSE_EMAIL_PROVIDED_AT_BOOKING =
 export const COMMUNICATION_VIEW_CHOSE_NEW_EMAIL =
   '[CommunicationPage] Communication page chose new email';
 export const COMMUNICATION_VIEW_ADDED_NEW_CANDIDATE_EMAIL = '[CommunicationPage] Added new candidate email';
+export const COMMUNICATION_SUBMIT_INFO = '[CommunicationPage] Submit Waiting Room Info';
+export const COMMUNICATION_SUBMIT_INFO_ERROR = '[CommunicationPage] Submit Waiting Room Info Error';
 export const COMMUNICATION_VALIDATION_ERROR = '[CommunicationPage] Communication page validation error';
 
 export class CommunicationViewDidEnter implements Action {
@@ -25,6 +27,15 @@ export class CommunicationViewInputNewEmail implements Action {
   constructor(public payload: string) {}
 }
 
+export class CommunicationSubmitInfo implements Action {
+  readonly type = COMMUNICATION_SUBMIT_INFO;
+}
+
+export class CommunicationSubmitInfoError implements Action {
+  readonly type = COMMUNICATION_SUBMIT_INFO_ERROR;
+  constructor(public errorMessage: string) { }
+}
+
 export class CommunicationValidationError implements Action {
   readonly type = COMMUNICATION_VALIDATION_ERROR;
   constructor(public errorMessage: string) { }
@@ -34,4 +45,7 @@ export type Types =
   | CommunicationViewDidEnter
   | CommunicationViewChoseEmailProvidedAtBooking
   | CommunicationViewChoseNewEmail
-  | CommunicationViewInputNewEmail;
+  | CommunicationViewInputNewEmail
+  | CommunicationSubmitInfo
+  | CommunicationSubmitInfoError
+  | CommunicationValidationError;

--- a/src/pages/communication-page/communication.effects.ts
+++ b/src/pages/communication-page/communication.effects.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Effect, Actions, ofType } from '@ngrx/effects';
 import { switchMap, withLatestFrom, concatMap } from 'rxjs/operators';
 
-import * as waitingRoomActions from './waiting-room.actions';
+import * as communicationActions from './communication.actions';
 import * as testStatusActions from '../../modules/tests/test-status/test-status.actions';
 import * as testsActions from '../../modules/tests/tests.actions';
 import { StoreModel } from '../../shared/models/store.model';
@@ -12,15 +12,15 @@ import { getCurrentTestSlotId } from '../../modules/tests/tests.selector';
 import { of } from 'rxjs/observable/of';
 
 @Injectable()
-export class WaitingRoomEffects {
+export class CommunicationEffects {
   constructor(
     private actions$: Actions,
     private store$: Store<StoreModel>,
   ) {}
 
   @Effect()
-  submitWaitingRoomInfoEffect$ = this.actions$.pipe(
-    ofType(waitingRoomActions.SUBMIT_WAITING_ROOM_INFO),
+  communicationSubmitInfoEffect$ = this.actions$.pipe(
+    ofType(communicationActions.COMMUNICATION_SUBMIT_INFO),
     concatMap(action => of(action).pipe(
       withLatestFrom(
         this.store$.pipe(

--- a/src/pages/communication-page/communication.module.ts
+++ b/src/pages/communication-page/communication.module.ts
@@ -7,6 +7,7 @@ import { TranslateModule } from 'ng2-translate';
 import { EffectsModule } from '@ngrx/effects';
 import { CommunicationAnalyticsEffects } from './communication.analytics.effects';
 import { CommunicationComponentsModule } from './components/communication.components.module';
+import { CommunicationEffects } from './communication.effects';
 
 @NgModule({
   declarations: [
@@ -15,6 +16,7 @@ import { CommunicationComponentsModule } from './components/communication.compon
   imports: [
     IonicPageModule.forChild(CommunicationPage),
     EffectsModule.forFeature([
+      CommunicationEffects,
       CommunicationAnalyticsEffects,
     ]),
     ComponentsModule,

--- a/src/pages/waiting-room/__tests__/waiting-room.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../providers/device-authentication/__mocks__/device-authentication.mock';
 import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
-import { SubmitWaitingRoomInfo, WaitingRoomValidationError } from '../waiting-room.actions';
+import { WaitingRoomValidationError } from '../waiting-room.actions';
 import { of } from 'rxjs/observable/of';
 import { TranslateModule, TranslateService } from 'ng2-translate';
 import { Subscription } from 'rxjs/Subscription';
@@ -121,9 +121,9 @@ describe('WaitingRoomPage', () => {
   });
 
   describe('clickBack', () => {
-    it('should should not trigger the lock screen', () => {
+    it('should should trigger the lock screen', () => {
       component.clickBack();
-      expect(deviceAuthenticationProvider.triggerLockScreen).not.toHaveBeenCalled();
+      expect(deviceAuthenticationProvider.triggerLockScreen).toHaveBeenCalled();
     });
 
     describe('Declaration Validation', () => {
@@ -164,15 +164,6 @@ describe('WaitingRoomPage', () => {
     });
   });
   describe('onSubmit', () => {
-    it('should dispatch the SubmitWaitingRoomInfo action', fakeAsync(() => {
-      const form = component.form;
-      form.get('insuranceCheckboxCtrl').setValue(true);
-      form.get('residencyCheckboxCtrl').setValue(true);
-      form.get('signatureAreaCtrl').setValue('sig');
-      component.onSubmit();
-      tick();
-      expect(store$.dispatch).toHaveBeenCalledWith(new SubmitWaitingRoomInfo());
-    }));
     it('should dispatch the WaitingRoomValidationError action', fakeAsync(() => {
       const form = component.form;
       form.get('insuranceCheckboxCtrl').setValue(false);

--- a/src/pages/waiting-room/waiting-room.module.ts
+++ b/src/pages/waiting-room/waiting-room.module.ts
@@ -7,7 +7,6 @@ import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import { ComponentsModule } from '../../components/common/common-components.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from 'ng2-translate';
-import { WaitingRoomEffects } from './waiting-room.effects';
 
 @NgModule({
   declarations: [
@@ -16,7 +15,6 @@ import { WaitingRoomEffects } from './waiting-room.effects';
   imports: [
     IonicPageModule.forChild(WaitingRoomPage),
     EffectsModule.forFeature([
-      WaitingRoomEffects,
       WaitingRoomAnalyticsEffects,
     ]),
     ComponentsModule,

--- a/src/pages/waiting-room/waiting-room.ts
+++ b/src/pages/waiting-room/waiting-room.ts
@@ -32,7 +32,7 @@ import {
   getCommunicationPreference,
 } from '../../modules/tests/communication-preferences/communication-preferences.reducer';
 import { getConductedLanguage } from '../../modules/tests/communication-preferences/communication-preferences.selector';
-import { COMMUNICATION_PAGE, WAITING_ROOM_PAGE, WAITING_ROOM_TO_CAR_PAGE } from '../page-names.constants';
+import { COMMUNICATION_PAGE } from '../page-names.constants';
 
 interface WaitingRoomPageState {
   insuranceDeclarationAccepted$: Observable<boolean>;
@@ -94,7 +94,13 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
   }
 
   clickBack(): void {
-    this.navController.pop();
+    this.deviceAuthenticationProvider.triggerLockScreen()
+      .then(() => {
+        this.navController.pop();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
   }
 
   ngOnInit(): void {
@@ -214,23 +220,7 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
   onSubmit() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
-      this.deviceAuthenticationProvider.triggerLockScreen()
-        .then(() => {
-          this.store$.dispatch(new waitingRoomActions.SubmitWaitingRoomInfo());
-          this.navController.push(WAITING_ROOM_TO_CAR_PAGE).then(() => {
-            const communicationPage = this.navController.getViews().find(view => view.id === COMMUNICATION_PAGE);
-            if (communicationPage) {
-              this.navController.removeView(communicationPage);
-            }
-            const waitingRoomPage = this.navController.getViews().find(view => view.id === WAITING_ROOM_PAGE);
-            if (waitingRoomPage) {
-              this.navController.removeView(waitingRoomPage);
-            }
-          });
-        })
-        .catch((err) => {
-          this.store$.dispatch(new waitingRoomActions.SubmitWaitingRoomInfoError(err));
-        });
+      this.navController.push(COMMUNICATION_PAGE);
     } else {
       Object.keys(this.form.controls).forEach((controlName) => {
         if (this.form.controls[controlName].invalid) {


### PR DESCRIPTION
## Description and relevant Jira numbers
Switch the order of the pages the candidate sees at the start of the test.

**Old order**
Journal - Communication Page - Waiting Room - Waiting Room to Car

**New order**
Journal - Waiting Room - Communication Page - Waiting Room to Car

The effects have been updated as well as the code to ensure the lock screen is shown.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [x] Screenshot(s) captured on the physical device (if applicable)
- [x] Tested by QA
- [x] PO's approval
