### PR TITLE
MES-2651 - Waiting Room Page Analytics Cat B+E

### DIFF
--- a/src/pages/waiting-room/__tests__/waiting-room.analytics.effects.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.analytics.effects.spec.ts
@@ -24,6 +24,7 @@ import * as applicationReferenceActions
   from '../../../modules/tests/journal-data/application-reference/application-reference.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
+import { PopulateTestCategory } from '../../../modules/tests/category/category.actions';
 
 describe('Waiting Room Analytics Effects', () => {
 
@@ -65,11 +66,14 @@ describe('Waiting Room Analytics Effects', () => {
       store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
+      store$.dispatch(new PopulateTestCategory(TestCategory.B));
       // ACT
       actions$.next(new waitingRoomActions.WaitingRoomViewDidEnter());
       // ASSERT
       effects.waitingRoomViewDidEnter$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+        .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_CATEGORY, 'B');
         expect(analyticsProviderMock.addCustomDimension)
           .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1');
         expect(analyticsProviderMock.addCustomDimension)
@@ -84,11 +88,14 @@ describe('Waiting Room Analytics Effects', () => {
       store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
       store$.dispatch(new applicationReferenceActions.PopulateApplicationReference(mockApplication));
+      store$.dispatch(new PopulateTestCategory(TestCategory.B));
       // ACT
       actions$.next(new waitingRoomActions.WaitingRoomViewDidEnter());
       // ASSERT
       effects.waitingRoomViewDidEnter$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+        .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_CATEGORY, 'B');
         expect(analyticsProviderMock.addCustomDimension)
           .toHaveBeenCalledWith(AnalyticsDimensionIndices.CANDIDATE_ID, '1');
         expect(analyticsProviderMock.addCustomDimension)
@@ -106,11 +113,14 @@ describe('Waiting Room Analytics Effects', () => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      store$.dispatch(new PopulateTestCategory(TestCategory.B));
       // ACT
       actions$.next(new waitingRoomActions.SubmitWaitingRoomInfoError('error 123'));
       // ASSERT
       effects.submitWaitingRoomInfoError$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+        .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_CATEGORY, 'B');
         expect(analyticsProviderMock.logError)
           .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${screenName})`,
           'error 123');
@@ -121,11 +131,14 @@ describe('Waiting Room Analytics Effects', () => {
       // ARRANGE
       store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      store$.dispatch(new PopulateTestCategory(TestCategory.B));
       // ACT
       actions$.next(new waitingRoomActions.SubmitWaitingRoomInfoError('error 123'));
       // ASSERT
       effects.submitWaitingRoomInfoError$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+        .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_CATEGORY, 'B');
         expect(analyticsProviderMock.logError)
           .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${screenNamePracticeMode})`,
           'error 123');
@@ -140,11 +153,14 @@ describe('Waiting Room Analytics Effects', () => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      store$.dispatch(new PopulateTestCategory(TestCategory.B));
       // ACT
       actions$.next(new waitingRoomActions.WaitingRoomValidationError('formControl1'));
       // ASSERT
       effects.submitWaitingRoomInfoErrorValidation$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+        .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_CATEGORY, 'B');
         expect(analyticsProviderMock.logError)
           .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenName})`,
           'formControl1');
@@ -155,11 +171,14 @@ describe('Waiting Room Analytics Effects', () => {
       // ARRANGE
       store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      store$.dispatch(new PopulateTestCategory(TestCategory.B));
       // ACT
       actions$.next(new waitingRoomActions.WaitingRoomValidationError('formControl1'));
       // ASSERT
       effects.submitWaitingRoomInfoErrorValidation$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.addCustomDimension)
+        .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_CATEGORY, 'B');
         expect(analyticsProviderMock.logError)
           .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenNamePracticeMode})`,
           'formControl1');

--- a/src/pages/waiting-room/__tests__/waiting-room.analytics.effects.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.analytics.effects.spec.ts
@@ -108,47 +108,7 @@ describe('Waiting Room Analytics Effects', () => {
 
   });
 
