### PR TITLE
use staffNumber from test when authenticated staffNumber is null

### DIFF
--- a/src/environment/test-schema-version.ts
+++ b/src/environment/test-schema-version.ts
@@ -1,1 +1,1 @@
-export const version = '3.2.4';
+export const version = '3.2.5';

--- a/src/modules/tests/tests.effects.ts
+++ b/src/modules/tests/tests.effects.ts
@@ -133,7 +133,7 @@ export class TestsEffects {
     switchMap(([action, journal, rekeySearch]: [testActions.StartTest, JournalModel, RekeySearchModel]) => {
       const startTestAction = action as testActions.StartTest;
       const isRekeySearch = this.navigationStateProvider.isRekeySearch();
-      const employeeId = this.authenticationProvider.getEmployeeId();
+      const employeeId = this.authenticationProvider.getEmployeeId() || journal.examiner.staffNumber;
 
       let slot: TestSlot;
       let examiner: Examiner;


### PR DESCRIPTION
Populate staffNumber from the journal when authenticated staffNumber is null to fix issues of tests stuck at pending.

