### PR TITLE
MES-3064 - Analytics for Rekey

### DIFF
--- a/src/modules/tests/tests.analytics.effects.ts
+++ b/src/modules/tests/tests.analytics.effects.ts
@@ -17,11 +17,14 @@ import {
   SendCompletedTestsFailure,
   TEST_OUTCOME_CHANGED,
   TestOutcomeChanged,
+  START_TEST,
+  StartTest,
 } from './tests.actions';
 import { of } from 'rxjs/observable/of';
 import { TestsModel } from './tests.model';
 import { AnalyticRecorded } from '../../providers/analytics/analytics.actions';
 import { formatApplicationReference } from '../../shared/helpers/formatters';
+import { NavigationStateProvider } from '../../providers/navigation-state/navigation-state';
 
 @Injectable()
 export class TestsAnalyticsEffects {
@@ -29,6 +32,7 @@ export class TestsAnalyticsEffects {
     private analytics: AnalyticsProvider,
     private actions$: Actions,
     private store$: Store<StoreModel>,
+    private navigationStateProvider: NavigationStateProvider,
   ) {
     this.analytics.initialiseAnalytics()
       .then(() => {})
@@ -107,6 +111,20 @@ export class TestsAnalyticsEffects {
       this.analytics.addCustomDimension(
         AnalyticsDimensionIndices.CANDIDATE_ID, journalDataOfTest.candidate.candidateId.toString());
 
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  startTestAnalyticsEffect$ = this.actions$.pipe(
+    ofType(START_TEST),
+    switchMap((action: StartTest) => {
+      if (this.navigationStateProvider.isRekeySearch()) {
+        this.analytics.logEvent(
+          AnalyticsEventCategories.REKEY_SEARCH,
+          AnalyticsEvents.START_TEST,
+        );
+      }
       return of(new AnalyticRecorded());
     }),
   );

--- a/src/pages/rekey-search/__tests__/rekey-search.analytics.effects.spec.ts
+++ b/src/pages/rekey-search/__tests__/rekey-search.analytics.effects.spec.ts
@@ -4,7 +4,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { AnalyticsProvider } from '../../../providers/analytics/analytics';
 import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
 import {
-  AnalyticsScreenNames,
+  AnalyticsScreenNames, AnalyticsEventCategories, AnalyticsEvents,
 } from '../../../providers/analytics/analytics.model';
 import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
 import { RekeySearchAnalyticsEffects } from '../rekey-search.analytics.effects';
@@ -29,6 +29,7 @@ describe('Rekey Search Analytics Effects', () => {
     effects = TestBed.get(RekeySearchAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     spyOn(analyticsProviderMock, 'setCurrentPage').and.callThrough();
+    spyOn(analyticsProviderMock, 'logEvent').and.callThrough();
   });
 
   describe('rekeySearchViewDidEnter', () => {
@@ -39,6 +40,21 @@ describe('Rekey Search Analytics Effects', () => {
       effects.rekeySearchViewDidEnter$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.setCurrentPage).toHaveBeenCalledWith(screenName);
+        done();
+      });
+    });
+  });
+  describe('rekeySearchPerformed', () => {
+    it('should log an event with the correct values', (done) => {
+      // ACT
+      actions$.next(new rekeySearchActions.SearchBookedTest('', ''));
+      // ASSERT
+      effects.rekeySearchPerformed$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.REKEY_SEARCH,
+          AnalyticsEvents.TEST_BOOKING_SEARCH,
+        );
         done();
       });
     });

--- a/src/pages/rekey-search/rekey-search.analytics.effects.ts
+++ b/src/pages/rekey-search/rekey-search.analytics.effects.ts
@@ -7,9 +7,11 @@ import { AnalyticRecorded } from '../../providers/analytics/analytics.actions';
 import {
   REKEY_SEARCH_VIEW_DID_ENTER,
   RekeySearchViewDidEnter,
+  SEARCH_BOOKED_TEST,
+  SearchBookedTest,
 } from './rekey-search.actions';
 import {
-  AnalyticsScreenNames,
+  AnalyticsScreenNames, AnalyticsEventCategories, AnalyticsEvents,
 } from '../../providers/analytics/analytics.model';
 
 @Injectable()
