### PR TITLE
MES-3767: Refactoring pass-finalisation.ts to use conductedLanguage

### DIFF
--- a/src/pages/test-finalisation/pass-finalisation/pass-finalisation.html
+++ b/src/pages/test-finalisation/pass-finalisation/pass-finalisation.html
@@ -115,7 +115,7 @@
         <d255 [display]=true [d255]="pageState.d255$ | async" [outcome]="testOutcome" [formGroup]="form"
           (d255Change)="d255Changed($event)"></d255>
 
-        <language-preferences [formGroup]="form" [isWelsh]="pageState.isWelshTest$ | async"
+        <language-preferences [formGroup]="form" [isWelsh]="(pageState.conductedLanguage$ | async) === 'Cymraeg'"
           (welshChanged)="isWelshChanged($event)"></language-preferences>
 
         <debrief-witnessed [display]=true [formGroup]="form" [debriefWitnessed]="pageState.debriefWitnessed$ | async"

--- a/src/pages/test-finalisation/pass-finalisation/pass-finalisation.ts
+++ b/src/pages/test-finalisation/pass-finalisation/pass-finalisation.ts
@@ -46,8 +46,6 @@ import { GearboxCategoryChanged } from '../../../modules/tests/vehicle-details/v
 import { HEALTH_DECLARATION_PAGE } from '../../page-names.constants';
 import { getTestSummary } from '../../../modules/tests/test-summary/test-summary.reducer';
 import { isDebriefWitnessed, getD255 } from '../../../modules/tests/test-summary/test-summary.selector';
-import { getTestSlotAttributes } from '../../../modules/tests/test-slot-attributes/test-slot-attributes.reducer';
-import { isWelshTest } from '../../../modules/tests/test-slot-attributes/test-slot-attributes.selector';
 import {
   D255Yes,
   D255No,
@@ -61,6 +59,12 @@ import {
   CandidateChoseToProceedWithTestInWelsh,
   CandidateChoseToProceedWithTestInEnglish,
 } from '../../../modules/tests/communication-preferences/communication-preferences.actions';
+import {
+  getCommunicationPreference,
+} from '../../../modules/tests/communication-preferences/communication-preferences.reducer';
+import {
+  getConductedLanguage,
+} from '../../../modules/tests/communication-preferences/communication-preferences.selector';
 
 interface PassFinalisationPageState {
   candidateName$: Observable<string>;
@@ -76,7 +80,7 @@ interface PassFinalisationPageState {
   transmissionManualRadioChecked$: Observable<boolean>;
   d255$: Observable<boolean>;
   debriefWitnessed$: Observable<boolean>;
-  isWelshTest$: Observable<boolean>;
+  conductedLanguage$: Observable<string>;
 }
 
 @IonicPage()
@@ -183,10 +187,9 @@ export class PassFinalisationPage extends PracticeableBasePageComponent {
         select(getTestSummary),
         select(getD255),
       ),
-      isWelshTest$: currentTest$.pipe(
-        select(getJournalData),
-        select(getTestSlotAttributes),
-        select(isWelshTest),
+      conductedLanguage$: currentTest$.pipe(
+        select(getCommunicationPreference),
+        select(getConductedLanguage),
       ),
     };
     this.store$.dispatch(new PopulatePassCompletion());


### PR DESCRIPTION
## Description
`pass finalisation` page was always pre-selecting Welsh if a test was booked in Welsh, regardless of whether the conducted language had been changed to English.
- Use `conductedLanguage` as opposed to `isWelshTest` to pre-select value on `pass-finalisation` page.
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
