### PR TITLE
MES-3565 Welsh language bug

### DIFF
--- a/src/components/common/conducted-language/conducted-language.scss
+++ b/src/components/common/conducted-language/conducted-language.scss
@@ -1,23 +1,23 @@
 conducted-language {
+  .col {
+    text-align: right;
+    padding-right: 48px;
+  }
   button {
     &.conducted-language-link {
       background: transparent;
       margin-top: 12px;
       font-size: 23px;
-      padding-left: 550px;
+      padding-left: 8px;
       padding-right: 8px;
     }
     &.focused {
-      background: transparent;
       color: #3572b0;
       text-decoration: underline;
       text-underline-position: under;
       font-weight: 500;
       line-height: 20px;
       padding-bottom: 3px;
-    }
-    &.conducted-language-link-welsh {
-      padding-left: 8px;
     }
   }
 }

--- a/src/modules/tests/__tests__/tests.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.effects.spec.ts
@@ -237,14 +237,14 @@ describe('Tests Effects', () => {
       // ASSERT
       effects.startTestEffect$
       .pipe(
-        bufferCount(11),
+        bufferCount(12),
       )
-      .subscribe(([res1, res2, res3, res4, res5, res6, res7, res8, res9, res10, res11]) => {
+      .subscribe(([res1, res2, res3, res4, res5, res6, res7, res8, res9, res10, res11, res12]) => {
         expect(res1).toEqual(new PopulateExaminer(examiner)),
         expect(res8).toEqual(new SetExaminerBooked(parseInt(examiner.staffNumber, 10))),
         expect(res9).toEqual(new SetExaminerConducted(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
         expect(res10).toEqual(new SetExaminerKeyed(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
-        expect(res11).toEqual(new rekeyActions.MarkAsRekey()),
+        expect(res12).toEqual(new rekeyActions.MarkAsRekey()),
         done();
       });
     });
@@ -275,16 +275,16 @@ describe('Tests Effects', () => {
       // ASSERT
       effects.startTestEffect$
       .pipe(
-        bufferCount(11),
+        bufferCount(12),
       )
-      .subscribe(([res1, res2, res3, res4, res5, res6, res7, res8, res9, res10, res11]) => {
+      .subscribe(([res1, res2, res3, res4, res5, res6, res7, res8, res9, res10, res11, res12]) => {
         expect(res1).toEqual(new PopulateExaminer({ staffNumber })),
         expect(res2).toEqual(new PopulateApplicationReference(testSlot.booking.application)),
         expect(res3).toEqual(new PopulateCandidateDetails(testSlot.booking.candidate)),
         expect(res8).toEqual(new SetExaminerBooked(parseInt(staffNumber, 10))),
         expect(res9).toEqual(new SetExaminerConducted(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
         expect(res10).toEqual(new SetExaminerKeyed(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
-        expect(res11).toEqual(new rekeyActions.MarkAsRekey()),
+        expect(res12).toEqual(new rekeyActions.MarkAsRekey()),
         done();
       });
     });

--- a/src/modules/tests/communication-preferences/communication-preferences.actions.ts
+++ b/src/modules/tests/communication-preferences/communication-preferences.actions.ts
@@ -2,13 +2,14 @@ import { Action } from '@ngrx/store';
 import { CommunicationMethod, ConductedLanguage } from '@dvsa/mes-test-schema/categories/B';
 
 export const CANDIDATE_CONFIRMED_COMMUNICATION_PREFERENCE_AS_EMAIL
-  = '[Communication page] Candidate confirmed communication preferences as email';
+  = '[Communication Preferences] Candidate confirmed communication preferences as email';
 export const CANDIDATE_CONFIRMED_COMMUNICATION_PREFERENCE_AS_POST
-  = '[Communication page] Candidate confirmed communication preferences as post';
+  = '[Communication Preferences] Candidate confirmed communication preferences as post';
 export const CANDIDATE_CHOSE_TO_PROCEED_WITH_TEST_IN_ENGLISH
-  = '[Communication page] Candidate chose to proceed with test in English';
+  = '[Communication Preferences] Candidate chose to proceed with test in English';
 export const CANDIDATE_CHOSE_TO_PROCEED_WITH_TEST_IN_WELSH
-  = '[Communication page] Candidate chose to proceed with test in Welsh';
+  = '[Communication Preferences] Candidate chose to proceed with test in Welsh';
+export const POPULATE_CONDUCTED_LANGUAGE = '[Communication Preferences] Populate Conducted Language';
 
 export class CandidateChoseEmailAsCommunicationPreference implements Action {
   readonly type = CANDIDATE_CONFIRMED_COMMUNICATION_PREFERENCE_AS_EMAIL;
@@ -30,8 +31,14 @@ export class CandidateChoseToProceedWithTestInWelsh implements Action {
   constructor(public conductedLanguage: ConductedLanguage) { }
 }
 
+export class PopulateConductedLanguage implements Action {
+  readonly type = POPULATE_CONDUCTED_LANGUAGE;
+  constructor(public conductedLanguage: ConductedLanguage) {}
+}
+
 export type Types =
   | CandidateChoseEmailAsCommunicationPreference
   | CandidateChosePostAsCommunicationPreference
   | CandidateChoseToProceedWithTestInEnglish
-  | CandidateChoseToProceedWithTestInWelsh;
+  | CandidateChoseToProceedWithTestInWelsh
+  | PopulateConductedLanguage;

--- a/src/modules/tests/communication-preferences/communication-preferences.model.ts
+++ b/src/modules/tests/communication-preferences/communication-preferences.model.ts
@@ -1,0 +1,5 @@
+export enum Language {
+  ENGLISH = 'English',
+  CYMRAEG = 'Cymraeg',
+  NOT_PROVIDED = 'Not provided',
+}

--- a/src/modules/tests/communication-preferences/communication-preferences.reducer.ts
+++ b/src/modules/tests/communication-preferences/communication-preferences.reducer.ts
@@ -34,6 +34,13 @@ export const communicationPreferencesReducer = (
         ...state,
         conductedLanguage: action.conductedLanguage,
       };
+    case communicationPrefActions.POPULATE_CONDUCTED_LANGUAGE:
+      return {
+        ...state,
+        conductedLanguage: state.conductedLanguage === initialState.conductedLanguage
+          ? action.conductedLanguage
+          : state.conductedLanguage,
+      };
     default:
       return state;
   }

--- a/src/modules/tests/communication-preferences/communication-preferences.selector.ts
+++ b/src/modules/tests/communication-preferences/communication-preferences.selector.ts
@@ -8,5 +8,4 @@ export const getCommunicationPreferenceType
   = (communicationPreferences: CommunicationPreferences) => get(communicationPreferences, 'communicationMethod', '');
 
 export const getConductedLanguage
-  = (communicationPreferences: CommunicationPreferences) =>
-  communicationPreferences.conductedLanguage ? communicationPreferences.conductedLanguage : '';
+  = (communicationPreferences: CommunicationPreferences) => communicationPreferences.conductedLanguage;

--- a/src/modules/tests/tests.effects.ts
+++ b/src/modules/tests/tests.effects.ts
@@ -38,10 +38,12 @@ import { SetExaminerKeyed } from './examiner-keyed/examiner-keyed.actions';
 import { MarkAsRekey } from './rekey/rekey.actions';
 import { getRekeySearchState, RekeySearchModel } from '../../pages/rekey-search/rekey-search.reducer';
 import { getBookedTestSlot, getStaffNumber } from '../../pages/rekey-search/rekey-search.selector';
-import { Examiner } from '@dvsa/mes-test-schema/categories/B';
+import { Examiner, TestSlotAttributes, ConductedLanguage } from '@dvsa/mes-test-schema/categories/B';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
 import { NavigationStateProvider } from '../../providers/navigation-state/navigation-state';
 import { JournalModel } from '../../pages/journal/journal.model';
+import { PopulateConductedLanguage } from './communication-preferences/communication-preferences.actions';
+import { Language } from './communication-preferences/communication-preferences.model';
 
 @Injectable()
 export class TestsEffects {
@@ -148,18 +150,21 @@ export class TestsEffects {
         const slotData = slots.map(slot => slot.slotData);
         slot = slotData.find(data => data.slotDetail.slotId === startTestAction.slotId && has(data, 'booking'));
       }
+      const testSlotAttributes: TestSlotAttributes = extractTestSlotAttributes(slot);
+      const conductedLanguage: ConductedLanguage = testSlotAttributes.welshTest ? Language.CYMRAEG : Language.ENGLISH;
 
       const arrayOfActions: Action[] = [
         new PopulateExaminer(examiner),
         new PopulateApplicationReference(slot.booking.application),
         new PopulateCandidateDetails(slot.booking.candidate),
-        new PopulateTestSlotAttributes(extractTestSlotAttributes(slot)),
+        new PopulateTestSlotAttributes(testSlotAttributes),
         new PopulateTestCentre(extractTestCentre(slot)),
         new testStatusActions.SetTestStatusBooked(startTestAction.slotId.toString()),
         new PopulateTestCategory(slot.booking.application.testCategory),
         new SetExaminerBooked(parseInt(examinerBooked, 10)),
         new SetExaminerConducted(parseInt(examinerConducted, 10)),
         new SetExaminerKeyed(parseInt(examinerKeyed, 10)),
+        new PopulateConductedLanguage(conductedLanguage),
       ];
 
       if (startTestAction.rekey) {

--- a/src/pages/communication-page/__tests__/communication.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.spec.ts
@@ -36,6 +36,7 @@ import { PopulateTestSlotAttributes } from '../../../modules/tests/test-slot-att
 import * as welshTranslations from '../../../assets/i18n/cy.json';
 import { PrivacyNoticeComponent } from '../components/privacy-notice/privacy-notice';
 import { CommunicationSubmitInfo } from '../communication.actions';
+import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
 
 describe('CommunicationPage', () => {
   let fixture: ComponentFixture<CommunicationPage>;
@@ -227,24 +228,6 @@ describe('CommunicationPage', () => {
       });
     });
 
-    describe('Welsh text selected', () => {
-      it('it should dispatch CandidateChoseToProceedWithTestInWelsh action', () => {
-        component.dispatchCandidateChoseToProceedInWelsh();
-        expect(store$.dispatch)
-          .toHaveBeenCalledWith(new communicationPreferenceActions.CandidateChoseToProceedWithTestInWelsh(
-            CommunicationPage.welshLanguage));
-      });
-    });
-
-    describe('English text selected', () => {
-      it('it should dispatch CandidateChoseToProceedWithTestInEnglish action', () => {
-        component.dispatchCandidateChoseToProceedInEnglish();
-        expect(store$.dispatch)
-          .toHaveBeenCalledWith(new communicationPreferenceActions.CandidateChoseToProceedWithTestInEnglish(
-            CommunicationPage.englishLanguage));
-      });
-    });
-
     describe('Communication class level funcitons', () => {
       it('should set setCommunicationType', () => {
         component.setCommunicationType(CommunicationPage.email, CommunicationPage.providedEmail);
@@ -317,8 +300,7 @@ describe('CommunicationPage', () => {
       });
       it('should render the page in Welsh for a Welsh test', (done) => {
         fixture.detectChanges();
-        component.isBookedInWelsh = true;
-        component.configureI18N(true);
+        component.configureI18N(Language.CYMRAEG);
         translate.onLangChange.subscribe(() => {
           fixture.detectChanges();
           expect(fixture.debugElement.query(By.css('h4')).nativeElement.innerHTML)

--- a/src/pages/communication-page/communication.html
+++ b/src/pages/communication-page/communication.html
@@ -16,13 +16,7 @@
         [candidateDriverNumber]="pageState.candidateDriverNumber$ | async" (continueClickEvent)="onSubmit()">
       </candidate-section>
       <div class="mes-full-width-card-separator"></div>
-      <conducted-language [shouldRender]="pageState.welshTest$ | async"
-        [welshIsSelected]="(pageState.conductedLanguage$ | async) === 'Cymraeg'"
-        [englishIsSelected]="(pageState.conductedLanguage$ | async) === 'English'"
-        (welshTextSelect)="dispatchCandidateChoseToProceedInWelsh()"
-        (englishTextSelect)="dispatchCandidateChoseToProceedInEnglish()">
-      </conducted-language>
-      <privacy-notice [isWelsh]="this.isBookedInWelsh"></privacy-notice>
+      <privacy-notice [language]="pageState.conductedLanguage$ | async"></privacy-notice>
       <div class="mes-full-width-card" id="declaration-section">
 
         <ion-row class="mes-validated-row">

--- a/src/pages/communication-page/components/privacy-notice/privacy-notice.ts
+++ b/src/pages/communication-page/components/privacy-notice/privacy-notice.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { TranslateService } from 'ng2-translate';
+import { Language } from '../../../../modules/tests/communication-preferences/communication-preferences.model';
 
 @Component({
   selector: 'privacy-notice',
@@ -8,13 +9,15 @@ import { TranslateService } from 'ng2-translate';
 export class PrivacyNoticeComponent {
 
   @Input()
-  isWelsh: boolean;
+  language: Language;
 
   constructor(private translate: TranslateService) {}
 
-  configureI18N(isWelsh: boolean): void {
-    if (this.isWelsh) {
+  configureI18N(language: Language): void {
+    if (language === Language.CYMRAEG) {
       this.translate.use('cy');
+    } else {
+      this.translate.use('en');
     }
   }
 }

--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -195,6 +195,7 @@ describe('DebriefPage', () => {
             expect(fixture.debugElement.query(By.css('#etaFaults')).nativeElement.innerHTML).toBe('Physical');
           });
           it('should display in Welsh for a Welsh test', (done) => {
+            fixture.detectChanges();
             translate.use('cy').subscribe(() => {
               store$.dispatch(new ToggleETA(ExaminerActions.physical));
               fixture.detectChanges();
@@ -212,6 +213,7 @@ describe('DebriefPage', () => {
             expect(fixture.debugElement.query(By.css('#etaFaults')).nativeElement.innerHTML).toBe('Verbal');
           });
           it('should display in Welsh for a Welsh test', (done) => {
+            fixture.detectChanges();
             translate.use('cy').subscribe(() => {
               store$.dispatch(new ToggleETA(ExaminerActions.verbal));
               fixture.detectChanges();
@@ -231,6 +233,7 @@ describe('DebriefPage', () => {
           expect(fixture.debugElement.query(By.css('#etaFaults')).nativeElement.innerHTML).toBe('Physical and Verbal');
         });
         it('should display in Welsh for a Welsh test', (done) => {
+          fixture.detectChanges();
           translate.use('cy').subscribe(() => {
             store$.dispatch(new ToggleETA(ExaminerActions.verbal));
             store$.dispatch(new ToggleETA(ExaminerActions.physical));
@@ -262,6 +265,7 @@ describe('DebriefPage', () => {
             expect(fixture.debugElement.query(By.css('#ecoFaults')).nativeElement.innerHTML.trim()).toBe('Planning');
           });
           it('should display in Welsh for a Welsh test', (done) => {
+            fixture.detectChanges();
             translate.use('cy').subscribe(() => {
               store$.dispatch(new TogglePlanningEco());
               fixture.detectChanges();
@@ -279,6 +283,7 @@ describe('DebriefPage', () => {
             expect(fixture.debugElement.query(By.css('#ecoFaults')).nativeElement.innerHTML.trim()).toBe('Control');
           });
           it('should display in Welsh for a Welsh test', (done) => {
+            fixture.detectChanges();
             translate.use('cy').subscribe(() => {
               store$.dispatch(new ToggleControlEco());
               fixture.detectChanges();
@@ -299,6 +304,7 @@ describe('DebriefPage', () => {
             .toBe('Control and Planning');
         });
         it('should display in Welsh for a Welsh test', (done) => {
+          fixture.detectChanges();
           translate.use('cy').subscribe(() => {
             store$.dispatch(new TogglePlanningEco());
             store$.dispatch(new ToggleControlEco());

--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -35,6 +35,7 @@ import { PopulateTestSlotAttributes } from '../../../modules/tests/test-slot-att
 import { EndDebrief } from '../debrief.actions';
 import * as welshTranslations from '../../../assets/i18n/cy.json';
 import { PASS_FINALISATION_PAGE, POST_DEBRIEF_HOLDING_PAGE } from '../../page-names.constants';
+import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
 
 describe('DebriefPage', () => {
   let fixture: ComponentFixture<DebriefPage>;
@@ -390,8 +391,7 @@ describe('DebriefPage', () => {
         store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsSignalling));
         store$.dispatch(new AddDangerousFault(Competencies.useOfMirrorsChangeDirection));
         fixture.detectChanges();
-        component.isBookedInWelsh = true;
-        component.configureI18N(true);
+        component.configureI18N(Language.CYMRAEG);
         translate.onLangChange.subscribe(() => {
           fixture.detectChanges();
           const drivingFaultLabel = fixture.debugElement.query(By.css('#driving-fault .counter-label')).nativeElement;

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -3,7 +3,7 @@ import { PracticeableBasePageComponent } from '../../shared/classes/practiceable
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
-import { getCurrentTest, getJournalData } from '../../modules/tests/tests.selector';
+import { getCurrentTest } from '../../modules/tests/tests.selector';
 import { DebriefViewDidEnter, EndDebrief } from '../../pages/debrief/debrief.actions';
 import { Observable } from 'rxjs/Observable';
 import { getTests } from '../../modules/tests/tests.reducer';
@@ -13,7 +13,7 @@ import {
   getEco,
   getDrivingFaultSummaryCount,
 } from '../../modules/tests/test-data/test-data.selector';
-import { map } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 import { Component } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 import { merge } from 'rxjs/observable/merge';
@@ -37,8 +37,6 @@ import {
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
 import { TranslateService } from 'ng2-translate';
-import { getTestSlotAttributes } from '../../modules/tests/test-slot-attributes/test-slot-attributes.reducer';
-import { isWelshTest } from '../../modules/tests/test-slot-attributes/test-slot-attributes.selector';
 import { ETA, Eco } from '@dvsa/mes-test-schema/categories/B';
 import {
   getCommunicationPreference,
@@ -51,6 +49,7 @@ import {
   POST_DEBRIEF_HOLDING_PAGE,
   DASHBOARD_PAGE,
 } from '../page-names.constants';
+import { Language } from '../../modules/tests/communication-preferences/communication-preferences.model';
 
 interface DebriefPageState {
   seriousFaults$: Observable<string[]>;
@@ -60,7 +59,6 @@ interface DebriefPageState {
   etaFaults$: Observable<ETA>;
   ecoFaults$: Observable<Eco>;
   testResult$: Observable<string>;
-  welshTest$: Observable<boolean>;
   conductedLanguage$: Observable<string>;
 }
 
@@ -72,12 +70,8 @@ interface DebriefPageState {
 
 export class DebriefPage extends PracticeableBasePageComponent {
 
-  static readonly welshLanguage: string = 'Cymraeg';
-
   pageState: DebriefPageState;
   subscription: Subscription;
-  conductedLanguage: string;
-  isBookedInWelsh: boolean;
   isPassed: boolean;
 
   // Used for now to test displaying pass/fail/terminated messages
@@ -177,22 +171,16 @@ export class DebriefPage extends PracticeableBasePageComponent {
       testResult$: currentTest$.pipe(
         select(getTestOutcome),
       ),
-      welshTest$: currentTest$.pipe(
-        select(getJournalData),
-        select(getTestSlotAttributes),
-        select(isWelshTest),
-      ),
       conductedLanguage$: currentTest$.pipe(
         select(getCommunicationPreference),
         select(getConductedLanguage),
       ),
     };
 
-    const { testResult$, welshTest$, etaFaults$, ecoFaults$, conductedLanguage$ } = this.pageState;
+    const { testResult$, etaFaults$, ecoFaults$, conductedLanguage$ } = this.pageState;
 
     this.subscription = merge(
       testResult$.pipe(map(result => this.outcome = result)),
-      welshTest$.pipe(map(isWelsh => this.isBookedInWelsh = isWelsh)),
       etaFaults$.pipe(
         map((eta) => {
           this.hasPhysicalEta = eta.physical;
@@ -205,15 +193,15 @@ export class DebriefPage extends PracticeableBasePageComponent {
           this.adviceGivenPlanning = eco.adviceGivenPlanning;
         }),
       ),
-      conductedLanguage$.pipe(map(language => this.conductedLanguage = language)),
+      conductedLanguage$.pipe(tap(this.configureI18N)),
     ).subscribe();
-
-    this.configureI18N(this.conductedLanguage === DebriefPage.welshLanguage);
   }
 
-  configureI18N(isWelsh: boolean): void {
-    if (this.isBookedInWelsh && isWelsh) {
+  configureI18N = (language: Language): void => {
+    if (language === Language.CYMRAEG) {
       this.translate.use('cy');
+    } else {
+      this.translate.use('en');
     }
   }
 

--- a/src/pages/health-declaration/__tests__/health-declaration.spec.ts
+++ b/src/pages/health-declaration/__tests__/health-declaration.spec.ts
@@ -26,6 +26,7 @@ import { By } from '@angular/platform-browser';
 import { PopulateTestSlotAttributes } from '../../../modules/tests/test-slot-attributes/test-slot-attributes.actions';
 import { TestSlotAttributes } from '@dvsa/mes-test-schema/categories/B';
 import { Subscription } from 'rxjs/Subscription';
+import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
 
 const mockCandidate = {
   driverNumber: '123',
@@ -218,8 +219,7 @@ describe('HealthDeclarationPage', () => {
       });
       it('should render the page in Welsh for a Welsh test', (done) => {
         fixture.detectChanges();
-        component.isBookedInWelsh = true;
-        component.configureI18N(true);
+        component.configureI18N(Language.CYMRAEG);
         translate.onLangChange.subscribe(() => {
           fixture.detectChanges();
           const declarationIntent = fixture.debugElement.query(By.css('h4')).nativeElement;

--- a/src/pages/waiting-room/__tests__/waiting-room.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.spec.ts
@@ -28,6 +28,9 @@ import { WaitingRoomValidationError } from '../waiting-room.actions';
 import { of } from 'rxjs/observable/of';
 import { TranslateModule, TranslateService } from 'ng2-translate';
 import { Subscription } from 'rxjs/Subscription';
+import * as communicationPreferenceActions
+  from '../../../modules/tests/communication-preferences/communication-preferences.actions';
+import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
 
 describe('WaitingRoomPage', () => {
   let fixture: ComponentFixture<WaitingRoomPage>;
@@ -118,6 +121,24 @@ describe('WaitingRoomPage', () => {
         expect(store$.dispatch).toHaveBeenCalledWith(new ToggleInsuranceDeclaration());
       });
     });
+
+    describe('Welsh text selected', () => {
+      it('it should dispatch CandidateChoseToProceedWithTestInWelsh action', () => {
+        component.dispatchCandidateChoseToProceedInWelsh();
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(new communicationPreferenceActions.CandidateChoseToProceedWithTestInWelsh(
+            Language.CYMRAEG));
+      });
+    });
+
+    describe('English text selected', () => {
+      it('it should dispatch CandidateChoseToProceedWithTestInEnglish action', () => {
+        component.dispatchCandidateChoseToProceedInEnglish();
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(new communicationPreferenceActions.CandidateChoseToProceedWithTestInEnglish(
+            Language.ENGLISH));
+      });
+    });
   });
 
   describe('clickBack', () => {
@@ -143,24 +164,20 @@ describe('WaitingRoomPage', () => {
 
   describe('DOM', () => {
     describe('Declaration checkboxes', () => {
-      it('should call residency change handler when residency declaration is (un)checked', fakeAsync(() => {
+      it('should call residency change handler when residency declaration is (un)checked', () => {
         fixture.detectChanges();
         spyOn(component, 'residencyDeclarationChanged');
         const residencyCb = fixture.debugElement.query(By.css('#residency-declaration-checkbox'));
         residencyCb.triggerEventHandler('click', null);
-        tick();
-        fixture.detectChanges();
         expect(component.residencyDeclarationChanged).toHaveBeenCalled();
-      }));
-      it('should call insurance change handler when insurance declaration is (un)checked', fakeAsync(() => {
+      });
+      it('should call insurance change handler when insurance declaration is (un)checked', () => {
         fixture.detectChanges();
         spyOn(component, 'insuranceDeclarationChanged');
         const insuranceCb = fixture.debugElement.query(By.css('#insurance-declaration-checkbox'));
         insuranceCb.triggerEventHandler('click', null);
-        tick();
-        fixture.detectChanges();
         expect(component.insuranceDeclarationChanged).toHaveBeenCalled();
-      }));
+      });
     });
   });
   describe('onSubmit', () => {

--- a/src/pages/waiting-room/waiting-room.html
+++ b/src/pages/waiting-room/waiting-room.html
@@ -14,6 +14,12 @@
       [candidateDriverNumber]="pageState.candidateDriverNumber$ | async" (continueClickEvent)="onSubmit()">
     </candidate-section>
     <div class="mes-full-width-card-separator"></div>
+    <conducted-language [shouldRender]="pageState.welshTest$ | async"
+      [welshIsSelected]="(pageState.conductedLanguage$ | async) === 'Cymraeg'"
+      [englishIsSelected]="(pageState.conductedLanguage$ | async) === 'English'"
+      (welshTextSelect)="dispatchCandidateChoseToProceedInWelsh()"
+      (englishTextSelect)="dispatchCandidateChoseToProceedInEnglish()">
+    </conducted-language>
     <div class="mes-full-width-card" id="declaration-section">
       <ion-row>
         <ion-col>

--- a/src/pages/waiting-room/waiting-room.scss
+++ b/src/pages/waiting-room/waiting-room.scss
@@ -34,5 +34,9 @@ page-waiting-room {
     .signature-validation-row {
       height: 300px;
     }
+    
+    conducted-language > ion-row {
+      margin-bottom: -36px;
+    }
   }
 }


### PR DESCRIPTION
## Description
Rework of translations to fix bug introduced in PR [730](https://github.com/dvsa/mes-mobile-app/pull/730).

The initial conducted language is now set when the test is started, using a new action. The value is based on the `welshTest` flag from the journal.

The `English | Cymraeg` selector is now on the waiting room page.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![IMG_0161](https://user-images.githubusercontent.com/8069071/64876307-c4d72680-d646-11e9-83df-f73c25562eba.PNG)


