### PR TITLE
MES-3512 - Stop access to dashboard when not authorised

### DIFF
--- a/src/pages/dashboard/dashboard.ts
+++ b/src/pages/dashboard/dashboard.ts
@@ -1,7 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
 import { IonicPage, NavController, NavParams, Platform, Navbar } from 'ionic-angular';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
-import { PracticeableBasePageComponent } from '../../shared/classes/practiceable-base-page';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { DashboardViewDidEnter } from './dashboard.actions';
@@ -17,6 +16,7 @@ import { DeviceProvider } from '../../providers/device/device';
 import { Insomnia } from '@ionic-native/insomnia';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { ExaminerRoleDescription } from '../../providers/app-config/constants/examiner-role.constants';
+import { BasePageComponent } from '../../shared/classes/base-page';
 
 interface DashboardPageState {
   appVersion$: Observable<string>;
@@ -27,7 +27,7 @@ interface DashboardPageState {
   selector: 'page-dashboard',
   templateUrl: 'dashboard.html',
 })
-export class DashboardPage extends PracticeableBasePageComponent {
+export class DashboardPage extends BasePageComponent {
 
   @ViewChild(Navbar) navBar: Navbar;
 
@@ -40,7 +40,7 @@ export class DashboardPage extends PracticeableBasePageComponent {
   todaysDate: string;
 
   constructor(
-    store$: Store<StoreModel>,
+    public store$: Store<StoreModel>,
     public navController: NavController,
     public navParams: NavParams,
     public platform: Platform,
@@ -52,7 +52,7 @@ export class DashboardPage extends PracticeableBasePageComponent {
     public screenOrientation: ScreenOrientation,
     public insomnia: Insomnia,
   ) {
-    super(platform, navController, authenticationProvider, store$);
+    super(platform, navController, authenticationProvider);
     this.employeeId = this.authenticationProvider.getEmployeeId() || 'NOT_KNOWN';
     this.name = this.authenticationProvider.getEmployeeName() || 'Unknown Name';
     this.role = ExaminerRoleDescription[this.appConfigProvider.getAppConfig().role] || 'Unknown Role';
@@ -91,6 +91,7 @@ export class DashboardPage extends PracticeableBasePageComponent {
   }
 
   ionViewWillEnter(): boolean {
+    super.ionViewWillEnter();
     if (this.merged$) {
       this.subscription = this.merged$.subscribe();
     }
@@ -99,7 +100,6 @@ export class DashboardPage extends PracticeableBasePageComponent {
   }
 
   ionViewDidLeave(): void {
-    super.ionViewDidLeave();
     if (this.subscription) {
       this.subscription.unsubscribe();
     }

--- a/src/providers/app-config/app-config.ts
+++ b/src/providers/app-config/app-config.ts
@@ -138,9 +138,14 @@ export class AppConfigProvider {
             (error) => {
               this.store$.dispatch(new SaveLog(this.logHelper
                 .createLog(LogType.ERROR, 'Getting remote config failed, using cached data', error)));
-              this.getCachedRemoteConfig()
-                .then(data => resolve(data))
-                .catch(error => reject(error));
+              reject(error);
+              if (error !== AuthenticationError.USER_NOT_AUTHORISED) {
+                this.getCachedRemoteConfig()
+                  .then(data => resolve(data))
+                  .catch(error => reject(error));
+              } else {
+                reject(error);
+              }
             },
           );
       } else {


### PR DESCRIPTION
## Description and relevant Jira numbers
- Changed the dashboard to use the correct Base Page
- Now check for a token when loading the dashboard page
- Updated the config provider so if a 403 is returned we don't try and load cached config, meaning they are shown the 'You're not authorised to use this app' message
## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
