### PR TITLE
MES-3628 continue tests blocked by rekey

### DIFF
--- a/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
@@ -107,7 +107,7 @@ describe('Test Outcome', () => {
       it('should dispatch an ActivateTest action and navigate to the Pass Finalisation page', () => {
         component.testStatus = TestStatus.Decided;
         component.slotDetail = testSlotDetail;
-        this.activityCode === ActivityCodes.PASS;
+        component.activityCode === ActivityCodes.PASS;
         component.resumeTest();
 
         expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId));
@@ -117,7 +117,7 @@ describe('Test Outcome', () => {
       it('should dispatch an ActivateTest action and navigate to the Non Pass Finalisation page', () => {
         component.testStatus = TestStatus.Decided;
         component.slotDetail = testSlotDetail;
-        this.activityCode === ActivityCodes.FAIL;
+        component.activityCode === ActivityCodes.FAIL;
         component.resumeTest();
 
         expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId));

--- a/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
@@ -107,7 +107,7 @@ describe('Test Outcome', () => {
       it('should dispatch an ActivateTest action and navigate to the Pass Finalisation page', () => {
         component.testStatus = TestStatus.Decided;
         component.slotDetail = testSlotDetail;
-        component.activityCode === ActivityCodes.PASS;
+        component.activityCode = ActivityCodes.PASS;
         component.resumeTest();
 
         expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId));
@@ -117,7 +117,7 @@ describe('Test Outcome', () => {
       it('should dispatch an ActivateTest action and navigate to the Non Pass Finalisation page', () => {
         component.testStatus = TestStatus.Decided;
         component.slotDetail = testSlotDetail;
-        component.activityCode === ActivityCodes.FAIL;
+        component.activityCode = ActivityCodes.FAIL;
         component.resumeTest();
 
         expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId));

--- a/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
@@ -91,7 +91,8 @@ describe('Test Outcome', () => {
     });
 
     describe('resumeTest', () => {
-      it('should dispatch an ActivateTest action and navigate to the Office page', () => {
+      it('should dispatch an ActivateTest action and navigate to the Waiting Room page', () => {
+        component.testStatus = TestStatus.Started;
         component.slotDetail = testSlotDetail;
         component.resumeTest();
 
@@ -113,7 +114,7 @@ describe('Test Outcome', () => {
 
         expect(component.showRekeyButton()).toEqual(true);
       });
-      it('should return true for a resumed test if date is in past', () => {
+      it('should return false for a resumed test if date is in past', () => {
         component.slotDetail = testSlotDetail;
         const dateTime = new DateTime();
         dateTime.subtract(1, Duration.DAY);
@@ -122,7 +123,7 @@ describe('Test Outcome', () => {
 
         component.showRekeyButton();
 
-        expect(component.showRekeyButton()).toEqual(true);
+        expect(component.showRekeyButton()).toEqual(false);
       });
       it('should return true for a booked test on the rekey search page', () => {
         component.slotDetail = testSlotDetail;
@@ -191,16 +192,16 @@ describe('Test Outcome', () => {
     });
 
     describe('debrief a test', () => {
-      it('should call the debriefTest method when `Resume` is clicked', () => {
+      it('should call the resumeTest method when `Resume` is clicked', () => {
         component.slotDetail = testSlotDetail;
         component.testStatus = TestStatus.Decided;
         fixture.detectChanges();
-        spyOn(component, 'debriefTest');
+        spyOn(component, 'resumeTest');
 
         const debriefButton = fixture.debugElement.query(By.css('.mes-secondary-button'));
         debriefButton.triggerEventHandler('click', null);
 
-        expect(component.debriefTest).toHaveBeenCalled();
+        expect(component.resumeTest).toHaveBeenCalled();
       });
     });
 

--- a/src/components/test-slot/test-outcome/test-outcome.html
+++ b/src/components/test-slot/test-outcome/test-outcome.html
@@ -14,9 +14,9 @@
         </span>
       </ion-col>
       <ng-template #nonRekey>
-        <ion-col *ngIf="needsDebrief()">
+        <ion-col *ngIf="showResumeButton()">
           <span>
-            <button class="mes-secondary-button mes-warning-button" ion-button (click)="debriefTest()">
+            <button class="mes-secondary-button mes-warning-button" ion-button (click)="clickStartOrResumeTest()">
               <h3 class="write-up-label">Resume</h3>
             </button>
           </span>
@@ -32,13 +32,6 @@
           <span>
             <button class="mes-secondary-button mes-warning-button" ion-button (click)="writeUpTest()">
               <h3 class="write-up-label">Write-up</h3>
-            </button>
-          </span>
-        </ion-col>
-        <ion-col *ngIf="showResumeTestButton()">
-          <span>
-            <button class="mes-secondary-button mes-warning-button" ion-button (click)="clickStartOrResumeTest()">
-              <h3 class="write-up-label">Resume</h3>
             </button>
           </span>
         </ion-col>

--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -26,6 +26,7 @@ import { getRekeySearchState } from '../../../pages/rekey-search/rekey-search.re
 import { getBookedTestSlot } from '../../../pages/rekey-search/rekey-search.selector';
 import { merge } from 'rxjs/observable/merge';
 import { ActivityCodes } from '../../../shared/models/activity-codes';
+import { MarkAsNonRekey } from '../../../modules/tests/rekey/rekey.actions';
 
 @Component({
   selector: 'test-outcome',
@@ -153,7 +154,7 @@ export class TestOutcomeComponent implements OnInit {
   }
 
   startTest() {
-    if (this.isE2EPracticeMode() && this.testStatus === TestStatus.Booked) {
+    if (this.isE2EPracticeMode()) {
       this.store$.dispatch(new StartE2EPracticeTest(this.slotDetail.slotId.toString()));
     } else {
       this.store$.dispatch(new StartTest(this.slotDetail.slotId, this.startTestAsRekey || this.isRekey));
@@ -188,6 +189,10 @@ export class TestOutcomeComponent implements OnInit {
     switch (event) {
       case ModalEvent.START:
         this.startTestAsRekey = false;
+        this.isRekey = false;
+        if (this.testStatus !== null) {
+          this.store$.dispatch(new MarkAsNonRekey());
+        }
         this.startOrResumeTestDependingOnStatus();
         break;
       case ModalEvent.REKEY:

--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -51,8 +51,11 @@ export class TestOutcomeComponent implements OnInit {
   @Input()
   hasSeenCandidateDetails: boolean;
 
+  @Input()
+  isRekey: boolean;
+
   modal: Modal;
-  isRekey: boolean = false;
+  startTestAsRekey: boolean = false;
   isTestSlotOnRekeySearch: boolean = false;
 
   candidateDetailsViewed: boolean;
@@ -100,15 +103,32 @@ export class TestOutcomeComponent implements OnInit {
   }
 
   showRekeyButton(): boolean {
-    return this.isTestIncomplete() && (this.isDateInPast() || this.isTestSlotOnRekeySearch);
+    if (this.testStatus === TestStatus.Completed || this.testStatus === TestStatus.Submitted) {
+      return false; // because the test is complete
+    }
+
+    if (this.isTestSlotOnRekeySearch) {
+      return true; // because the test is incomplete AND this is the rekey search
+    }
+
+    if (this.isRekey && this.isDateInPast()) {
+      return true; // because the test is incomplete AND this is not the rekey search...
+      // ...AND it was started as a rekey AND the test date is in the past
+    }
+
+    // the test is incomplete AND this is not the rekey search AND it was not started as a rekey
+    if (this.isDateInPast() && (this.testStatus === null || this.testStatus === TestStatus.Booked)) {
+      return true; // because the test date is in the past AND it has never been seen OR started
+    }
+    return false;
   }
 
   showStartTestButton(): boolean {
     return this.testStatus === TestStatus.Booked;
   }
 
-  showResumeTestButton(): boolean {
-    return this.testStatus === TestStatus.Started;
+  showResumeButton(): boolean {
+    return this.testStatus === TestStatus.Started || this.testStatus === TestStatus.Decided;
   }
 
   showWriteUpButton(): boolean {
@@ -121,41 +141,33 @@ export class TestOutcomeComponent implements OnInit {
     this.navController.push(OFFICE_PAGE);
   }
 
-  debriefTest() {
+  resumeTest() {
     this.store$.dispatch(new ActivateTest(this.slotDetail.slotId));
-    if (this.activityCode === ActivityCodes.PASS) {
+    if (this.testStatus === TestStatus.Started) {
+      this.navController.push(WAITING_ROOM_PAGE);
+    } else if (this.activityCode === ActivityCodes.PASS) {
       this.navController.push(PASS_FINALISATION_PAGE);
     } else {
       this.navController.push(NON_PASS_FINALISATION_PAGE);
     }
   }
 
-  resumeTest() {
-    this.store$.dispatch(new ActivateTest(this.slotDetail.slotId, this.isRekey));
-    this.navController.push(WAITING_ROOM_PAGE);
-  }
-
-  needsDebrief(): boolean {
-    return this.testStatus === TestStatus.Decided;
-  }
-
-  needsWriteUp(): boolean {
-    return this.testStatus === TestStatus.WriteUp || this.testStatus === TestStatus.Autosaved;
-  }
-
   startTest() {
     if (this.isE2EPracticeMode() && this.testStatus === TestStatus.Booked) {
       this.store$.dispatch(new StartE2EPracticeTest(this.slotDetail.slotId.toString()));
     } else {
-      this.store$.dispatch(new StartTest(this.slotDetail.slotId, this.isRekey));
+      this.store$.dispatch(new StartTest(this.slotDetail.slotId, this.startTestAsRekey || this.isRekey));
     }
     this.navController.push(WAITING_ROOM_PAGE);
   }
 
   rekeyTest() {
-    this.isRekey = true;
-    this.store$.dispatch(new ActivateTest(this.slotDetail.slotId, this.isRekey));
-    this.startOrResumeTestDependingOnStatus();
+    if (this.testStatus === null || this.testStatus === TestStatus.Booked) {
+      this.store$.dispatch(new StartTest(this.slotDetail.slotId, true));
+    } else {
+      this.store$.dispatch(new ActivateTest(this.slotDetail.slotId, true));
+    }
+    this.navController.push(WAITING_ROOM_PAGE);
   }
 
   displayRekeyModal = (): void => {
@@ -175,10 +187,11 @@ export class TestOutcomeComponent implements OnInit {
   onModalDismiss = (event: ModalEvent): void => {
     switch (event) {
       case ModalEvent.START:
+        this.startTestAsRekey = false;
         this.startOrResumeTestDependingOnStatus();
         break;
       case ModalEvent.REKEY:
-        this.isRekey = true;
+        this.startTestAsRekey = true;
         this.startOrResumeTestDependingOnStatus();
         break;
     }
@@ -224,7 +237,7 @@ export class TestOutcomeComponent implements OnInit {
   startOrResumeTestDependingOnStatus() {
     if (this.testStatus === TestStatus.Booked) {
       this.startTest();
-    } else if (this.testStatus === TestStatus.Started) {
+    } else {
       this.resumeTest();
     }
   }

--- a/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
+++ b/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
@@ -278,7 +278,11 @@ describe('TestSlotComponent', () => {
 
       it('should pass something to sub-component test-outcome input', () => {
         fixture.detectChanges();
-        component.componentState = { testStatus$: of(TestStatus.Booked), testActivityCode$: of(ActivityCodes.PASS) };
+        component.componentState = {
+          testStatus$: of(TestStatus.Booked),
+          testActivityCode$: of(ActivityCodes.PASS),
+          isRekey$: of(false),
+        };
         fixture.detectChanges();
         const subByDirective = fixture.debugElement.query(
           By.directive(MockComponent(TestOutcomeComponent))).componentInstance;

--- a/src/components/test-slot/test-slot/test-slot.html
+++ b/src/components/test-slot/test-slot/test-slot.html
@@ -45,7 +45,7 @@
         <ion-col class="test-outcome-col" no-padding padding-right>
           <test-outcome [slotDetail]="slot.slotDetail" [canStartTest]="canStartTest()" [testStatus]="componentState.testStatus$ | async"
             [activityCode]="componentState.testActivityCode$ | async" [specialRequirements]="isIndicatorNeededForSlot()"
-            [hasSeenCandidateDetails]="hasSeenCandidateDetails"></test-outcome>
+            [hasSeenCandidateDetails]="hasSeenCandidateDetails" [isRekey]="componentState.isRekey$ | async"></test-outcome>
         </ion-col>
       </ion-row>
       <ion-row class="slot-footer" [ngClass]="{'vehicle-details-displayed': showVehicleDetails()}" align-items-center>

--- a/src/components/test-slot/test-slot/test-slot.ts
+++ b/src/components/test-slot/test-slot/test-slot.ts
@@ -11,17 +11,20 @@ import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../../shared/models/store.model';
 import { Observable } from 'rxjs/Observable';
 import { getTests } from '../../../modules/tests/tests.reducer';
-import { getTestStatus, getActivityCodeBySlotId } from '../../../modules/tests/tests.selector';
+import { getTestStatus, getActivityCodeBySlotId, getTestById } from '../../../modules/tests/tests.selector';
 import { SlotTypes } from '../../../shared/models/slot-types';
-import { map } from 'rxjs/operators';
+import { map, filter } from 'rxjs/operators';
 import { TestSlot } from '@dvsa/mes-journal-schema';
 import { ActivityCode } from '@dvsa/mes-test-schema/categories/B';
 import { getSlotType } from '../../../shared/helpers/get-slot-type';
 import { SlotProvider } from '../../../providers/slot/slot';
+import { isRekey } from '../../../modules/tests/rekey/rekey.selector';
+import { getRekeyIndicator } from '../../../modules/tests/rekey/rekey.reducer';
 
 interface TestSlotComponentState {
   testStatus$: Observable<TestStatus>;
   testActivityCode$: Observable<ActivityCode>;
+  isRekey$: Observable<boolean>;
 }
 
 @Component({
@@ -61,6 +64,13 @@ export class TestSlotComponent implements SlotComponent, OnInit {
       testActivityCode$: this.store$.pipe(
         select(getTests),
         map(tests => getActivityCodeBySlotId(tests, this.slot.slotDetail.slotId)),
+      ),
+      isRekey$: this.store$.pipe(
+        select(getTests),
+        map(tests => getTestById(tests, this.slot.slotDetail.slotId.toString())),
+        filter(test => test !== undefined),
+        select(getRekeyIndicator),
+        select(isRekey),
       ),
     };
   }

--- a/src/modules/tests/rekey/rekey.actions.ts
+++ b/src/modules/tests/rekey/rekey.actions.ts
@@ -1,10 +1,14 @@
 import { Action } from '@ngrx/store';
 
 export const MARK_AS_REKEY = '[Rekey Actions] Mark the test as being rekeyed';
+export const MARK_AS_NON_REKEY = '[Rekey Actions] Mark the test as not being a rekey';
 export const END_REKEY = '[Rekey Actions] End rekey';
 
 export class MarkAsRekey implements Action {
   readonly type = MARK_AS_REKEY;
+}
+export class MarkAsNonRekey implements Action {
+  readonly type = MARK_AS_NON_REKEY;
 }
 
 export class EndRekey implements Action {
@@ -12,4 +16,5 @@ export class EndRekey implements Action {
 }
 
 export type Types = MarkAsRekey
+  | MarkAsNonRekey
   | EndRekey;

--- a/src/modules/tests/rekey/rekey.reducer.ts
+++ b/src/modules/tests/rekey/rekey.reducer.ts
@@ -10,6 +10,8 @@ export const rekeyReducer = (
   switch (action.type) {
     case rekeyActions.MARK_AS_REKEY:
       return true;
+    case rekeyActions.MARK_AS_NON_REKEY:
+      return false;
     default:
       return state;
   }


### PR DESCRIPTION
## Description
- Pass down the `isRekey` value from started tests into the Test Outcome component
- Update `showRekeyButton()` to handle new scenarios and make it easier to follow the logic being applied (comments help in the case).
- Remove duplicate "Resume" button from template and merge resume/debrief code
- Create a new `MarkAsNonRekey` action to handle an edge case where a test for today could be started as a rekey (using the modal prompt) but then the user presses back, reopens the modal again and starts the test as a regular test.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
