### PR TITLE
MES-3526: Moving checkComplete flags to slotItem

### DIFF
--- a/mock/generate-local-journal.ts
+++ b/mock/generate-local-journal.ts
@@ -17,6 +17,18 @@ const localJournal: ExaminerWorkSchedule = {
     individualId: 9000000,
   },
   nonTestActivities: [],
+  personalCommitments: [
+    {
+      commitmentId: 123400,
+      startDate: today,
+      startTime: '10:00:00',
+      endDate: today,
+      endTime: '11:00:00',
+      activityCode: '104',
+      activityDescription: 'Medical appointment',
+      slotId: 1001,
+    },
+  ],
   testSlots: [
     {
       booking: {

--- a/mock/generate-local-journal.ts
+++ b/mock/generate-local-journal.ts
@@ -17,18 +17,6 @@ const localJournal: ExaminerWorkSchedule = {
     individualId: 9000000,
   },
   nonTestActivities: [],
-  personalCommitments: [
-    {
-      commitmentId: 123400,
-      startDate: today,
-      startTime: '10:00:00',
-      endDate: today,
-      endTime: '11:00:00',
-      activityCode: '104',
-      activityDescription: 'Medical appointment',
-      slotId: 1001,
-    },
-  ],
   testSlots: [
     {
       booking: {

--- a/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
@@ -33,11 +33,6 @@ describe('Test Outcome', () => {
     slots: {},
     selectedDate: 'dummy',
     examiner: { staffNumber: '123', individualId: 456 },
-    checkComplete: [
-      {
-        slotId: 123456,
-      },
-    ],
   };
 
   beforeEach(async(() => {
@@ -280,6 +275,7 @@ describe('Test Outcome', () => {
           component.specialRequirements = true;
           component.slotDetail = testSlotDetail;
           component.testStatus = TestStatus.Booked;
+          component.hasSeenCandidateDetails = false;
           spyOn(component, 'displayForceCheckModal');
           fixture.detectChanges();
 
@@ -296,6 +292,7 @@ describe('Test Outcome', () => {
           component.slotDetail = testSlotDetail;
           component.testStatus = TestStatus.Booked;
           component.slotDetail.slotId = 123456;
+          component.hasSeenCandidateDetails = true;
           spyOn(component, 'displayForceCheckModal');
           fixture.detectChanges();
 

--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -19,8 +19,6 @@ import { ModalEvent } from '../../../pages/journal/journal-rekey-modal/journal-r
 import { DateTime, Duration } from '../../../shared/helpers/date-time';
 import { SlotDetail, TestSlot } from '@dvsa/mes-journal-schema';
 import { ActivityCode } from '@dvsa/mes-test-schema/categories/B';
-// import { getCheckComplete } from '../../../pages/journal/journal.selector';
-// import { getJournalState } from '../../../pages/journal/journal.reducer';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs/Observable';
 import { StoreModel } from '../../../shared/models/store.model';
@@ -68,20 +66,12 @@ export class TestOutcomeComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    // const seenCandidateDetails$ = this.store$.pipe(
-    //   select(getJournalState),
-    //   map(journalData => getCheckComplete(journalData, this.slotDetail.slotId)),
-    // );
-
     const bookedTestSlot$ = this.store$.pipe(
       select(getRekeySearchState),
       map(getBookedTestSlot),
     );
 
     const merged$ = merge(
-      // seenCandidateDetails$.pipe(
-      //   map(candidateDetails => this.candidateDetailsViewed = candidateDetails),
-      // ),
       bookedTestSlot$.pipe(
         map((testSlot: TestSlot) => {
           if (isEmpty(testSlot)) {

--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -19,8 +19,8 @@ import { ModalEvent } from '../../../pages/journal/journal-rekey-modal/journal-r
 import { DateTime, Duration } from '../../../shared/helpers/date-time';
 import { SlotDetail, TestSlot } from '@dvsa/mes-journal-schema';
 import { ActivityCode } from '@dvsa/mes-test-schema/categories/B';
-import { getCheckComplete } from '../../../pages/journal/journal.selector';
-import { getJournalState } from '../../../pages/journal/journal.reducer';
+// import { getCheckComplete } from '../../../pages/journal/journal.selector';
+// import { getJournalState } from '../../../pages/journal/journal.reducer';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs/Observable';
 import { StoreModel } from '../../../shared/models/store.model';
@@ -50,6 +50,9 @@ export class TestOutcomeComponent implements OnInit {
   @Input()
   specialRequirements: boolean;
 
+  @Input()
+  hasSeenCandidateDetails: boolean;
+
   modal: Modal;
   isRekey: boolean = false;
   isTestSlotOnRekeySearch: boolean = false;
@@ -65,10 +68,10 @@ export class TestOutcomeComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    const seenCandidateDetails$ = this.store$.pipe(
-      select(getJournalState),
-      map(journalData => getCheckComplete(journalData, this.slotDetail.slotId)),
-    );
+    // const seenCandidateDetails$ = this.store$.pipe(
+    //   select(getJournalState),
+    //   map(journalData => getCheckComplete(journalData, this.slotDetail.slotId)),
+    // );
 
     const bookedTestSlot$ = this.store$.pipe(
       select(getRekeySearchState),
@@ -76,9 +79,9 @@ export class TestOutcomeComponent implements OnInit {
     );
 
     const merged$ = merge(
-      seenCandidateDetails$.pipe(
-        map(candidateDetails => this.candidateDetailsViewed = candidateDetails),
-      ),
+      // seenCandidateDetails$.pipe(
+      //   map(candidateDetails => this.candidateDetailsViewed = candidateDetails),
+      // ),
       bookedTestSlot$.pipe(
         map((testSlot: TestSlot) => {
           if (isEmpty(testSlot)) {
@@ -196,7 +199,7 @@ export class TestOutcomeComponent implements OnInit {
   }
 
   clickStartOrResumeTest() {
-    if (this.specialRequirements && !this.candidateDetailsViewed) {
+    if (this.specialRequirements && !this.hasSeenCandidateDetails) {
       this.displayForceCheckModal();
       return;
     }

--- a/src/components/test-slot/test-slot/test-slot.html
+++ b/src/components/test-slot/test-slot/test-slot.html
@@ -44,7 +44,8 @@
         </ion-col>
         <ion-col class="test-outcome-col" no-padding padding-right>
           <test-outcome [slotDetail]="slot.slotDetail" [canStartTest]="canStartTest()" [testStatus]="componentState.testStatus$ | async"
-            [activityCode]="componentState.testActivityCode$ | async" [specialRequirements]="isIndicatorNeededForSlot()"></test-outcome>
+            [activityCode]="componentState.testActivityCode$ | async" [specialRequirements]="isIndicatorNeededForSlot()"
+            [hasSeenCandidateDetails]="hasSeenCandidateDetails"></test-outcome>
         </ion-col>
       </ion-row>
       <ion-row class="slot-footer" [ngClass]="{'vehicle-details-displayed': showVehicleDetails()}" align-items-center>

--- a/src/components/test-slot/test-slot/test-slot.ts
+++ b/src/components/test-slot/test-slot/test-slot.ts
@@ -36,6 +36,9 @@ export class TestSlotComponent implements SlotComponent, OnInit {
   hasSlotChanged: boolean;
 
   @Input()
+  hasSeenCandidateDetails: boolean;
+
+  @Input()
   showLocation: boolean;
 
   componentState: TestSlotComponentState;

--- a/src/modules/tests/__tests__/tests.selector.spec.ts
+++ b/src/modules/tests/__tests__/tests.selector.spec.ts
@@ -63,7 +63,6 @@ describe('testsSelector', () => {
         slots: {},
         selectedDate: 'dummy',
         examiner: { staffNumber: '123', individualId: 456 },
-        checkComplete: [],
       };
       const appInfo: AppInfoModel = { versionNumber: '0.0.0' };
       const logs: LogsModel = [];

--- a/src/pages/journal/__tests__/journal.reducer.spec.ts
+++ b/src/pages/journal/__tests__/journal.reducer.spec.ts
@@ -41,6 +41,7 @@ describe('Journal Reducer', () => {
         slotItemsByDate: {
           ['2019-01-13']: [{
             hasSlotChanged: false,
+            hasSeenCandidateDetails: false,
             slotData: {},
           },
           ],
@@ -68,6 +69,7 @@ describe('Journal Reducer', () => {
         slots: {
           ['2019-01-13']: [{
             hasSlotChanged: false,
+            hasSeenCandidateDetails: false,
             slotData: {},
           },
           ],
@@ -79,7 +81,7 @@ describe('Journal Reducer', () => {
 
   describe('[JournalPage] Unload Journal', () => {
     it('should clear the journal slots', () => {
-      const stateWithJournals = { ...initialState, slots: { ['2019-01-13']: [new SlotItem({}, false)] } };
+      const stateWithJournals = { ...initialState, slots: { ['2019-01-13']: [new SlotItem({}, false, false)] } };
       const action = new UnloadJournal();
       const result = journalReducer(stateWithJournals, action);
       expect(result.slots).toEqual({});
@@ -89,7 +91,7 @@ describe('Journal Reducer', () => {
         isLoading: true,
         lastRefreshed: new Date(),
         selectedDate: 'dummy',
-        slots: { ['2019-01-13']: [new SlotItem({}, false)] },
+        slots: { ['2019-01-13']: [new SlotItem({}, false, false)] },
         examiner: { staffNumber: '123', individualId: 456 },
         checkComplete: [],
       };
@@ -118,7 +120,7 @@ describe('Journal Reducer', () => {
         ...initialState,
         selectedDate: slotDate,
         slots: {
-          [`${slotDate}`]: [new SlotItem({ slotDetail: { slotId: 1234 } }, true)],
+          [`${slotDate}`]: [new SlotItem({ slotDetail: { slotId: 1234 } }, true, false)],
         },
       };
       const action = new ClearChangedSlot(1234);
@@ -128,21 +130,20 @@ describe('Journal Reducer', () => {
     });
   });
 
-  describe('[JournalPage] Check Complete', () => {
-    it('Candidate details was checked', () => {
+  describe('[JournalPage] Candidate Details Seen', () => {
+    it('should record that has seen candidate details for a specific slot', () => {
       const slotDate = '2019-01-13';
       const stateWithChangedSlot = {
         ...initialState,
         selectedDate: slotDate,
-        checkComplete: [],
+        slots: {
+          [`${slotDate}`]: [new SlotItem({ slotDetail: { slotId: 1234 } }, true, false)],
+        },
       };
       const action = new CandidateDetailsSeen(1234);
       const result = journalReducer(stateWithChangedSlot, action);
 
-      expect(result.checkComplete.length).toEqual(1);
-      expect(result.checkComplete[0]).toEqual({
-        slotId: 1234,
-      });
+      expect(result.slots[slotDate][0].hasSeenCandidateDetails).toEqual(true);
 
     });
   });

--- a/src/pages/journal/__tests__/journal.selector.spec.ts
+++ b/src/pages/journal/__tests__/journal.selector.spec.ts
@@ -2,7 +2,7 @@ import { JournalModel } from '../journal.model';
 import {
   getSlotsOnSelectedDate, getLastRefreshed, getIsLoading,
   getError, getLastRefreshedTime,
-  canNavigateToNextDay, canNavigateToPreviousDay, getCheckComplete,
+  canNavigateToNextDay, canNavigateToPreviousDay,
 } from '../journal.selector';
 import { MesError } from '../../../shared/models/mes-error.model';
 import { DateTime } from '../../../shared/helpers/date-time';
@@ -16,6 +16,7 @@ describe('JournalSelector', () => {
       '2019-01-17': [
         {
           hasSlotChanged: false,
+          hasSeenCandidateDetails: false,
           slotData: {},
         },
       ],
@@ -27,7 +28,6 @@ describe('JournalSelector', () => {
     },
     selectedDate: '2019-01-17',
     examiner: { staffNumber: '123', individualId: 456 },
-    checkComplete: [],
   };
 
   describe('getIsLoading', () => {
@@ -82,19 +82,20 @@ describe('JournalSelector', () => {
           '2019-01-29': [
             {
               hasSlotChanged: false,
+              hasSeenCandidateDetails: false,
               slotData: {},
             },
           ],
           '2019-01-30': [
             {
               hasSlotChanged: false,
+              hasSeenCandidateDetails: false,
               slotData: {},
             },
           ],
         },
         selectedDate: '2019-01-29',
         examiner: { staffNumber: '123', individualId: 456 },
-        checkComplete: [],
       };
 
       const result = canNavigateToNextDay(journal);
@@ -110,19 +111,20 @@ describe('JournalSelector', () => {
           '2019-01-28': [
             {
               hasSlotChanged: false,
+              hasSeenCandidateDetails: false,
               slotData: {},
             },
           ],
           '2019-01-29': [
             {
               hasSlotChanged: false,
+              hasSeenCandidateDetails: false,
               slotData: {},
             },
           ],
         },
         selectedDate: '2019-01-28',
         examiner: { staffNumber: '123', individualId: 456 },
-        checkComplete: [],
       };
 
       const result = canNavigateToNextDay(journal);
@@ -138,19 +140,20 @@ describe('JournalSelector', () => {
           '2019-01-28': [
             {
               hasSlotChanged: false,
+              hasSeenCandidateDetails: false,
               slotData: {},
             },
           ],
           '2019-01-29': [
             {
               hasSlotChanged: false,
+              hasSeenCandidateDetails: false,
               slotData: {},
             },
           ],
         },
         selectedDate: '2019-02-04',
         examiner: { staffNumber: '123', individualId: 456 },
-        checkComplete: [],
       };
 
       const result = canNavigateToNextDay(journal);
@@ -168,13 +171,13 @@ describe('JournalSelector', () => {
           ['2019-01-01']: [
             {
               hasSlotChanged: false,
+              hasSeenCandidateDetails: false,
               slotData: {},
             },
           ],
         },
         selectedDate: '2019-01-01',
         examiner: { staffNumber: '123', individualId: 456 },
-        checkComplete: [],
       };
 
       const result = canNavigateToPreviousDay(journal, DateTime.at('2019-01-15'));
@@ -190,45 +193,26 @@ describe('JournalSelector', () => {
           ['2019-01-13']: [
             {
               hasSlotChanged: false,
+              hasSeenCandidateDetails: false,
               slotData: {},
             },
           ],
           ['2019-01-14']: [
             {
               hasSlotChanged: false,
+              hasSeenCandidateDetails: false,
               slotData: {},
             },
           ],
         },
         selectedDate: '2019-01-14',
         examiner: { staffNumber: '123', individualId: 456 },
-        checkComplete: [],
       };
 
       const result = canNavigateToPreviousDay(journal, DateTime.at('2019-01-13'));
 
       expect(result).toBe(true);
     });
-  });
-
-  describe('getCheckComplete', () => {
-    it('returns all the checkComplete data', () => {
-      const journal: JournalModel = {
-        isLoading: true,
-        lastRefreshed: new Date(0),
-        slots: {},
-        selectedDate: '2019-01-01',
-        examiner: { staffNumber: '123', individualId: 456 },
-        checkComplete: [{
-          slotId: 1234,
-        }],
-      };
-
-      const result = getCheckComplete(journal, 1234);
-
-      expect(result).toBe(true);
-    });
-
   });
 
 });

--- a/src/pages/journal/journal.model.ts
+++ b/src/pages/journal/journal.model.ts
@@ -18,12 +18,7 @@ export type JournalModel = {
   error?: MesError,
   selectedDate: string,
   examiner: Examiner,
-  checkComplete: CheckComplete[],
 };
-
-export interface CheckComplete {
-  slotId: number;
-}
 
 export interface ExaminerSlotItems {
   examiner: Examiner;

--- a/src/pages/journal/journal.selector.ts
+++ b/src/pages/journal/journal.selector.ts
@@ -4,10 +4,6 @@ import { isNil } from 'lodash';
 import { DateTime, Duration } from '../../shared/helpers/date-time';
 import { SlotItem } from '../../providers/slot-selector/slot-item';
 
-export const getCheckComplete = (journal: JournalModel, slotId: number) => {
-  return journal.checkComplete.filter(item => item.slotId === slotId).length === 1;
-};
-
 export const getSlots = (journal: JournalModel) => journal.slots;
 
 export const getSlotsOnSelectedDate = (journal: JournalModel) => journal.slots[journal.selectedDate];

--- a/src/pages/journal/journal.ts
+++ b/src/pages/journal/journal.ts
@@ -35,6 +35,7 @@ import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { DeviceProvider } from '../../providers/device/device';
 import { Insomnia } from '@ionic-native/insomnia';
 import { PersonalCommitmentSlotComponent } from './personal-commitment/personal-commitment';
+import { TestSlotComponent } from '../../components/test-slot/test-slot/test-slot';
 
 interface JournalPageState {
   selectedDate$: Observable<string>;
@@ -226,14 +227,21 @@ export class JournalPage extends BasePageComponent implements OnInit {
     for (const slot of slots) {
       const factory = this.resolver.resolveComponentFactory(slot.component);
       const componentRef = this.slotContainer.createComponent(factory);
+
       (<SlotComponent>componentRef.instance).slot = slot.slotData;
       (<SlotComponent>componentRef.instance).hasSlotChanged = slot.hasSlotChanged;
       (<SlotComponent>componentRef.instance).showLocation = (slot.slotData.testCentre.centreName !== lastLocation);
       lastLocation = slot.slotData.testCentre.centreName;
 
-      // if this is a personal commitment assign it to the component
-      (<PersonalCommitmentSlotComponent>componentRef.instance).personalCommitments =
-        slot.personalCommitment;
+      if (componentRef.instance instanceof PersonalCommitmentSlotComponent) {
+        // if this is a personal commitment assign it to the component
+        (<PersonalCommitmentSlotComponent>componentRef.instance).personalCommitments = slot.personalCommitment;
+      }
+
+      if (componentRef.instance instanceof TestSlotComponent) {
+        // if this is a test slot assign hasSeenCandidateDetails separately
+        (<TestSlotComponent>componentRef.instance).hasSeenCandidateDetails = slot.hasSeenCandidateDetails;
+      }
     }
   }
 
@@ -244,10 +252,6 @@ export class JournalPage extends BasePageComponent implements OnInit {
 
   public refreshJournal = () => {
     this.loadJournalManually();
-  }
-
-  gotoWaitingRoom($event) {
-    console.log('going to waiting room with ', $event);
   }
 
   logout() {

--- a/src/pages/rekey-search/rekey-search.html
+++ b/src/pages/rekey-search/rekey-search.html
@@ -58,7 +58,8 @@
     </div>
 
     <p class="results-message" *ngIf="!isBookedTestSlotEmpty(pageState.bookedTestSlot$ | async)">
-      <test-slot [slot]="(pageState.bookedTestSlot$ | async)" [hasSlotChanged]="false" [showLocation]="false"></test-slot>
+      <test-slot [slot]="(pageState.bookedTestSlot$ | async)" [hasSlotChanged]="false"
+      [hasSeenCandidateDetails]="true" [showLocation]="false"></test-slot>
     </p>
 
   </div>

--- a/src/providers/incomplete-tests/incomplete-tests.spec.ts
+++ b/src/providers/incomplete-tests/incomplete-tests.spec.ts
@@ -13,6 +13,7 @@ describe('Incomplete Tests Provider', () => {
 
   const catBTest: SlotItem = {
     hasSlotChanged: false,
+    hasSeenCandidateDetails: false,
     slotData: {
       booking: {
         application: {
@@ -34,6 +35,7 @@ describe('Incomplete Tests Provider', () => {
 
   const catBETest: SlotItem = {
     hasSlotChanged: false,
+    hasSeenCandidateDetails: false,
     slotData: {
       booking: {
         application: {
@@ -79,6 +81,7 @@ describe('Incomplete Tests Provider', () => {
         vehicleTypeCode: '',
       },
       hasSlotChanged: false,
+      hasSeenCandidateDetails: false,
     },
     {
       slotData: {
@@ -97,6 +100,7 @@ describe('Incomplete Tests Provider', () => {
         vehicleTypeCode: '',
       },
       hasSlotChanged: false,
+      hasSeenCandidateDetails: false,
     },
     {
       slotData: {
@@ -115,6 +119,7 @@ describe('Incomplete Tests Provider', () => {
         vehicleTypeCode: '',
       },
       hasSlotChanged: false,
+      hasSeenCandidateDetails: false,
     },
     {
       slotData: {
@@ -133,6 +138,7 @@ describe('Incomplete Tests Provider', () => {
         vehicleTypeCode: '',
       },
       hasSlotChanged: false,
+      hasSeenCandidateDetails: false,
     },
     {
       slotData: {
@@ -151,6 +157,7 @@ describe('Incomplete Tests Provider', () => {
         vehicleTypeCode: '',
       },
       hasSlotChanged: false,
+      hasSeenCandidateDetails: false,
     }];
 
   beforeEach(() => {

--- a/src/providers/slot-selector/__tests__/slot-selector.spec.ts
+++ b/src/providers/slot-selector/__tests__/slot-selector.spec.ts
@@ -27,7 +27,7 @@ describe('Slot Selector', () => {
       activityCode: code,
     };
     const journalSlots = [
-      new SlotItem(travelSlot, false),
+      new SlotItem(travelSlot, false, false),
     ];
     return journalSlots;
   };
@@ -50,7 +50,7 @@ describe('Slot Selector', () => {
       },
     };
     const journalSlots = [
-      new SlotItem(slot, false),
+      new SlotItem(slot, false, false),
     ];
     return journalSlots;
   };
@@ -109,7 +109,7 @@ describe('Slot Selector', () => {
       it('should provide the EmptySlotComponent for slots that have no booking or activity code', () => {
         const slot = {};
         const journalSlots = [
-          new SlotItem(slot, false),
+          new SlotItem(slot, false, false),
         ];
         const response = slotSelector.getSlotTypes(journalSlots);
 

--- a/src/providers/slot-selector/slot-item.ts
+++ b/src/providers/slot-selector/slot-item.ts
@@ -6,6 +6,7 @@ export class SlotItem {
   constructor(
     public slotData: TestSlot | NonTestActivity,
     public hasSlotChanged: boolean,
+    public hasSeenCandidateDetails: boolean,
     public component?: Type<SlotComponent>,
     public activityCode?: string,
     public personalCommitment?: PersonalCommitment[],

--- a/src/providers/slot/slot.ts
+++ b/src/providers/slot/slot.ts
@@ -35,8 +35,10 @@ export class SlotProvider {
       const replacedJournalSlot = oldJournalSlots.find(oldSlot => oldSlot.slotData.slotDetail.slotId === newSlotId);
 
       let differenceFound = false;
+      let hasSeenCandidateDetails = false;
       if (replacedJournalSlot) {
         differenceFound = replacedJournalSlot.hasSlotChanged;
+        hasSeenCandidateDetails = replacedJournalSlot.hasSeenCandidateDetails;
         const differenceToSlot = DeepDiff(replacedJournalSlot.slotData, newSlot);
         if (Array.isArray(differenceToSlot) && differenceToSlot.some(change => change.kind === 'E')) {
           this.store$.dispatch(new SlotHasChanged(newSlotId));
@@ -52,7 +54,7 @@ export class SlotProvider {
 
       // add personalCommitment information to SlotItem, component and activityCode set to null
       // as they are not constructed at this stage.
-      return new SlotItem(newSlot, differenceFound, null, null, personalCommitment);
+      return new SlotItem(newSlot, differenceFound, hasSeenCandidateDetails, null, null, personalCommitment);
     });
   }
 


### PR DESCRIPTION
Initially the JournalPage was the first page that loaded in the mobile app. And that module brought its slice of the state and all that. After introducing the Dashboard page we don't need to go to the Journal in order to search for a test to rekey from the RekeySearchPage.
The fact that we are reusing the the same test journey for normal test or rekey from both pages (Journal, RekeySearch) requires us to be generic. So the checkComplete array had to be removed and the information stored there had to be moved to the individual SlotItems.

