### PR TITLE
MES-3575 do not fallback to dev config if no MDM config

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -97,5 +97,6 @@
     <plugin name="cordova-plugin-device-authentication" spec="https://github.com/dvsa/cordova-plugin-device-authentication" />
     <plugin name="cordova-plugin-appconfig" spec="1.1.4" />
     <hook src="scripts/editPlist.js" type="before_build" />
+    <plugin name="cordova-plugin-is-debug" spec="1.0.0" />
     <engine name="ios" spec="^4.5.5" />
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -693,6 +693,11 @@
       "resolved": "https://registry.npmjs.org/@ionic-native/insomnia/-/insomnia-4.20.0.tgz",
       "integrity": "sha512-o4df9d+zghiPJgCFKWTjIx04xC/RGHINI3/rQgOULViTEMIaOTHlah4m1CB7D7sO5zyXnDZnaB4fRUVLHIvQ8Q=="
     },
+    "@ionic-native/is-debug": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@ionic-native/is-debug/-/is-debug-4.20.0.tgz",
+      "integrity": "sha512-2ol/J8Mva81fjkd9F4VAmxLgcm7vrdO3/S2hENpHaAtxaZGVqlV4RfoEq0083hbr15/d19KcLAu/13IHEL4yHQ=="
+    },
     "@ionic-native/mobile-accessibility": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@ionic-native/mobile-accessibility/-/mobile-accessibility-5.1.0.tgz",
@@ -1046,7 +1051,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1067,12 +1073,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1087,17 +1095,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1214,7 +1225,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1226,6 +1238,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1240,6 +1253,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -1247,12 +1261,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -1271,6 +1287,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1351,7 +1368,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1363,6 +1381,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -1448,7 +1467,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -1484,6 +1504,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -1503,6 +1524,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1546,12 +1568,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -8451,6 +8475,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -8627,7 +8652,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -10108,6 +10134,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cordova-plugin-ios-disableshaketoedit/-/cordova-plugin-ios-disableshaketoedit-1.0.0.tgz",
       "integrity": "sha1-lRn8bPtPwmvt0kxuPnsuC6nn4pA="
+    },
+    "cordova-plugin-is-debug": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-is-debug/-/cordova-plugin-is-debug-1.0.0.tgz",
+      "integrity": "sha1-W9GIgXzqXhCDtgOs5umePBf7/ik="
     },
     "cordova-plugin-ms-adal": {
       "version": "0.10.1",
@@ -12663,7 +12694,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -12684,12 +12716,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12704,17 +12738,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -12831,7 +12868,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -12843,6 +12881,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -12857,6 +12896,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -12864,12 +12904,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -12888,6 +12930,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -12968,7 +13011,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -12980,6 +13024,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -13065,7 +13110,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -13101,6 +13147,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -13120,6 +13167,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -13163,12 +13211,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -13744,7 +13794,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -13922,6 +13973,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -13932,6 +13984,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -13983,6 +14036,7 @@
       "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "httpreq": ">=0.4.22",
         "underscore": "~1.7.0"
@@ -13992,7 +14046,8 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
       "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "https-browserify": {
       "version": "1.0.0",
@@ -14692,7 +14747,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -16018,13 +16074,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
       "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "libmime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/libmime/-/libmime-3.0.0.tgz",
       "integrity": "sha1-UaGp50SOy9Ms2lRCFnW7IbwJPaY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "iconv-lite": "0.4.15",
         "libbase64": "0.1.0",
@@ -16035,7 +16093,8 @@
           "version": "0.4.15",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
           "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -16043,7 +16102,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "license-webpack-plugin": {
       "version": "1.5.0",
@@ -17337,13 +17397,15 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
       "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nodemailer-shared": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
       "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "nodemailer-fetch": "1.6.0"
       }
@@ -17376,7 +17438,8 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz",
       "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nopt": {
       "version": "3.0.6",
@@ -22583,13 +22646,15 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
       "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "smtp-connection": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
       "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
       "dev": true,
+      "optional": true,
       "requires": {
         "httpntlm": "1.6.1",
         "nodemailer-shared": "1.1.0"
@@ -22830,6 +22895,7 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.2.3.tgz",
       "integrity": "sha512-+2r83WaRT3PXYoO/1z+RDEBE7Z2f9YcdQnJ0K/ncXXbV5gJ6wYfNAebYFYiiUjM6E4JyXnPY8cimwyvFYHVUUA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "ip": "^1.1.5",
         "smart-buffer": "4.0.2"
@@ -22840,6 +22906,7 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "~4.2.0",
         "socks": "~2.2.0"
@@ -25090,7 +25157,8 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "unherit": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@ionic-native/google-analytics": "^4.20.0",
     "@ionic-native/in-app-browser": "^4.18.0",
     "@ionic-native/insomnia": "^4.20.0",
+    "@ionic-native/is-debug": "^4.20.0",
     "@ionic-native/mobile-accessibility": "^5.1.0",
     "@ionic-native/ms-adal": "^4.18.0",
     "@ionic-native/network": "^4.20.0",
@@ -82,6 +83,7 @@
     "cordova-plugin-ionic-keyboard": "^2.1.3",
     "cordova-plugin-ionic-webview": "^3.1.2",
     "cordova-plugin-ios-disableshaketoedit": "1.0.0",
+    "cordova-plugin-is-debug": "1.0.0",
     "cordova-plugin-ms-adal": "^0.10.1",
     "cordova-plugin-network-information": "^2.0.1",
     "cordova-plugin-screen-orientation": "^3.0.1",
@@ -188,7 +190,8 @@
       "cordova-plugin-secure-storage": {},
       "cordova-plugin-device-authentication": {},
       "cordova-plugin-appconfig": {},
-      "cordova-plugin-ios-disableshaketoedit": {}
+      "cordova-plugin-ios-disableshaketoedit": {},
+      "cordova-plugin-is-debug": {}
     },
     "platforms": [
       "ios"

--- a/src/providers/app-config/__mocks__/app-config.mock.ts
+++ b/src/providers/app-config/__mocks__/app-config.mock.ts
@@ -56,4 +56,9 @@ export class AppConfigProviderMock {
       requestTimeout: localEnvironmentMock.requestTimeout,
     };
   }
+
+  public getDebugMode = jasmine.createSpy('getDebugMode')
+  .and
+  .returnValue(Promise.resolve());
+
 }

