### PR TITLE
mes-3185 - Fixed PassCertificate validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@angular/compiler-cli": "^5.2.11",
     "@dvsa/mes-journal-schema": "1.1.0",
     "@dvsa/mes-search-schema": "1.0.3",
-    "@dvsa/mes-test-schema": "2.0.2",
+    "@dvsa/mes-test-schema": "2.0.3",
     "@hapi/joi": "^15.1.0",
     "@ionic-native-mocks/device": "^2.0.12",
     "@ionic-native-mocks/secure-storage": "^2.0.12",

--- a/src/pages/test-finalisation/pass-finalisation/pass-finalisation.html
+++ b/src/pages/test-finalisation/pass-finalisation/pass-finalisation.html
@@ -100,7 +100,7 @@
               <ion-col>
                 <input #passCertificateNumberInput formControlName="passCertificateNumberCtrl" [class.ng-invalid]="isCtrlDirtyAndInvalid('passCertificateNumberCtrl') ||
                   passCertificateValidation()" type="text" value="{{pageState.passCertificateNumber$ | async}}"
-                  id="pass-certificate-number" class="pass-cert-input">
+                  id="pass-certificate-number" class="pass-cert-input" maxlength="8">
               </ion-col>
             </ion-row>
             <ion-row class="validation-message-row" align-items-center>

--- a/src/pages/test-finalisation/pass-finalisation/pass-finalisation.ts
+++ b/src/pages/test-finalisation/pass-finalisation/pass-finalisation.ts
@@ -236,7 +236,7 @@ export class PassFinalisationPage extends PracticeableBasePageComponent {
       provisionalLicenseProvidedCtrl: new FormControl(null, [Validators.required]),
       passCertificateNumberCtrl: new FormControl(null,
         {
-          validators: Validators.compose([Validators.maxLength(8), Validators.minLength(8)]),
+          validators: Validators.compose([Validators.maxLength(8), Validators.minLength(8), Validators.required]),
           updateOn: 'blur',
         },
       ),


### PR DESCRIPTION
## Description

Story: https://jira.dvsacloud.uk/browse/MES-3185
- Added required validator to ensure the user cannot continue without adding a certificate number
- Added maxLength html attribute to prevent typing any more than 8 characters

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
