### PR TITLE
MES-3829: Setting test category early

### DIFF
--- a/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
@@ -14,6 +14,7 @@ import { ActivityCodes } from '../../../../shared/models/activity-codes';
 import { JournalModel } from '../../../../modules/journal/journal.model';
 import { LogHelper } from '../../../../providers/logs/logsHelper';
 import { LogHelperMock } from '../../../../providers/logs/__mocks__/logsHelper.mock';
+import { TestCategory } from '../../../../shared/models/test-category';
 
 describe('Test Outcome', () => {
   let fixture: ComponentFixture<TestOutcomeComponent>;
@@ -76,18 +77,20 @@ describe('Test Outcome', () => {
     describe('startTest', () => {
       it('should dispatch a start test action with the slot', () => {
         component.slotDetail = testSlotDetail;
+        component.category = TestCategory.B;
         component.startTest();
 
-        expect(store$.dispatch).toHaveBeenCalledWith(new StartTest(component.slotDetail.slotId));
+        expect(store$.dispatch).toHaveBeenCalledWith(new StartTest(component.slotDetail.slotId, component.category));
       });
     });
 
     describe('writeUpTest', () => {
       it('should dispatch an ActivateTest action and navigate to the Office page', () => {
         component.slotDetail = testSlotDetail;
+        component.category = TestCategory.B;
         component.writeUpTest();
 
-        expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId));
+        expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId, component.category));
         const { calls } = navController.push as jasmine.Spy;
         expect(calls.argsFor(0)[0]).toBe(CAT_B.OFFICE_PAGE);
       });
@@ -97,9 +100,10 @@ describe('Test Outcome', () => {
       it('should dispatch an ActivateTest action and navigate to the Waiting Room page', () => {
         component.testStatus = TestStatus.Started;
         component.slotDetail = testSlotDetail;
+        component.category = TestCategory.B;
         component.resumeTest();
 
-        expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId));
+        expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId, component.category));
         const { calls } = navController.push as jasmine.Spy;
         expect(calls.argsFor(0)[0]).toBe(CAT_B.WAITING_ROOM_PAGE);
       });
@@ -107,9 +111,10 @@ describe('Test Outcome', () => {
         component.testStatus = TestStatus.Decided;
         component.slotDetail = testSlotDetail;
         component.activityCode = ActivityCodes.PASS;
+        component.category = TestCategory.B;
         component.resumeTest();
 
-        expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId));
+        expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId, component.category));
         const { calls } = navController.push as jasmine.Spy;
         expect(calls.argsFor(0)[0]).toBe(CAT_B.PASS_FINALISATION_PAGE);
       });
@@ -117,9 +122,10 @@ describe('Test Outcome', () => {
         component.testStatus = TestStatus.Decided;
         component.slotDetail = testSlotDetail;
         component.activityCode = ActivityCodes.FAIL;
+        component.category = TestCategory.B;
         component.resumeTest();
 
-        expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId));
+        expect(store$.dispatch).toHaveBeenCalledWith(new ActivateTest(component.slotDetail.slotId, component.category));
         const { calls } = navController.push as jasmine.Spy;
         expect(calls.argsFor(0)[0]).toBe(CAT_B.NON_PASS_FINALISATION_PAGE);
       });