-  describe('submitWaitingRoomInfoError', () => {
-    it('should call logError', (done) => {
-      // ARRANGE
-      store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
-      store$.dispatch(new PopulateCandidateDetails(candidateMock));
-      store$.dispatch(new PopulateTestCategory(TestCategory.B));
-      // ACT
-      actions$.next(new waitingRoomActions.SubmitWaitingRoomInfoError('error 123'));
-      // ASSERT
-      effects.submitWaitingRoomInfoError$.subscribe((result) => {
-        expect(result instanceof AnalyticRecorded).toBe(true);
-        expect(analyticsProviderMock.addCustomDimension)
-        .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_CATEGORY, 'B');
-        expect(analyticsProviderMock.logError)
-          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${screenName})`,
-          'error 123');
-        done();
-      });
-    });
-    it('should call logError, prefixed with practice mode', (done) => {
-      // ARRANGE
-      store$.dispatch(new fakeJournalActions.StartE2EPracticeTest(end2endPracticeSlotId));
-      store$.dispatch(new PopulateCandidateDetails(candidateMock));
-      store$.dispatch(new PopulateTestCategory(TestCategory.B));
-      // ACT
-      actions$.next(new waitingRoomActions.SubmitWaitingRoomInfoError('error 123'));
-      // ASSERT
-      effects.submitWaitingRoomInfoError$.subscribe((result) => {
-        expect(result instanceof AnalyticRecorded).toBe(true);
-        expect(analyticsProviderMock.addCustomDimension)
-        .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_CATEGORY, 'B');
-        expect(analyticsProviderMock.logError)
-          .toHaveBeenCalledWith(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${screenNamePracticeMode})`,
-          'error 123');
-        done();
-      });
-    });
-
-  });
-
-  describe('submitWaitingRoomInfoErrorValidation', () => {
+  describe('waitingRoomValidationError', () => {
     it('should call logError', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123, TestCategory.B));
@@ -157,7 +117,7 @@ describe('Waiting Room Analytics Effects', () => {
       // ACT
       actions$.next(new waitingRoomActions.WaitingRoomValidationError('formControl1'));
       // ASSERT
-      effects.submitWaitingRoomInfoErrorValidation$.subscribe((result) => {
+      effects.waitingRoomValidationError$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.addCustomDimension)
         .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_CATEGORY, 'B');
@@ -175,7 +135,7 @@ describe('Waiting Room Analytics Effects', () => {
       // ACT
       actions$.next(new waitingRoomActions.WaitingRoomValidationError('formControl1'));
       // ASSERT
-      effects.submitWaitingRoomInfoErrorValidation$.subscribe((result) => {
+      effects.waitingRoomValidationError$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
         expect(analyticsProviderMock.addCustomDimension)
         .toHaveBeenCalledWith(AnalyticsDimensionIndices.TEST_CATEGORY, 'B');

--- a/src/pages/waiting-room/waiting-room.actions.ts
+++ b/src/pages/waiting-room/waiting-room.actions.ts
@@ -1,21 +1,10 @@
 import { Action } from '@ngrx/store';
 
 export const WAITING_ROOM_VIEW_DID_ENTER = '[WaitingRoomPage] Waiting Room Did Enter';
-export const SUBMIT_WAITING_ROOM_INFO = '[WaitingRoomPage] Submit Waiting Room Info';
-export const SUBMIT_WAITING_ROOM_INFO_ERROR = '[WaitingRoomPage] Submit Waiting Room Info Error';
 export const WAITING_ROOM_VALIDATION_ERROR = '[WaitingRoomPage] Waiting Room Validation Error';
 
 export class WaitingRoomViewDidEnter implements Action {
   readonly type = WAITING_ROOM_VIEW_DID_ENTER;
-}
-
-export class SubmitWaitingRoomInfo implements Action {
-  readonly type = SUBMIT_WAITING_ROOM_INFO;
-}
-
-export class SubmitWaitingRoomInfoError implements Action {
-  readonly type = SUBMIT_WAITING_ROOM_INFO_ERROR;
-  constructor(public errorMessage: string) { }
 }
 
 export class WaitingRoomValidationError implements Action {
@@ -25,6 +14,4 @@ export class WaitingRoomValidationError implements Action {
 
 export type Types =
   | WaitingRoomViewDidEnter
-  | SubmitWaitingRoomInfo
-  | SubmitWaitingRoomInfoError
   | WaitingRoomValidationError;

--- a/src/pages/waiting-room/waiting-room.analytics.effects.ts
+++ b/src/pages/waiting-room/waiting-room.analytics.effects.ts
@@ -31,6 +31,7 @@ import {
 import {
   getApplicationNumber,
 } from '../../modules/tests/journal-data/application-reference/application-reference.selector';
+import { getTestCategory } from '../../modules/tests/category/category.reducer';
 
 @Injectable()
 export class WaitingRoomAnalyticsEffects {
@@ -64,12 +65,18 @@ export class WaitingRoomAnalyticsEffects {
           select(getCandidate),
           select(getCandidateId),
           ),
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getTestCategory),
+        ),
       ),
     )),
     switchMap((
-      [action, tests, applicationReference, candidateId]:
-      [WaitingRoomViewDidEnter, TestsModel, string, number],
+      [action, tests, applicationReference, candidateId, category]:
+      [WaitingRoomViewDidEnter, TestsModel, string, number, string],
     ) => {
+      this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_CATEGORY, category);
       this.analytics.addCustomDimension(AnalyticsDimensionIndices.CANDIDATE_ID, `${candidateId}`);
       this.analytics.addCustomDimension(AnalyticsDimensionIndices.APPLICATION_REFERENCE, applicationReference);
       this.analytics.setCurrentPage(
@@ -87,10 +94,16 @@ export class WaitingRoomAnalyticsEffects {
         this.store$.pipe(
           select(getTests),
         ),
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getTestCategory),
+        ),
       ),
     )),
-    switchMap(([action, tests]: [SubmitWaitingRoomInfoError, TestsModel]) => {
+    switchMap(([action, tests, category]: [SubmitWaitingRoomInfoError, TestsModel, string]) => {
       const screenName = formatAnalyticsText(AnalyticsScreenNames.WAITING_ROOM, tests);
+      this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_CATEGORY, category);
       this.analytics.logError(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${screenName})`,
         action.errorMessage);
       return of(new AnalyticRecorded());
@@ -105,10 +118,16 @@ export class WaitingRoomAnalyticsEffects {
         this.store$.pipe(
           select(getTests),
         ),
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getTestCategory),
+        ),
       ),
     )),
-    switchMap(([action, tests]: [WaitingRoomValidationError, TestsModel]) => {
+    switchMap(([action, tests, category]: [WaitingRoomValidationError, TestsModel, string]) => {
       const screenName = formatAnalyticsText(AnalyticsScreenNames.WAITING_ROOM, tests);
+      this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_CATEGORY, category);
       this.analytics.logError(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${screenName})`,
         action.errorMessage);
       return of(new AnalyticRecorded());

--- a/src/pages/waiting-room/waiting-room.analytics.effects.ts
+++ b/src/pages/waiting-room/waiting-room.analytics.effects.ts
@@ -11,8 +11,6 @@ import {
 import {
   WAITING_ROOM_VIEW_DID_ENTER,
   WaitingRoomViewDidEnter,
-  SUBMIT_WAITING_ROOM_INFO_ERROR,
-  SubmitWaitingRoomInfoError,
   WAITING_ROOM_VALIDATION_ERROR,
   WaitingRoomValidationError,
 } from '../../pages/waiting-room/waiting-room.actions';
@@ -87,31 +85,7 @@ export class WaitingRoomAnalyticsEffects {
   );
 
   @Effect()
-  submitWaitingRoomInfoError$ = this.actions$.pipe(
-    ofType(SUBMIT_WAITING_ROOM_INFO_ERROR),
-    concatMap(action => of(action).pipe(
-      withLatestFrom(
-        this.store$.pipe(
-          select(getTests),
-        ),
-        this.store$.pipe(
-          select(getTests),
-          select(getCurrentTest),
-          select(getTestCategory),
-        ),
-      ),
-    )),
-    switchMap(([action, tests, category]: [SubmitWaitingRoomInfoError, TestsModel, string]) => {
-      const screenName = formatAnalyticsText(AnalyticsScreenNames.WAITING_ROOM, tests);
-      this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_CATEGORY, category);
-      this.analytics.logError(`${AnalyticsErrorTypes.SUBMIT_FORM_ERROR} (${screenName})`,
-        action.errorMessage);
-      return of(new AnalyticRecorded());
-    }),
-  );
-
-  @Effect()
-  submitWaitingRoomInfoErrorValidation$ = this.actions$.pipe(
+  waitingRoomValidationError$ = this.actions$.pipe(
     ofType(WAITING_ROOM_VALIDATION_ERROR),
     concatMap(action => of(action).pipe(
       withLatestFrom(


### PR DESCRIPTION
## Description
- We now set the category custom dimension in the waiting room page analytics events.
- Removed some actions/analytics effects which are not in use in the app

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
