### PR TITLE
MES-3612 Dispatch status update when leaving page

### DIFF
--- a/src/pages/test-finalisation/non-pass-finalisation/__tests__/non-pass-finalisation.spec.ts
+++ b/src/pages/test-finalisation/non-pass-finalisation/__tests__/non-pass-finalisation.spec.ts
@@ -12,6 +12,8 @@ import { NonPassFinalisationPage } from '../non-pass-finalisation';
 import { NonPassFinalisationViewDidEnter } from '../non-pass-finalisation.actions';
 import { ActivityCodeComponent } from '../../../office/components/activity-code/activity-code';
 import { TestFinalisationComponentsModule } from '../../components/test-finalisation.module';
+import { SetTestStatusWriteUp } from '../../../../modules/tests/test-status/test-status.actions';
+import * as testActions from '../../../../modules/tests/tests.actions';
 
 describe('NonPassFinalisationPage', () => {
   let fixture: ComponentFixture<NonPassFinalisationPage>;
@@ -52,6 +54,20 @@ describe('NonPassFinalisationPage', () => {
         component.ionViewDidEnter();
         expect(store$.dispatch).toHaveBeenCalledWith(new NonPassFinalisationViewDidEnter());
       });
+    });
+  });
+
+  describe('OnContinue', () => {
+    it('should dispatch a change test state to WriteUp action', () => {
+      // Arrange
+      store$.dispatch(new testActions.StartTest(123));
+      component.slotId = '123';
+
+      // Act
+      component.continue();
+
+      // Assert
+      expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusWriteUp('123'))
     });
   });
 });

--- a/src/pages/test-finalisation/non-pass-finalisation/non-pass-finalisation.ts
+++ b/src/pages/test-finalisation/non-pass-finalisation/non-pass-finalisation.ts
@@ -45,6 +45,7 @@ import {
   CandidateChoseToProceedWithTestInWelsh,
   CandidateChoseToProceedWithTestInEnglish,
 } from '../../../modules/tests/communication-preferences/communication-preferences.actions';
+import { SetTestStatusWriteUp } from '../../../modules/tests/test-status/test-status.actions';
 
 interface NonPassFinalisationPageState {
   candidateName$: Observable<string>;
@@ -70,6 +71,7 @@ export class NonPassFinalisationPage extends PracticeableBasePageComponent {
   pageState: NonPassFinalisationPageState;
   form: FormGroup;
   activityCodeOptions: ActivityCodeModel[];
+  slotId: string;
 
   constructor(
     store$: Store<StoreModel>,
@@ -85,6 +87,11 @@ export class NonPassFinalisationPage extends PracticeableBasePageComponent {
   }
 
   ngOnInit() {
+    this.store$.pipe(
+      select(getTests),
+      map(tests => tests.currentTest.slotId),
+    ).subscribe(slotId => this.slotId = slotId);
+
     const currentTest$ = this.store$.pipe(
       select(getTests),
       select(getCurrentTest),
@@ -152,6 +159,7 @@ export class NonPassFinalisationPage extends PracticeableBasePageComponent {
   continue() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
+      this.store$.dispatch(new SetTestStatusWriteUp(this.slotId));
       this.store$.dispatch(new PersistTests());
       this.navController.push(BACK_TO_OFFICE_PAGE);
     }


### PR DESCRIPTION
## Description

The status of the test is not moved to write up on the non-pass-finalisation page like it is on the pass page. This is now fixed and works like for like on both outcomes.