--- a/src/providers/app-config/__tests__/app-config.spec.ts
+++ b/src/providers/app-config/__tests__/app-config.spec.ts
@@ -46,6 +46,8 @@ describe('App Config Provider', () => {
     appConfig = TestBed.get(AppConfigProvider);
     httpMock = TestBed.get(HttpTestingController);
     platform = TestBed.get(Platform);
+    appConfig.isDebugMode = true;
+    spyOn(appConfig, 'getDebugMode').and.returnValue(Promise.resolve());
   });
 
   afterEach(() => {
@@ -53,22 +55,24 @@ describe('App Config Provider', () => {
   });
 
   describe('initialiseAppConfig', () => {
-    it('should run loadMangedConfig() when platform is Ios', () => {
+    it('should run loadMangedConfig() when platform is Ios', fakeAsync(() => {
       platform.is = jasmine.createSpy('platform.is').and.returnValue(true);
       appConfig.loadManagedConfig = jasmine.createSpy('appConfig.loadManagedConfig');
 
       appConfig.initialiseAppConfig();
+      tick();
 
       expect(appConfig.loadManagedConfig).toHaveBeenCalled();
-    });
-    it('should not run loadMangedConfig() when platform is not ios', () => {
+    }));
+    it('should not run loadMangedConfig() when platform is not ios', fakeAsync(() => {
       platform.is = jasmine.createSpy('platform.is').and.returnValue(false);
       appConfig.loadManagedConfig = jasmine.createSpy('appConfig.loadManagedConfig');
 
       appConfig.initialiseAppConfig();
+      tick();
 
       expect(appConfig.loadManagedConfig).toHaveBeenCalledTimes(0);
-    });
+    }));
   });
 
   describe('loadRemoteConfig', () => {

--- a/src/providers/app-config/app-config.constants.ts
+++ b/src/providers/app-config/app-config.constants.ts
@@ -1,4 +1,5 @@
 export enum AppConfigError {
   UNKNOWN_ERROR = 'error getting remote config',
   MDM_ERROR = 'error getting mobile device management config',
+  MISSING_REMOTE_CONFIG_URL_ERROR = 'error getting remote config url from mobile device management config',
 }

--- a/src/providers/app-config/app-config.ts
+++ b/src/providers/app-config/app-config.ts
@@ -123,10 +123,11 @@ export class AppConfigProvider {
       // Check to see if we have any config
       if (newEnvFile.configUrl) {
         this.environmentFile = newEnvFile;
-      } else {
-        if (!this.isDebugMode) {
-          throw AppConfigError.MISSING_REMOTE_CONFIG_URL_ERROR;
-        }
+        return;
+      }
+
+      if (!this.isDebugMode) {
+        throw AppConfigError.MISSING_REMOTE_CONFIG_URL_ERROR;
       }
     }
   }


### PR DESCRIPTION
## Description
Use a Cordova plugin to determine if the app is running in debug or release mode. Local builds performed in Xcode already have the config to ensure this flag is set (in Objective-C, the `DEBUG` flag is defined as a preprocessor macro by default). 

Release builds on Jenkins will not have this flag set and so will not be identified as debug builds.

With the ability to identify debug mode, we can now skip the validation of the MDM config and fall back to dev config. In production, when the MDM validation fails (at this stage, just the `configUrl` is checked) an error will be shown.

To test this, the app has been:
- built locally, run on iPad and simulator and the MDM validation is skipped ✅ 
- built on Jenkins, deployed to App Center, installed on an enrolled device and works normally ✅ 
- built on Jenkins, deployed to App Center, installed on an enrolled device, MDM config url deleted in airwatch lab, app throws error message ✅ 

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

Error messages displayed on enrolled devices when the MDM config validation fails.
![IMG_0003](https://user-images.githubusercontent.com/8069071/65504282-7e8f8c00-debe-11e9-9578-cb5bcd6151ed.PNG)
![IMG_0002](https://user-images.githubusercontent.com/8069071/65504285-80594f80-debe-11e9-821b-ae6b76971482.PNG)
