### PR TITLE
MES-2620 - Retry autosave until successful

### DIFF
--- a/src/modules/tests/tests.effects.ts
+++ b/src/modules/tests/tests.effects.ts
@@ -219,8 +219,8 @@ export class TestsEffects {
       const completedTestKeys = Object.keys(tests.testStatus).filter((slotId: string) => (
         slotId !== testReportPracticeSlotId &&
         !startsWith(slotId, end2endPracticeSlotId) &&
-        tests.testStatus[slotId] === TestStatus.Completed) &&
-        !tests.startedTests[slotId].rekey,
+        [TestStatus.Completed, TestStatus.WriteUp].includes(tests.testStatus[slotId]) &&
+        !tests.startedTests[slotId].rekey),
       );
 
       const completedTests: TestToSubmit[] = completedTestKeys.map((slotId: string, index: number) => ({


### PR DESCRIPTION
## Description and relevant Jira numbers

**DEPENDENCY ON MES-2617** - https://jira.dvsacloud.uk/browse/MES-2617

PR to retry autosave submission (where `TestStatus='WriteUp'`) until successful - https://jira.dvsacloud.uk/browse/MES-2620

This was achieved by:

- Tying into the current test submission provider that selects tests where `TestStatus='Completed'`, to also select tests where `TestStatus='WriteUp'`

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
