### PR TITLE
MES-3574 reload app config when app resumes

### DIFF
--- a/src/app/__tests__/app.component.spec.ts
+++ b/src/app/__tests__/app.component.spec.ts
@@ -46,6 +46,7 @@ describe('App', () => {
       store$ = TestBed.get(Store);
 
       spyOn(store$, 'dispatch');
+      spyOn(component, 'configureAccessibility');
       spyOn(component, 'configurePlatformSubscriptions');
     });
   }));

--- a/src/app/__tests__/app.component.spec.ts
+++ b/src/app/__tests__/app.component.spec.ts
@@ -38,16 +38,16 @@ describe('App', () => {
         { provide: TranslateService, useValue: translateServiceMock },
       ],
     })
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(App);
-        component = fixture.componentInstance;
-      });
+    .compileComponents()
+    .then(() => {
+      fixture = TestBed.createComponent(App);
+      component = fixture.componentInstance;
+      statusBar = TestBed.get(StatusBar);
+      store$ = TestBed.get(Store);
 
-    statusBar = TestBed.get(StatusBar);
-
-    store$ = TestBed.get(Store);
-    spyOn(store$, 'dispatch');
+      spyOn(store$, 'dispatch');
+      spyOn(component, 'configurePlatformSubscriptions');
+    });
   }));
 
   describe('Class', () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,7 +37,7 @@ export class App {
         this.loadAppInfo();
         if (this.platform.is('ios')) {
           this.configureAccessibility();
-          this.createPlatformSubscriptions();
+          this.configurePlatformSubscriptions();
         }
       });
   }
@@ -65,7 +65,7 @@ export class App {
     this.store$.dispatch(new LoadAppInfo());
   }
 
-  createPlatformSubscriptions() {
+  configurePlatformSubscriptions() {
     const merged$ = merge(
       this.platform.resume.pipe(map(this.onAppResumed)),
       this.platform.pause.pipe(map(this.onAppSuspended)),

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -48,3 +48,6 @@ img {
   height: 100% !important;
   width: 100% !important;
 }
+
+body {
+  -webkit-text-size-adjust: 100% !important; // prevents the iOS text size config from adjusting webview zoom level

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -51,3 +51,4 @@ img {
 
 body {
   -webkit-text-size-adjust: 100% !important; // prevents the iOS text size config from adjusting webview zoom level
+}

--- a/src/modules/app-info/app-info.actions.ts
+++ b/src/modules/app-info/app-info.actions.ts
@@ -4,6 +4,11 @@ export const LOAD_APP_INFO = '[AppComponent] Load App Info';
 export const LOAD_APP_INFO_SUCCESS = '[AppInfoEffects] Load App Info Success';
 export const LOAD_APP_INFO_FAILURE = '[AppInfoEffects] Load App Info Failure';
 export const LOAD_EMPLOYEE_ID = '[LoginComponent] Load employee ID';
+export const LOAD_CONFIG_SUCCESS = '[AppInfoEffects] Load Config Success';
+export const SET_DATE_CONFIG_LOADED = '[AppInfoEffects] Set Date Config Loaded';
+export const APP_SUSPENDED = '[AppInfoEffects] App Suspended';
+export const APP_RESUMED = '[AppInfoEffects] App Resumed';
+export const RESTART_APP = '[AppInfoEffects] Restart App';
 
 export class LoadAppInfo implements Action {
   readonly type = LOAD_APP_INFO;
@@ -24,8 +29,34 @@ export class LoadEmployeeId implements Action {
   constructor(public employeeId: string) {}
 }
 
+export class LoadConfigSuccess implements Action {
+  readonly type = LOAD_CONFIG_SUCCESS;
+}
+
+export class SetDateConfigLoaded implements Action {
+  readonly type = SET_DATE_CONFIG_LOADED;
+  constructor(public refreshDate: string) {}
+}
+
+export class AppSuspended implements Action {
+  readonly type = APP_SUSPENDED;
+}
+
+export class AppResumed implements Action {
+  readonly type = APP_RESUMED;
+}
+
+export class RestartApp implements Action {
+  readonly type = RESTART_APP;
+}
+
 export type Types =
   LoadAppInfo |
   LoadAppInfoSuccess |
   LoadAppInfoFailure |
-  LoadEmployeeId;
+  LoadEmployeeId |
+  LoadConfigSuccess |
+  SetDateConfigLoaded |
+  AppSuspended |
+  AppResumed |
+  RestartApp;

--- a/src/modules/app-info/app-info.effects.ts
+++ b/src/modules/app-info/app-info.effects.ts
@@ -2,17 +2,26 @@ import { Injectable } from '@angular/core';
 import { Effect, Actions, ofType } from '@ngrx/effects';
 
 import { of } from 'rxjs/observable/of';
-import { map, switchMap, catchError } from 'rxjs/operators';
-
+import { map, switchMap, catchError, concatMap, withLatestFrom, filter } from 'rxjs/operators';
+import { StoreModel } from '../../shared/models/store.model';
+import { Store, select } from '@ngrx/store';
 import * as appInfoActions from './app-info.actions';
 import { AppInfoProvider } from '../../providers/app-info/app-info';
 import { HttpErrorResponse } from '@angular/common/http';
+import { DateTimeProvider } from '../../providers/date-time/date-time';
+import { getAppInfoState } from './app-info.reducer';
+import { getDateConfigLoaded } from './app-info.selector';
+import { LOGIN_PAGE } from '../../pages/page-names.constants';
+import { NavigationProvider } from '../../providers/navigation/navigation';
 
 @Injectable()
 export class AppInfoEffects {
   constructor(
     private actions$: Actions,
     private appInfoProvider: AppInfoProvider,
+    private dateTimeProvider: DateTimeProvider,
+    private store$: Store<StoreModel>,
+    private navigationProvider: NavigationProvider,
   ) {}
 
   @Effect()
@@ -25,6 +34,34 @@ export class AppInfoEffects {
           map((versionNumber: string) => new appInfoActions.LoadAppInfoSuccess(versionNumber)),
           catchError((err: HttpErrorResponse) => of(new appInfoActions.LoadAppInfoFailure(err))),
         );
+    }),
+  );
+
+  @Effect()
+  loadConfigSuccessEffect$ = this.actions$.pipe(
+    ofType(appInfoActions.LOAD_CONFIG_SUCCESS),
+    switchMap(() => {
+      console.log('Config loaded successfully');
+      return of(new appInfoActions.SetDateConfigLoaded(this.dateTimeProvider.now().format('YYYY-MM-DD')));
+    }),
+  );
+
+  @Effect()
+  appResumedEffect$ = this.actions$.pipe(
+    ofType(appInfoActions.APP_RESUMED),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getAppInfoState),
+          select(getDateConfigLoaded),
+        ),
+      ),
+    )),
+    filter(([action, dateConfigLoaded]) => dateConfigLoaded !== this.dateTimeProvider.now().format('YYYY-MM-DD')),
+    switchMap(([action, dateConfigLoaded]) => {
+      console.log('App resumed after being suspended. Config was not loaded today... app will refresh');
+      this.navigationProvider.getNav().setRoot(LOGIN_PAGE);
+      return of(new appInfoActions.RestartApp());
     }),
   );
 }

