### PR TITLE
Feature mes 3959 pass certificate validation improvements

### DIFF
--- a/src/pages/test-finalisation/pass-finalisation/__tests__/pass-finalisation.spec.ts
+++ b/src/pages/test-finalisation/pass-finalisation/__tests__/pass-finalisation.spec.ts
@@ -15,7 +15,7 @@ import { MockComponent } from 'ng-mocks';
 import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { TestFinalisationComponentsModule } from '../../components/test-finalisation.module';
 
-describe('PassFinalisationPage', () => {
+fdescribe('PassFinalisationPage', () => {
   let fixture: ComponentFixture<PassFinalisationPage>;
   let component: PassFinalisationPage;
   let store$: Store<StoreModel>;
@@ -50,7 +50,8 @@ describe('PassFinalisationPage', () => {
     it('should dispatch the PersistTests action', () => {
       const form = component.form;
       form.get('provisionalLicenseProvidedCtrl').setValue(true);
-      form.get('passCertificateNumberCtrl').setValue('A123456*');
+      // note: needs to be a valid pass certificate
+      form.get('passCertificateNumberCtrl').setValue('C867544H');
       form.get('transmissionCtrl').setValue('Manual');
       component.onSubmit();
       expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
@@ -80,4 +81,110 @@ describe('PassFinalisationPage', () => {
       expect(formCtrl.hasError('maxlength')).toBe(false);
     });
   });
+
+  describe('calculateMod37CheckDigit', () => {
+    it('should return invalid if second character is not a digit', () => {
+      const checkDigit = component.calculateMod37CheckDigit('CX23458');
+      expect(checkDigit).toBe('invalid');
+    });
+  });
+  describe('calculateMod37CheckDigit', () => {
+    it('should return invalid if third character is not a digit', () => {
+      const checkDigit = component.calculateMod37CheckDigit('C1X3458');
+      expect(checkDigit).toBe('invalid');
+    });
+  });
+  describe('calculateMod37CheckDigit', () => {
+    it('should return invalid if fourth character is not a digit', () => {
+      const checkDigit = component.calculateMod37CheckDigit('C12X458');
+      expect(checkDigit).toBe('invalid');
+    });
+  });
+  describe('calculateMod37CheckDigit', () => {
+    it('should return invalid if fifth character is not a digit', () => {
+      const checkDigit = component.calculateMod37CheckDigit('C123X58');
+      expect(checkDigit).toBe('invalid');
+    });
+  });
+  describe('calculateMod37CheckDigit', () => {
+    it('should return invalid if sixth character is not a digit', () => {
+      const checkDigit = component.calculateMod37CheckDigit('C1234X8');
+      expect(checkDigit).toBe('invalid');
+    });
+  });
+  describe('calculateMod37CheckDigit', () => {
+    it('should return invalid if seventh character is not a digit', () => {
+      const checkDigit = component.calculateMod37CheckDigit('C12345X');
+      expect(checkDigit).toBe('invalid');
+    });
+  });
+  describe('calculateMod37CheckDigit', () => {
+    it('should return a check digit of N if passed C758920', () => {
+      const checkDigit = component.calculateMod37CheckDigit('C758920');
+      expect(checkDigit).toBe('N');
+    });
+  });
+  describe('calculateMod37CheckDigit', () => {
+    it('should return a check digit of W if passed C839255', () => {
+      const checkDigit = component.calculateMod37CheckDigit('C839255');
+      expect(checkDigit).toBe('W');
+    });
+  });
+
+  describe('isLetter', () => {
+    it('should return true if passed a alpha character', () => {
+      const result = component.isLetter('C');
+      expect(result).toBeTruthy();
+    });
+  });
+  describe('isLetter', () => {
+    it('should return false if passed a numeric character', () => {
+      const result = component.isLetter('9');
+      expect(result).toBeFalsy();
+    });
+  });
+  describe('isLetter', () => {
+    it('should return false if passed a punctuation character', () => {
+      const result = component.isLetter('@');
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe('isPassCertificateValid', () => {
+    it('should return false if passed a short certificate', () => {
+      const result = component.isPassCertificateValid('C123');
+      expect(result).toBeFalsy();
+    });
+  });
+  describe('isPassCertificateValid', () => {
+    it('should return false if passed a certificate starting with a non alphabet character', () => {
+      const result = component.isPassCertificateValid('1123456X');
+      expect(result).toBeFalsy();
+    });
+  });
+  describe('isPassCertificateValid', () => {
+    it('should return false if passed a certificate with a letter in place of a number', () => {
+      const result = component.isPassCertificateValid('C12X456X');
+      expect(result).toBeFalsy();
+    });
+  });
+  describe('isPassCertificateValid', () => {
+    it('should return false if passed a certificate with an incorrect check digit', () => {
+      const result = component.isPassCertificateValid('C839255T');
+      expect(result).toBeFalsy();
+    });
+  });
+  describe('isPassCertificateValid', () => {
+    it('should return true if passed a valid certificate', () => {
+      const result = component.isPassCertificateValid('C839255W');
+      expect(result).toBeTruthy();
+    });
+  });
+  describe('isPassCertificateValid', () => {
+    it('should return true if passed a valid certificate with lowercase letters', () => {
+      const result = component.isPassCertificateValid('c839255w');
+      expect(result).toBeTruthy();
+    });
+  });
+
 });

--- a/src/pages/test-finalisation/pass-finalisation/__tests__/pass-finalisation.spec.ts
+++ b/src/pages/test-finalisation/pass-finalisation/__tests__/pass-finalisation.spec.ts
@@ -15,7 +15,7 @@ import { MockComponent } from 'ng-mocks';
 import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { TestFinalisationComponentsModule } from '../../components/test-finalisation.module';
 
-fdescribe('PassFinalisationPage', () => {
+describe('PassFinalisationPage', () => {
   let fixture: ComponentFixture<PassFinalisationPage>;
   let component: PassFinalisationPage;
   let store$: Store<StoreModel>;

--- a/src/pages/test-finalisation/pass-finalisation/pass-finalisation.ts
+++ b/src/pages/test-finalisation/pass-finalisation/pass-finalisation.ts
@@ -231,7 +231,7 @@ export class PassFinalisationPage extends PracticeableBasePageComponent {
     this.store$.dispatch(new GearboxCategoryChanged(transmission));
   }
 
-  onSubmit() {
+  onSubmit = () => {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
       this.store$.dispatch(new PersistTests());
@@ -239,18 +239,23 @@ export class PassFinalisationPage extends PracticeableBasePageComponent {
     }
   }
 
-  getFormValidation(): { [key: string]: FormControl } {
+  getFormValidation = (): { [key: string]: FormControl } => {
     return {
       provisionalLicenseProvidedCtrl: new FormControl(null, [Validators.required]),
       passCertificateNumberCtrl: new FormControl(null,
         {
-          validators: Validators.compose([Validators.maxLength(8), Validators.minLength(8), Validators.required]),
+          validators: Validators.compose([
+            Validators.maxLength(8),
+            Validators.minLength(8),
+            Validators.required,
+            this.validatePassCertificate.bind(this)]),
           updateOn: 'blur',
         },
       ),
       transmissionCtrl: new FormControl(null, [Validators.required]),
     };
   }
+
   isCtrlDirtyAndInvalid(controlName: string): boolean {
     return !this.form.value[controlName] && this.form.get(controlName).dirty;
   }
@@ -258,6 +263,70 @@ export class PassFinalisationPage extends PracticeableBasePageComponent {
   passCertificateValidation() {
     const ctrlHasErrors = this.form.get(this.passCertificateCtrl).errors ? true : false;
     return ctrlHasErrors && this.form.get(this.passCertificateCtrl).dirty;
+  }
+
+  // Custom validator for FormControls
+  validatePassCertificate(c: FormControl) {
+    return this.isPassCertificateValid(c.value) ? null :
+      {
+        validatePassCertificate: {
+          valid: false,
+        },
+      };
+  }
+
+  isPassCertificateValid(certificate: string | null): boolean {
+    if (!certificate || certificate.length !== 8) {
+      return false;
+    }
+    if (!this.isLetter(certificate[0])) {
+      return false;
+    }
+
+    const checkDigit = this.calculateMod37CheckDigit(certificate);
+
+    if (checkDigit === 'invalid') {
+      return false;
+    }
+
+    // compare entered checkdigit with generated one
+    if (checkDigit !== certificate.toUpperCase()[7]) {
+      return false;
+    }
+
+    return true;
+  }
+
+  isLetter(char: string): boolean {
+    return char.length === 1 && char.match(/[a-z]/i) !== null;
+  }
+
+  calculateMod37CheckDigit(certificate: string): string {
+    const digitMultipliers: number[] = [7, 6, 5, 4, 3, 2];
+    const checkDigits: string[] = Array.from(
+      '%ZYXWVUT/RQP+NMLKJ-HGFEDC&A9876543210');
+
+    const digit1 = parseInt(certificate[1], 10);
+    const digit2 = parseInt(certificate[2], 10);
+    const digit3 = parseInt(certificate[3], 10);
+    const digit4 = parseInt(certificate[4], 10);
+    const digit5 = parseInt(certificate[5], 10);
+    const digit6 = parseInt(certificate[6], 10);
+
+    if (isNaN(digit1) || isNaN(digit2) || isNaN(digit3) ||
+      isNaN(digit4) || isNaN(digit5) || isNaN(digit6)) {
+      return 'invalid';
+    }
+
+    const position: number  = ((digit1 * digitMultipliers[0]) +
+      (digit2 * digitMultipliers[1]) +
+      (digit3 * digitMultipliers[2]) +
+      (digit4 * digitMultipliers[3]) +
+      (digit5 * digitMultipliers[4]) +
+      (digit6 * digitMultipliers[5])) % 37;
+
+    const checkDigit = checkDigits[position];
+    return checkDigit;
   }
 
   /**


### PR DESCRIPTION
Added mod37 validation logic to ensure pass certificate is valid or display an error message if it isn't.

Note: due to tight time constraints I didn't create a provider but put the logic within the pass-finalisation page.  Due to significant differences between hotfix and develop I will refactor into a provider and associated unit tests.