### PR TITLE
MES-3567 persist rekey tests and remove conflicting status effect

### DIFF
--- a/src/modules/tests/tests.effects.ts
+++ b/src/modules/tests/tests.effects.ts
@@ -22,8 +22,6 @@ import { find, startsWith, omit, has } from 'lodash';
 import { HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { HttpStatusCodes } from '../../shared/models/http-status-codes';
 import { TestStatus } from './test-status/test-status.model';
-import { getRekeyIndicator } from './rekey/rekey.reducer';
-import { isRekey } from './rekey/rekey.selector';
 import { TestsModel } from './tests.model';
 import { TestSlot } from '@dvsa/mes-journal-schema';
 import { getJournalState } from '../../pages/journal/journal.reducer';
@@ -70,15 +68,9 @@ export class TestsEffects {
           select(getTests),
           select(isPracticeMode),
         ),
-        this.store$.pipe(
-          select(getTests),
-          select(getCurrentTest),
-          select(getRekeyIndicator),
-          map(isRekey),
-        ),
       ),
     )),
-    filter(([action, tests, isPracticeMode, isRekey]) => !isPracticeMode && !isRekey),
+    filter(([action, tests, isPracticeMode]) => !isPracticeMode),
     switchMap(([action, tests]) => {
       return this.testPersistenceProvider.persistTests(
         this.getSaveableTestsObject(tests),
@@ -332,26 +324,6 @@ export class TestsEffects {
       ),
     )),
     switchMap(([action, slotId]: [testActions.SendCurrentTestSuccess, string]) => {
-      return [
-        new testStatusActions.SetTestStatusSubmitted(slotId),
-        new testActions.PersistTests(),
-      ];
-    }),
-  );
-
-  @Effect()
-  sendCurrentTestFailureEffect$ = this.actions$.pipe(
-    ofType(testActions.SEND_CURRENT_TEST_FAILURE),
-    concatMap(action => of(action).pipe(
-      withLatestFrom(
-        this.store$.pipe(
-          select(getTests),
-          select(getCurrentTestSlotId),
-        ),
-      ),
-    )),
-    filter(([action, slotId]: [testActions.SendCurrentTestFailure, string]) => action.isDuplicateUpload),
-    switchMap(([action, slotId]: [testActions.SendCurrentTestFailure, string]) => {
       return [
         new testStatusActions.SetTestStatusSubmitted(slotId),
         new testActions.PersistTests(),

--- a/src/pages/rekey-reason/rekey-reason.effects.ts
+++ b/src/pages/rekey-reason/rekey-reason.effects.ts
@@ -1,14 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Effect, Actions, ofType } from '@ngrx/effects';
-import { switchMap, withLatestFrom, concatMap, catchError } from 'rxjs/operators';
+import { switchMap, catchError } from 'rxjs/operators';
 
-import * as testActions from '../../modules/tests/tests.actions';
 import * as rekeyActions from './rekey-reason.actions';
-import * as testStatusActions from '../../modules/tests/test-status/test-status.actions';
-import { StoreModel } from '../../shared/models/store.model';
-import { Store, select } from '@ngrx/store';
-import { getTests } from '../../modules/tests/tests.reducer';
-import { getCurrentTestSlotId } from '../../modules/tests/tests.selector';
 import { of } from 'rxjs/observable/of';
 import { FindUserProvider } from '../../providers/find-user/find-user';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
@@ -18,27 +12,8 @@ import { map } from 'rxjs/operators/map';
 export class RekeyReasonEffects {
   constructor(
     private actions$: Actions,
-    private store$: Store<StoreModel>,
     private findUserProvider: FindUserProvider,
   ) { }
-
-  @Effect()
-  sendCurrentTestSuccessEffect$ = this.actions$.pipe(
-    ofType(testActions.SEND_CURRENT_TEST_SUCCESS),
-    concatMap(action => of(action).pipe(
-      withLatestFrom(
-        this.store$.pipe(
-          select(getTests),
-          select(getCurrentTestSlotId),
-        ),
-      ),
-    )),
-    switchMap(([action, slotId]: [testActions.SendCurrentTestSuccess, string]) => {
-      return [
-        new testStatusActions.SetTestStatusCompleted(slotId),
-      ];
-    }),
-  );
 
   @Effect()
   findUserEffect$ = this.actions$.pipe(


### PR DESCRIPTION
## Description and relevant Jira numbers
- Remove `sendCurrentTestFailureEffect` form the test effects as the test status should not change when the upload fails.
- Remove `sendCurrentTestSuccessEffect` from the rekey reason page as it somehow snuck back in to the code and it was erroneously setting the test status to complete.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [x] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [x] Any new reusable component/widget added to component library on Confluence

- [ ] Screenshot(s) captured on the physical device (if applicable)
- [ ] Tested by QA
- [ ] PO's approval