--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -49,6 +49,9 @@ export class TestOutcomeComponent implements OnInit {
   @Input()
   isRekey: boolean;
 
+  @Input()
+  category: string;
+
   modal: Modal;
   startTestAsRekey: boolean = false;
   isTestSlotOnRekeySearch: boolean = false;
@@ -131,13 +134,13 @@ export class TestOutcomeComponent implements OnInit {
   }
 
   writeUpTest() {
-    this.store$.dispatch(new ActivateTest(this.slotDetail.slotId));
+    this.store$.dispatch(new ActivateTest(this.slotDetail.slotId, this.category));
     this.store$.dispatch(new ResumingWriteUp(this.slotDetail.slotId.toString()));
     this.navController.push(CAT_B.OFFICE_PAGE);
   }
 
   resumeTest() {
-    this.store$.dispatch(new ActivateTest(this.slotDetail.slotId));
+    this.store$.dispatch(new ActivateTest(this.slotDetail.slotId, this.category));
     if (this.testStatus === TestStatus.Started) {
       this.navController.push(CAT_B.WAITING_ROOM_PAGE);
     } else if (this.activityCode === ActivityCodes.PASS) {
@@ -151,16 +154,16 @@ export class TestOutcomeComponent implements OnInit {
     if (this.isE2EPracticeMode()) {
       this.store$.dispatch(new StartE2EPracticeTest(this.slotDetail.slotId.toString()));
     } else {
-      this.store$.dispatch(new StartTest(this.slotDetail.slotId, this.startTestAsRekey || this.isRekey));
+      this.store$.dispatch(new StartTest(this.slotDetail.slotId, this.category, this.startTestAsRekey || this.isRekey));
     }
     this.navController.push(CAT_B.WAITING_ROOM_PAGE);
   }
 
   rekeyTest() {
     if (this.testStatus === null || this.testStatus === TestStatus.Booked) {
-      this.store$.dispatch(new StartTest(this.slotDetail.slotId, true));
+      this.store$.dispatch(new StartTest(this.slotDetail.slotId, this.category, true));
     } else {
-      this.store$.dispatch(new ActivateTest(this.slotDetail.slotId, true));
+      this.store$.dispatch(new ActivateTest(this.slotDetail.slotId, this.category, true));
     }
     this.navController.push(CAT_B.WAITING_ROOM_PAGE);
   }

--- a/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
+++ b/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
@@ -294,7 +294,7 @@ describe('TestSlotComponent', () => {
 
       it('should pass test status decided to the test-outcome component when the outcome observable changes', () => {
         fixture.detectChanges();
-        store$.dispatch(new StartTest(mockSlot.slotDetail.slotId));
+        store$.dispatch(new StartTest(mockSlot.slotDetail.slotId, mockSlot.booking.application.testCategory));
         store$.dispatch(new SetTestStatusDecided(mockSlot.slotDetail.slotId.toString()));
         fixture.detectChanges();
 

--- a/src/components/test-slot/test-slot/test-slot.html
+++ b/src/components/test-slot/test-slot/test-slot.html
@@ -42,9 +42,13 @@
           </ion-grid>
         </ion-col>
         <ion-col class="test-outcome-col" no-padding padding-right>
-          <test-outcome [slotDetail]="slot.slotDetail" [canStartTest]="canStartTest()" [testStatus]="componentState.testStatus$ | async"
-            [activityCode]="componentState.testActivityCode$ | async" [specialRequirements]="isIndicatorNeededForSlot()"
-            [hasSeenCandidateDetails]="hasSeenCandidateDetails" [isRekey]="componentState.isRekey$ | async"></test-outcome>
+          <test-outcome 
+            [slotDetail]="slot.slotDetail" [canStartTest]="canStartTest()" 
+            [testStatus]="componentState.testStatus$ | async"
+            [activityCode]="componentState.testActivityCode$ | async"
+            [specialRequirements]="isIndicatorNeededForSlot()"
+            [hasSeenCandidateDetails]="hasSeenCandidateDetails"
+            [isRekey]="componentState.isRekey$ | async" [category]="slot.booking.application.testCategory"></test-outcome>
         </ion-col>
       </ion-row>
       <ion-row class="slot-footer" [ngClass]="{'vehicle-details-displayed': showVehicleDetails()}" align-items-center>

--- a/src/modules/tests/__tests__/tests.analytics.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.analytics.effects.spec.ts
@@ -25,6 +25,7 @@ import { Application } from '@dvsa/mes-journal-schema';
 import { NavigationStateProviderMock } from '../../../providers/navigation-state/__mocks__/navigation-state.mock';
 import { NavigationStateProvider } from '../../../providers/navigation-state/navigation-state';
 import { candidateMock } from '../__mocks__/tests.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Tests Analytics Effects', () => {
 
@@ -65,7 +66,7 @@ describe('Tests Analytics Effects', () => {
   describe('setTestStatusSubmittedEffect', () => {
     it('should set an action saying the test has been submitted if it is not a rekey', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(12345));
+      store$.dispatch(new testsActions.StartTest(12345, TestCategory.B));
       store$.dispatch(new candidateActions.PopulateCandidateDetails(candidateMock));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.PASS));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
@@ -89,7 +90,7 @@ describe('Tests Analytics Effects', () => {
     });
     it('should set an action saying the test has been submitted if it is a rekey', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(12345));
+      store$.dispatch(new testsActions.StartTest(12345, TestCategory.B));
       store$.dispatch(new candidateActions.PopulateCandidateDetails(candidateMock));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.FAIL));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
@@ -135,7 +136,7 @@ describe('Tests Analytics Effects', () => {
   describe('testOutcomeChangedEffect', () => {
     it('should log an event', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(12345));
+      store$.dispatch(new testsActions.StartTest(12345, TestCategory.B));
       store$.dispatch(new candidateActions.PopulateCandidateDetails(candidateMock));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
       const eventLabel = 'fail to pass';
@@ -161,7 +162,7 @@ describe('Tests Analytics Effects', () => {
   describe('startTestAnalyticsEffect', () => {
     it('should log an event', (done) => {
       // ACT
-      actions$.next(new testsActions.StartTest(12345));
+      actions$.next(new testsActions.StartTest(12345, TestCategory.B));
       // ASSERT
       effects.startTestAnalyticsEffect$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);

--- a/src/modules/tests/__tests__/tests.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.effects.spec.ts
@@ -43,7 +43,7 @@ import { SetExaminerKeyed } from '../examiner-keyed/examiner-keyed.actions';
 import { TestCategory } from '../../../shared/models/test-category';
 import { PopulateTestCategory } from '../category/category.actions';
 
-fdescribe('Tests Effects', () => {
+describe('Tests Effects', () => {
 
   let effects: TestsEffects;
   let actions$: any;

--- a/src/modules/tests/__tests__/tests.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.effects.spec.ts
@@ -40,8 +40,10 @@ import { SetExaminerBooked } from '../examiner-booked/examiner-booked.actions';
 import { bufferCount } from 'rxjs/operators';
 import { SetExaminerConducted } from '../examiner-conducted/examiner-conducted.actions';
 import { SetExaminerKeyed } from '../examiner-keyed/examiner-keyed.actions';
+import { TestCategory } from '../../../shared/models/test-category';
+import { PopulateTestCategory } from '../category/category.actions';
 
-describe('Tests Effects', () => {
+fdescribe('Tests Effects', () => {
 
   let effects: TestsEffects;
   let actions$: any;
@@ -82,7 +84,7 @@ describe('Tests Effects', () => {
   describe('persistTestsEffect', () => {
     it('should respond to a PERSIST_TESTS action and delegate to the persistence provider', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(12345));
+      store$.dispatch(new testsActions.StartTest(12345, TestCategory.B));
       testPersistenceProviderMock.persistTests.and.returnValue(Promise.resolve());
       // ACT
       actions$.next(new testsActions.PersistTests());
@@ -143,11 +145,11 @@ describe('Tests Effects', () => {
       const currentTestSlotId2 = '1234567'; // Mocked as a 500 http error response
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       store$.dispatch(new testStatusActions.SetTestStatusCompleted(testReportPracticeModeSlot.slotDetail.slotId));
-      store$.dispatch(new testsActions.StartTest(Number(currentTestSlotId)));
+      store$.dispatch(new testsActions.StartTest(Number(currentTestSlotId), TestCategory.B));
       store$.dispatch(new testStatusActions.SetTestStatusCompleted(currentTestSlotId));
-      store$.dispatch(new testsActions.StartTest(Number(currentTestSlotId1)));
+      store$.dispatch(new testsActions.StartTest(Number(currentTestSlotId1), TestCategory.B));
       store$.dispatch(new testStatusActions.SetTestStatusCompleted(currentTestSlotId1));
-      store$.dispatch(new testsActions.StartTest(Number(currentTestSlotId2)));
+      store$.dispatch(new testsActions.StartTest(Number(currentTestSlotId2), TestCategory.B));
       store$.dispatch(new testStatusActions.SetTestStatusCompleted(currentTestSlotId2));
       // ACT
       actions$.next(new testsActions.SendCompletedTests());
@@ -175,7 +177,7 @@ describe('Tests Effects', () => {
   describe('sendCurrentTestSuccessEffect', () => {
     it('should dispatch the TestStatusSubmitted action', (done) => {
       const currentTestSlotId = '12345';
-      store$.dispatch(new testsActions.StartTest(12345));
+      store$.dispatch(new testsActions.StartTest(12345, TestCategory.B));
       // ACT
       actions$.next(new testsActions.SendCurrentTestSuccess());
       // ASSERT
@@ -205,17 +207,17 @@ describe('Tests Effects', () => {
         ),
       ); // Load in mock journal state
       // ACT
-      actions$.next(new testsActions.StartTest(1001));
+      actions$.next(new testsActions.StartTest(1001, TestCategory.B));
       // ASSERT
       effects.startTestEffect$
       .pipe(
         bufferCount(10),
       )
-      .subscribe(([res1, res2, res3, res4, res5, res6, res7, res8, res9, res10]) => {
+      .subscribe(([res0, res1, res2, res3, res4, res5, res6, res7, res8, res9]) => {
         expect(res1).toEqual(new PopulateExaminer(examiner)),
-        expect(res8).toEqual(new SetExaminerBooked(parseInt(examiner.staffNumber, 10))),
-        expect(res9).toEqual(new SetExaminerConducted(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
-        expect(res10).toEqual(new SetExaminerKeyed(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
+        expect(res7).toEqual(new SetExaminerBooked(parseInt(examiner.staffNumber, 10))),
+        expect(res8).toEqual(new SetExaminerConducted(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
+        expect(res9).toEqual(new SetExaminerKeyed(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
         done();
       });
     });
@@ -233,18 +235,18 @@ describe('Tests Effects', () => {
         ),
       ); // Load in mock journal state
       // ACT
-      actions$.next(new testsActions.StartTest(1001, true));
+      actions$.next(new testsActions.StartTest(1001, TestCategory.B, true));
       // ASSERT
       effects.startTestEffect$
       .pipe(
         bufferCount(13),
       )
-      .subscribe(([res1, res2, res3, res4, res5, res6, res7, res8, res9, res10, res11, res12, res13]) => {
+      .subscribe(([res0, res1, res2, res3, res4, res5, res6, res7, res8, res9, res10, res11, res12]) => {
         expect(res1).toEqual(new PopulateExaminer(examiner)),
-        expect(res8).toEqual(new SetExaminerBooked(parseInt(examiner.staffNumber, 10))),
-        expect(res9).toEqual(new SetExaminerConducted(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
-        expect(res10).toEqual(new SetExaminerKeyed(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
-        expect(res13).toEqual(new rekeyActions.MarkAsRekey()),
+        expect(res7).toEqual(new SetExaminerBooked(parseInt(examiner.staffNumber, 10))),
+        expect(res8).toEqual(new SetExaminerConducted(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
+        expect(res9).toEqual(new SetExaminerKeyed(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
+        expect(res12).toEqual(new rekeyActions.MarkAsRekey()),
         done();
       });
     });
@@ -265,26 +267,28 @@ describe('Tests Effects', () => {
             applicationId: 12345,
             bookingSequence: 11,
             checkDigit: 1,
+            testCategory: TestCategory.B,
           },
         },
       };
       const staffNumber = '654321';
       store$.dispatch(new rekeySearchActions.SearchBookedTestSuccess(testSlot, staffNumber));
       // ACT
-      actions$.next(new testsActions.StartTest(1001, true));
+      actions$.next(new testsActions.StartTest(1001, testSlot.booking.application.testCategory, true));
       // ASSERT
       effects.startTestEffect$
       .pipe(
         bufferCount(13),
       )
-      .subscribe(([res1, res2, res3, res4, res5, res6, res7, res8, res9, res10, res11, res12, res13]) => {
+      .subscribe(([res0, res1, res2, res3, res4, res5, res6, res7, res8, res9, res10, res11, res12]) => {
+        expect(res0).toEqual(new PopulateTestCategory(testSlot.booking.application.testCategory));
         expect(res1).toEqual(new PopulateExaminer({ staffNumber })),
         expect(res2).toEqual(new PopulateApplicationReference(testSlot.booking.application)),
         expect(res3).toEqual(new PopulateCandidateDetails(testSlot.booking.candidate)),
-        expect(res8).toEqual(new SetExaminerBooked(parseInt(staffNumber, 10))),
-        expect(res9).toEqual(new SetExaminerConducted(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
-        expect(res10).toEqual(new SetExaminerKeyed(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
-        expect(res13).toEqual(new rekeyActions.MarkAsRekey()),
+        expect(res7).toEqual(new SetExaminerBooked(parseInt(staffNumber, 10))),
+        expect(res8).toEqual(new SetExaminerConducted(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
+        expect(res9).toEqual(new SetExaminerKeyed(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
+        expect(res12).toEqual(new rekeyActions.MarkAsRekey()),
         done();
       });
     });
@@ -293,7 +297,7 @@ describe('Tests Effects', () => {
   describe('activateTestEffect', () => {
     it('should call theMarkAsRekey action', (done) => {
       // ACT
-      actions$.next(new testsActions.ActivateTest(1234, true));
+      actions$.next(new testsActions.ActivateTest(1234, TestCategory.B, true));
       // ASSERT
       effects.activateTestEffect$.subscribe((result) => {
         expect(result instanceof rekeyActions.MarkAsRekey).toBe(true);

--- a/src/modules/tests/__tests__/tests.reducer.spec.ts
+++ b/src/modules/tests/__tests__/tests.reducer.spec.ts
@@ -6,6 +6,7 @@ import { TestsModel } from '../tests.model';
 import * as testsActions from './../tests.actions';
 import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 import { testReportPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('testsReducer', () => {
   const newCandidate = { candidate: { candidateId: 456 } };
@@ -23,7 +24,7 @@ describe('testsReducer', () => {
       testStatus: {},
     };
     const slotId = 123;
-    const action = new testsActions.StartTest(slotId);
+    const action = new testsActions.StartTest(slotId, TestCategory.B);
 
     const output = testsReducer(state, action);
 
@@ -155,7 +156,7 @@ describe('testsReducer', () => {
       testStatus: {},
     };
 
-    const result = testsReducer(state, new testsActions.StartTest(123));
+    const result = testsReducer(state, new testsActions.StartTest(123, TestCategory.B));
 
     expect(candidateReducer.candidateReducer).toHaveBeenCalled();
     expect(preTestDeclarationsReducer.preTestDeclarationsReducer).toHaveBeenCalled();
@@ -170,7 +171,7 @@ describe('testsReducer', () => {
       testStatus: {},
     };
 
-    const result = testsReducer(state, new testsActions.ActivateTest(456));
+    const result = testsReducer(state, new testsActions.ActivateTest(456, TestCategory.B));
 
     expect(result.currentTest.slotId).toBe('456');
   });

--- a/src/modules/tests/examiner-booked/__tests__/examiner-booked.effects.spec.ts
+++ b/src/modules/tests/examiner-booked/__tests__/examiner-booked.effects.spec.ts
@@ -9,6 +9,7 @@ import { StoreModel } from '../../../../shared/models/store.model';
 import { SetChangeMarker } from '../../change-marker/change-marker.actions';
 import { StartTest } from '../../tests.actions';
 import { SetExaminerConducted } from '../../examiner-conducted/examiner-conducted.actions';
+import { TestCategory } from '../../../../shared/models/test-category';
 
 describe('Examiner Booked Effects', () => {
 
@@ -37,7 +38,7 @@ describe('Examiner Booked Effects', () => {
   describe('setExaminerBookedEffect', () => {
     it('should set the change marker to true when the examiner booked is different to the conducted', (done) => {
       // ARRANGE
-      store$.dispatch(new StartTest(12345));
+      store$.dispatch(new StartTest(12345, TestCategory.B));
       store$.dispatch(new SetExaminerConducted(123456));
       // ACT
       actions$.next(new SetExaminerBooked(100001));
@@ -49,7 +50,7 @@ describe('Examiner Booked Effects', () => {
     });
     it('should set the change marker to false when the examiner booked is the same as the conducted', (done) => {
       // ARRANGE
-      store$.dispatch(new StartTest(12345));
+      store$.dispatch(new StartTest(12345, TestCategory.B));
       store$.dispatch(new SetExaminerConducted(123456));
       // ACT
       actions$.next(new SetExaminerBooked(123456));

--- a/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.effects.spec.ts
+++ b/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.effects.spec.ts
@@ -10,6 +10,7 @@ import { SetChangeMarker } from '../../change-marker/change-marker.actions';
 import { StartTest } from '../../tests.actions';
 import { SetExaminerBooked } from '../../examiner-booked/examiner-booked.actions';
 import { journalReducer } from '../../../journal/journal.reducer';
+import { TestCategory } from '../../../../shared/models/test-category';
 
 describe('Examiner Conducted Effects', () => {
 
@@ -39,7 +40,7 @@ describe('Examiner Conducted Effects', () => {
   describe('setExaminerConductedEffect', () => {
     it('should set the change marker to true when the examiner conducted is different to the booked', (done) => {
       // ARRANGE
-      store$.dispatch(new StartTest(12345));
+      store$.dispatch(new StartTest(12345, TestCategory.B));
       store$.dispatch(new SetExaminerBooked(123456));
       // ACT
       actions$.next(new SetExaminerConducted(100001));
@@ -51,7 +52,7 @@ describe('Examiner Conducted Effects', () => {
     });
     it('should set the change marker to false when the examiner conducted is the same as the booked', (done) => {
       // ARRANGE
-      store$.dispatch(new StartTest(12345));
+      store$.dispatch(new StartTest(12345, TestCategory.B));
       store$.dispatch(new SetExaminerBooked(123456));
       // ACT
       actions$.next(new SetExaminerConducted(123456));

--- a/src/modules/tests/test-data/__tests__/test-data.effects.spec.ts
+++ b/src/modules/tests/test-data/__tests__/test-data.effects.spec.ts
@@ -10,6 +10,7 @@ import { Store, StoreModule } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
 import { Competencies } from '../test-data.constants';
 import { FaultPayload } from '../test-data.models';
+import { TestCategory } from '../../../../shared/models/test-category';
 
 describe('Test Data Effects', () => {
 
@@ -43,7 +44,7 @@ describe('Test Data Effects', () => {
       };
       const throttleAddDrivingFault = new drivingFaultsActions.ThrottleAddDrivingFault(faultPayload);
       // ARRANGE - setup the store
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       store$.dispatch(throttleAddDrivingFault);
       // ACT - replay the action for the effect
       actions$.next(throttleAddDrivingFault);
@@ -59,7 +60,7 @@ describe('Test Data Effects', () => {
     it('should dispatch an action to toggle eco to be completed', (done) => {
       const toggleControlEcoAction = new ecoActions.ToggleControlEco();
       // ARRANGE - setup the store
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       store$.dispatch(toggleControlEcoAction);
       // ACT - replay the action for the effect
       actions$.next(toggleControlEcoAction);
@@ -75,7 +76,7 @@ describe('Test Data Effects', () => {
     it('should dispatch an action to toggle eco to be completed', (done) => {
       const togglePlanningEcoAction = new ecoActions.TogglePlanningEco();
       // ARRANGE - setup the store
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       store$.dispatch(togglePlanningEcoAction);
       // ACT - replay the action for the effect
       actions$.next(togglePlanningEcoAction);

--- a/src/modules/tests/tests.actions.ts
+++ b/src/modules/tests/tests.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 import { TestsModel } from './tests.model';
+import { TestCategory } from '../../shared/models/test-category';
 
 export const START_SENDING_COMPLETED_TESTS = '[TestsEffects] Start Sending Completed Test';
 export const SEND_COMPLETED_TESTS = '[TestsEffects] Send Completed Tests';
@@ -44,17 +45,17 @@ export class TestOutcomeChanged implements Action {
 
 export class StartTest implements Action {
   readonly type = START_TEST;
-  constructor(public slotId: number, public rekey: boolean = false) { }
+  constructor(public slotId: number, public category: string, public rekey: boolean = false) { }
 }
 
 export class ActivateTest implements Action {
   readonly type = ACTIVATE_TEST;
-  constructor(public slotId: number, public rekey: boolean = false) { }
+  constructor(public slotId: number, public category: string, public rekey: boolean = false) { }
 }
 
 export class StartTestReportPracticeTest implements Action {
   readonly type = START_TEST_REPORT_PRACTICE_TEST;
-  constructor(public slotId: string) { }
+  constructor(public slotId: string, public category: string = TestCategory.B) { }
 }
 
 export class StartSendingCompletedTests implements Action {

--- a/src/modules/tests/tests.effects.ts
+++ b/src/modules/tests/tests.effects.ts
@@ -156,13 +156,13 @@ export class TestsEffects {
       const conductedLanguage: ConductedLanguage = testSlotAttributes.welshTest ? Language.CYMRAEG : Language.ENGLISH;
 
       const arrayOfActions: Action[] = [
+        new PopulateTestCategory(slot.booking.application.testCategory),
         new PopulateExaminer(examiner),
         new PopulateApplicationReference(slot.booking.application),
         new PopulateCandidateDetails(slot.booking.candidate),
         new PopulateTestSlotAttributes(testSlotAttributes),
         new PopulateTestCentre(extractTestCentre(slot)),
         new testStatusActions.SetTestStatusBooked(startTestAction.slotId.toString()),
-        new PopulateTestCategory(slot.booking.application.testCategory),
         new SetExaminerBooked(parseInt(examinerBooked, 10) ? parseInt(examinerBooked, 10) : null),
         new SetExaminerConducted(parseInt(examinerConducted, 10) ? parseInt(examinerConducted, 10) : null),
         new SetExaminerKeyed(parseInt(examinerKeyed, 10) ? parseInt(examinerKeyed, 10) : null),
@@ -199,6 +199,7 @@ export class TestsEffects {
       };
 
       return [
+        new PopulateTestCategory(slotData.booking.application.testCategory),
         new PopulateApplicationReference(slotData.booking.application),
         new PopulateCandidateDetails(slotData.booking.candidate),
       ];

--- a/src/pages/back-to-office/__tests__/back-to-office.analytics.effects.spec.ts
+++ b/src/pages/back-to-office/__tests__/back-to-office.analytics.effects.spec.ts
@@ -25,6 +25,7 @@ import * as applicationReferenceActions
   from '../../../modules/tests/journal-data/application-reference/application-reference.actions';
 import * as activityCodeActions from '../../../modules/tests/activity-code/activity-code.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Back To Office Analytics Effects', () => {
 
@@ -63,7 +64,7 @@ describe('Back To Office Analytics Effects', () => {
   describe('backToOfficeViewDidEnter', () => {
     it('should call setCurrentPage', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       // ACT
       actions$.next(new backToOfficeActions.BackToOfficeViewDidEnter());
@@ -95,7 +96,7 @@ describe('Back To Office Analytics Effects', () => {
   describe('deferWriteUpEffect', () => {
     it('should call logEvent with pass page and addCustomDimension', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.PASS));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
@@ -119,7 +120,7 @@ describe('Back To Office Analytics Effects', () => {
     });
     it('should call logEvent with fail page and addCustomDimension', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.FAIL));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));

--- a/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
@@ -23,6 +23,7 @@ import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock'
 import * as applicationReferenceActions
   from '../../../modules/tests/journal-data/application-reference/application-reference.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Communication Analytics Effects', () => {
 
@@ -61,7 +62,7 @@ describe('Communication Analytics Effects', () => {
   describe('communicationViewDidEnter', () => {
     it('should call setCurrentPage and addCustomDimension', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
       // ACT
@@ -103,7 +104,7 @@ describe('Communication Analytics Effects', () => {
   describe('communicationValidationError', () => {
     it('should call logError', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       // ACT
       actions$.next(new communicationActions.CommunicationValidationError('formControl1'));

--- a/src/pages/debrief/__tests__/debrief.analytics.effects.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.analytics.effects.spec.ts
@@ -18,6 +18,7 @@ import * as activityCodeActions from '../../../modules/tests/activity-code/activ
 import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
 import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
 import { ActivityCodes } from '../../../shared/models/activity-codes';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Debrief Analytics Effects', () => {
 
@@ -53,7 +54,7 @@ describe('Debrief Analytics Effects', () => {
   describe('debriefViewDidEnter', () => {
     it('should call setCurrentPage with pass page', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.PASS));
       // ACT
       actions$.next(new debriefActions.DebriefViewDidEnter());
@@ -67,7 +68,7 @@ describe('Debrief Analytics Effects', () => {
     });
     it('should call setCurrentPage with fail page', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.FAIL));
       // ACT
       actions$.next(new debriefActions.DebriefViewDidEnter());

--- a/src/pages/debrief/__tests__/debrief.effects.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.effects.spec.ts
@@ -10,6 +10,7 @@ import * as activityCodeActions from '../../../modules/tests/activity-code/activ
 import { ActivityCodes } from '../../../shared/models/activity-codes';
 import { StoreModel } from '../../../shared/models/store.model';
 import { testsReducer } from '../../../modules/tests/tests.reducer';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Debrief Effects', () => {
 
@@ -41,7 +42,7 @@ describe('Debrief Effects', () => {
 
     it('should return SET_TEST_STATUS_DECIDED & PERSIST_TESTS actions when passed test', (done) => {
       // Set activity code as passed
-      store$.dispatch(new testsActions.StartTest(1234));
+      store$.dispatch(new testsActions.StartTest(1234, TestCategory.B));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.PASS));
 
       actions$.next(new debriefActions.EndDebrief());
@@ -60,7 +61,7 @@ describe('Debrief Effects', () => {
 
     it('should return SET_TEST_STATUS_DECIDED & PERSIST_TESTS actions when failed test', (done) => {
       // Set activity code as failed
-      store$.dispatch(new testsActions.StartTest(1234));
+      store$.dispatch(new testsActions.StartTest(1234, TestCategory.B));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.FAIL));
 
       actions$.next(new debriefActions.EndDebrief());

--- a/src/pages/debrief/components/vehicle-checks-card/__tests__/vehicle-checks-card.spec.ts
+++ b/src/pages/debrief/components/vehicle-checks-card/__tests__/vehicle-checks-card.spec.ts
@@ -19,6 +19,7 @@ import { TranslateService, TranslateModule, TranslateLoader } from 'ng2-translat
 import { createTranslateLoader } from '../../../../../app/app.module';
 import { Http } from '@angular/http';
 import * as welshTranslations from '../../../../../assets/i18n/cy.json';
+import { TestCategory } from '../../../../../shared/models/test-category';
 
 describe('VehicleChecksCardComponent', () => {
   let fixture: ComponentFixture<VehicleChecksCardComponent>;
@@ -47,7 +48,7 @@ describe('VehicleChecksCardComponent', () => {
       .then(() => {
         fixture = TestBed.createComponent(VehicleChecksCardComponent);
         store$ = TestBed.get(Store);
-        store$.dispatch(new StartTest(105));
+        store$.dispatch(new StartTest(105, TestCategory.B));
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
       });

--- a/src/pages/fake-journal/components/fake-test-slot/fake-test-slot.html
+++ b/src/pages/fake-journal/components/fake-test-slot/fake-test-slot.html
@@ -44,6 +44,7 @@
         </ion-col>
         <ion-col class="test-outcome-col" no-padding padding-right>
           <test-outcome
+            [category]="slot.booking.application.testCategory"
             [slotDetail]="slot.slotDetail" 
             [canStartTest]="canStartTest"
             [testStatus]="testStatus"

--- a/src/pages/fake-journal/fake-journal.actions.ts
+++ b/src/pages/fake-journal/fake-journal.actions.ts
@@ -1,10 +1,11 @@
 import { Action } from '@ngrx/store';
+import { TestCategory } from '../../shared/models/test-category';
 
 export const START_E2E_PRACTICE_TEST = '[Tests] Start Full Practice Test';
 
 export class StartE2EPracticeTest implements Action {
   readonly type = START_E2E_PRACTICE_TEST;
-  constructor(public slotId: string) { }
+  constructor(public slotId: string, public category: string = TestCategory.B) { }
 }
 
 export type Types =

--- a/src/pages/fake-journal/fake-journal.effects.ts
+++ b/src/pages/fake-journal/fake-journal.effects.ts
@@ -16,6 +16,7 @@ import { Application } from '@dvsa/mes-journal-schema';
 import {
   extractTestSlotAttributes,
 } from '../../modules/tests/journal-data/test-slot-attributes/test-slot-attributes.selector';
+import { PopulateTestCategory } from '../../modules/tests/category/category.actions';
 
 @Injectable()
 export class FakeJournalEffects {
@@ -31,6 +32,7 @@ export class FakeJournalEffects {
       const slot = fakeJournalTestSlots.find(s => s.slotDetail.slotId === startTestAction.slotId);
 
       return [
+        new PopulateTestCategory(slot.booking.application.testCategory),
         new PopulateApplicationReference(slot.booking.application as Application),
         new PopulateCandidateDetails(slot.booking.candidate),
         new PopulateTestSlotAttributes(extractTestSlotAttributes(slot)),

--- a/src/pages/health-declaration/__tests__/health-declaration.analytics.effects.spec.ts
+++ b/src/pages/health-declaration/__tests__/health-declaration.analytics.effects.spec.ts
@@ -18,6 +18,7 @@ import { testsReducer } from '../../../modules/tests/tests.reducer';
 import { PopulateCandidateDetails } from '../../../modules/tests/journal-data/candidate/candidate.actions';
 import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Health Declaration Analytics Effects', () => {
 
@@ -52,7 +53,7 @@ describe('Health Declaration Analytics Effects', () => {
   describe('healthDeclarationViewDidEnter', () => {
     it('should call setCurrentPage', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       // ACT
       actions$.next(new healthDeclarationActions.HealthDeclarationViewDidEnter());

--- a/src/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
+++ b/src/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
@@ -15,6 +15,7 @@ import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock'
 import { NonPassFinalisationAnalyticsEffects } from '../non-pass-finalisation.analytics.effects';
 import * as nonPassFinalisationActions from '../non-pass-finalisation.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Non Pass Finalisation Analytics Effects', () => {
 
@@ -49,7 +50,7 @@ describe('Non Pass Finalisation Analytics Effects', () => {
   describe('nonPassFinalisationViewDidEnter', () => {
     it('should call setCurrentPage', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       // ACT
       actions$.next(new nonPassFinalisationActions.NonPassFinalisationViewDidEnter());

--- a/src/pages/non-pass-finalisation/__tests__/non-pass-finalisation.spec.ts
+++ b/src/pages/non-pass-finalisation/__tests__/non-pass-finalisation.spec.ts
@@ -15,6 +15,7 @@ import { SetTestStatusWriteUp } from '../../../modules/tests/test-status/test-st
 import * as testActions from '../../../modules/tests/tests.actions';
 import { TestFinalisationComponentsModule } from
 '../../../components/test-finalisation/test-finalisation-component.module';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('NonPassFinalisationPage', () => {
   let fixture: ComponentFixture<NonPassFinalisationPage>;
@@ -61,7 +62,7 @@ describe('NonPassFinalisationPage', () => {
   describe('OnContinue', () => {
     it('should dispatch a change test state to WriteUp action', () => {
       // Arrange
-      store$.dispatch(new testActions.StartTest(123));
+      store$.dispatch(new testActions.StartTest(123, TestCategory.B));
       component.slotId = '123';
 
       // Act

--- a/src/pages/office/__tests__/office.analytics.effects.spec.ts
+++ b/src/pages/office/__tests__/office.analytics.effects.spec.ts
@@ -27,6 +27,7 @@ import * as applicationReferenceActions
   from '../../../modules/tests/journal-data/application-reference/application-reference.actions';
 import * as activityCodeActions from '../../../modules/tests/activity-code/activity-code.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Office Analytics Effects', () => {
 
@@ -69,7 +70,7 @@ describe('Office Analytics Effects', () => {
   describe('officeViewDidEnter', () => {
     it('should call setCurrentPage with pass page and addCustomDimension', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.PASS));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
@@ -89,7 +90,7 @@ describe('Office Analytics Effects', () => {
     });
     it('should call setCurrentPage with fail page and addCustomDimension', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.FAIL));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
@@ -153,7 +154,7 @@ describe('Office Analytics Effects', () => {
   describe('savingWriteUpForLaterEffect', () => {
     it('should call logEvent with pass page and addCustomDimension', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.PASS));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
@@ -177,7 +178,7 @@ describe('Office Analytics Effects', () => {
     });
     it('should call logEvent with fail page and addCustomDimension', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.FAIL));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
@@ -252,7 +253,7 @@ describe('Office Analytics Effects', () => {
   describe('validationErrorEffect', () => {
     it('should call logError with pass', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.PASS));
       // ACT
@@ -268,7 +269,7 @@ describe('Office Analytics Effects', () => {
     });
     it('should call logError with fail', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.FAIL));
       // ACT
@@ -319,7 +320,7 @@ describe('Office Analytics Effects', () => {
   describe('completeTest', () => {
     it('should log an event COMPLETE_TEST event when the test is not a rekey', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.PASS));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
@@ -343,7 +344,7 @@ describe('Office Analytics Effects', () => {
     });
     it('should log an event COMPLETE_REKEY_TEST event when the test is a rekey', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new activityCodeActions.SetActivityCode(ActivityCodes.PASS));
       store$.dispatch(new rekeyActions.MarkAsRekey());

--- a/src/pages/pass-finalisation/__tests__/pass-finalisation.analytics.effects.spec.ts
+++ b/src/pages/pass-finalisation/__tests__/pass-finalisation.analytics.effects.spec.ts
@@ -15,6 +15,7 @@ import { PopulateCandidateDetails } from '../../../modules/tests/journal-data/ca
 import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Pass Finalisation Analytics Effects', () => {
 
@@ -49,7 +50,7 @@ describe('Pass Finalisation Analytics Effects', () => {
   describe('passFinalisationViewDidEnter', () => {
     it('should call setCurrentPage and addCustomDimension', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       // ACT
       actions$.next(new passFinalisationActions.PassFinalisationViewDidEnter());

--- a/src/pages/post-debrief-holding/__tests__/post-debrief-holding.analytics.spec.ts
+++ b/src/pages/post-debrief-holding/__tests__/post-debrief-holding.analytics.spec.ts
@@ -15,6 +15,7 @@ import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock'
 import { PostDebriefHoldingAnalyticsEffects } from '../post-debrief-holding.analytics.effects';
 import * as postDebriefHoldingActions from '../post-debrief-holding.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Post Debrief Holding Analytics Effects', () => {
 
@@ -48,7 +49,7 @@ describe('Post Debrief Holding Analytics Effects', () => {
   describe('backToOfficeViewDidEnter', () => {
     it('should call setCurrentPage', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       // ACT
       actions$.next(new postDebriefHoldingActions.PostDebriefHoldingViewDidEnter());

--- a/src/pages/rekey-reason/__tests__/rekey-reason.analytics.effects.spec.ts
+++ b/src/pages/rekey-reason/__tests__/rekey-reason.analytics.effects.spec.ts
@@ -15,6 +15,7 @@ import { StoreModel } from '../../../shared/models/store.model';
 import * as testsActions from '../../../modules/tests/tests.actions';
 import * as candidateActions from '../../../modules/tests/journal-data/candidate/candidate.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Rekey Reason Analytics Effects', () => {
 
@@ -47,7 +48,7 @@ describe('Rekey Reason Analytics Effects', () => {
   describe('rekeyReasonViewDidEnter', () => {
     it('should call setCurrentPage', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new candidateActions.PopulateCandidateDetails(candidateMock));
       // ACT
       actions$.next(new rekeyReasonActions.RekeyReasonViewDidEnter());

--- a/src/pages/rekey-reason/__tests__/rekey-reason.effects.spec.ts
+++ b/src/pages/rekey-reason/__tests__/rekey-reason.effects.spec.ts
@@ -15,6 +15,7 @@ import { SetExaminerBooked } from '../../../modules/tests/examiner-booked/examin
 import { SetExaminerConducted } from '../../../modules/tests/examiner-conducted/examiner-conducted.actions';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { defer } from 'rxjs/observable/defer';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Rekey Reason Effects', () => {
   let effects: RekeyReasonEffects;
@@ -48,7 +49,7 @@ describe('Rekey Reason Effects', () => {
     describe('not a transfer', () => {
       it('should send the current test and not call the find user provider', (done) => {
         // ARRANGE
-        store$.dispatch(new testActions.StartTest(12345));
+        store$.dispatch(new testActions.StartTest(12345, TestCategory.B));
         store$.dispatch(new SetExaminerBooked(333));
         store$.dispatch(new SetExaminerConducted(333));
         spyOn(findUserProvider, 'userExists');
@@ -65,7 +66,7 @@ describe('Rekey Reason Effects', () => {
     describe('transfer', () => {
       it('should send the current test when the staff number is valid', (done) => {
         // ARRANGE
-        store$.dispatch(new testActions.StartTest(12345));
+        store$.dispatch(new testActions.StartTest(12345, TestCategory.B));
         store$.dispatch(new SetExaminerBooked(333));
         store$.dispatch(new SetExaminerConducted(789));
         spyOn(findUserProvider, 'userExists').and.returnValue(asyncSuccess(new HttpResponse({
@@ -83,7 +84,7 @@ describe('Rekey Reason Effects', () => {
       });
       it('should return a failure action with a true payload when the staff number is not valid', (done) => {
         // ARRANGE
-        store$.dispatch(new testActions.StartTest(12345));
+        store$.dispatch(new testActions.StartTest(12345, TestCategory.B));
         store$.dispatch(new SetExaminerBooked(333));
         store$.dispatch(new SetExaminerConducted(57463524));
         spyOn(findUserProvider, 'userExists').and.returnValue(asyncError(new HttpErrorResponse({
@@ -107,7 +108,7 @@ describe('Rekey Reason Effects', () => {
           status: 401,
           statusText: 'OK',
         })));
-        store$.dispatch(new testActions.StartTest(12345));
+        store$.dispatch(new testActions.StartTest(12345, TestCategory.B));
         store$.dispatch(new SetExaminerBooked(333));
         store$.dispatch(new SetExaminerConducted(789));
         // ACT

--- a/src/pages/rekey-upload-outcome/__tests__/rekey-upload-outcome.analytics.effects.spec.ts
+++ b/src/pages/rekey-upload-outcome/__tests__/rekey-upload-outcome.analytics.effects.spec.ts
@@ -15,6 +15,7 @@ import * as testsActions from '../../../modules/tests/tests.actions';
 import { testsReducer } from '../../../modules/tests/tests.reducer';
 import { PopulateCandidateDetails } from '../../../modules/tests/journal-data/candidate/candidate.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Rekey Uploaded Analytics Effects', () => {
 
@@ -47,7 +48,7 @@ describe('Rekey Uploaded Analytics Effects', () => {
   describe('rekeyUploadedViewDidEnter', () => {
     it('should call setCurrentPage', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       // ACT
       actions$.next(new rekeyUploadedActions.RekeyUploadOutcomeViewDidEnter());

--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -38,6 +38,7 @@ import {
 import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
 import { legalRequirementsLabels, legalRequirementToggleValues }
   from '../../../shared/constants/legal-requirements/catb-legal-requirements';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Test Report Analytics Effects', () => {
 
@@ -69,7 +70,7 @@ describe('Test Report Analytics Effects', () => {
   describe('testReportViewDidEnter', () => {
     it('should call setCurrentPage and addCustomDimension', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new testReportActions.TestReportViewDidEnter());
       // ASSERT
@@ -85,7 +86,7 @@ describe('Test Report Analytics Effects', () => {
   describe('toggleRemoveFaultMode', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new testReportActions.ToggleRemoveFaultMode());
       // ASSERT
@@ -120,7 +121,7 @@ describe('Test Report Analytics Effects', () => {
   describe('toggleSeriousFaultMode', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new testReportActions.ToggleSeriousFaultMode());
       // ASSERT
@@ -155,7 +156,7 @@ describe('Test Report Analytics Effects', () => {
   describe('toggleDangerousFaultMode', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new testReportActions.ToggleDangerousFaultMode());
       // ASSERT
@@ -190,7 +191,7 @@ describe('Test Report Analytics Effects', () => {
   describe('addDrivingFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new drivingFaultsActions.AddDrivingFault({
         competency: Competencies.controlsGears,
@@ -235,7 +236,7 @@ describe('Test Report Analytics Effects', () => {
   describe('addSeriousFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new seriousFaultsActions.AddSeriousFault(Competencies.controlsGears));
       // ASSERT
@@ -274,7 +275,7 @@ describe('Test Report Analytics Effects', () => {
   describe('addDangerousFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new dangerousFaultsActions.AddDangerousFault(Competencies.controlsGears));
       // ASSERT
@@ -313,7 +314,7 @@ describe('Test Report Analytics Effects', () => {
   describe('addManoeuvreDrivingFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new manoeuvresActions.AddManoeuvreDrivingFault({
         manoeuvre: ManoeuvreTypes.reverseRight,
@@ -360,7 +361,7 @@ describe('Test Report Analytics Effects', () => {
   describe('addManoeuvreSeriousFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new manoeuvresActions.AddManoeuvreSeriousFault({
         manoeuvre: ManoeuvreTypes.reverseRight,
@@ -407,7 +408,7 @@ describe('Test Report Analytics Effects', () => {
   describe('addManoeuvreDangerousFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new manoeuvresActions.AddManoeuvreDangerousFault({
         manoeuvre: ManoeuvreTypes.reverseRight,
@@ -454,7 +455,7 @@ describe('Test Report Analytics Effects', () => {
   describe('controlledStopAddDrivingFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new controlledStopActions.ControlledStopAddDrivingFault());
       // ASSERT
@@ -493,7 +494,7 @@ describe('Test Report Analytics Effects', () => {
   describe('controlledStopAddSeriousFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new controlledStopActions.ControlledStopAddSeriousFault());
       // ASSERT
@@ -532,7 +533,7 @@ describe('Test Report Analytics Effects', () => {
   describe('controlledStopAddDangerousFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new controlledStopActions.ControlledStopAddDangerousFault());
       // ASSERT
@@ -571,7 +572,7 @@ describe('Test Report Analytics Effects', () => {
   describe('showMeQuestionDrivingFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new vehicleChecksActions.ShowMeQuestionDrivingFault());
       // ASSERT
@@ -610,7 +611,7 @@ describe('Test Report Analytics Effects', () => {
   describe('showMeQuestionSeriousFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new vehicleChecksActions.ShowMeQuestionSeriousFault());
       // ASSERT
@@ -649,7 +650,7 @@ describe('Test Report Analytics Effects', () => {
   describe('showMeQuestionDangerousFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new vehicleChecksActions.ShowMeQuestionDangerousFault());
       // ASSERT
@@ -688,7 +689,7 @@ describe('Test Report Analytics Effects', () => {
   describe('removeDrivingFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new drivingFaultsActions.RemoveDrivingFault({
         competency: Competencies.controlsGears,
@@ -733,7 +734,7 @@ describe('Test Report Analytics Effects', () => {
   describe('removeSeriousFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new seriousFaultsActions.RemoveSeriousFault(Competencies.controlsGears));
       // ASSERT
@@ -772,7 +773,7 @@ describe('Test Report Analytics Effects', () => {
   describe('removeDangerousFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new dangerousFaultsActions.RemoveDangerousFault(Competencies.controlsGears));
       // ASSERT
@@ -811,7 +812,7 @@ describe('Test Report Analytics Effects', () => {
   describe('removeManoeuvreDrivingFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new manoeuvresActions.RemoveManoeuvreFault({
         manoeuvre: ManoeuvreTypes.reverseRight,
@@ -856,7 +857,7 @@ describe('Test Report Analytics Effects', () => {
   describe('controlledStopRemoveFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new controlledStopActions.ControlledStopRemoveFault());
       // ASSERT
@@ -893,7 +894,7 @@ describe('Test Report Analytics Effects', () => {
   describe('showMeQuestionRemoveFault', () => {
     it('should call logEvent for this competency', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new vehicleChecksActions.ShowMeQuestionRemoveFault());
       // ASSERT
@@ -930,7 +931,7 @@ describe('Test Report Analytics Effects', () => {
   describe('testTermination', () => {
     it('should call logEvent for termination event', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new testReportActions.TerminateTestFromTestReport());
       // ASSERT
@@ -967,7 +968,7 @@ describe('Test Report Analytics Effects', () => {
   describe('toggleLegalRequirement', () => {
     it('should call logEvent for normal start completed', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       store$.dispatch(new testRequirementsActions.ToggleLegalRequirement(LegalRequirements.normalStart1));
       // ACT
       actions$.next(new testRequirementsActions.ToggleLegalRequirement(LegalRequirements.normalStart1));
@@ -985,7 +986,7 @@ describe('Test Report Analytics Effects', () => {
     });
     it('should call logEvent for normal start uncompleted', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       store$.dispatch(new testRequirementsActions.ToggleLegalRequirement(LegalRequirements.normalStart1));
       store$.dispatch(new testRequirementsActions.ToggleLegalRequirement(LegalRequirements.normalStart1));
       // ACT
@@ -1004,7 +1005,7 @@ describe('Test Report Analytics Effects', () => {
     });
     it('should call logEvent for eco completed', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       store$.dispatch(new ecoActions.ToggleEco());
       // ACT
       actions$.next(new ecoActions.ToggleEco());
@@ -1022,7 +1023,7 @@ describe('Test Report Analytics Effects', () => {
     });
     it('should call logEvent for eco uncompleted', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       store$.dispatch(new ecoActions.ToggleEco());
       store$.dispatch(new ecoActions.ToggleEco());
       // ACT
@@ -1041,7 +1042,7 @@ describe('Test Report Analytics Effects', () => {
     });
     it('should call logEvent for selected manoeuvre', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
       actions$.next(new manoeuvresActions.RecordManoeuvresSelection(ManoeuvreTypes.reverseParkRoad));
       // ASSERT
@@ -1096,7 +1097,7 @@ describe('Test Report Analytics Effects', () => {
 
     it('should call logEvent for show me / tell me completed', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       const showMeQuestionPassedAction = new vehicleChecksActions.ShowMeQuestionPassed();
       store$.dispatch(showMeQuestionPassedAction);
       // ACT
@@ -1116,7 +1117,7 @@ describe('Test Report Analytics Effects', () => {
 
     it('should call logEvent for show me / tell me uncompleted', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       store$.dispatch(new vehicleChecksActions.ShowMeQuestionPassed());
       const showMeQuestionRemoveFaultAction = new vehicleChecksActions.ShowMeQuestionRemoveFault();
       store$.dispatch(showMeQuestionRemoveFaultAction);

--- a/src/pages/test-report/__tests__/test-report.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.effects.spec.ts
@@ -28,6 +28,7 @@ import {
   ManoeuvreCompetencies,
   ManoeuvreTypes,
 } from '../../../modules/tests/test-data/test-data.constants';
+import { TestCategory } from '../../../shared/models/test-category';
 
 export class TestActions extends Actions {
   constructor() {
@@ -72,7 +73,7 @@ describe('Test Report Effects', () => {
   describe('validateCatBLegalRequirements', () => {
 
     beforeEach(() => {
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
     });
 
     it('should dispatch a success action when the effect is triggered and test is valid', (done) => {
@@ -104,7 +105,7 @@ describe('Test Report Effects', () => {
 
   describe('validateCatBTestEta', () => {
     beforeEach(() => {
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
     });
 
     it('should dispatch a success action when the effect is triggered and the eta is valid', (done) => {
@@ -303,7 +304,7 @@ describe('Test Report Effects', () => {
   describe('calculateTestResult', () => {
 
     beforeEach(() => {
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
     });
 
     it('should dispatch an action containing the correct result for a test', (done) => {
@@ -323,7 +324,7 @@ describe('Test Report Effects', () => {
   describe('persistTestReport', () => {
 
     beforeEach(() => {
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
     });
 
     it('should dispatch an action requesting the test data to be saved when triggered', (done) => {
@@ -345,7 +346,7 @@ describe('Test Report Effects', () => {
 
   describe('terminateTestReport', () => {
     beforeEach(() => {
-      store$.dispatch(new testsActions.StartTest(123456));
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
     });
 
     it('should dispatch an action terminating the test', (done) => {

--- a/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
+++ b/src/pages/test-report/components/controlled-stop/__tests__/controlled-stop.spec.ts
@@ -21,6 +21,7 @@ import {
   ControlledStopRemoveFault,
 } from '../../../../../modules/tests/test-data/controlled-stop/controlled-stop.actions';
 import { CompetencyOutcome } from '../../../../../shared/models/competency-outcome';
+import { TestCategory } from '../../../../../shared/models/test-category';
 
 describe('ControlledStopComponent', () => {
   let fixture: ComponentFixture<ControlledStopComponent>;
@@ -47,7 +48,7 @@ describe('ControlledStopComponent', () => {
         fixture = TestBed.createComponent(ControlledStopComponent);
         component = fixture.componentInstance;
         store$ = TestBed.get(Store);
-        store$.dispatch(new StartTest(105));
+        store$.dispatch(new StartTest(105, TestCategory.B));
       });
   }));
 

--- a/src/pages/test-report/components/driving-fault-summary/__tests__/driving-fault-summary.spec.ts
+++ b/src/pages/test-report/components/driving-fault-summary/__tests__/driving-fault-summary.spec.ts
@@ -11,6 +11,7 @@ import { testsReducer } from '../../../../../modules/tests/tests.reducer';
 import { StartTest } from '../../../../../modules/tests/tests.actions';
 import { AddDrivingFault } from '../../../../../modules/tests/test-data/driving-faults/driving-faults.actions';
 import { Competencies } from '../../../../../modules/tests/test-data/test-data.constants';
+import { TestCategory } from '../../../../../shared/models/test-category';
 
 describe('DrivingFaultSummary', () => {
   let fixture: ComponentFixture<DrivingFaultSummaryComponent>;
@@ -45,7 +46,7 @@ describe('DrivingFaultSummary', () => {
     beforeEach(() => {
       componentEl = fixture.debugElement;
 
-      store$.dispatch(new StartTest(103));
+      store$.dispatch(new StartTest(103, TestCategory.B));
     });
 
     it('should display 0 driving faults for a new test', () => {

--- a/src/pages/test-report/components/eco/__tests__/eco.spec.ts
+++ b/src/pages/test-report/components/eco/__tests__/eco.spec.ts
@@ -15,6 +15,7 @@ import {
   ToggleControlEco,
 }
 from '../../../../../modules/tests/test-data/eco/eco.actions';
+import { TestCategory } from '../../../../../shared/models/test-category';
 
 describe('Eco component', () => {
   let fixture: ComponentFixture<EcoComponent>;
@@ -39,7 +40,7 @@ describe('Eco component', () => {
         fixture = TestBed.createComponent(EcoComponent);
         component = fixture.componentInstance;
         store$ = TestBed.get(Store);
-        store$.dispatch(new StartTest(105));
+        store$.dispatch(new StartTest(105, TestCategory.B));
         storeDispatchSpy = spyOn(store$, 'dispatch');
       });
   }));

--- a/src/pages/test-report/components/vehicle-check/__tests__/vehicle-check.spec.ts
+++ b/src/pages/test-report/components/vehicle-check/__tests__/vehicle-check.spec.ts
@@ -27,6 +27,7 @@ import {
   ShowMeQuestionRemoveFault,
 } from '../../../../../modules/tests/test-data/vehicle-checks/vehicle-checks.actions';
 import { CompetencyOutcome } from '../../../../../shared/models/competency-outcome';
+import { TestCategory } from '../../../../../shared/models/test-category';
 
 describe('VehicleCheckComponent', () => {
 
@@ -54,7 +55,7 @@ describe('VehicleCheckComponent', () => {
         fixture = TestBed.createComponent(VehicleCheckComponent);
         component = fixture.componentInstance;
         store$ = TestBed.get(Store);
-        store$.dispatch(new StartTest(105));
+        store$.dispatch(new StartTest(105, TestCategory.B));
       });
   }));
 

--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
@@ -23,6 +23,7 @@ import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock'
 import * as applicationReferenceActions
   from '../../../modules/tests/journal-data/application-reference/application-reference.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Waiting Room To Car Analytics Effects', () => {
 
@@ -62,7 +63,7 @@ describe('Waiting Room To Car Analytics Effects', () => {
   describe('waitingRoomToCarViewDidEnter', () => {
     it('should call setCurrentPage and addCustomDimension', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
       // ACT
@@ -104,7 +105,7 @@ describe('Waiting Room To Car Analytics Effects', () => {
   describe('waitingRoomToCarError', () => {
     it('should call logError', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       // ACT
       actions$.next(new waitingRoomToCarActions.WaitingRoomToCarError('error 123'));
@@ -139,7 +140,7 @@ describe('Waiting Room To Car Analytics Effects', () => {
   describe('waitingRoomToCarValidationError', () => {
     it('should call logError', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       // ACT
       actions$.next(new waitingRoomToCarActions.WaitingRoomToCarValidationError('formControl1'));

--- a/src/pages/waiting-room/__tests__/waiting-room.analytics.effects.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.analytics.effects.spec.ts
@@ -23,6 +23,7 @@ import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock'
 import * as applicationReferenceActions
   from '../../../modules/tests/journal-data/application-reference/application-reference.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
+import { TestCategory } from '../../../shared/models/test-category';
 
 describe('Waiting Room Analytics Effects', () => {
 
@@ -61,7 +62,7 @@ describe('Waiting Room Analytics Effects', () => {
   describe('waitingRoomViewDidEnter', () => {
     it('should call setCurrentPage and addCustomDimension', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
       // ACT
@@ -103,7 +104,7 @@ describe('Waiting Room Analytics Effects', () => {
   describe('submitWaitingRoomInfoError', () => {
     it('should call logError', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       // ACT
       actions$.next(new waitingRoomActions.SubmitWaitingRoomInfoError('error 123'));
@@ -137,7 +138,7 @@ describe('Waiting Room Analytics Effects', () => {
   describe('submitWaitingRoomInfoErrorValidation', () => {
     it('should call logError', (done) => {
       // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123));
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       // ACT
       actions$.next(new waitingRoomActions.WaitingRoomValidationError('formControl1'));

--- a/src/shared/helpers/__tests__/format-analytics-text.spec.ts
+++ b/src/shared/helpers/__tests__/format-analytics-text.spec.ts
@@ -5,6 +5,7 @@ import { testsReducer } from '../../../modules/tests/tests.reducer';
 import { testReportPracticeSlotId, end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
 import { formatAnalyticsText } from '../format-analytics-text';
 import { AnalyticsEventCategories } from '../../../providers/analytics/analytics.model';
+import { TestCategory } from '../../models/test-category';
 
 describe('formatAnalyticsText', () => {
   const initialState = {
@@ -37,7 +38,7 @@ describe('formatAnalyticsText', () => {
 
   it('should prefix rekey tests with the correct text', () => {
     const state = { ...initialState };
-    const action = new testsActions.StartTest(12345);
+    const action = new testsActions.StartTest(12345, TestCategory.B);
     const tests: TestsModel = testsReducer(state, action);
     tests.startedTests[tests.currentTest.slotId].rekey = true;
 
@@ -48,7 +49,7 @@ describe('formatAnalyticsText', () => {
 
   it('should not prefix regular tests with any additional text', () => {
     const state = { ...initialState };
-    const action = new testsActions.StartTest(slotId);
+    const action = new testsActions.StartTest(slotId, TestCategory.B);
     const tests: TestsModel = testsReducer(state, action);
 
     const result = formatAnalyticsText(eventString, tests);


### PR DESCRIPTION
## Description

- Adding `category` to Start and Activate test actions
- Also adding `category` to start practice tests actions
- Making so that the application works after the change
- Fixing all the unit tests

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
