### PR TITLE
MES-3509 set the change marker when examiner conducted is changed

### DIFF
--- a/src/modules/tests/examiner-booked/__tests__/examiner-booked.effects.spec.ts
+++ b/src/modules/tests/examiner-booked/__tests__/examiner-booked.effects.spec.ts
@@ -1,0 +1,64 @@
+import { ExaminerBookedEffects } from '../examiner-booked.effects';
+import { SetExaminerBooked } from '../examiner-booked.actions';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { testsReducer } from '../../tests.reducer';
+import { Store, StoreModule } from '@ngrx/store';
+import { StoreModel } from '../../../../shared/models/store.model';
+import { SetChangeMarker } from '../../change-marker/change-marker.actions';
+import { StartTest } from '../../tests.actions';
+import { SetExaminerConducted } from '../../examiner-conducted/examiner-conducted.actions';
+
+describe('Examiner Booked Effects', () => {
+
+  let effects: ExaminerBookedEffects;
+  let actions$: any;
+  let store$: Store<StoreModel>;
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: testsReducer,
+        }),
+      ],
+      providers: [
+        ExaminerBookedEffects,
+        provideMockActions(() => actions$),
+        Store,
+      ],
+    });
+    effects = TestBed.get(ExaminerBookedEffects);
+    store$ = TestBed.get(Store);
+  });
+
+  describe('setExaminerBookedEffect', () => {
+    it('should set the change marker to true when the examiner booked is different to the conducted', (done) => {
+      // ARRANGE
+      store$.dispatch(new StartTest(12345));
+      store$.dispatch(new SetExaminerConducted(123456));
+      // ACT
+      actions$.next(new SetExaminerBooked(100001));
+      // ASSERT
+      effects.setExaminerBookedEffect$.subscribe((result) => {
+        expect(result).toEqual(new SetChangeMarker(true));
+        done();
+      });
+    });
+    it('should set the change marker to false when the examiner booked is the same as the conducted', (done) => {
+      // ARRANGE
+      store$.dispatch(new StartTest(12345));
+      store$.dispatch(new SetExaminerConducted(123456));
+      // ACT
+      actions$.next(new SetExaminerBooked(123456));
+      // ASSERT
+      effects.setExaminerBookedEffect$.subscribe((result) => {
+        expect(result).toEqual(new SetChangeMarker(false));
+        done();
+      });
+    });
+  });
+
+});

--- a/src/modules/tests/examiner-booked/examiner-booked.effects.ts
+++ b/src/modules/tests/examiner-booked/examiner-booked.effects.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { map, withLatestFrom, concatMap } from 'rxjs/operators';
+import { of } from 'rxjs/observable/of';
+import { StoreModel } from '../../../shared/models/store.model';
+import { Store, select } from '@ngrx/store';
+import { getTests } from './../tests.reducer';
+import { getCurrentTest } from './../tests.selector';
+import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
+import { SetChangeMarker } from '../change-marker/change-marker.actions';
+import { SetExaminerBooked, SET_EXAMINER_BOOKED } from './examiner-booked.actions';
+
+@Injectable()
+export class ExaminerBookedEffects {
+  constructor(
+    private actions$: Actions,
+    private store$: Store<StoreModel>,
+  ) {}
+
+  @Effect()
+  setExaminerBookedEffect$ = this.actions$.pipe(
+    ofType(SET_EXAMINER_BOOKED),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+        ),
+      ),
+    )),
+    map(([action, test]: [SetExaminerBooked, StandardCarTestCATBSchema]) =>
+      new SetChangeMarker(action.examinerBooked !== test.examinerConducted)),
+  );
+
+}

