### PR TITLE
MES-3185 - Modifying Pass Certification Number validation

### DIFF
--- a/src/pages/test-finalisation/pass-finalisation/pass-finalisation.html
+++ b/src/pages/test-finalisation/pass-finalisation/pass-finalisation.html
@@ -106,7 +106,7 @@
             <ion-row class="validation-message-row" align-items-center>
               <div class="validation-text" [class.ng-invalid]="isCtrlDirtyAndInvalid('passCertificateNumberCtrl') ||
                 passCertificateValidation()" id="pass-finalisation-certificate-number-validation-text">
-                Enter a valid certificate number (max 8 characters)
+                Enter a valid certificate number (8 characters)
               </div>
             </ion-row>
           </ion-col>

--- a/src/pages/test-finalisation/pass-finalisation/pass-finalisation.ts
+++ b/src/pages/test-finalisation/pass-finalisation/pass-finalisation.ts
@@ -234,10 +234,12 @@ export class PassFinalisationPage extends PracticeableBasePageComponent {
   getFormValidation(): { [key: string]: FormControl } {
     return {
       provisionalLicenseProvidedCtrl: new FormControl(null, [Validators.required]),
-      passCertificateNumberCtrl: new FormControl(null, [
-        Validators.required,
-        Validators.maxLength(8),
-      ]),
+      passCertificateNumberCtrl: new FormControl(null,
+        {
+          validators: Validators.compose([Validators.maxLength(8), Validators.minLength(8)]),
+          updateOn: 'blur',
+        },
+      ),
       transmissionCtrl: new FormControl(null, [Validators.required]),
     };
   }


### PR DESCRIPTION
## Description

Story: https://jira.dvsacloud.uk/browse/MES-3185

- Added minLength validation as well as the current maxLength so that only a string of 8 characters will be accepted.

- Also added the updateOn('blur') option to only trigger the validation when you click off the field.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