--- a/src/modules/app-info/app-info.model.ts
+++ b/src/modules/app-info/app-info.model.ts
@@ -6,4 +6,5 @@ export type AppInfoModel = {
   versionNumber: string,
   employeeId: string | null,
   error?: any,
+  dateConfigLoaded?: string,
 };

--- a/src/modules/app-info/app-info.reducer.ts
+++ b/src/modules/app-info/app-info.reducer.ts
@@ -25,6 +25,11 @@ export function appInfoReducer(state = initialState, action: appInfoActions.Type
         ...state,
         employeeId: action.employeeId,
       };
+    case appInfoActions.SET_DATE_CONFIG_LOADED:
+      return {
+        ...state,
+        dateConfigLoaded: action.refreshDate,
+      };
     default:
       return state;
   }

--- a/src/modules/app-info/app-info.selector.ts
+++ b/src/modules/app-info/app-info.selector.ts
@@ -3,3 +3,5 @@ import { AppInfoModel } from './app-info.model';
 export const getVersionNumber = (appInfo: AppInfoModel) => appInfo.versionNumber;
 
 export const getEmployeeId = (appInfo: AppInfoModel) => appInfo.employeeId;
+
+export const getDateConfigLoaded = (appInfo: AppInfoModel) => appInfo.dateConfigLoaded;

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -30,6 +30,7 @@ import { LogsProvider } from '../../providers/logs/logs';
 import { LogType } from '../../shared/models/log.model';
 import { DASHBOARD_PAGE } from '../page-names.constants';
 import { LogHelper } from '../../providers/logs/logsHelper';
+import { LoadConfigSuccess } from '../../modules/app-info/app-info.actions';
 
 @IonicPage()
 @Component({
@@ -104,6 +105,7 @@ export class LoginPage extends BasePageComponent {
       await this.initialisePersistentStorage();
 
       await this.appConfigProvider.loadRemoteConfig();
+      this.store$.dispatch(new LoadConfigSuccess());
 
       this.analytics.initialiseAnalytics();
 


### PR DESCRIPTION
## Description
When the app starts up and loads the configuration successfully, store the current date in the `appInfo` part of the store.

Then using the platform 'resume` event, check if the date the app config was loaded is different to today's date, and if so, reload the app by setting the app root as the login page.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