@@ -31,4 +33,15 @@ export class RekeySearchAnalyticsEffects {
     }),
   );
 
+  @Effect()
+  rekeySearchPerformed$ = this.actions$.pipe(
+    ofType(SEARCH_BOOKED_TEST),
+    switchMap((action: SearchBookedTest) => {
+      this.analytics.logEvent(
+        AnalyticsEventCategories.REKEY_SEARCH,
+        AnalyticsEvents.TEST_BOOKING_SEARCH,
+      );
+      return of(new AnalyticRecorded());
+    }),
+  );
 }

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -53,6 +53,7 @@ export enum AnalyticsEventCategories {
   PRACTICE_TEST = 'practice test',
   PRACTICE_MODE = 'practice mode',
   TEST_RESULTS_SEARCH = 'test results search',
+  REKEY_SEARCH = 'rekey search',
 }
 
 export enum AnalyticsEvents {
@@ -87,6 +88,7 @@ export enum AnalyticsEvents {
   LDTM_SEARCH = 'perform ldtm search',
   TOGGLE_LEGAL_REQUIREMENT = 'toggle legal requirement',
   TEST_OUTCOME_CHANGED = 'test outcome changed',
+  TEST_BOOKING_SEARCH = 'perform test booking search',
 }
 
 export enum AnalyticsLabels {

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -54,6 +54,7 @@ export enum AnalyticsEventCategories {
   PRACTICE_MODE = 'practice mode',
   TEST_RESULTS_SEARCH = 'test results search',
   REKEY_SEARCH = 'rekey search',
+  REKEY = 'rekey',
 }
 
 export enum AnalyticsEvents {

--- a/src/shared/helpers/__tests__/format-analytics-text.spec.ts
+++ b/src/shared/helpers/__tests__/format-analytics-text.spec.ts
@@ -35,6 +35,17 @@ describe('formatAnalyticsText', () => {
     expect(result).toBe(`${AnalyticsEventCategories.PRACTICE_TEST} - ${eventString}`);
   });
 
+  it('should prefix rekey tests with the correct text', () => {
+    const state = { ...initialState };
+    const action = new testsActions.StartTest(12345);
+    const tests: TestsModel = testsReducer(state, action);
+    tests.startedTests[tests.currentTest.slotId].rekey = true;
+
+    const result = formatAnalyticsText(eventString, tests);
+
+    expect(result).toBe(`${AnalyticsEventCategories.REKEY} - ${eventString}`);
+  });
+
   it('should not prefix regular tests with any additional text', () => {
     const state = { ...initialState };
     const action = new testsActions.StartTest(slotId);

--- a/src/shared/helpers/format-analytics-text.ts
+++ b/src/shared/helpers/format-analytics-text.ts
@@ -1,5 +1,5 @@
 import { TestsModel } from '../../modules/tests/tests.model';
-import { isEndToEndPracticeTest, isTestReportPracticeTest } from '../../modules/tests/tests.selector';
+import { isEndToEndPracticeTest, isTestReportPracticeTest, getCurrentTest } from '../../modules/tests/tests.selector';
 import { AnalyticsEventCategories } from '../../providers/analytics/analytics.model';
 
 export function formatAnalyticsText(eventText: string, tests: TestsModel): string {
@@ -8,6 +8,9 @@ export function formatAnalyticsText(eventText: string, tests: TestsModel): strin
   }
   if (isTestReportPracticeTest(tests)) {
     return `${AnalyticsEventCategories.PRACTICE_TEST} - ${eventText}`;
+  }
+  if (getCurrentTest(tests).rekey) {
+    return `${AnalyticsEventCategories.REKEY} - ${eventText}`;
   }
   return eventText;
 }


### PR DESCRIPTION
## Description and relevant Jira numbers
- Added event when you search for a test booked in rekey search
- Added an event which fires when you click rekey on a test result from rekey search
- When a test is being rekeyed analytics events are prefixed with Rekey when setting the current page a user is on. (Same as practice mode)

## Pull Request checklist:

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist:

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [ ] Code has been tested manually
- [ ] Tests are passing
- [ ] PR link added to JIRA
- [ ] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
