### PR TITLE
MES-2293 - Added Start Tests Analytics

### DIFF
--- a/src/modules/tests/__tests__/tests.analytics.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.analytics.effects.spec.ts
@@ -60,7 +60,6 @@ describe('Tests Analytics Effects', () => {
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     navigationStateProviderMock = TestBed.get(NavigationStateProvider);
     store$ = TestBed.get(Store);
-    spyOn(navigationStateProviderMock, 'isRekeySearch').and.returnValue(true);
   });
 
   describe('setTestStatusSubmittedEffect', () => {
@@ -160,12 +159,38 @@ describe('Tests Analytics Effects', () => {
     });
   });
   describe('startTestAnalyticsEffect', () => {
-    it('should log an event', (done) => {
+    it('should log the correct event if it triggered from the journal page', (done) => {
+      // ARRANGE
+      spyOn(navigationStateProviderMock, 'isRekeySearch').and.returnValue(false);
+      // ACT
+      actions$.next(new testsActions.StartTest(12345, TestCategory.BE));
+      // ASSERT
+      effects.startTestAnalyticsEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension).toHaveBeenCalledWith(
+          AnalyticsDimensionIndices.TEST_CATEGORY,
+          TestCategory.BE,
+        );
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.JOURNAL,
+            AnalyticsEvents.START_TEST,
+          );
+        done();
+      });
+    });
+    it('should log the correct event if it is triggered from the Rekey Search page', (done) => {
+      // ARRANGE
+      spyOn(navigationStateProviderMock, 'isRekeySearch').and.returnValue(true);
       // ACT
       actions$.next(new testsActions.StartTest(12345, TestCategory.B));
       // ASSERT
       effects.startTestAnalyticsEffect$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension).toHaveBeenCalledWith(
+          AnalyticsDimensionIndices.TEST_CATEGORY,
+          TestCategory.B,
+        );
         expect(analyticsProviderMock.logEvent)
           .toHaveBeenCalledWith(
             AnalyticsEventCategories.REKEY_SEARCH,

--- a/src/modules/tests/tests.analytics.effects.ts
+++ b/src/modules/tests/tests.analytics.effects.ts
@@ -125,12 +125,17 @@ export class TestsAnalyticsEffects {
   startTestAnalyticsEffect$ = this.actions$.pipe(
     ofType(START_TEST),
     switchMap((action: StartTest) => {
-      if (this.navigationStateProvider.isRekeySearch()) {
-        this.analytics.logEvent(
-          AnalyticsEventCategories.REKEY_SEARCH,
-          AnalyticsEvents.START_TEST,
-        );
-      }
+
+      const category: AnalyticsEventCategories = this.navigationStateProvider.isRekeySearch() ?
+        AnalyticsEventCategories.REKEY_SEARCH :
+        AnalyticsEventCategories.JOURNAL;
+
+      this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_CATEGORY, action.category);
+      this.analytics.logEvent(
+        category,
+        AnalyticsEvents.START_TEST,
+      );
+
       return of(new AnalyticRecorded());
     }),
   );

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -103,7 +103,7 @@ export enum AnalyticsDimensionIndices {
   CANDIDATE_WITH_CHECK = 4,
   CANDIDATE_ID = 5,
   APPLICATION_REFERENCE = 6,
-  METHOD = 10,
+  TEST_CATEGORY = 7,
   USER_ID = 11,
 }
 


### PR DESCRIPTION
## Description
- Fixes bug MES-3700 where the start test event wasn't firing on the journal
- Start test event now sets a category custom dimension based on the category in the action
- Removed unused custom dimension 

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
