### PR TITLE
mes-3805: correcting spelling from license to licence

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -98,7 +98,7 @@
     "certificateReceived": "I have received the pass certificate number",
     "certificateReceivedValidation": "Confirm that you have received the pass certificate number",
     "declarationIntent": "I declare that",
-    "healthDeclaration": "There has been no change in my health status since I last applied for a license.",
+    "healthDeclaration": "There has been no change in my health status since I last applied for a licence.",
     "healthDeclarationValidation": "Confirm that there has been no change in your health status",
     "signaturePrompt": "Sign here",
     "signatureRetry": "Retry",

--- a/src/pages/health-declaration/health-declaration.ts
+++ b/src/pages/health-declaration/health-declaration.ts
@@ -235,7 +235,7 @@ export class HealthDeclarationPage extends PracticeableBasePageComponent {
     const shortMessage = 'Remind the candidate to contact DVLA';
     const extendedMessage =
       // tslint:disable-next-line:max-line-length
-      `You need to give the provisional license back to the candidate.<br/>The field 'Driver license received' will be automatically changed to 'no'.<br/>${shortMessage}`;
+      `You need to give the provisional licence back to the candidate.<br/>The field 'Driver licence received' will be automatically changed to 'no'.<br/>${shortMessage}`;
     const alert = this.alertController.create({
       title: 'The candidate has not confirmed the health declaration',
       message: this.licenseProvided ? extendedMessage : shortMessage,


### PR DESCRIPTION
## Description
- Correcting typo on `Health Declaration` and `Candidate` page (license => licence)
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

<img width="497" alt="Screenshot 2019-10-22 at 11 58 48" src="https://user-images.githubusercontent.com/30832405/67281607-b131a200-f4c7-11e9-824d-b2f858a32840.png">
<img width="497" alt="Screenshot 2019-10-22 at 11 59 00" src="https://user-images.githubusercontent.com/30832405/67281617-b55dbf80-f4c7-11e9-98df-cf3d094dfc87.png">

