### PR TITLE
Feature/mes 3089 display rekey data on completed test search result

### DIFF
--- a/src/pages/rekey-search/rekey-search.module.ts
+++ b/src/pages/rekey-search/rekey-search.module.ts
@@ -11,6 +11,7 @@ import { rekeySearchReducer } from './rekey-search.reducer';
 import { RekeySearchProvider } from '../../providers/rekey-search/rekey-search';
 import { CompressionProvider } from '../../providers/compression/compression';
 import { TestSlotComponentsModule } from '../../components/test-slot/test-slot-components.module';
+import { SlotProvider } from '../../providers/slot/slot';
 
 @NgModule({
   declarations: [
@@ -30,6 +31,7 @@ import { TestSlotComponentsModule } from '../../components/test-slot/test-slot-c
   providers: [
     RekeySearchProvider,
     CompressionProvider,
+    SlotProvider,
   ],
 })
 export class RekeySearchPageModule {}

--- a/src/pages/view-test-result/__tests__/view-test-result.spec.ts
+++ b/src/pages/view-test-result/__tests__/view-test-result.spec.ts
@@ -44,7 +44,7 @@ import { DebriefCardModel } from '../components/debrief-card/debrief-card.model'
 import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 import { ErrorMessageComponent } from '../../../components/common/error-message/error-message';
 
-describe('ViewTestResultPage', () => {
+fdescribe('ViewTestResultPage', () => {
   let fixture: ComponentFixture<ViewTestResultPage>;
   let component: ViewTestResultPage;
   let loadingController: LoadingController;

--- a/src/pages/view-test-result/__tests__/view-test-result.spec.ts
+++ b/src/pages/view-test-result/__tests__/view-test-result.spec.ts
@@ -44,7 +44,7 @@ import { DebriefCardModel } from '../components/debrief-card/debrief-card.model'
 import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 import { ErrorMessageComponent } from '../../../components/common/error-message/error-message';
 
-fdescribe('ViewTestResultPage', () => {
+describe('ViewTestResultPage', () => {
   let fixture: ComponentFixture<ViewTestResultPage>;
   let component: ViewTestResultPage;
   let loadingController: LoadingController;

--- a/src/pages/view-test-result/__tests__/view-test-result.spec.ts
+++ b/src/pages/view-test-result/__tests__/view-test-result.spec.ts
@@ -22,6 +22,8 @@ import { MockComponent } from 'ng-mocks';
 import { TestDetailsCardComponent } from '../components/test-details-card/test-details-card';
 import { RekeyDetailsCardComponent } from '../components/rekey-details-card/rekey-details';
 import { RekeyDetailsModel } from '../components/rekey-details-card/rekey-details-card.model';
+import { RekeyReasonCardComponent } from '../components/rekey-reason-card/rekey-reason';
+import { RekeyReasonModel } from '../components/rekey-reason-card/rekey-reason-card.model';
 import { ExaminerDetailsCardComponent } from '../components/examiner-details-card/examiner-details';
 import { By } from '@angular/platform-browser';
 import { ExaminerDetailsModel } from '../components/examiner-details-card/examiner-details-card.model';
@@ -42,7 +44,7 @@ import { DebriefCardModel } from '../components/debrief-card/debrief-card.model'
 import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 import { ErrorMessageComponent } from '../../../components/common/error-message/error-message';
 
-describe('ViewTestResultPage', () => {
+fdescribe('ViewTestResultPage', () => {
   let fixture: ComponentFixture<ViewTestResultPage>;
   let component: ViewTestResultPage;
   let loadingController: LoadingController;
@@ -53,6 +55,7 @@ describe('ViewTestResultPage', () => {
         ViewTestResultPage,
         MockComponent(TestDetailsCardComponent),
         MockComponent(RekeyDetailsCardComponent),
+        MockComponent(RekeyReasonCardComponent),
         MockComponent(ExaminerDetailsCardComponent),
         MockComponent(VehicleDetailsCardComponent),
         MockComponent(TestSummaryCardComponent),
@@ -136,6 +139,21 @@ describe('ViewTestResultPage', () => {
         expect(result.testDate).toBe('Friday 5th July 2019');
         expect(result.rekeyedStaffNumber).toBe(1);
         expect(result.rekeyDate).toBe('Monday 5th August 2019');
+      });
+      it('should return null when there is no test result', () => {
+        const result: RekeyDetailsModel = component.getRekeyDetails();
+        expect(result).toBeNull();
+      });
+    });
+    describe('getRekeyReason', () => {
+      it('should correctly generate the data', () => {
+        component.testResult = categoryBTestResultMock;
+
+        const result: RekeyReasonModel = component.getRekeyReason();
+
+        expect(result.ipadIssue).toBe('Lost');
+        expect(result.transfer).toBe('No');
+        expect(result.other).toBe('mock reason');
       });
       it('should return null when there is no test result', () => {
         const result: RekeyDetailsModel = component.getRekeyDetails();
@@ -397,6 +415,9 @@ describe('ViewTestResultPage', () => {
         fixture.debugElement.query(By.css('rekey-details-card')),
       ).toBeNull();
       expect(
+        fixture.debugElement.query(By.css('rekey-reason-card')),
+      ).toBeNull();
+      expect(
         fixture.debugElement.query(By.css('examiner-details-card')),
       ).toBeNull();
       expect(
@@ -420,6 +441,9 @@ describe('ViewTestResultPage', () => {
       ).toBeNull();
       expect(
         fixture.debugElement.query(By.css('rekey-details-card')),
+      ).toBeNull();
+      expect(
+        fixture.debugElement.query(By.css('rekey-reason-card')),
       ).toBeNull();
       expect(
         fixture.debugElement.query(By.css('examiner-details-card')),
@@ -451,6 +475,9 @@ describe('ViewTestResultPage', () => {
         fixture.debugElement.query(By.css('rekey-details-card')),
       ).toBeNull();
       expect(
+        fixture.debugElement.query(By.css('rekey-reason-card')),
+      ).toBeNull();
+      expect(
         fixture.debugElement.query(By.css('examiner-details-card')),
       ).not.toBeNull();
       expect(
@@ -472,6 +499,9 @@ describe('ViewTestResultPage', () => {
 
     expect(
       fixture.debugElement.query(By.css('rekey-details-card')),
+    ).not.toBeNull();
+    expect(
+      fixture.debugElement.query(By.css('rekey-reason-card')),
     ).not.toBeNull();
   });
 });

--- a/src/pages/view-test-result/__tests__/view-test-result.spec.ts
+++ b/src/pages/view-test-result/__tests__/view-test-result.spec.ts
@@ -20,6 +20,8 @@ import { SearchProvider } from '../../../providers/search/search';
 import { SearchProviderMock } from '../../../providers/search/__mocks__/search.mock';
 import { MockComponent } from 'ng-mocks';
 import { TestDetailsCardComponent } from '../components/test-details-card/test-details-card';
+import { RekeyDetailsCardComponent } from '../components/rekey-details-card/rekey-details';
+import { RekeyDetailsModel } from '../components/rekey-details-card/rekey-details-card.model';
 import { ExaminerDetailsCardComponent } from '../components/examiner-details-card/examiner-details';
 import { By } from '@angular/platform-browser';
 import { ExaminerDetailsModel } from '../components/examiner-details-card/examiner-details-card.model';
@@ -50,6 +52,7 @@ describe('ViewTestResultPage', () => {
       declarations: [
         ViewTestResultPage,
         MockComponent(TestDetailsCardComponent),
+        MockComponent(RekeyDetailsCardComponent),
         MockComponent(ExaminerDetailsCardComponent),
         MockComponent(VehicleDetailsCardComponent),
         MockComponent(TestSummaryCardComponent),
@@ -119,6 +122,23 @@ describe('ViewTestResultPage', () => {
       });
       it('should return null when there is no test result', () => {
         const result: TestDetailsModel = component.getTestDetails();
+        expect(result).toBeNull();
+      });
+    });
+    describe('getRekeyDetails', () => {
+      it('should correctly generate the data', () => {
+        component.testResult = categoryBTestResultMock;
+
+        const result: RekeyDetailsModel = component.getRekeyDetails();
+
+        expect(result.scheduledStaffNumber).toBe(1);
+        expect(result.conductedStaffNumber).toBe(1);
+        expect(result.testDate).toBe('Friday 5th July 2019');
+        expect(result.rekeyedStaffNumber).toBe(1);
+        expect(result.rekeyDate).toBe('Monday 5th August 2019');
+      });
+      it('should return null when there is no test result', () => {
+        const result: RekeyDetailsModel = component.getRekeyDetails();
         expect(result).toBeNull();
       });
     });
@@ -374,6 +394,9 @@ describe('ViewTestResultPage', () => {
         fixture.debugElement.query(By.css('test-details-card')),
       ).toBeNull();
       expect(
+        fixture.debugElement.query(By.css('rekey-details-card')),
+      ).toBeNull();
+      expect(
         fixture.debugElement.query(By.css('examiner-details-card')),
       ).toBeNull();
       expect(
@@ -396,6 +419,9 @@ describe('ViewTestResultPage', () => {
         fixture.debugElement.query(By.css('test-details-card')),
       ).toBeNull();
       expect(
+        fixture.debugElement.query(By.css('rekey-details-card')),
+      ).toBeNull();
+      expect(
         fixture.debugElement.query(By.css('examiner-details-card')),
       ).toBeNull();
       expect(
@@ -410,6 +436,7 @@ describe('ViewTestResultPage', () => {
     it('should show the cards when the data is not loading and there is no error', () => {
       component.isLoading = false;
       component.testResult = categoryBTestResultMock;
+
       fixture.detectChanges();
 
       expect(fixture.debugElement.query(By.css('.error'))).toBeNull();
@@ -421,6 +448,9 @@ describe('ViewTestResultPage', () => {
         fixture.debugElement.query(By.css('test-details-card')),
       ).not.toBeNull();
       expect(
+        fixture.debugElement.query(By.css('rekey-details-card')),
+      ).toBeNull();
+      expect(
         fixture.debugElement.query(By.css('examiner-details-card')),
       ).not.toBeNull();
       expect(
@@ -431,5 +461,17 @@ describe('ViewTestResultPage', () => {
         fixture.debugElement.query(By.css('test-summary-card')),
       ).not.toBeNull();
     });
+  });
+
+  it('should show rekey cards only when rekey is true', () => {
+    component.isLoading = false;
+    component.testResult = categoryBTestResultMock;
+    component.testResult.rekey = true;
+
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.query(By.css('rekey-details-card')),
+    ).not.toBeNull();
   });
 });

--- a/src/pages/view-test-result/components/rekey-details-card/__tests__/rekey-details-card.spec.ts
+++ b/src/pages/view-test-result/components/rekey-details-card/__tests__/rekey-details-card.spec.ts
@@ -1,0 +1,36 @@
+
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { IonicModule, Config } from 'ionic-angular';
+import { RekeyDetailsCardComponent } from '../rekey-details';
+import { ConfigMock } from 'ionic-mocks';
+
+describe('ExaminerDetailsCardComponent', () => {
+  let fixture: ComponentFixture<RekeyDetailsCardComponent>;
+  let component: RekeyDetailsCardComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        RekeyDetailsCardComponent,
+      ],
+      imports: [
+        IonicModule,
+      ],
+      providers: [
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(RekeyDetailsCardComponent);
+        component = fixture.componentInstance;
+      });
+  }));
+
+  describe('Class', () => {
+    // Unit tests for the components TypeScript class
+    it('should create', () => {
+      expect(component).toBeDefined();
+    });
+  });
+});

--- a/src/pages/view-test-result/components/rekey-details-card/rekey-details-card.html
+++ b/src/pages/view-test-result/components/rekey-details-card/rekey-details-card.html
@@ -9,7 +9,7 @@
             <label>Scheduled for</label>
           </ion-col>
           <ion-col col-56>
-            <span class="mes-data">{{ data.scheduledStaffNumber }}</span>
+            <span class="mes-data">{{ rekeyDetails.scheduledStaffNumber }}</span>
           </ion-col>
         </ion-row>
         <ion-row class="mes-data-row-with-separator">
@@ -17,7 +17,7 @@
             <label>Conducted by</label>
           </ion-col>
           <ion-col col-56>
-            <span class="mes-data">{{ data.conductedStaffNumber }}</span>
+            <span class="mes-data">{{ rekeyDetails.conductedStaffNumber }}</span>
           </ion-col>
         </ion-row>
         <ion-row class="mes-data-row-with-separator">
@@ -25,7 +25,7 @@
             <label>Date of test</label>
           </ion-col>
           <ion-col col-56>
-            <span class="mes-data">{{ data.testDate }}</span>
+            <span class="mes-data">{{ rekeyDetails.testDate }}</span>
           </ion-col>
         </ion-row>
         <ion-row class="mes-data-row-with-separator">
@@ -33,7 +33,7 @@
             <label>Rekeyed by</label>
           </ion-col>
           <ion-col col-56>
-            <span class="mes-data">{{ data.rekeyedStaffNumber }}</span>
+            <span class="mes-data">{{ rekeyDetails.rekeyedStaffNumber }}</span>
           </ion-col>
         </ion-row>
         <ion-row class="mes-data-row">
@@ -41,7 +41,7 @@
             <label>Date of rekey</label>
           </ion-col>
           <ion-col col-56>
-            <span class="mes-data">{{ data.rekeyDate }}</span>
+            <span class="mes-data">{{ rekeyDetails.rekeyDate }}</span>
           </ion-col>
         </ion-row>
       </ion-grid>

--- a/src/pages/view-test-result/components/rekey-details-card/rekey-details-card.html
+++ b/src/pages/view-test-result/components/rekey-details-card/rekey-details-card.html
@@ -1,0 +1,49 @@
+<ion-card>
+    <ion-card-header>
+      <h4>Rekey details</h4>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-grid>
+        <ion-row class="mes-data-row-with-separator">
+          <ion-col col-40>
+            <label>Scheduled for</label>
+          </ion-col>
+          <ion-col col-56>
+            <span class="mes-data">{{ data.scheduledStaffNumber }}</span>
+          </ion-col>
+        </ion-row>
+        <ion-row class="mes-data-row-with-separator">
+          <ion-col col-40>
+            <label>Conducted by</label>
+          </ion-col>
+          <ion-col col-56>
+            <span class="mes-data">{{ data.conductedStaffNumber }}</span>
+          </ion-col>
+        </ion-row>
+        <ion-row class="mes-data-row-with-separator">
+          <ion-col col-40>
+            <label>Date of test</label>
+          </ion-col>
+          <ion-col col-56>
+            <span class="mes-data">{{ data.testDate }}</span>
+          </ion-col>
+        </ion-row>
+        <ion-row class="mes-data-row-with-separator">
+          <ion-col col-40>
+            <label>Rekeyed by</label>
+          </ion-col>
+          <ion-col col-56>
+            <span class="mes-data">{{ data.rekeyedStaffNumber }}</span>
+          </ion-col>
+        </ion-row>
+        <ion-row class="mes-data-row">
+          <ion-col col-40>
+            <label>Date of rekey</label>
+          </ion-col>
+          <ion-col col-56>
+            <span class="mes-data">{{ data.rekeyDate }}</span>
+          </ion-col>
+        </ion-row>
+      </ion-grid>
+    </ion-card-content>
+  </ion-card>

--- a/src/pages/view-test-result/components/rekey-details-card/rekey-details-card.model.ts
+++ b/src/pages/view-test-result/components/rekey-details-card/rekey-details-card.model.ts
@@ -1,0 +1,7 @@
+export interface RekeyDetailsModel {
+  scheduledStaffNumber: number;
+  conductedStaffNumber: number;
+  testDate: string;
+  rekeyedStaffNumber: number;
+  rekeyDate:string;
+}

--- a/src/pages/view-test-result/components/rekey-details-card/rekey-details-card.scss
+++ b/src/pages/view-test-result/components/rekey-details-card/rekey-details-card.scss
@@ -1,0 +1,3 @@
+rekey-details-card {
+
+}

--- a/src/pages/view-test-result/components/rekey-details-card/rekey-details.ts
+++ b/src/pages/view-test-result/components/rekey-details-card/rekey-details.ts
@@ -8,7 +8,7 @@ import { RekeyDetailsModel } from './rekey-details-card.model';
 export class RekeyDetailsCardComponent {
 
   @Input()
-  data: RekeyDetailsModel;
+  rekeyDetails: RekeyDetailsModel;
 
   constructor() {}
 

--- a/src/pages/view-test-result/components/rekey-details-card/rekey-details.ts
+++ b/src/pages/view-test-result/components/rekey-details-card/rekey-details.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+import { RekeyDetailsModel } from './rekey-details-card.model';
+
+@Component({
+  selector: 'rekey-details-card',
+  templateUrl: 'rekey-details-card.html',
+})
+export class RekeyDetailsCardComponent {
+
+  @Input()
+  data: RekeyDetailsModel;
+
+  constructor() {}
+
+}

--- a/src/pages/view-test-result/components/rekey-reason-card/__tests__/rekey-reason-card.spec.ts
+++ b/src/pages/view-test-result/components/rekey-reason-card/__tests__/rekey-reason-card.spec.ts
@@ -1,0 +1,36 @@
+
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { IonicModule, Config } from 'ionic-angular';
+import { RekeyReasonCardComponent } from '../rekey-reason';
+import { ConfigMock } from 'ionic-mocks';
+
+describe('ExaminerDetailsCardComponent', () => {
+  let fixture: ComponentFixture<RekeyReasonCardComponent>;
+  let component: RekeyReasonCardComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        RekeyReasonCardComponent,
+      ],
+      imports: [
+        IonicModule,
+      ],
+      providers: [
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(RekeyReasonCardComponent);
+        component = fixture.componentInstance;
+      });
+  }));
+
+  describe('Class', () => {
+    // Unit tests for the components TypeScript class
+    it('should create', () => {
+      expect(component).toBeDefined();
+    });
+  });
+});

--- a/src/pages/view-test-result/components/rekey-reason-card/rekey-reason-card.html
+++ b/src/pages/view-test-result/components/rekey-reason-card/rekey-reason-card.html
@@ -1,0 +1,33 @@
+<ion-card>
+    <ion-card-header>
+      <h4>Reason for rekey</h4>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-grid>
+        <ion-row class="mes-data-row-with-separator">
+          <ion-col col-40>
+            <label>IPad issue</label>
+          </ion-col>
+          <ion-col col-56>
+            <span class="mes-data">{{ data.ipadIssue }}</span>
+          </ion-col>
+        </ion-row>
+        <ion-row class="mes-data-row-with-separator">
+          <ion-col col-40>
+            <label>Transfer</label>
+          </ion-col>
+          <ion-col col-56>
+            <span class="mes-data">{{ data.transfer }}</span>
+          </ion-col>
+        </ion-row>
+        <ion-row class="mes-data-row">
+          <ion-col col-40>
+            <label>Other (specify reason)</label>
+          </ion-col>
+          <ion-col col-56>
+            <span class="mes-data">{{ data.other }}</span>
+          </ion-col>
+        </ion-row>
+      </ion-grid>
+    </ion-card-content>
+  </ion-card>

--- a/src/pages/view-test-result/components/rekey-reason-card/rekey-reason-card.html
+++ b/src/pages/view-test-result/components/rekey-reason-card/rekey-reason-card.html
@@ -9,7 +9,7 @@
             <label>IPad issue</label>
           </ion-col>
           <ion-col col-56>
-            <span class="mes-data">{{ data.ipadIssue }}</span>
+            <span class="mes-data">{{ rekeyReason.ipadIssue }}</span>
           </ion-col>
         </ion-row>
         <ion-row class="mes-data-row-with-separator">
@@ -17,7 +17,7 @@
             <label>Transfer</label>
           </ion-col>
           <ion-col col-56>
-            <span class="mes-data">{{ data.transfer }}</span>
+            <span class="mes-data">{{ rekeyReason.transfer }}</span>
           </ion-col>
         </ion-row>
         <ion-row class="mes-data-row">
@@ -25,7 +25,7 @@
             <label>Other (specify reason)</label>
           </ion-col>
           <ion-col col-56>
-            <span class="mes-data">{{ data.other }}</span>
+            <span class="mes-data">{{ rekeyReason.other }}</span>
           </ion-col>
         </ion-row>
       </ion-grid>

--- a/src/pages/view-test-result/components/rekey-reason-card/rekey-reason-card.model.ts
+++ b/src/pages/view-test-result/components/rekey-reason-card/rekey-reason-card.model.ts
@@ -1,0 +1,5 @@
+export interface RekeyReasonModel {
+  ipadIssue: string;
+  transfer: string;
+  other: string;
+}

--- a/src/pages/view-test-result/components/rekey-reason-card/rekey-reason-card.scss
+++ b/src/pages/view-test-result/components/rekey-reason-card/rekey-reason-card.scss
@@ -1,0 +1,3 @@
+rekey-reason-card {
+
+}

--- a/src/pages/view-test-result/components/rekey-reason-card/rekey-reason.ts
+++ b/src/pages/view-test-result/components/rekey-reason-card/rekey-reason.ts
@@ -8,7 +8,7 @@ import { RekeyReason } from '@dvsa/mes-test-schema/categories/B';
 export class RekeyReasonCardComponent {
 
   @Input()
-  data: RekeyReason;
+  rekeyReason: RekeyReason;
 
   constructor() {}
 

--- a/src/pages/view-test-result/components/rekey-reason-card/rekey-reason.ts
+++ b/src/pages/view-test-result/components/rekey-reason-card/rekey-reason.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+import { RekeyReason } from '@dvsa/mes-test-schema/categories/B';
+
+@Component({
+  selector: 'rekey-reason-card',
+  templateUrl: 'rekey-reason-card.html',
+})
+export class RekeyReasonCardComponent {
+
+  @Input()
+  data: RekeyReason;
+
+  constructor() {}
+
+}

--- a/src/pages/view-test-result/components/view-test-result.components.module.ts
+++ b/src/pages/view-test-result/components/view-test-result.components.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { IonicModule } from 'ionic-angular';
 import { TestDetailsCardComponent } from './test-details-card/test-details-card';
 import { RekeyDetailsCardComponent } from './rekey-details-card/rekey-details';
+import { RekeyReasonCardComponent } from './rekey-reason-card/rekey-reason';
 import { ExaminerDetailsCardComponent } from './examiner-details-card/examiner-details';
 import { VehicleDetailsCardComponent } from './vehicle-details-card/vehicle-details-card';
 import { TestSummaryCardComponent } from './test-summary-card/test-summary-card';
@@ -14,6 +15,7 @@ import { ComponentsModule } from '../../../components/common/common-components.m
   declarations: [
     TestDetailsCardComponent,
     RekeyDetailsCardComponent,
+    RekeyReasonCardComponent,
     ExaminerDetailsCardComponent,
     VehicleDetailsCardComponent,
     TestSummaryCardComponent,
@@ -28,6 +30,7 @@ import { ComponentsModule } from '../../../components/common/common-components.m
   exports: [
     TestDetailsCardComponent,
     RekeyDetailsCardComponent,
+    RekeyReasonCardComponent,
     ExaminerDetailsCardComponent,
     VehicleDetailsCardComponent,
     TestSummaryCardComponent,

--- a/src/pages/view-test-result/components/view-test-result.components.module.ts
+++ b/src/pages/view-test-result/components/view-test-result.components.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IonicModule } from 'ionic-angular';
 import { TestDetailsCardComponent } from './test-details-card/test-details-card';
+import { RekeyDetailsCardComponent } from './rekey-details-card/rekey-details';
 import { ExaminerDetailsCardComponent } from './examiner-details-card/examiner-details';
 import { VehicleDetailsCardComponent } from './vehicle-details-card/vehicle-details-card';
 import { TestSummaryCardComponent } from './test-summary-card/test-summary-card';
@@ -12,6 +13,7 @@ import { ComponentsModule } from '../../../components/common/common-components.m
 @NgModule({
   declarations: [
     TestDetailsCardComponent,
+    RekeyDetailsCardComponent,
     ExaminerDetailsCardComponent,
     VehicleDetailsCardComponent,
     TestSummaryCardComponent,
@@ -25,6 +27,7 @@ import { ComponentsModule } from '../../../components/common/common-components.m
   ],
   exports: [
     TestDetailsCardComponent,
+    RekeyDetailsCardComponent,
     ExaminerDetailsCardComponent,
     VehicleDetailsCardComponent,
     TestSummaryCardComponent,

--- a/src/pages/view-test-result/view-test-result.html
+++ b/src/pages/view-test-result/view-test-result.html
@@ -16,8 +16,8 @@
     <view-test-header [data]="getHeaderDetails()"></view-test-header>
     <test-details-card [data]="getTestDetails()"></test-details-card>
     <div *ngIf="testResult.rekey">
-      <rekey-details-card [data]='getRekeyDetails()'></rekey-details-card>
-      <rekey-reason-card [data]='getRekeyReason()'></rekey-reason-card>
+      <rekey-details-card [rekeyDetails]='getRekeyDetails()'></rekey-details-card>
+      <rekey-reason-card [rekeyReason]='getRekeyReason()'></rekey-reason-card>
     </div>
     <examiner-details-card [data]='getExaminerDetails()'></examiner-details-card>
     <vehicle-details-card [data]='getVehicleDetails()'></vehicle-details-card>

--- a/src/pages/view-test-result/view-test-result.html
+++ b/src/pages/view-test-result/view-test-result.html
@@ -15,6 +15,7 @@
   <div *ngIf="!isLoading && !showErrorMessage">
     <view-test-header [data]="getHeaderDetails()"></view-test-header>
     <test-details-card [data]="getTestDetails()"></test-details-card>
+    <rekey-details-card *ngIf="testResult.rekey" [data]='getRekeyDetails()'></rekey-details-card>
     <examiner-details-card [data]='getExaminerDetails()'></examiner-details-card>
     <vehicle-details-card [data]='getVehicleDetails()'></vehicle-details-card>
     <debrief-card [data]='getDebrief()'></debrief-card>

--- a/src/pages/view-test-result/view-test-result.html
+++ b/src/pages/view-test-result/view-test-result.html
@@ -16,6 +16,7 @@
     <view-test-header [data]="getHeaderDetails()"></view-test-header>
     <test-details-card [data]="getTestDetails()"></test-details-card>
     <rekey-details-card *ngIf="testResult.rekey" [data]='getRekeyDetails()'></rekey-details-card>
+    <rekey-reason-card *ngIf="testResult.rekey" [data]='getRekeyReason()'></rekey-reason-card>
     <examiner-details-card [data]='getExaminerDetails()'></examiner-details-card>
     <vehicle-details-card [data]='getVehicleDetails()'></vehicle-details-card>
     <debrief-card [data]='getDebrief()'></debrief-card>

--- a/src/pages/view-test-result/view-test-result.html
+++ b/src/pages/view-test-result/view-test-result.html
@@ -15,8 +15,10 @@
   <div *ngIf="!isLoading && !showErrorMessage">
     <view-test-header [data]="getHeaderDetails()"></view-test-header>
     <test-details-card [data]="getTestDetails()"></test-details-card>
-    <rekey-details-card *ngIf="testResult.rekey" [data]='getRekeyDetails()'></rekey-details-card>
-    <rekey-reason-card *ngIf="testResult.rekey" [data]='getRekeyReason()'></rekey-reason-card>
+    <div *ngIf="testResult.rekey">
+      <rekey-details-card [data]='getRekeyDetails()'></rekey-details-card>
+      <rekey-reason-card [data]='getRekeyReason()'></rekey-reason-card>
+    </div>
     <examiner-details-card [data]='getExaminerDetails()'></examiner-details-card>
     <vehicle-details-card [data]='getVehicleDetails()'></vehicle-details-card>
     <debrief-card [data]='getDebrief()'></debrief-card>

--- a/src/pages/view-test-result/view-test-result.ts
+++ b/src/pages/view-test-result/view-test-result.ts
@@ -18,6 +18,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { DateTime } from '../../shared/helpers/date-time';
 import { ExaminerDetailsModel } from './components/examiner-details-card/examiner-details-card.model';
 import { VehicleDetailsModel } from './components/vehicle-details-card/vehicle-details-card.model';
+import { RekeyDetailsModel } from './components/rekey-details-card/rekey-details-card.model';
 import { CompressionProvider } from '../../providers/compression/compression';
 import { formatApplicationReference } from '../../shared/helpers/formatters';
 import { TestSummaryCardModel } from './components/test-summary-card/test-summary-card-model';
@@ -331,6 +332,24 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit {
 
   getEyesightTestSeriousFault(eyesightTest: EyesightTest) {
     return getEyesightTestSeriousFaultAndComment(eyesightTest).map(this.parseResult);
+  }
+
+  getRekeyDetails(): RekeyDetailsModel {
+    if (!this.testResult) {
+      return null;
+    }
+
+    const testDate: DateTime = new DateTime(this.testResult.journalData.testSlotAttributes.start);
+    const rekeyDate: DateTime = new DateTime(this.testResult.rekeyDate);
+
+    return {
+
+      scheduledStaffNumber: this.testResult.examinerBooked,
+      conductedStaffNumber: this.testResult.examinerConducted,
+      testDate: testDate.format('dddd Do MMMM YYYY'),
+      rekeyedStaffNumber: this.testResult.examinerKeyed,
+      rekeyDate: rekeyDate.format('dddd Do MMMM YYYY'),
+    };
   }
 
   parseResult(result: CommentedCompetency) {

--- a/src/pages/view-test-result/view-test-result.ts
+++ b/src/pages/view-test-result/view-test-result.ts
@@ -19,6 +19,7 @@ import { DateTime } from '../../shared/helpers/date-time';
 import { ExaminerDetailsModel } from './components/examiner-details-card/examiner-details-card.model';
 import { VehicleDetailsModel } from './components/vehicle-details-card/vehicle-details-card.model';
 import { RekeyDetailsModel } from './components/rekey-details-card/rekey-details-card.model';
+import { RekeyReasonModel } from './components/rekey-reason-card/rekey-reason-card.model';
 import { CompressionProvider } from '../../providers/compression/compression';
 import { formatApplicationReference } from '../../shared/helpers/formatters';
 import { TestSummaryCardModel } from './components/test-summary-card/test-summary-card-model';
@@ -343,12 +344,46 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit {
     const rekeyDate: DateTime = new DateTime(this.testResult.rekeyDate);
 
     return {
-
       scheduledStaffNumber: this.testResult.examinerBooked,
       conductedStaffNumber: this.testResult.examinerConducted,
       testDate: testDate.format('dddd Do MMMM YYYY'),
       rekeyedStaffNumber: this.testResult.examinerKeyed,
       rekeyDate: rekeyDate.format('dddd Do MMMM YYYY'),
+    };
+  }
+
+  getRekeyReason(): RekeyReasonModel {
+    if (!this.testResult) {
+      return null;
+    }
+
+    const getIpadIssueDisplayText = (reasonType): string => {
+
+      const ipadIssueText = {
+        broken: 'Broken',
+        lost: 'Lost',
+        technicalFault: 'Technical fault',
+        stolen: 'Stolen',
+      };
+
+      let value = '';
+
+      for (const prop in reasonType) {
+        if (reasonType[prop] && prop !== 'selected') {
+          value = ipadIssueText[prop];
+        }
+      }
+      return value;
+    };
+
+    const getIpadIssue = reasonType => reasonType.selected ? getIpadIssueDisplayText(reasonType) : 'None';
+    const getTransferStatus = reasonType => reasonType.selected ? 'Yes' : 'No';
+    const getOtherReason = reasonType => reasonType.selected ? reasonType.reason : 'N/A';
+
+    return {
+      ipadIssue: getIpadIssue(this.testResult.rekeyReason.ipadIssue),
+      transfer: getTransferStatus(this.testResult.rekeyReason.transfer),
+      other: getOtherReason(this.testResult.rekeyReason.other),
     };
   }
 

--- a/src/pages/view-test-result/view-test-result.ts
+++ b/src/pages/view-test-result/view-test-result.ts
@@ -359,20 +359,24 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit {
 
     const getIpadIssueDisplayText = (reasonType): string => {
 
-      const ipadIssueText = {
-        broken: 'Broken',
-        lost: 'Lost',
-        technicalFault: 'Technical fault',
-        stolen: 'Stolen',
-      };
-
       let value = '';
 
-      for (const prop in reasonType) {
-        if (reasonType[prop] && prop !== 'selected') {
-          value = ipadIssueText[prop];
-        }
+      if (reasonType.broken) {
+        value = 'Broken';
       }
+
+      if (reasonType.lost) {
+        value = 'Lost';
+      }
+
+      if (reasonType.technicalFault) {
+        value = 'Technical fault';
+      }
+
+      if (reasonType.stolen) {
+        value = 'Stolen';
+      }
+
       return value;
     };
 

--- a/src/shared/mocks/cat-b-test-result.mock.ts
+++ b/src/shared/mocks/cat-b-test-result.mock.ts
@@ -5,6 +5,22 @@ export const categoryBTestResultMock : StandardCarTestCATBSchema = {
   activityCode: '2',
   rekey: false,
   rekeyDate: '2019-08-05T09:00:00',
+  rekeyReason: {
+    ipadIssue: {
+      selected: true,
+      broken: false,
+      lost: true,
+      technicalFault: false,
+      stolen: false,
+    },
+    transfer: {
+      selected: false,
+    },
+    other: {
+      selected: true,
+      reason: 'mock reason',
+    },
+  },
   changeMarker: false,
   examinerBooked: 1,
   examinerConducted: 1,

--- a/src/shared/mocks/cat-b-test-result.mock.ts
+++ b/src/shared/mocks/cat-b-test-result.mock.ts
@@ -4,6 +4,7 @@ export const categoryBTestResultMock : StandardCarTestCATBSchema = {
   category: 'B',
   activityCode: '2',
   rekey: false,
+  rekeyDate: '2019-08-05T09:00:00',
   changeMarker: false,
   examinerBooked: 1,
   examinerConducted: 1,


### PR DESCRIPTION
## Description and relevant Jira numbers
Display a new cards for Rekey details and Rekey reason on the completed tests search results screen.

**Related PR's**
- https://github.com/dvsa/mes-mobile-app/pull/743
- https://github.com/dvsa/mes-mobile-app/pull/745

https://jira.dvsacloud.uk/browse/MES-3089

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval

![Simulator Screen Shot - iPad Pro (10 5-inch) - 2019-09-10 at 12 05 52](https://user-images.githubusercontent.com/54100299/64608806-5b93b100-d3c3-11e9-90dc-8c6c2f9cb66a.png)


