### PR TITLE
MES-2789 remove redundant code from test slot component and fix date rollover bug

### DIFF
--- a/src/components/common/incomplete-tests-banner/incomplete-tests-banner.ts
+++ b/src/components/common/incomplete-tests-banner/incomplete-tests-banner.ts
@@ -1,10 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../../shared/models/store.model';
-import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { Observable } from 'rxjs/Observable';
 import { getIncompleteTestsCount } from './incomplete-tests-banner.selector';
 import { SlotProvider } from '../../../providers/slot/slot';
+import { DateTime } from '../../../shared/helpers/date-time';
 
 interface IncompleteTestsBannerComponentState {
   count$: Observable<number>;
@@ -17,19 +17,20 @@ interface IncompleteTestsBannerComponentState {
 
 export class IncompleteTestsBanner implements OnInit {
 
+  @Input()
+  public todaysDate: DateTime;
+
   componentState: IncompleteTestsBannerComponentState;
 
   constructor(
     private store$: Store<StoreModel>,
-    private dateTimeProvider: DateTimeProvider,
     private slotProvider: SlotProvider,
   ) {}
 
   ngOnInit() {
-    const today = this.dateTimeProvider.now();
     this.componentState = {
       count$: this.store$.pipe(
-        select(store => getIncompleteTestsCount(store, today, this.slotProvider)),
+        select(store => getIncompleteTestsCount(store, this.todaysDate, this.slotProvider)),
       ),
     };
   }

--- a/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
+++ b/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
@@ -29,9 +29,9 @@ import { SubmissionStatusComponent } from '../../submission-status/submission-st
 import { ProgressiveAccessComponent } from '../../progressive-access/progressive-access';
 import { ActivityCodes } from '../../../../shared/models/activity-codes';
 import { TestSlot } from '@dvsa/mes-journal-schema';
-import { DateTime, Duration } from '../../../../shared/helpers/date-time';
 import { SpecialNeedsCode } from '../../../../shared/helpers/get-slot-type';
 import { LocationComponent } from '../../location/location';
+import { SlotProvider } from '../../../../providers/slot/slot';
 
 describe('TestSlotComponent', () => {
   let fixture: ComponentFixture<TestSlotComponent>;
@@ -122,6 +122,7 @@ describe('TestSlotComponent', () => {
         { provide: ScreenOrientation, useClass: ScreenOrientationMock },
         { provide: AppConfigProvider, useClass: AppConfigProviderMock },
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
+        { provide: SlotProvider, useClass: SlotProvider },
       ],
     }).compileComponents().then(() => {
       fixture = TestBed.createComponent(TestSlotComponent);
@@ -221,112 +222,6 @@ describe('TestSlotComponent', () => {
         expect(component.isPortrait()).toEqual(false);
         component.screenOrientation.type = component.screenOrientation.ORIENTATIONS.LANDSCAPE;
         expect(component.isPortrait()).toEqual(false);
-      });
-    });
-
-    describe('canStartTest', () => {
-      let getAppConfigSpy;
-      beforeEach(() => {
-        getAppConfigSpy = jasmine.createSpy('getAppConfig');
-        component.appConfig.getAppConfig = getAppConfigSpy;
-      });
-      it('should disallow the test when there are no permissions', () => {
-        getAppConfigSpy.and.returnValue({ journal: { testPermissionPeriods: [] } });
-        expect(component.canStartTest()).toBe(false);
-      });
-      it('should disallow the test when there are only permissions for other test categories', () => {
-        getAppConfigSpy.and.returnValue({
-          journal: {
-            testPermissionPeriods: [
-              { testCategory: 'C', from: '2019-01-01', to: null },
-            ],
-          },
-        });
-        expect(component.canStartTest()).toBe(false);
-      });
-      it('should disallow the test when there are permissions for the category which have expired', () => {
-        getAppConfigSpy.and.returnValue({
-          journal: {
-            testPermissionPeriods: [
-              { testCategory: 'B', from: '2019-01-01', to: '2019-01-20' },
-            ],
-          },
-        });
-        expect(component.canStartTest()).toBe(false);
-      });
-      it('should allow the test when there are multiple expired ranges and a subsequent valid range', () => {
-        getAppConfigSpy.and.returnValue({
-          journal: {
-            testPermissionPeriods: [
-              { testCategory: 'B', from: '2018-01-01', to: '2018-03-01' },
-              { testCategory: 'B', from: '2018-05-01', to: '2018-07-01' },
-              { testCategory: 'B', from: '2019-01-01', to: '2019-02-01' },
-            ],
-          },
-        });
-        expect(component.canStartTest()).toBe(true);
-      });
-      it('should allow the test when there is a permission range including the slot date', () => {
-        getAppConfigSpy.and.returnValue({
-          journal: {
-            testPermissionPeriods: [
-              { testCategory: 'B', from: '2019-01-01', to: '2019-02-02' },
-            ],
-          },
-        });
-        expect(component.canStartTest()).toBe(true);
-      });
-      it('should allow the test when there is a permission range starting on the slot date', () => {
-        getAppConfigSpy.and.returnValue({
-          journal: {
-            testPermissionPeriods: [
-              { testCategory: 'B', from: '2019-02-01', to: '2019-02-20' },
-            ],
-          },
-        });
-        expect(component.canStartTest()).toBe(true);
-      });
-      it('should allow the test when there is a permission range ending on the slot date', () => {
-        getAppConfigSpy.and.returnValue({
-          journal: {
-            testPermissionPeriods: [
-              { testCategory: 'B', from: '2019-01-20', to: '2019-02-01' },
-            ],
-          },
-        });
-        expect(component.canStartTest()).toBe(true);
-      });
-      it('should allow the test when there is a permission range for the slot date only', () => {
-        getAppConfigSpy.and.returnValue({
-          journal: {
-            testPermissionPeriods: [
-              { testCategory: 'B', from: '2019-02-01', to: '2019-02-01' },
-            ],
-          },
-        });
-        expect(component.canStartTest()).toBe(true);
-      });
-      it('should allow the test when there is a non-date bounded permission range', () => {
-        getAppConfigSpy.and.returnValue({
-          journal: {
-            testPermissionPeriods: [
-              { testCategory: 'B', from: '2019-02-01', to: null },
-            ],
-          },
-        });
-        expect(component.canStartTest()).toBe(true);
-      });
-      it('should disallow starting of tests that arent today', () => {
-        getAppConfigSpy.and.returnValue({
-          journal: {
-            testPermissionPeriods: [
-              { testCategory: 'B', from: '2019-01-01', to: null },
-            ],
-          },
-        });
-        component.slot.slotDetail.start =
-          DateTime.at(startTime).add(1, Duration.DAY).format('YYYY-MM-DDTHH:mm:ss+00:00');
-        expect(component.canStartTest()).toEqual(false);
       });
     });
 

--- a/src/components/test-slot/test-slot/test-slot.ts
+++ b/src/components/test-slot/test-slot/test-slot.ts
@@ -16,8 +16,8 @@ import { SlotTypes } from '../../../shared/models/slot-types';
 import { map } from 'rxjs/operators';
 import { TestSlot } from '@dvsa/mes-journal-schema';
 import { ActivityCode } from '@dvsa/mes-test-schema/categories/B';
-import { DateTime } from '../../../shared/helpers/date-time';
 import { getSlotType } from '../../../shared/helpers/get-slot-type';
+import { SlotProvider } from '../../../providers/slot/slot';
 
 interface TestSlotComponentState {
   testStatus$: Observable<TestStatus>;
@@ -48,6 +48,7 @@ export class TestSlotComponent implements SlotComponent, OnInit {
     public appConfig: AppConfigProvider,
     public dateTimeProvider: DateTimeProvider,
     public store$: Store<StoreModel>,
+    private slotProvider: SlotProvider,
   ) { }
 
   ngOnInit(): void {
@@ -87,32 +88,6 @@ export class TestSlotComponent implements SlotComponent, OnInit {
   }
 
   canStartTest(): boolean {
-    const { testPermissionPeriods } = this.appConfig.getAppConfig().journal;
-    const { testCategory } = this.slot.booking.application;
-    const startDate = new DateTime(this.slot.slotDetail.start);
-
-    if (startDate.daysDiff(this.dateTimeProvider.now()) < 0) {
-      return false;
-    }
-
-    const periodsPermittingStart = testPermissionPeriods.filter((period) => {
-      const slotHasPeriodStartCriteria = this.hasPeriodStartCriteria(startDate, period.from);
-      const slotHasPeriodEndCriteria = this.hasPeriodEndCritiera(startDate, period.to);
-      return period.testCategory === testCategory && slotHasPeriodStartCriteria && slotHasPeriodEndCriteria;
-    });
-    return periodsPermittingStart.length > 0;
-  }
-
-  private hasPeriodStartCriteria(slotDate: DateTime, periodFrom: string) {
-    const periodStartDate = new DateTime(periodFrom);
-    return slotDate.daysDiff(periodStartDate) <= 0;
-  }
-
-  private hasPeriodEndCritiera(slotDate: DateTime, periodTo: string) {
-    if (periodTo === null) {
-      return true;
-    }
-    const periodEndDate = new DateTime(periodTo);
-    return slotDate.daysDiff(periodEndDate) >= 0;
+    return this.slotProvider.canStartTest(this.slot);
   }
 }

--- a/src/pages/dashboard/dashboard.html
+++ b/src/pages/dashboard/dashboard.html
@@ -13,10 +13,10 @@
   </ion-navbar>
 </ion-header>
 <ion-content no-bounce>
-  <incomplete-tests-banner></incomplete-tests-banner>
+  <incomplete-tests-banner [todaysDate]="todaysDate"></incomplete-tests-banner>
   <profile-header [employeeId]="employeeId" [name]="name" [role]="role"></profile-header>
   <hr/>
-  <h4 class="date">{{todaysDate}}</h4>
+  <h4 class="date">{{todaysDateFormatted}}</h4>
   <ion-grid no-padding>
     <ion-row>
       <ion-col no-padding col-96 col-lg-32>

--- a/src/pages/dashboard/dashboard.ts
+++ b/src/pages/dashboard/dashboard.ts
@@ -19,6 +19,7 @@ import { ExaminerRoleDescription } from '../../providers/app-config/constants/ex
 import { BasePageComponent } from '../../shared/classes/base-page';
 import { IncompleteTestsBanner } from '../../components/common/incomplete-tests-banner/incomplete-tests-banner';
 import * as journalActions from './../journal/journal.actions';
+import { DateTime } from '../../shared/helpers/date-time';
 
 interface DashboardPageState {
   appVersion$: Observable<string>;
@@ -42,7 +43,8 @@ export class DashboardPage extends BasePageComponent {
   employeeId: string;
   name: string;
   role: string;
-  todaysDate: string;
+  todaysDate: DateTime;
+  todaysDateFormatted: string;
 
   constructor(
     public store$: Store<StoreModel>,
@@ -61,7 +63,8 @@ export class DashboardPage extends BasePageComponent {
     this.employeeId = this.authenticationProvider.getEmployeeId() || 'NOT_KNOWN';
     this.name = this.authenticationProvider.getEmployeeName() || 'Unknown Name';
     this.role = ExaminerRoleDescription[this.appConfigProvider.getAppConfig().role] || 'Unknown Role';
-    this.todaysDate = this.dateTimeProvider.now().format('dddd Do MMMM YYYY');
+    this.todaysDate = this.dateTimeProvider.now();
+    this.todaysDateFormatted = this.dateTimeProvider.now().format('dddd Do MMMM YYYY');
   }
 
   ionViewDidEnter(): void {
@@ -101,6 +104,8 @@ export class DashboardPage extends BasePageComponent {
     if (this.merged$) {
       this.subscription = this.merged$.subscribe();
     }
+    this.todaysDate = this.dateTimeProvider.now();
+    this.todaysDateFormatted = this.dateTimeProvider.now().format('dddd Do MMMM YYYY');
 
     return true;
   }

--- a/src/pages/journal/journal.html
+++ b/src/pages/journal/journal.html
@@ -18,7 +18,7 @@
     <label id="unauth-text">You are offline. Some features may be unavailable.</label>
   </div>
 
-  <incomplete-tests-banner></incomplete-tests-banner>
+  <incomplete-tests-banner [todaysDate]="todaysDate"></incomplete-tests-banner>
 
   <ion-refresher (ionRefresh)="pullRefreshJournal($event)">
     <ion-refresher-content

--- a/src/pages/journal/journal.ts
+++ b/src/pages/journal/journal.ts
@@ -36,6 +36,7 @@ import { Insomnia } from '@ionic-native/insomnia';
 import { PersonalCommitmentSlotComponent } from './personal-commitment/personal-commitment';
 import { TestSlotComponent } from '../../components/test-slot/test-slot/test-slot';
 import { IncompleteTestsBanner } from '../../components/common/incomplete-tests-banner/incomplete-tests-banner';
+import { DateTime } from '../../shared/helpers/date-time';
 
 interface JournalPageState {
   selectedDate$: Observable<string>;
@@ -68,6 +69,7 @@ export class JournalPage extends BasePageComponent implements OnInit {
   employeeId: string;
   start = '2018-12-10T08:10:00+00:00';
   merged$: Observable<void | number>;
+  todaysDate: DateTime;
 
   constructor(
     public modalController: ModalController,
@@ -93,6 +95,7 @@ export class JournalPage extends BasePageComponent implements OnInit {
     this.employeeId = this.authenticationProvider.getEmployeeId();
     this.isUnauthenticated = this.authenticationProvider.isInUnAuthenticatedMode();
     this.store$.dispatch(new journalActions.SetSelectedDate(this.dateTimeProvider.now().format('YYYY-MM-DD')));
+    this.todaysDate = this.dateTimeProvider.now();
   }
 
   ngOnInit(): void {
@@ -154,6 +157,7 @@ export class JournalPage extends BasePageComponent implements OnInit {
     if (this.merged$) {
       this.subscription = this.merged$.subscribe();
     }
+    this.todaysDate = this.dateTimeProvider.now();
 
     return true;
   }


### PR DESCRIPTION
## Description and relevant Jira numbers
The function to calculate if a test can be started was moved to the slot provider in PR [#742](https://github.com/dvsa/mes-mobile-app/pull/742). This PR tidies up the code by removing the method from the Test Slot component and moving the tests to the provider.

The incomplete tests banner component has also been changed to accept a date input so that when the date changes on the iPad, the banner updates.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