--- a/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.effects.spec.ts
+++ b/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.effects.spec.ts
@@ -1,0 +1,64 @@
+import { ExaminerConductedEffects } from '../examiner-conducted.effects';
+import { SetExaminerConducted } from '../examiner-conducted.actions';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { testsReducer } from '../../tests.reducer';
+import { Store, StoreModule } from '@ngrx/store';
+import { StoreModel } from '../../../../shared/models/store.model';
+import { SetChangeMarker } from '../../change-marker/change-marker.actions';
+import { StartTest } from '../../tests.actions';
+import { SetExaminerBooked } from '../../examiner-booked/examiner-booked.actions';
+
+describe('Examiner Conducted Effects', () => {
+
+  let effects: ExaminerConductedEffects;
+  let actions$: any;
+  let store$: Store<StoreModel>;
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          tests: testsReducer,
+        }),
+      ],
+      providers: [
+        ExaminerConductedEffects,
+        provideMockActions(() => actions$),
+        Store,
+      ],
+    });
+    effects = TestBed.get(ExaminerConductedEffects);
+    store$ = TestBed.get(Store);
+  });
+
+  describe('setExaminerConductedEffect', () => {
+    it('should set the change marker to true when the examiner conducted is different to the booked', (done) => {
+      // ARRANGE
+      store$.dispatch(new StartTest(12345));
+      store$.dispatch(new SetExaminerBooked(123456));
+      // ACT
+      actions$.next(new SetExaminerConducted(100001));
+      // ASSERT
+      effects.setExaminerConductedEffect$.subscribe((result) => {
+        expect(result).toEqual(new SetChangeMarker(true));
+        done();
+      });
+    });
+    it('should set the change marker to false when the examiner conducted is the same as the booked', (done) => {
+      // ARRANGE
+      store$.dispatch(new StartTest(12345));
+      store$.dispatch(new SetExaminerBooked(123456));
+      // ACT
+      actions$.next(new SetExaminerConducted(123456));
+      // ASSERT
+      effects.setExaminerConductedEffect$.subscribe((result) => {
+        expect(result).toEqual(new SetChangeMarker(false));
+        done();
+      });
+    });
+  });
+
+});

--- a/src/modules/tests/examiner-conducted/examiner-conducted.effects.ts
+++ b/src/modules/tests/examiner-conducted/examiner-conducted.effects.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { map, withLatestFrom, concatMap } from 'rxjs/operators';
+import { of } from 'rxjs/observable/of';
+import { StoreModel } from '../../../shared/models/store.model';
+import { Store, select } from '@ngrx/store';
+import { getTests } from './../tests.reducer';
+import { getCurrentTest } from './../tests.selector';
+import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
+import { SetChangeMarker } from '../change-marker/change-marker.actions';
+import { SetExaminerConducted, SET_EXAMINER_CONDUCTED } from './examiner-conducted.actions';
+
+@Injectable()
+export class ExaminerConductedEffects {
+  constructor(
+    private actions$: Actions,
+    private store$: Store<StoreModel>,
+  ) {}
+
+  @Effect()
+  setExaminerConductedEffect$ = this.actions$.pipe(
+    ofType(SET_EXAMINER_CONDUCTED),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+        ),
+      ),
+    )),
+    map(([action, test]: [SetExaminerConducted, StandardCarTestCATBSchema]) =>
+      new SetChangeMarker(action.examinerConducted !== test.examinerBooked)),
+  );
+
+}

--- a/src/modules/tests/tests.module.ts
+++ b/src/modules/tests/tests.module.ts
@@ -9,6 +9,8 @@ import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import { TestDataEffects } from './test-data/test-data.effects';
 import { NavigationProvider } from '../../providers/navigation/navigation';
 import { NavigationStateProvider } from '../../providers/navigation-state/navigation-state';
+import { ExaminerBookedEffects } from './examiner-booked/examiner-booked.effects';
+import { ExaminerConductedEffects } from './examiner-conducted/examiner-conducted.effects';
 
 @NgModule({
   imports: [
@@ -17,6 +19,8 @@ import { NavigationStateProvider } from '../../providers/navigation-state/naviga
       TestsEffects,
       TestsAnalyticsEffects,
       TestDataEffects,
+      ExaminerBookedEffects,
+      ExaminerConductedEffects,
     ]),
   ],
   providers:[


### PR DESCRIPTION
## Description and relevant Jira numbers
- set the value of change marker when the value of examiner booked or conducted is changed
 
## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
