### PR TITLE
MES-3620 Correctly show rekey button on rekey search

### DIFF
--- a/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
@@ -100,6 +100,60 @@ describe('Test Outcome', () => {
         expect(calls.argsFor(0)[0]).toBe(WAITING_ROOM_PAGE);
       });
     });
+
+    describe('showRekeyButton', () => {
+      it('should return true for a booked test if date is in past', () => {
+        component.slotDetail = testSlotDetail;
+        const dateTime = new DateTime();
+        dateTime.subtract(1, Duration.DAY);
+        component.slotDetail.start = dateTime.toString();
+        component.testStatus = TestStatus.Booked;
+
+        component.showRekeyButton();
+
+        expect(component.showRekeyButton()).toEqual(true);
+      });
+      it('should return true for a resumed test if date is in past', () => {
+        component.slotDetail = testSlotDetail;
+        const dateTime = new DateTime();
+        dateTime.subtract(1, Duration.DAY);
+        component.slotDetail.start = dateTime.toString();
+        component.testStatus = TestStatus.Started;
+
+        component.showRekeyButton();
+
+        expect(component.showRekeyButton()).toEqual(true);
+      });
+      it('should return true for a booked test on the rekey search page', () => {
+        component.slotDetail = testSlotDetail;
+        component.testStatus = TestStatus.Booked;
+        component.isTestSlotOnRekeySearch = true;
+
+        component.showRekeyButton();
+
+        expect(component.showRekeyButton()).toEqual(true);
+      });
+      it('should return false for a booked test if date is today', () => {
+        component.slotDetail = testSlotDetail;
+        const dateTime = new DateTime();
+        component.slotDetail.start = dateTime.toString();
+        component.testStatus = TestStatus.Booked;
+
+        component.showRekeyButton();
+
+        expect(component.showRekeyButton()).toEqual(false);
+      });
+      it('should return false for a resumed test if date is today', () => {
+        component.slotDetail = testSlotDetail;
+        const dateTime = new DateTime();
+        component.slotDetail.start = dateTime.toString();
+        component.testStatus = TestStatus.Started;
+
+        component.showRekeyButton();
+
+        expect(component.showRekeyButton()).toEqual(false);
+      });
+    });
   });
 
   describe('DOM', () => {
@@ -178,61 +232,26 @@ describe('Test Outcome', () => {
       });
     });
 
-    describe('show rekey button', () => {
-      it('should show rekey button for a booked test if date is in past', () => {
-        component.slotDetail = testSlotDetail;
-
-        const dateTime = new DateTime();
-        dateTime.subtract(1, Duration.DAY);
-
-        component.slotDetail.start = dateTime.toString();
-        component.testStatus = TestStatus.Booked;
+    describe('rekey button', () => {
+      it('should show rekey button', () => {
+        spyOn(component, 'showRekeyButton').and.returnValue(true);
         fixture.detectChanges();
 
         const rekeyButton = fixture.debugElement.query(By.css('.mes-rekey-button'));
 
         expect(rekeyButton).not.toBeNull();
       });
-      it('should show rekey button for a resumed test if date is in past', () => {
-        component.slotDetail = testSlotDetail;
-
-        const dateTime = new DateTime();
-        dateTime.subtract(1, Duration.DAY);
-
-        component.slotDetail.start = dateTime.toString();
-        component.testStatus = TestStatus.Started;
-        fixture.detectChanges();
-
-        const rekeyButton = fixture.debugElement.query(By.css('.mes-rekey-button'));
-
-        expect(rekeyButton).not.toBeNull();
-      });
-      it('should hide rekey button for a booked test if date is today', () => {
-        component.slotDetail = testSlotDetail;
-
-        const dateTime = new DateTime();
-
-        component.slotDetail.start = dateTime.toString();
-        component.testStatus = TestStatus.Booked;
+      it('should hide rekey button', () => {
+        spyOn(component, 'showRekeyButton').and.returnValue(false);
         fixture.detectChanges();
 
         const rekeyButton = fixture.debugElement.query(By.css('.mes-rekey-button'));
 
         expect(rekeyButton).toBeNull();
       });
-      it('should hide rekey button for a resumed test if date is today', () => {
-        component.slotDetail = testSlotDetail;
+    });
 
-        const dateTime = new DateTime();
-
-        component.slotDetail.start = dateTime.toString();
-        component.testStatus = TestStatus.Started;
-        fixture.detectChanges();
-
-        const rekeyButton = fixture.debugElement.query(By.css('.mes-rekey-button'));
-
-        expect(rekeyButton).toBeNull();
-      });
+    describe('rekey modal', () => {
       it('should display the rekey modal for a test today that has ended', () => {
         component.slotDetail = testSlotDetail;
 

--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -100,7 +100,7 @@ export class TestOutcomeComponent implements OnInit {
   }
 
   showRekeyButton(): boolean {
-    return this.isTestIncomplete() && this.isDateInPast() || this.isTestSlotOnRekeySearch;
+    return this.isTestIncomplete() && (this.isDateInPast() || this.isTestSlotOnRekeySearch);
   }
 
   showStartTestButton(): boolean {

--- a/src/pages/rekey-search/rekey-search.reducer.ts
+++ b/src/pages/rekey-search/rekey-search.reducer.ts
@@ -28,7 +28,9 @@ export function rekeySearchReducer(state = initialState, action: rekeySearchActi
     case rekeySearchActions.SEARCH_BOOKED_TEST:
       return {
         ...state,
+        bookedTestSlot: {},
         isLoading: true,
+        hasSearched: false,
       };
     case rekeySearchActions.SEARCH_BOOKED_TEST_SUCCESS:
       return {


### PR DESCRIPTION
## Description
- Update the test outcome component (the thing that displays the start test / rekey button etc) so that it doesn't display the rekey button when it was already rekeyed on this device.
- Update the tests to split up the class and DOM tests.
- Make the rekey search page clear/hide the previous search results when a new search is started.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
