### PR TITLE
MES-3783 use 10 minutes instead of slot duration to calculate when rekey can start

### DIFF
--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -235,7 +235,7 @@ export class TestOutcomeComponent implements OnInit {
   }
 
   hasTestTimeFinished(): boolean {
-    const cutOffTime = new DateTime(this.slotDetail.start).add(this.slotDetail.duration, Duration.MINUTE);
+    const cutOffTime = new DateTime(this.slotDetail.start).add(10, Duration.MINUTE);
     return new DateTime() > cutOffTime;
   }
 


### PR DESCRIPTION
allow rekeys to take place within 10 minutes of the test starting.