### PR TITLE
MES - 3592 add DE ID to all mobile app logs

### DIFF
--- a/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.selector.spec.ts
+++ b/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.selector.spec.ts
@@ -37,6 +37,7 @@ describe('IncompleteTestsBannerSelector', () => {
       const appInfo = {
         versionNumber: 'VERSION_NOT_LOADED',
         error: 'cordova_not_available',
+        employeeId: '1234567',
       };
       const logs = [];
       const journal: JournalModel = {

--- a/src/modules/app-info/__tests__/app-info.reducer.spec.ts
+++ b/src/modules/app-info/__tests__/app-info.reducer.spec.ts
@@ -20,6 +20,7 @@ describe('App Info Reducer', () => {
 
       expect(result).toEqual({
         versionNumber,
+        employeeId: null,
       });
     });
   });
@@ -33,6 +34,19 @@ describe('App Info Reducer', () => {
       expect(result).toEqual({
         ...initialState,
         error,
+      });
+    });
+  });
+
+  describe('[LoginComponent] Load employee ID', () => {
+    it('should save employeeId to state', () => {
+      const employeeId = '6543632';
+      const action = new appInfoActions.LoadEmployeeId(employeeId);
+      const result = appInfoReducer(initialState, action);
+
+      expect(result).toEqual({
+        versionNumber: 'VERSION_NOT_LOADED',
+        employeeId: '6543632',
       });
     });
   });

