### PR TITLE
MES-3530 add rekey date to submitted rekey tests

### DIFF
--- a/src/modules/tests/rekey-date/__tests__/rekey.reducer.spec.ts
+++ b/src/modules/tests/rekey-date/__tests__/rekey.reducer.spec.ts
@@ -1,0 +1,9 @@
+import { rekeyDateReducer } from '../rekey-date.reducer';
+import { SetRekeyDate } from '../rekey-date.actions';
+
+describe('rekeyDateReducer', () => {
+  it('should return a date', () => {
+    const result = rekeyDateReducer(null, new SetRekeyDate());
+    expect(result).not.toBeNull();
+  });
+});

--- a/src/modules/tests/rekey-date/rekey-date.actions.ts
+++ b/src/modules/tests/rekey-date/rekey-date.actions.ts
@@ -1,0 +1,9 @@
+import { Action } from '@ngrx/store';
+
+export const SET_REKEY_DATE = '[Rekey Date Actions] Set the date the test was rekeyed';
+
+export class SetRekeyDate implements Action {
+  readonly type = SET_REKEY_DATE;
+}
+
+export type Types = SetRekeyDate;

--- a/src/modules/tests/rekey-date/rekey-date.reducer.ts
+++ b/src/modules/tests/rekey-date/rekey-date.reducer.ts
@@ -1,0 +1,16 @@
+import  * as rekeyDateActions from './rekey-date.actions';
+import { createFeatureSelector } from '@ngrx/store';
+import { DateTime } from '../../../shared/helpers/date-time';
+
+export const initialState: string = null;
+
+export const rekeyDateReducer = (state = initialState, action: rekeyDateActions.Types) => {
+  switch (action.type) {
+    case rekeyDateActions.SET_REKEY_DATE:
+      return new DateTime().format('YYYY-MM-DDTHH:mm:ss');
+    default:
+      return state;
+  }
+};
+
+export const getRekeyDate = createFeatureSelector<boolean>('rekeyDate');

--- a/src/modules/tests/rekey-date/rekey-date.reducer.ts
+++ b/src/modules/tests/rekey-date/rekey-date.reducer.ts
@@ -7,7 +7,7 @@ export const initialState: string = null;
 export const rekeyDateReducer = (state = initialState, action: rekeyDateActions.Types) => {
   switch (action.type) {
     case rekeyDateActions.SET_REKEY_DATE:
-      return new DateTime().format('YYYY-MM-DDTHH:mm:ss');
+      return state ? state : new DateTime().format('YYYY-MM-DDTHH:mm:ss');
     default:
       return state;
   }

--- a/src/modules/tests/tests.reducer.ts
+++ b/src/modules/tests/tests.reducer.ts
@@ -31,6 +31,7 @@ import { examinerConductedReducer } from './examiner-conducted/examiner-conducte
 import { examinerKeyedReducer } from './examiner-keyed/examiner-keyed.reducer';
 import { changeMarkerReducer } from './change-marker/change-marker';
 import { rekeyReasonReducer } from './rekey-reason/rekey-reason.reducer';
+import { rekeyDateReducer } from './rekey-date/rekey-date.reducer';
 
 export const initialState: TestsModel = {
   currentTest: { slotId: null },
@@ -117,6 +118,7 @@ const createStateObject = (state: TestsModel, action: Action, slotId: string) =>
             testSummary: testSummaryReducer,
             communicationPreferences: communicationPreferencesReducer,
             rekey: rekeyReducer,
+            rekeyDate: rekeyDateReducer,
             rekeyReason: rekeyReasonReducer,
             examinerBooked: examinerBookedReducer,
             examinerConducted: examinerConductedReducer,

--- a/src/pages/rekey-reason/rekey-reason.ts
+++ b/src/pages/rekey-reason/rekey-reason.ts
@@ -46,6 +46,7 @@ import { getCurrentTest } from '../../modules/tests/tests.selector';
 import { IpadIssue, Transfer, Other } from '@dvsa/mes-test-schema/categories/B';
 import { EndRekey } from '../../modules/tests/rekey/rekey.actions';
 import { ExitRekeyModalEvent } from './components/exit-rekey-modal/exit-rekey-modal.constants';
+import { SetRekeyDate } from '../../modules/tests/rekey-date/rekey-date.actions';
 
 interface RekeyReasonPageState {
   uploadStatus$: Observable<RekeyReasonUploadModel>;
@@ -158,6 +159,7 @@ export class RekeyReasonPage extends BasePageComponent {
   onUploadRekeyModalDismiss = (event: UploadRekeyModalEvent): void => {
     switch (event) {
       case UploadRekeyModalEvent.UPLOAD:
+        this.store$.dispatch(new SetRekeyDate());
         this.store$.dispatch(new SendCurrentTest());
         break;
     }


### PR DESCRIPTION
## Description and relevant Jira numbers
- Add the rekey date (without timezones) when the rekey test is submitted
- Only set the date the first time the submission is attempted

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

![Screenshot 2019-09-04 at 17 38 55](https://user-images.githubusercontent.com/8069071/64274426-45a56c80-cf3b-11e9-9dd2-abf54671d9c0.png)
