### PR TITLE
Update tests to stop errors

### DIFF
--- a/src/components/common/terminate-test-modal/terminate-test-modal.ts
+++ b/src/components/common/terminate-test-modal/terminate-test-modal.ts
@@ -9,16 +9,17 @@ import { DeviceAuthenticationProvider } from '../../../providers/device-authenti
 })
 export class TerminateTestModal {
 
-  onCancel: Function;
-
-  onTerminate: Function;
-
   constructor(
     private navParams: NavParams,
     private deviceAuthenticationProvider: DeviceAuthenticationProvider,
-  ) {
-    this.onCancel = this.navParams.get('onCancel');
-    this.onTerminate = this.navParams.get('onTerminate');
+  ) {}
+
+  onCancel() {
+    return this.navParams.get('onCancel');
+  }
+
+  onTerminate() {
+    return this.navParams.get('onTerminate');
   }
 
   /**

--- a/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
@@ -16,6 +16,8 @@ import { DateTime, Duration } from '../../../../shared/helpers/date-time';
 import { SlotDetail } from '@dvsa/mes-journal-schema/Journal';
 import { ActivityCodes } from '../../../../shared/models/activity-codes';
 import { JournalModel } from '../../../../modules/journal/journal.model';
+import { LogHelper } from '../../../../providers/logs/logsHelper';
+import { LogHelperMock } from '../../../../providers/logs/__mocks__/logsHelper.mock';
 
 describe('Test Outcome', () => {
   let fixture: ComponentFixture<TestOutcomeComponent>;
@@ -61,6 +63,7 @@ describe('Test Outcome', () => {
       ],
       providers: [
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
+        { provide: LogHelper, useClass: LogHelperMock },
       ],
     })
       .compileComponents()

--- a/src/components/test-slot/time/__tests__/time.spec.ts
+++ b/src/components/test-slot/time/__tests__/time.spec.ts
@@ -3,6 +3,8 @@ import { TimeComponent } from '../time';
 import { IonicModule } from 'ionic-angular';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
+import { LogHelper } from '../../../../providers/logs/logsHelper';
+import { LogHelperMock } from '../../../../providers/logs/__mocks__/logsHelper.mock';
 
 describe('TimeComponent', () => {
   let component: TimeComponent;
@@ -12,6 +14,9 @@ describe('TimeComponent', () => {
     TestBed.configureTestingModule({
       declarations: [TimeComponent],
       imports: [IonicModule],
+      providers: [
+        { provide: LogHelper, useClass: LogHelperMock },
+      ],
     })
       .compileComponents()
       .then(() => {

--- a/src/karmaGlobalMocks.js
+++ b/src/karmaGlobalMocks.js
@@ -18,19 +18,16 @@ const cordova = {
   plugins: {
     ASAM: {
       toggle: (flag, cb) => {
-        console.log('Calling ASAM plugin mock');
         cb(true);
       },
     },
     DeviceAuthentication: {
       runAuthentication: (prompt, successCB, failedCB) => {
-        console.log('Calling Device Auth plugin mock');
         successCB(true);
       },
     },
     AppConfig: {
       getValue: (key) => {
-        console.log('Calling App Config plugin mock')
         return 'AppConfigMock';
       }
     }

--- a/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.effects.spec.ts
+++ b/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.effects.spec.ts
@@ -9,6 +9,7 @@ import { StoreModel } from '../../../../shared/models/store.model';
 import { SetChangeMarker } from '../../change-marker/change-marker.actions';
 import { StartTest } from '../../tests.actions';
 import { SetExaminerBooked } from '../../examiner-booked/examiner-booked.actions';
+import { journalReducer } from '../../../journal/journal.reducer';
 
 describe('Examiner Conducted Effects', () => {
 
@@ -22,6 +23,7 @@ describe('Examiner Conducted Effects', () => {
       imports: [
         StoreModule.forRoot({
           tests: testsReducer,
+          journal: journalReducer,
         }),
       ],
       providers: [

--- a/src/pages/journal/journal-rekey-modal/journal-rekey-modal.spec.ts
+++ b/src/pages/journal/journal-rekey-modal/journal-rekey-modal.spec.ts
@@ -5,6 +5,10 @@ import { IonicModule, NavParams, ViewController } from 'ionic-angular';
 import { NavParamsMock, ViewControllerMock } from 'ionic-mocks';
 import { By } from '@angular/platform-browser';
 import { ComponentsModule } from '../../../components/common/common-components.module';
+import { DeviceProvider } from '../../../providers/device/device';
+import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
+import { LogHelper } from '../../../providers/logs/logsHelper';
+import { LogHelperMock } from '../../../providers/logs/__mocks__/logsHelper.mock';
 
 describe('JournalRekeyModal', () => {
   let fixture: ComponentFixture<JournalRekeyModal>;
@@ -23,6 +27,8 @@ describe('JournalRekeyModal', () => {
       providers: [
         { provide: NavParams, useFactory: () => NavParamsMock.instance() },
         { provide: ViewController, useFactory: () => ViewControllerMock.instance() },
+        { provide: DeviceProvider, useClass: DeviceProviderMock },
+        { provide: LogHelper, useClass: LogHelperMock },
       ],
     })
       .compileComponents()

--- a/src/pages/login/__tests__/login.spec.ts
+++ b/src/pages/login/__tests__/login.spec.ts
@@ -45,6 +45,8 @@ import { StartSendingCompletedTests } from '../../../modules/tests/tests.actions
 import { DASHBOARD_PAGE } from '../../page-names.constants';
 import { LoadEmployeeId, LoadConfigSuccess } from '../../../modules/app-info/app-info.actions';
 import { AppConfigError } from '../../../providers/app-config/app-config.constants';
+import { LogHelper } from '../../../providers/logs/logsHelper';
+import { LogHelperMock } from '../../../providers/logs/__mocks__/logsHelper.mock';
 
 describe('LoginPage', () => {
   let fixture: ComponentFixture<LoginPage>;
@@ -79,6 +81,7 @@ describe('LoginPage', () => {
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
         { provide: DataStoreProvider, useClass: DataStoreProviderMock },
         { provide: SecureStorage, useClass: SecureStorageMock },
+        { provide: LogHelper, useClass: LogHelperMock },
       ],
     })
       .compileComponents()

--- a/src/pages/office/__tests__/office.spec.ts
+++ b/src/pages/office/__tests__/office.spec.ts
@@ -64,6 +64,8 @@ import { ActivityCodes } from '../../../shared/models/activity-codes';
 import { CompleteTest, ValidationError } from '../office.actions';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { ToastControllerMock } from '../__mocks__/toast-controller-mock';
+import { NavigationStateProvider } from '../../../providers/navigation-state/navigation-state';
+import { NavigationStateProviderMock } from '../../../providers/navigation-state/__mocks__/navigation-state.mock';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficePage>;
@@ -142,6 +144,7 @@ describe('OfficePage', () => {
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
         { provide: AlertController, useClass: AlertControllerMock },
         { provide: ToastController, useClass: ToastControllerMock },
+        { provide: NavigationStateProvider, useClass: NavigationStateProviderMock },
       ],
     })
       .compileComponents()

--- a/src/pages/rekey-reason/__tests__/rekey-reason.spec.ts
+++ b/src/pages/rekey-reason/__tests__/rekey-reason.spec.ts
@@ -12,12 +12,10 @@ import {
   SendCurrentTest,
   SendCurrentTestSuccess,
   SendCurrentTestFailure,
-  StartTest,
 } from '../../../modules/tests/tests.actions';
 import { rekeyReasonReducer } from '../rekey-reason.reducer';
 import { REKEY_UPLOAD_OUTCOME_PAGE } from '../../page-names.constants';
 import { AppInfoModel } from '../../../modules/app-info/app-info.model';
-import { testsReducer } from '../../../modules/tests/tests.reducer';
 import {
   IpadIssueSelected,
   OtherSelected,
@@ -33,6 +31,8 @@ import { FindUserProviderMock } from '../../../providers/find-user/__mocks__/fin
 import { IpadIssueComponent } from '../components/ipad-issue/ipad-issue';
 import { TransferComponent } from '../components/transfer/transfer';
 import { OtherReasonComponent } from '../components/other-reason/other-reason';
+import { NavigationStateProvider } from '../../../providers/navigation-state/navigation-state';
+import { NavigationStateProviderMock } from '../../../providers/navigation-state/__mocks__/navigation-state.mock';
 
 describe('RekeyReasonPage', () => {
   let fixture: ComponentFixture<RekeyReasonPage>;
@@ -53,7 +53,57 @@ describe('RekeyReasonPage', () => {
       imports: [
         IonicModule,
         StoreModule.forRoot({
-          tests: testsReducer,
+          journal: () => ({
+            isLoading: false,
+            lastRefreshed: null,
+            slots: {},
+            selectedDate: '',
+            examiner: {
+              staffNumber: '1234567',
+            },
+          }),
+          tests: () => ({
+            currentTest: {
+              slotId: '123',
+            },
+            testStatus: {},
+            startedTests: {
+              123: {
+                vehicleDetails: {},
+                accompaniment: {},
+                testData: {
+                  dangerousFaults: {},
+                  drivingFaults: {},
+                  manoeuvres: {},
+                  seriousFaults: {},
+                  testRequirements: {},
+                  ETA: {},
+                  eco: {},
+                  vehicleChecks: {
+                    showMeQuestion: {
+                      code: 'S3',
+                      description: '',
+                      outcome: '',
+                    },
+                    tellMeQuestion: {
+                      code: '',
+                      description: '',
+                      outcome: '',
+                    },
+                  },
+                  eyesightTest: {},
+                },
+                activityCode: '28',
+                journalData: {
+                  candidate: {
+                    candidateName: 'Joe Bloggs',
+                    driverNumber: '123',
+                  },
+                },
+                rekey: false,
+              },
+            },
+          }),
           rekeyReason: rekeyReasonReducer,
         }),
         AppModule,
@@ -66,6 +116,7 @@ describe('RekeyReasonPage', () => {
         { provide: LoadingController, useFactory: () => LoadingControllerMock.instance() },
         { provide: ModalController, useFactory: () => ModalControllerMock.instance() },
         { provide: FindUserProvider, useClass: FindUserProviderMock },
+        { provide: NavigationStateProvider, useClass: NavigationStateProviderMock },
         Store,
       ],
     })
@@ -163,10 +214,9 @@ describe('RekeyReasonPage', () => {
       });
     });
   });
-
   describe('DOM', () => {
+
     it('should pass the ipad issue values to the ipad issue subcomponent', () => {
-      store$.dispatch(new StartTest(123));
       store$.dispatch(new IpadIssueSelected(true));
       store$.dispatch(new IpadIssueLostSelected());
       fixture.detectChanges();
@@ -176,7 +226,6 @@ describe('RekeyReasonPage', () => {
       expect(ipadIssueElement.lost).toEqual(true);
     });
     it('should pass the transfer values to the transfer subcomponent', () => {
-      store$.dispatch(new StartTest(123));
       store$.dispatch(new TransferSelected(true));
       store$.dispatch(new SetExaminerConducted(123));
       fixture.detectChanges();
@@ -186,7 +235,6 @@ describe('RekeyReasonPage', () => {
       expect(transferElement.staffNumber).toEqual(123);
     });
     it('should pass the other reason values to the reason subcomponent', () => {
-      store$.dispatch(new StartTest(123));
       store$.dispatch(new OtherSelected(true));
       store$.dispatch(new OtherReasonUpdated('Reason text'));
       fixture.detectChanges();

--- a/src/pages/test-report/__tests__/test-report.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.spec.ts
@@ -46,6 +46,8 @@ import { ScreenOrientationMock } from '../../../shared/mocks/screen-orientation.
 import { PracticeModeBanner } from '../../../components/common/practice-mode-banner/practice-mode-banner';
 import { StatusBar } from '@ionic-native/status-bar';
 import { DEBRIEF_PAGE } from '../../page-names.constants';
+import { NavigationStateProvider } from '../../../providers/navigation-state/navigation-state';
+import { NavigationStateProviderMock } from '../../../providers/navigation-state/__mocks__/navigation-state.mock';
 
 describe('TestReportPage', () => {
   let fixture: ComponentFixture<TestReportPage>;
@@ -113,6 +115,7 @@ describe('TestReportPage', () => {
         { provide: ScreenOrientation, useClass: ScreenOrientationMock },
         { provide: Insomnia, useClass: InsomniaMock },
         { provide: StatusBar, useFactory: () => StatusBarMock.instance() },
+        { provide: NavigationStateProvider, useClass: NavigationStateProviderMock },
       ],
     })
       .compileComponents()

--- a/src/pages/test-report/components/competency/__tests__/competency.spec.ts
+++ b/src/pages/test-report/components/competency/__tests__/competency.spec.ts
@@ -26,10 +26,10 @@ import { IonicModule } from 'ionic-angular';
 import {
   DangerousFaultBadgeComponent,
 } from '../../../../../components/common/dangerous-fault-badge/dangerous-fault-badge';
-import { testsReducer } from '../../../../../modules/tests/tests.reducer';
 import { testReportReducer } from '../../../test-report.reducer';
 import { ToggleSeriousFaultMode, ToggleDangerousFaultMode, ToggleRemoveFaultMode } from '../../../test-report.actions';
-import { StartTest } from '../../../../../modules/tests/tests.actions';
+import { NavigationStateProvider } from '../../../../../providers/navigation-state/navigation-state';
+import { NavigationStateProviderMock } from '../../../../../providers/navigation-state/__mocks__/navigation-state.mock';
 
 describe('CompetencyComponent', () => {
   let fixture: ComponentFixture<CompetencyComponent>;
@@ -48,10 +48,64 @@ describe('CompetencyComponent', () => {
       imports: [
         AppModule,
         IonicModule,
-        StoreModule.forRoot({ tests: testsReducer, testReport : testReportReducer }),
+        StoreModule.forRoot({
+          journal: () => ({
+            isLoading: false,
+            lastRefreshed: null,
+            slots: {},
+            selectedDate: '',
+            examiner: {
+              staffNumber: '1234567',
+            },
+          }),
+          tests: () => ({
+            currentTest: {
+              slotId: '123',
+            },
+            testStatus: {},
+            startedTests: {
+              123: {
+                vehicleDetails: {},
+                accompaniment: {},
+                testData: {
+                  dangerousFaults: {},
+                  drivingFaults: {},
+                  manoeuvres: {},
+                  seriousFaults: {},
+                  testRequirements: {},
+                  ETA: {},
+                  eco: {},
+                  vehicleChecks: {
+                    showMeQuestion: {
+                      code: 'S3',
+                      description: '',
+                      outcome: '',
+                    },
+                    tellMeQuestion: {
+                      code: '',
+                      description: '',
+                      outcome: '',
+                    },
+                  },
+                  eyesightTest: {},
+                },
+                activityCode: '28',
+                journalData: {
+                  candidate: {
+                    candidateName: 'Joe Bloggs',
+                    driverNumber: '123',
+                  },
+                },
+                rekey: false,
+              },
+            },
+          }),
+          testReport : testReportReducer,
+        }),
       ],
       providers: [
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
+        { provide: NavigationStateProvider, useClass: NavigationStateProviderMock },
       ],
     })
       .compileComponents()
@@ -59,8 +113,6 @@ describe('CompetencyComponent', () => {
         fixture = TestBed.createComponent(CompetencyComponent);
         component = fixture.componentInstance;
         store$ = TestBed.get(Store);
-
-        store$.dispatch(new StartTest(103));
       });
   }));
 

--- a/src/pages/test-report/components/legal-requirement/__tests__/legal-requirement.spec.ts
+++ b/src/pages/test-report/components/legal-requirement/__tests__/legal-requirement.spec.ts
@@ -9,6 +9,8 @@ import { StoreModule, Store } from '@ngrx/store';
 import { StoreModel } from '../../../../../shared/models/store.model';
 import { ToggleLegalRequirement } from '../../../../../modules/tests/test-data/test-data.actions';
 import { LegalRequirements } from '../../../../../modules/tests/test-data/test-data.constants';
+import { NavigationStateProvider } from '../../../../../providers/navigation-state/navigation-state';
+import { NavigationStateProviderMock } from '../../../../../providers/navigation-state/__mocks__/navigation-state.mock';
 
 describe('LegalRequirementComponent', () => {
   let fixture: ComponentFixture<LegalRequirementComponent>;
@@ -26,6 +28,9 @@ describe('LegalRequirementComponent', () => {
       imports: [
         IonicModule,
         StoreModule.forRoot({ tests: testsReducer }),
+      ],
+      providers: [
+        { provide: NavigationStateProvider, useClass: NavigationStateProviderMock },
       ],
     })
       .compileComponents()

--- a/src/pages/test-report/components/manoeuvre-competency/__tests__/manoeuvre-competency.spec.ts
+++ b/src/pages/test-report/components/manoeuvre-competency/__tests__/manoeuvre-competency.spec.ts
@@ -10,9 +10,7 @@ import { SeriousFaultBadgeComponent } from '../../../../../components/common/ser
 import {
   DangerousFaultBadgeComponent,
 } from '../../../../../components/common/dangerous-fault-badge/dangerous-fault-badge';
-import { testsReducer } from '../../../../../modules/tests/tests.reducer';
 import { testReportReducer } from '../../../test-report.reducer';
-import { StartTest } from '../../../../../modules/tests/tests.actions';
 import { ManoeuvreCompetencyComponent } from '../manoeuvre-competency';
 import {
   AddManoeuvreDrivingFault,
@@ -27,6 +25,8 @@ import { StoreModule, Store } from '@ngrx/store';
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { CompetencyOutcome } from '../../../../../shared/models/competency-outcome';
 import { ToggleDangerousFaultMode, ToggleSeriousFaultMode, ToggleRemoveFaultMode } from '../../../test-report.actions';
+import { NavigationStateProvider } from '../../../../../providers/navigation-state/navigation-state';
+import { NavigationStateProviderMock } from '../../../../../providers/navigation-state/__mocks__/navigation-state.mock';
 
 describe('ManoeuvreCompetencyComponent', () => {
   let fixture: ComponentFixture<ManoeuvreCompetencyComponent>;
@@ -44,10 +44,64 @@ describe('ManoeuvreCompetencyComponent', () => {
       imports: [
         AppModule,
         IonicModule,
-        StoreModule.forRoot({ tests: testsReducer, testReport : testReportReducer }),
+        StoreModule.forRoot({
+          journal: () => ({
+            isLoading: false,
+            lastRefreshed: null,
+            slots: {},
+            selectedDate: '',
+            examiner: {
+              staffNumber: '1234567',
+            },
+          }),
+          tests: () => ({
+            currentTest: {
+              slotId: '123',
+            },
+            testStatus: {},
+            startedTests: {
+              123: {
+                vehicleDetails: {},
+                accompaniment: {},
+                testData: {
+                  dangerousFaults: {},
+                  drivingFaults: {},
+                  manoeuvres: {},
+                  seriousFaults: {},
+                  testRequirements: {},
+                  ETA: {},
+                  eco: {},
+                  vehicleChecks: {
+                    showMeQuestion: {
+                      code: 'S3',
+                      description: '',
+                      outcome: '',
+                    },
+                    tellMeQuestion: {
+                      code: '',
+                      description: '',
+                      outcome: '',
+                    },
+                  },
+                  eyesightTest: {},
+                },
+                activityCode: '28',
+                journalData: {
+                  candidate: {
+                    candidateName: 'Joe Bloggs',
+                    driverNumber: '123',
+                  },
+                },
+                rekey: false,
+              },
+            },
+          }),
+          testReport : testReportReducer,
+        }),
       ],
       providers: [
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
+        { provide: NavigationStateProvider, useClass: NavigationStateProviderMock },
       ],
     })
       .compileComponents()
@@ -55,8 +109,6 @@ describe('ManoeuvreCompetencyComponent', () => {
         fixture = TestBed.createComponent(ManoeuvreCompetencyComponent);
         component = fixture.componentInstance;
         store$ = TestBed.get(Store);
-
-        store$.dispatch(new StartTest(103));
       });
   }));
 

--- a/src/pages/test-report/components/manoeuvres-popover/__tests__/manoeuvres-popover.spec.ts
+++ b/src/pages/test-report/components/manoeuvres-popover/__tests__/manoeuvres-popover.spec.ts
@@ -1,6 +1,6 @@
 
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
-import { IonicModule } from 'ionic-angular';
+import { IonicModule, NavController } from 'ionic-angular';
 import { CompetencyComponent } from '../../competency/competency';
 import { ManoeuvresPopoverComponent } from '../manoeuvres-popover';
 import { AppModule } from '../../../../../app/app.module';
@@ -12,12 +12,13 @@ import { Store, StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng-mocks';
 import { By } from '@angular/platform-browser';
 import { ManoeuvreCompetencyComponent } from '../../manoeuvre-competency/manoeuvre-competency';
-import { testsReducer } from '../../../../../modules/tests/tests.reducer';
-import { StartTest } from '../../../../../modules/tests/tests.actions';
 import { ManoeuvreCompetencies, ManoeuvreTypes } from '../../../../../modules/tests/test-data/test-data.constants';
 import {
   DrivingFaultsBadgeComponent,
 } from '../../../../../components/common/driving-faults-badge/driving-faults-badge';
+import { NavControllerMock } from 'ionic-mocks';
+import { NavigationStateProvider } from '../../../../../providers/navigation-state/navigation-state';
+import { NavigationStateProviderMock } from '../../../../../providers/navigation-state/__mocks__/navigation-state.mock';
 
 describe('ManoeuvresPopoverComponent', () => {
   let fixture: ComponentFixture<ManoeuvresPopoverComponent>;
@@ -35,7 +36,55 @@ describe('ManoeuvresPopoverComponent', () => {
       imports: [
         IonicModule,
         AppModule,
-        StoreModule.forRoot({ tests: testsReducer }),
+        StoreModule.forRoot({
+          tests: () => ({
+            currentTest: {
+              slotId: '123',
+            },
+            testStatus: {},
+            startedTests: {
+              123: {
+                testData: {
+                  dangerousFaults: {},
+                  drivingFaults: {},
+                  manoeuvres: {},
+                  seriousFaults: {},
+                  testRequirements: {},
+                  ETA: {},
+                  eco: {},
+                  vehicleChecks: {
+                    showMeQuestion: {
+                      code: 'S3',
+                      description: '',
+                      outcome: '',
+                    },
+                    tellMeQuestion: {
+                      code: '',
+                      description: '',
+                      outcome: '',
+                    },
+                  },
+                  eyesightTest: {},
+                },
+                postTestDeclarations: {
+                  healthDeclarationAccepted: false,
+                  passCertificateNumberReceived: false,
+                  postTestSignature: '',
+                },
+                journalData: {},
+                communicationPreferences: {
+                  updatedEmail: '',
+                  communicationMethod: 'Not provided',
+                  conductedLanguage: 'Not provided',
+                },
+              },
+            },
+          }),
+        }),
+      ],
+      providers: [
+        { provide: NavController, useFactory: () => NavControllerMock.instance() },
+        { provide: NavigationStateProvider, useClass: NavigationStateProviderMock },
       ],
     })
       .compileComponents()
@@ -45,7 +94,6 @@ describe('ManoeuvresPopoverComponent', () => {
         fixture.detectChanges();
       });
     store$ = TestBed.get(Store);
-    store$.dispatch(new StartTest(1003));
     spyOn(store$, 'dispatch').and.callThrough();
   }));
 

--- a/src/pages/test-report/components/manoeuvres/__tests__/manoeuvres.spec.ts
+++ b/src/pages/test-report/components/manoeuvres/__tests__/manoeuvres.spec.ts
@@ -14,10 +14,10 @@ import { SeriousFaultBadgeComponent } from '../../../../../components/common/ser
 import {
   DangerousFaultBadgeComponent,
 } from '../../../../../components/common/dangerous-fault-badge/dangerous-fault-badge';
-import { StoreModule, Store } from '@ngrx/store';
-import { testsReducer } from '../../../../../modules/tests/tests.reducer';
+import { StoreModule } from '@ngrx/store';
 import { testReportReducer } from '../../../test-report.reducer';
-import { StartTest } from '../../../../../modules/tests/tests.actions';
+import { NavigationStateProvider } from '../../../../../providers/navigation-state/navigation-state';
+import { NavigationStateProviderMock } from '../../../../../providers/navigation-state/__mocks__/navigation-state.mock';
 
 describe('ManoeuvresComponent', () => {
   let fixture: ComponentFixture<ManoeuvresComponent>;
@@ -35,19 +35,62 @@ describe('ManoeuvresComponent', () => {
       imports: [
         IonicModule,
         AppModule,
-        StoreModule.forRoot({ tests: testsReducer, testReport: testReportReducer }),
+        StoreModule.forRoot({
+          tests: () => ({
+            currentTest: {
+              slotId: '123',
+            },
+            testStatus: {},
+            startedTests: {
+              123: {
+                testData: {
+                  dangerousFaults: {},
+                  drivingFaults: {},
+                  manoeuvres: {},
+                  seriousFaults: {},
+                  testRequirements: {},
+                  ETA: {},
+                  eco: {},
+                  vehicleChecks: {
+                    showMeQuestion: {
+                      code: 'S3',
+                      description: '',
+                      outcome: '',
+                    },
+                    tellMeQuestion: {
+                      code: '',
+                      description: '',
+                      outcome: '',
+                    },
+                  },
+                  eyesightTest: {},
+                },
+                postTestDeclarations: {
+                  healthDeclarationAccepted: false,
+                  passCertificateNumberReceived: false,
+                  postTestSignature: '',
+                },
+                journalData: {},
+                communicationPreferences: {
+                  updatedEmail: '',
+                  communicationMethod: 'Not provided',
+                  conductedLanguage: 'Not provided',
+                },
+              },
+            },
+          }),
+          testReport: testReportReducer,
+        }),
       ],
       providers: [
         { provide: DateTimeProvider, useCalss: DateTimeProviderMock },
+        { provide: NavigationStateProvider, useClass: NavigationStateProviderMock },
       ],
     })
       .compileComponents()
       .then(() => {
         fixture = TestBed.createComponent(ManoeuvresComponent);
         component = fixture.componentInstance;
-        const store$ = TestBed.get(Store);
-
-        store$.dispatch(new StartTest(103));
       });
   }));
 

--- a/src/shared/helpers/date-time.ts
+++ b/src/shared/helpers/date-time.ts
@@ -6,7 +6,9 @@ export class DateTime {
   constructor(sourceDateTime?: DateTime | string | Date) {
     if (sourceDateTime === undefined) {
       this.moment = moment();
-    } else if (typeof sourceDateTime === 'string' || sourceDateTime instanceof Date) {
+    } else if (typeof sourceDateTime === 'string') {
+      this.moment = moment(new Date(sourceDateTime));
+    } else if (sourceDateTime instanceof Date) {
       this.moment = moment(sourceDateTime);
     } else {
       this.moment = moment(sourceDateTime.moment);


### PR DESCRIPTION
## Description
Update tests to prevent various messages being displayed when the test are run, e.g.
`WARN LOG: 'Deprecation warning: value provided is not in a recognized RFC2822 or ISO format'`
`WARN: 'Ionic Native: tried calling Device.version, but the Device plugin is not installed.'`
`ERROR, TypeError: Cannot read property 'getActive' of undefined`
`ERROR: TypeError: _this.onTerminate is not a function`
`LOG: 'Calling App Config plugin mock'`

## Changes
- Split parsing of Date() objects and strings in `DateTime` to ensure all string dates are constructed using `new Date(string)` (see more at [moment construction using a non-iso string is deprecated](https://github.com/moment/moment/issues/1407)
- Add mocks to various tests for LogsHelper, Device, NavState
- Set up the store manually in some tests

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