--- a/src/modules/app-info/__tests__/app-info.selector.spec.ts
+++ b/src/modules/app-info/__tests__/app-info.selector.spec.ts
@@ -6,6 +6,7 @@ describe('AppInfoSelector', () => {
 
   const state: AppInfoModel = {
     versionNumber: '1.0.0',
+    employeeId: '1234567',
   };
 
   describe('getVersionNumber', () => {

--- a/src/modules/app-info/app-info.actions.ts
+++ b/src/modules/app-info/app-info.actions.ts
@@ -3,6 +3,7 @@ import { Action } from '@ngrx/store';
 export const LOAD_APP_INFO = '[AppComponent] Load App Info';
 export const LOAD_APP_INFO_SUCCESS = '[AppInfoEffects] Load App Info Success';
 export const LOAD_APP_INFO_FAILURE = '[AppInfoEffects] Load App Info Failure';
+export const LOAD_EMPLOYEE_ID = '[LoginComponent] ';
 
 export class LoadAppInfo implements Action {
   readonly type = LOAD_APP_INFO;
@@ -18,7 +19,13 @@ export class LoadAppInfoFailure implements Action {
   constructor(public error: any) {}
 }
 
+export class LoadEmployeeId implements Action {
+  readonly type = LOAD_EMPLOYEE_ID;
+  constructor(public employeeId: string) {}
+}
+
 export type Types =
   LoadAppInfo |
   LoadAppInfoSuccess |
-  LoadAppInfoFailure;
+  LoadAppInfoFailure |
+  LoadEmployeeId;

--- a/src/modules/app-info/app-info.actions.ts
+++ b/src/modules/app-info/app-info.actions.ts
@@ -3,7 +3,7 @@ import { Action } from '@ngrx/store';
 export const LOAD_APP_INFO = '[AppComponent] Load App Info';
 export const LOAD_APP_INFO_SUCCESS = '[AppInfoEffects] Load App Info Success';
 export const LOAD_APP_INFO_FAILURE = '[AppInfoEffects] Load App Info Failure';
-export const LOAD_EMPLOYEE_ID = '[LoginComponent] ';
+export const LOAD_EMPLOYEE_ID = '[LoginComponent] Load employee ID';
 
 export class LoadAppInfo implements Action {
   readonly type = LOAD_APP_INFO;

--- a/src/modules/app-info/app-info.model.ts
+++ b/src/modules/app-info/app-info.model.ts
@@ -4,5 +4,6 @@ export type AppInfoModel = {
   // i.e developing in the browser
 
   versionNumber: string,
+  employeeId: string | null,
   error?: any,
 };

--- a/src/modules/app-info/app-info.reducer.ts
+++ b/src/modules/app-info/app-info.reducer.ts
@@ -5,6 +5,7 @@ import * as appInfoActions from './app-info.actions';
 
 export const initialState: AppInfoModel = {
   versionNumber: 'VERSION_NOT_LOADED',
+  employeeId: null,
 };
 
 export function appInfoReducer(state = initialState, action: appInfoActions.Types) {
@@ -18,6 +19,11 @@ export function appInfoReducer(state = initialState, action: appInfoActions.Type
       return {
         ...state,
         error: action.error,
+      };
+    case appInfoActions.LOAD_EMPLOYEE_ID:
+      return {
+        ...state,
+        employeeId: action.employeeId,
       };
     default:
       return state;

--- a/src/modules/app-info/app-info.selector.ts
+++ b/src/modules/app-info/app-info.selector.ts
@@ -1,3 +1,5 @@
 import { AppInfoModel } from './app-info.model';
 
 export const getVersionNumber = (appInfo: AppInfoModel) => appInfo.versionNumber;
+
+export const getEmployeeId = (appInfo: AppInfoModel) => appInfo.employeeId;

--- a/src/modules/logs/__tests__/logs.effects.spec.ts
+++ b/src/modules/logs/__tests__/logs.effects.spec.ts
@@ -81,7 +81,13 @@ describe('Logs Effects', () => {
 
   it('should dispatch the persist logs action when an individual log is added', (done) => {
     // ARRANGE
-    const log: Log = { ['test']: 'xyz', type: LogType.DEBUG, message: 'test', timestamp: 1234567 };
+    const log: Log = {
+      ['test']: 'xyz',
+      type: LogType.DEBUG,
+      message: 'test',
+      timestamp: 1234567,
+      drivingExaminerId: '1234567',
+    };
     // ACT
     actions$.next(new logsActions.SaveLog(log));
     // ASSERT
@@ -125,7 +131,13 @@ describe('Logs Effects', () => {
 
   describe('getAndConvertPersistedLogs', () => {
     it('should empty cached data if cache is too old', (done) => {
-      const log: Log = { ['test']: 'xyz', type: LogType.DEBUG, message: 'test', timestamp: 1234567 };
+      const log: Log = {
+        ['test']: 'xyz',
+        type: LogType.DEBUG,
+        message: 'test',
+        timestamp: 1234567,
+        drivingExaminerId: '1234567',
+      };
 
       const agedCache = {
         dateStored: new DateTime().add(-(cacheDays + 1), Duration.DAY).format('YYYY/MM/DD'),
@@ -147,7 +159,13 @@ describe('Logs Effects', () => {
     });
 
     it('should return data without emptying cache if data is not too old', (done) => {
-      const log: Log = { ['test']: 'xyz', type: LogType.DEBUG, message: 'test', timestamp: 1234567 };
+      const log: Log = {
+        ['test']: 'xyz',
+        type: LogType.DEBUG,
+        message: 'test',
+        timestamp: 1234567,
+        drivingExaminerId: '1234567',
+      };
       const dataWthinWindowCache = {
         dateStored: new DateTime().add(cacheDays, Duration.DAY).format('YYYY/MM/DD'),
         data: log,

--- a/src/modules/logs/__tests__/logs.reducer.spec.ts
+++ b/src/modules/logs/__tests__/logs.reducer.spec.ts
@@ -19,6 +19,7 @@ describe('Logs Reducer', () => {
         type: LogType.INFO,
         message: 'DE with id: 12345678 - [JournalEffects] Load Journal Success',
         timestamp: Date.now(),
+        drivingExaminerId: '1234567',
       };
       const action = new logsActions.SaveLog(log);
 
@@ -34,6 +35,7 @@ describe('Logs Reducer', () => {
       type: LogType.WARNING,
       message: 'DE with id: 12345678 - [JournalEffects] Load Journal Silent Failure',
       timestamp: timestamps[2],
+      drivingExaminerId: '1234567',
     };
 
     const logs = [
@@ -41,11 +43,13 @@ describe('Logs Reducer', () => {
         type: LogType.INFO,
         message: 'DE with id: 12345678 - [JournalEffects] Load Journal Success',
         timestamp: timestamps[0],
+        drivingExaminerId: '1234567',
       },
       {
         type: LogType.ERROR,
         message: 'DE with id: 12345678 - [JournalEffects] Load Journal Failure',
         timestamp: timestamps[1],
+        drivingExaminerId: '1234567',
       },
       lastLog,
     ];

--- a/src/modules/tests/__tests__/tests.selector.spec.ts
+++ b/src/modules/tests/__tests__/tests.selector.spec.ts
@@ -67,7 +67,7 @@ describe('testsSelector', () => {
         selectedDate: 'dummy',
         examiner: { staffNumber: '123', individualId: 456 },
       };
-      const appInfo: AppInfoModel = { versionNumber: '0.0.0' };
+      const appInfo: AppInfoModel = { versionNumber: '0.0.0', employeeId: '1234567' };
       const logs: LogsModel = [];
       const state = {
         journal,

--- a/src/pages/journal/journal.logs.effects.ts
+++ b/src/pages/journal/journal.logs.effects.ts
@@ -35,10 +35,12 @@ export class JournalLogsEffects {
   );
 
   private createLog(logType: LogType, actionType: string): Log {
+    const employeeId: string = this.authenticationProvider.getEmployeeId();
     return {
       type: logType,
-      message: `DE with id: ${this.authenticationProvider.getEmployeeId()} - ${actionType}`,
+      message: `DE with id: ${employeeId} - ${actionType}`,
       timestamp: Date.now(),
+      drivingExaminerId: employeeId,
     };
   }
 

--- a/src/pages/login/__tests__/login.spec.ts
+++ b/src/pages/login/__tests__/login.spec.ts
@@ -43,6 +43,7 @@ import { SecureStorageMock } from '@ionic-native-mocks/secure-storage';
 import { LoadLog, StartSendingLogs } from '../../../modules/logs/logs.actions';
 import { StartSendingCompletedTests } from '../../../modules/tests/tests.actions';
 import { DASHBOARD_PAGE } from '../../page-names.constants';
+import { LoadEmployeeId } from '../../../modules/app-info/app-info.actions';
 
 describe('LoginPage', () => {
   let fixture: ComponentFixture<LoginPage>;
@@ -220,6 +221,7 @@ describe('LoginPage', () => {
       expect(store$.dispatch).toHaveBeenCalledWith(new LoadLog());
       expect(store$.dispatch).toHaveBeenCalledWith(new StartSendingLogs());
       expect(store$.dispatch).toHaveBeenCalledWith(new StartSendingCompletedTests());
+      expect(store$.dispatch).toHaveBeenCalledWith(new LoadEmployeeId(null));
     }));
   });
 

--- a/src/pages/login/__tests__/login.spec.ts
+++ b/src/pages/login/__tests__/login.spec.ts
@@ -221,7 +221,7 @@ describe('LoginPage', () => {
       expect(store$.dispatch).toHaveBeenCalledWith(new LoadLog());
       expect(store$.dispatch).toHaveBeenCalledWith(new StartSendingLogs());
       expect(store$.dispatch).toHaveBeenCalledWith(new StartSendingCompletedTests());
-      expect(store$.dispatch).toHaveBeenCalledWith(new LoadEmployeeId(null));
+      expect(store$.dispatch).toHaveBeenCalledWith(new LoadEmployeeId('12345678'));
     }));
   });
 

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -20,6 +20,7 @@ import { AnalyticsProvider } from '../../providers/analytics/analytics';
 import { AppConfigProvider } from '../../providers/app-config/app-config';
 import { StoreModel } from '../../shared/models/store.model';
 import { StartSendingLogs, LoadLog, SaveLog, SendLogs } from '../../modules/logs/logs.actions';
+import { LoadEmployeeId } from '../../modules/app-info/app-info.actions';
 import { NetworkStateProvider } from '../../providers/network-state/network-state';
 import { SecureStorage } from '@ionic-native/secure-storage';
 import { DataStoreProvider } from '../../providers/data-store/data-store';
@@ -95,6 +96,8 @@ export class LoginPage extends BasePageComponent {
       this.initialiseAuthentication();
 
       await this.authenticationProvider.login();
+
+      this.store$.dispatch(new LoadEmployeeId(this.authenticationProvider.getEmployeeId()));
 
       this.store$.dispatch(new LoadLog());
 

--- a/src/providers/authentication/authentication.ts
+++ b/src/providers/authentication/authentication.ts
@@ -62,7 +62,7 @@ export class AuthenticationProvider {
   }
 
   public getEmployeeId = (): string => {
-    return this.employeeId;
+    return this.employeeId || null;
   }
 
   public getEmployeeName = (): string => {

--- a/src/providers/logs/__tests__/logs.spec.ts
+++ b/src/providers/logs/__tests__/logs.spec.ts
@@ -44,6 +44,7 @@ describe('LogsProvider', () => {
         type: LogType.DEBUG,
         message: 'Successfully logged multiple',
         timestamp: new Date().getTime(),
+        drivingExaminerId: '1234567',
       }]).subscribe();
 
       httpMock.expectOne(LOGS_SERVICE_URL);

--- a/src/shared/models/log.model.ts
+++ b/src/shared/models/log.model.ts
@@ -9,5 +9,6 @@ export type Log = {
   type: LogType,
   message: string,
   timestamp: number,
+  drivingExaminerId: string;
   [propName: string]: any,
 };


### PR DESCRIPTION
## Description
- Adds a `drivingExaminerId` key to the logging helper and log model.
- This necessitated adding the employeeId to the store in order for it to be retrieved, it has been added to the existing `appInfo` store key. This happens in `login.ts` as soon as authentication has succeeded by dispatching the `LoadEmployeeId` action.
- Pre-authentication logs will have the `drivingExaminerId` set to `null`.
- Unit tests coverage for the new reducer case and the dispatching of the `LoadEmployeeId` action.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

**Pre-auth**

![image](https://user-images.githubusercontent.com/33695049/64860777-0c00ef80-d626-11e9-946e-a0223a73cfd3.png)
**Post-auth**

![image](https://user-images.githubusercontent.com/33695049/64860647-b3c9ed80-d625-11e9-8872-debd6937b3f5.png)
