### PR TITLE
MES-3698 - BUGFIX - update store selection in incomplete banner component

### DIFF
--- a/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.selector.spec.ts
+++ b/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.selector.spec.ts
@@ -1,7 +1,6 @@
 import { DateTime } from '../../../../shared/helpers/date-time';
 import { TestsModel } from '../../../../modules/tests/tests.model';
 import { getIncompleteTestsCount } from '../incomplete-tests-banner.selector';
-import { StoreModel } from '../../../../shared/models/store.model';
 import { TestStatus } from '../../../../modules/tests/test-status/test-status.model';
 import { JournalModel } from '../../../../modules/journal/journal.model';
 import { SlotProvider } from '../../../../providers/slot/slot';
@@ -34,13 +33,6 @@ describe('IncompleteTestsBannerSelector', () => {
 
   describe('getIncompleteTestsCount', () => {
     it('should get a count of incomplete tests', () => {
-      const appInfo = {
-        versionNumber: 'VERSION_NOT_LOADED',
-        error: 'cordova_not_available',
-        employeeId: '1234567',
-        employeeName: 'Fake Name',
-      };
-      const logs = [];
       const journal: JournalModel = {
         isLoading: true,
         lastRefreshed: new Date(0),
@@ -253,9 +245,8 @@ describe('IncompleteTestsBannerSelector', () => {
           1003: TestStatus.WriteUp,
         },
       };
-      const store: StoreModel = { tests, journal, appInfo, logs };
 
-      const count = getIncompleteTestsCount(store, DateTime.at('2019-01-14'), slotProvider);
+      const count = getIncompleteTestsCount(journal, tests, DateTime.at('2019-01-14'), slotProvider);
 
       expect(count).toBe(3);
     });

--- a/src/components/common/incomplete-tests-banner/incomplete-tests-banner.selector.ts
+++ b/src/components/common/incomplete-tests-banner/incomplete-tests-banner.selector.ts
@@ -1,31 +1,33 @@
-import { StoreModel } from '../../../shared/models/store.model';
+import { JournalModel } from '../../../modules/journal/journal.model';
+import { TestsModel } from '../../../modules/tests/tests.model';
 import * as testsSelectors from '../../../modules/tests/tests.selector';
 import { getPermittedSlotIdsBeforeToday } from '../../../modules/journal/journal.selector';
 import { DateTime } from '../../../shared/helpers/date-time';
 import { SlotProvider } from '../../../providers/slot/slot';
 
-export const getIncompleteTestsCount = (store: StoreModel, today: DateTime, slotProvider: SlotProvider): number => {
-/*
- * Incomplete tests are defined as those tests that:
- *  - are prior to today
- *  - the user is permitted to start (from app config)
- *  - haven't been submitted/completed
- *  - are yet to be rekeyed
- *
- * To count the number of incomplete tests, we first get an array of slot IDs of tests that this
- * user is (or was) permitted to start. Test status is not considered, so this list could include
- * completed tests.
- *
- * Then we loop through that list determine if the the test is an outstanding rekey (count it) or
- * an incomplete tests (count it too)
- */
+export const getIncompleteTestsCount =
+(journal: JournalModel, tests: TestsModel, today: DateTime, slotProvider: SlotProvider): number => {
+  /*
+  * Incomplete tests are defined as those tests that:
+  *  - are prior to today
+  *  - the user is permitted to start (from app config)
+  *  - haven't been submitted/completed
+  *  - are yet to be rekeyed
+  *
+  * To count the number of incomplete tests, we first get an array of slot IDs of tests that this
+  * user is (or was) permitted to start. Test status is not considered, so this list could include
+  * completed tests.
+  *
+  * Then we loop through that list determine if the the test is an outstanding rekey (count it) or
+  * an incomplete tests (count it too)
+  */
 
-  const slotIdsBeforeToday = getPermittedSlotIdsBeforeToday(store.journal, today, slotProvider);
+  const slotIdsBeforeToday = getPermittedSlotIdsBeforeToday(journal, today, slotProvider);
 
   // includes tests with status of Started, Decided and WriteUp, but not unstarted rekeys
-  const slotIdsOfInProgressTests = testsSelectors.getIncompleteTestsSlotIds(store.tests);
+  const slotIdsOfInProgressTests = testsSelectors.getIncompleteTestsSlotIds(tests);
 
-  const slotIdsOfAllStartedTests = Object.keys(store.tests.testStatus);
+  const slotIdsOfAllStartedTests = Object.keys(tests.testStatus);
 
   return slotIdsBeforeToday.reduce((count, slotId) => {
     // tests that are in the list of in progress tests are incomplete

--- a/src/components/common/incomplete-tests-banner/incomplete-tests-banner.ts
+++ b/src/components/common/incomplete-tests-banner/incomplete-tests-banner.ts
@@ -5,6 +5,9 @@ import { Observable } from 'rxjs/Observable';
 import { getIncompleteTestsCount } from './incomplete-tests-banner.selector';
 import { SlotProvider } from '../../../providers/slot/slot';
 import { DateTime } from '../../../shared/helpers/date-time';
+import { getJournalState } from '../../../modules/journal/journal.reducer';
+import { getTests } from '../../../modules/tests/tests.reducer';
+import { map, withLatestFrom } from 'rxjs/operators';
 
 interface IncompleteTestsBannerComponentState {
   count$: Observable<number>;
@@ -30,7 +33,12 @@ export class IncompleteTestsBanner implements OnInit {
   ngOnInit() {
     this.componentState = {
       count$: this.store$.pipe(
-        select(store => getIncompleteTestsCount(store, this.todaysDate, this.slotProvider)),
+        select(getJournalState),
+        withLatestFrom(this.store$.pipe(
+          select(getTests),
+        )),
+        map(([journal, tests]) =>
+          getIncompleteTestsCount(journal, tests, this.todaysDate, this.slotProvider)),
       ),
     };
   }


### PR DESCRIPTION
## Description
Change the incomplete test banner component so that instead of selecting the entire store, it selects journal and test states and passes those slices to the selector that counts incomplete tests.

This update drastically reduces the number of times `getIncompleteTestsCount` is called, which improves performance throughout the app.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
