### PR TITLE
Mes 3834 - Refactor fault count selectors into a provider

### DIFF
--- a/src/modules/tests/test-data/__tests__/test-data.selector.spec.ts
+++ b/src/modules/tests/test-data/__tests__/test-data.selector.spec.ts
@@ -9,15 +9,12 @@ import {
   getEcoFaultText,
   getManoeuvres,
   hasManoeuvreBeenCompleted,
-  getDrivingFaultSummaryCount,
   isTellMeQuestionSelected,
   isTellMeQuestionCorrect,
   isTellMeQuestionDrivingFault,
   hasVehicleChecksBeenCompleted,
   getCatBLegalRequirements,
   getShowMeQuestionOptions,
-  getSeriousFaultSummaryCount,
-  getDangerousFaultSummaryCount,
   hasEyesightTestBeenCompleted,
   hasEyesightTestGotSeriousFault,
 } from '../test-data.selector';
@@ -140,76 +137,6 @@ describe('TestDataSelectors', () => {
     });
     it('should return undefined when there hasnt been any driving faults', () => {
       expect(getDrivingFaultCount(state, Competencies.controlsParkingBrake)).toBeUndefined();
-    });
-  });
-
-  describe('getDrivingFaultSummaryCount', () => {
-    it('should return the driving fault count correctly', () => {
-      expect(getDrivingFaultSummaryCount(state)).toBe(3);
-    });
-  });
-
-  describe('getSeriousFaultSummaryCount', () => {
-    it('should return the serious faults count', () => {
-      expect(getSeriousFaultSummaryCount(state)).toBe(1);
-    });
-    it('should return the correct count of serious faults', () => {
-      const failedState: CatBUniqueTypes.TestData = {
-        ...state,
-        manoeuvres: {
-          forwardPark: {
-            selected: true,
-            controlFault: CompetencyOutcome.S,
-          },
-        },
-        controlledStop: {
-          selected: true,
-          fault: CompetencyOutcome.S,
-        },
-        vehicleChecks: {
-          tellMeQuestion: {
-            outcome: CompetencyOutcome.DF,
-          },
-          showMeQuestion: {
-            outcome: CompetencyOutcome.S,
-          },
-        },
-        eyesightTest: {
-          complete: true,
-          seriousFault: true,
-        },
-      };
-      expect(getSeriousFaultSummaryCount(failedState)).toBe(5);
-    });
-  });
-
-  describe('getDangerousFaultSummaryCount', () => {
-    it('should return the dangerous faults count', () => {
-      expect(getDangerousFaultSummaryCount(state)).toBe(1);
-    });
-    it('should return the correct number of dangerous faults', () => {
-      const failedState: CatBUniqueTypes.TestData = {
-        ...state,
-        manoeuvres: {
-          forwardPark: {
-            selected: true,
-            controlFault: CompetencyOutcome.D,
-          },
-        },
-        controlledStop: {
-          selected: true,
-          fault: CompetencyOutcome.D,
-        },
-        vehicleChecks: {
-          tellMeQuestion: {
-            outcome: CompetencyOutcome.DF,
-          },
-          showMeQuestion: {
-            outcome: CompetencyOutcome.D,
-          },
-        },
-      };
-      expect(getDangerousFaultSummaryCount(failedState)).toBe(4);
     });
   });
 

--- a/src/modules/tests/test-data/test-data.selector.ts
+++ b/src/modules/tests/test-data/test-data.selector.ts
@@ -2,7 +2,7 @@
 import { ETA, Eco, TestData } from '@dvsa/mes-test-schema/categories/Common';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { Competencies, LegalRequirements, ExaminerActions } from './test-data.constants';
-import { pickBy, sumBy, endsWith, get } from 'lodash';
+import { get } from 'lodash';
 import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 import { OutcomeBehaviourMapProvider } from '../../../providers/outcome-behaviour-map/outcome-behaviour-map';
 import { CatBLegalRequirements } from './test-data.models';
@@ -12,90 +12,6 @@ import { TestCategory } from '../../../shared/models/test-category';
 
 export const getDrivingFaultCount = (
   data: CatBUniqueTypes.TestData, competency: Competencies) => data.drivingFaults[competency];
-
-export const getDrivingFaultSummaryCount = (data: CatBUniqueTypes.TestData): number => {
-
-  // The way how we store the driving faults differs for certain competencies
-  // Because of this we need to pay extra attention on summing up all of them
-  const { drivingFaults, manoeuvres, controlledStop, vehicleChecks } = data;
-
-  const drivingFaultSumOfSimpleCompetencies =
-    Object.values(drivingFaults).reduce((acc, numberOfFaults) => acc + numberOfFaults, 0);
-
-  const controlledStopHasDrivingFault = (controlledStop && controlledStop.fault === CompetencyOutcome.DF) ? 1 : 0;
-
-  const result =
-    drivingFaultSumOfSimpleCompetencies +
-    sumManoeuvreFaults(manoeuvres, CompetencyOutcome.DF) +
-    sumVehicleCheckFaults(vehicleChecks) +
-    controlledStopHasDrivingFault;
-
-  return result;
-};
-
-export const getSeriousFaultSummaryCount = (data: CatBUniqueTypes.TestData): number => {
-
-  // The way how we store serious faults differs for certain competencies
-  // Because of this we need to pay extra attention on summing up all of them
-  const { seriousFaults, manoeuvres, controlledStop, vehicleChecks, eyesightTest } = data;
-
-  const seriousFaultSumOfSimpleCompetencies = Object.keys(pickBy(seriousFaults)).length;
-  const vehicleCheckSeriousFaults = vehicleChecks.showMeQuestion.outcome === CompetencyOutcome.S ? 1 : 0;
-  const controlledStopSeriousFaults = (controlledStop && controlledStop.fault === CompetencyOutcome.S) ? 1 : 0;
-  const eyesightTestSeriousFaults = (eyesightTest && eyesightTest.seriousFault) ? 1 : 0;
-
-  const result =
-    seriousFaultSumOfSimpleCompetencies +
-    sumManoeuvreFaults(manoeuvres, CompetencyOutcome.S) +
-    vehicleCheckSeriousFaults +
-    controlledStopSeriousFaults +
-    eyesightTestSeriousFaults;
-
-  return result;
-};
-
-export const getDangerousFaultSummaryCount = (data: CatBUniqueTypes.TestData): number => {
-
-  // The way how we store serious faults differs for certain competencies
-  // Because of this we need to pay extra attention on summing up all of them
-  const { dangerousFaults, manoeuvres, controlledStop, vehicleChecks } = data;
-
-  const dangerousFaultSumOfSimpleCompetencies = Object.keys(pickBy(dangerousFaults)).length;
-  const vehicleCheckDangerousFaults = vehicleChecks.showMeQuestion.outcome === CompetencyOutcome.D ? 1 : 0;
-  const controlledStopDangerousFaults = (controlledStop && controlledStop.fault === CompetencyOutcome.D) ? 1 : 0;
-
-  const result =
-    dangerousFaultSumOfSimpleCompetencies +
-    sumManoeuvreFaults(manoeuvres, CompetencyOutcome.D) +
-    vehicleCheckDangerousFaults +
-    controlledStopDangerousFaults;
-
-  return result;
-};
-
-export const sumVehicleCheckFaults = (vehicleChecks: CatBUniqueTypes.VehicleChecks): number => {
-  const { showMeQuestion, tellMeQuestion } = vehicleChecks;
-
-  if (showMeQuestion.outcome === CompetencyOutcome.S || showMeQuestion.outcome === CompetencyOutcome.D) {
-    return 0;
-  }
-
-  if (showMeQuestion.outcome === CompetencyOutcome.DF || tellMeQuestion.outcome === CompetencyOutcome.DF) {
-    return 1;
-  }
-
-  return 0;
-};
-
-export const sumManoeuvreFaults = (manoeuvres: CatBUniqueTypes.Manoeuvres, faultType: CompetencyOutcome): number => {
-  const manoeuvresCollection = Object.values(manoeuvres);
-  return sumBy(manoeuvresCollection, (manoeuvre) => {
-    if (manoeuvre.selected) {
-      const dFkeys = pickBy(manoeuvre, (val, key) => endsWith(key, 'Fault') && val === faultType);
-      return Object.keys(dFkeys).length;
-    }
-  });
-};
 
 export const hasSeriousFault = (
   data: TestData, competency: Competencies) => data.seriousFaults[competency];

--- a/src/modules/tests/tests.module.ts
+++ b/src/modules/tests/tests.module.ts
@@ -10,6 +10,7 @@ import { NavigationProvider } from '../../providers/navigation/navigation';
 import { NavigationStateProvider } from '../../providers/navigation-state/navigation-state';
 import { ExaminerBookedEffects } from './examiner-booked/examiner-booked.effects';
 import { ExaminerConductedEffects } from './examiner-conducted/examiner-conducted.effects';
+import { FaultCountProvider } from '../../providers/fault-count/fault-count';
 
 @NgModule({
   imports: [
@@ -24,6 +25,7 @@ import { ExaminerConductedEffects } from './examiner-conducted/examiner-conducte
   ],
   providers:[
     TestSubmissionProvider,
+    FaultCountProvider,
     NavigationProvider,
     NavigationStateProvider,
   ],

--- a/src/pages/debrief/cat-b/debrief.cat-b.page.ts
+++ b/src/pages/debrief/cat-b/debrief.cat-b.page.ts
@@ -11,7 +11,6 @@ import { getTestData } from '../../../modules/tests/test-data/test-data.reducer'
 import {
   getETA,
   getEco,
-  getDrivingFaultSummaryCount,
 } from '../../../modules/tests/test-data/test-data.selector';
 import { map, tap } from 'rxjs/operators';
 import { Component } from '@angular/core';
@@ -46,6 +45,7 @@ import { getConductedLanguage } from
 import { CAT_B, DASHBOARD_PAGE } from '../../page-names.constants';
 import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
 import { configureI18N } from '../../../shared/helpers/translation.helpers';
+import { FaultCountProvider } from '../../../providers/fault-count/fault-count';
 
 interface DebriefPageState {
   seriousFaults$: Observable<string[]>;
@@ -88,6 +88,7 @@ export class DebriefCatBPage extends PracticeableBasePageComponent {
     public screenOrientation: ScreenOrientation,
     public insomnia: Insomnia,
     private translate: TranslateService,
+    private faultCountProvider: FaultCountProvider,
   ) {
     super(platform, navController, authenticationProvider, store$);
   }
@@ -154,7 +155,7 @@ export class DebriefCatBPage extends PracticeableBasePageComponent {
       ),
       drivingFaultCount$: currentTest$.pipe(
         select(getTestData),
-        select(getDrivingFaultSummaryCount),
+        select(this.faultCountProvider.getDrivingFaultSummaryCount),
       ),
       etaFaults$: currentTest$.pipe(
         select(getTestData),

--- a/src/pages/debrief/cat-be/debrief.cat-be.page.ts
+++ b/src/pages/debrief/cat-be/debrief.cat-be.page.ts
@@ -10,7 +10,6 @@ import { getTestData } from '../../../modules/tests/test-data/test-data.reducer'
 import {
   getETA,
   getEco,
-  getDrivingFaultSummaryCount,
 } from '../../../modules/tests/test-data/test-data.selector';
 import { map, tap } from 'rxjs/operators';
 import { Component } from '@angular/core';
@@ -46,6 +45,7 @@ import { CAT_B } from '../../page-names.constants';
 import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
 import { configureI18N } from '../../../shared/helpers/translation.helpers';
 import { BasePageComponent } from '../../../shared/classes/base-page';
+import { FaultCountProvider } from '../../../providers/fault-count/fault-count';
 
 interface DebriefPageState {
   seriousFaults$: Observable<string[]>;
@@ -88,6 +88,7 @@ export class DebriefCatBEPage extends BasePageComponent {
     public screenOrientation: ScreenOrientation,
     public insomnia: Insomnia,
     private translate: TranslateService,
+    private faultCountProvider: FaultCountProvider,
   ) {
     super(platform, navController, authenticationProvider);
   }
@@ -153,7 +154,7 @@ export class DebriefCatBEPage extends BasePageComponent {
       ),
       drivingFaultCount$: currentTest$.pipe(
         select(getTestData),
-        select(getDrivingFaultSummaryCount),
+        select(this.faultCountProvider.getDrivingFaultSummaryCount),
       ),
       etaFaults$: currentTest$.pipe(
         select(getTestData),

--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -68,7 +68,6 @@ import {
   getVehicleChecks,
   getShowMeQuestionOptions,
   getTellMeQuestion,
-  getDrivingFaultSummaryCount,
 } from '../../modules/tests/test-data/test-data.selector';
 import { getTestData } from '../../modules/tests/test-data/test-data.reducer';
 import { PersistTests } from '../../modules/tests/tests.actions';
@@ -117,6 +116,7 @@ import { CAT_B , JOURNAL_PAGE } from '../page-names.constants';
 import { SetActivityCode } from '../../modules/tests/activity-code/activity-code.actions';
 import { VehicleChecksQuestion } from '../../providers/question/vehicle-checks-question.model';
 import { TestCategory } from '../../shared/models/test-category';
+import { FaultCountProvider } from '../../providers/fault-count/fault-count';
 
 interface OfficePageState {
   activityCode$: Observable<ActivityCodeModel>;
@@ -188,6 +188,7 @@ export class OfficePage extends PracticeableBasePageComponent {
     public keyboard: Keyboard,
     private outcomeBehaviourProvider: OutcomeBehaviourMapProvider,
     public alertController: AlertController,
+    private faultCountProvider: FaultCountProvider,
   ) {
     super(platform, navController, authenticationProvider, store$);
     this.form = new FormGroup({});
@@ -429,7 +430,7 @@ export class OfficePage extends PracticeableBasePageComponent {
       ),
       drivingFaultCount$: currentTest$.pipe(
         select(getTestData),
-        select(getDrivingFaultSummaryCount),
+        select(this.faultCountProvider.getDrivingFaultSummaryCount),
       ),
       displayDrivingFaultComments$: currentTest$.pipe(
         select(getTestData),

--- a/src/pages/test-report/__tests__/test-report.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.effects.spec.ts
@@ -29,6 +29,7 @@ import {
   ManoeuvreTypes,
 } from '../../../modules/tests/test-data/test-data.constants';
 import { TestCategory } from '../../../shared/models/test-category';
+import { FaultCountProvider } from '../../../providers/fault-count/fault-count';
 
 export class TestActions extends Actions {
   constructor() {
@@ -61,6 +62,7 @@ describe('Test Report Effects', () => {
         provideMockActions(() => actions$),
         TestReportValidatorProvider,
         TestResultProvider,
+        FaultCountProvider,
         Store,
       ],
     });

--- a/src/pages/test-report/cat-b/components/manoeuvres/manoeuvres.ts
+++ b/src/pages/test-report/cat-b/components/manoeuvres/manoeuvres.ts
@@ -3,13 +3,14 @@ import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { StoreModel } from '../../../../../shared/models/store.model';
 import { Store, select } from '@ngrx/store';
 import { getTestData } from '../../../../../modules/tests/test-data/test-data.reducer';
-import { getManoeuvres, sumManoeuvreFaults } from '../../../../../modules/tests/test-data/test-data.selector';
+import { getManoeuvres } from '../../../../../modules/tests/test-data/test-data.selector';
 import { getCurrentTest } from '../../../../../modules/tests/tests.selector';
 import { getTests } from '../../../../../modules/tests/tests.reducer';
 import { Subscription } from 'rxjs/Subscription';
 import { Observable } from 'rxjs/Observable';
 import { CompetencyOutcome } from '../../../../../shared/models/competency-outcome';
 import { OverlayCallback } from '../../../test-report.model';
+import { FaultCountProvider } from '../../../../../providers/fault-count/fault-count';
 
 @Component({
   selector: 'manoeuvres',
@@ -34,7 +35,10 @@ export class ManoeuvresComponent implements OnInit, OnDestroy {
   displayPopover: boolean;
   manoeuvres$: Observable<CatBUniqueTypes.Manoeuvres>;
 
-  constructor(private store$: Store<StoreModel>) {
+  constructor(
+    private store$: Store<StoreModel>,
+    private faultCountProvider: FaultCountProvider,
+  ) {
     this.displayPopover = false;
   }
 
@@ -47,9 +51,9 @@ export class ManoeuvresComponent implements OnInit, OnDestroy {
     );
 
     this.subscription = this.manoeuvres$.subscribe((manoeuvres: CatBUniqueTypes.Manoeuvres) => {
-      this.drivingFaults = sumManoeuvreFaults(manoeuvres, CompetencyOutcome.DF);
-      this.hasSeriousFault = sumManoeuvreFaults(manoeuvres, CompetencyOutcome.S) > 0;
-      this.hasDangerousFault = sumManoeuvreFaults(manoeuvres, CompetencyOutcome.D) > 0;
+      this.drivingFaults = this.faultCountProvider.sumManoeuvreFaults(manoeuvres, CompetencyOutcome.DF);
+      this.hasSeriousFault = this.faultCountProvider.sumManoeuvreFaults(manoeuvres, CompetencyOutcome.S) > 0;
+      this.hasDangerousFault = this.faultCountProvider.sumManoeuvreFaults(manoeuvres, CompetencyOutcome.D) > 0;
     });
   }
 

--- a/src/pages/test-report/components/driving-fault-summary/__tests__/driving-fault-summary.spec.ts
+++ b/src/pages/test-report/components/driving-fault-summary/__tests__/driving-fault-summary.spec.ts
@@ -12,6 +12,7 @@ import { StartTest } from '../../../../../modules/tests/tests.actions';
 import { AddDrivingFault } from '../../../../../modules/tests/test-data/driving-faults/driving-faults.actions';
 import { Competencies } from '../../../../../modules/tests/test-data/test-data.constants';
 import { TestCategory } from '../../../../../shared/models/test-category';
+import { FaultCountProvider } from '../../../../../providers/fault-count/fault-count';
 
 describe('DrivingFaultSummary', () => {
   let fixture: ComponentFixture<DrivingFaultSummaryComponent>;
@@ -29,6 +30,7 @@ describe('DrivingFaultSummary', () => {
       ],
       providers: [
         { provide: Config, useFactory: () => ConfigMock.instance() },
+        FaultCountProvider,
       ],
     }).compileComponents()
       .then(() => {

--- a/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.ts
+++ b/src/pages/test-report/components/driving-fault-summary/driving-fault-summary.ts
@@ -4,9 +4,9 @@ import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
 import { getCurrentTest } from '../../../../modules/tests/tests.selector';
 import { getTestData } from '../../../../modules/tests/test-data/test-data.reducer';
-import { getDrivingFaultSummaryCount } from '../../../../modules/tests/test-data/test-data.selector';
 import { Subscription } from 'rxjs/Subscription';
 import { getTests } from '../../../../modules/tests/tests.reducer';
+import { FaultCountProvider } from '../../../../providers/fault-count/fault-count';
 
 interface DrivingFaultSummaryState {
   count$: Observable<number>;
@@ -22,7 +22,9 @@ export class DrivingFaultSummaryComponent implements OnInit {
   subscription: Subscription;
 
   constructor(
-    private store$: Store<StoreModel>) { }
+    private store$: Store<StoreModel>,
+    private faultCountProvider: FaultCountProvider,
+  ) { }
 
   ngOnInit(): void {
     this.componentState = {
@@ -30,7 +32,7 @@ export class DrivingFaultSummaryComponent implements OnInit {
         select(getTests),
         select(getCurrentTest),
         select(getTestData),
-        select(getDrivingFaultSummaryCount),
+        select(this.faultCountProvider.getDrivingFaultSummaryCount),
       ),
     };
   }

--- a/src/pages/view-test-result/view-test-result.ts
+++ b/src/pages/view-test-result/view-test-result.ts
@@ -45,7 +45,6 @@ import {
   getEyesightTestSeriousFaultAndComment,
 } from '../debrief/debrief.selector';
 import { CompetencyOutcome } from '../../shared/models/competency-outcome';
-import { getDrivingFaultSummaryCount } from '../../modules/tests/test-data/test-data.selector';
 import { Store } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { ErrorTypes } from '../../shared/models/error-message';
@@ -56,6 +55,7 @@ import { LogHelper } from '../../providers/logs/logsHelper';
 import { VehicleChecksQuestion } from '../../providers/question/vehicle-checks-question.model';
 import { QuestionProvider } from '../../providers/question/question';
 import { TestCategory } from '../../shared/models/test-category';
+import { FaultCountProvider } from '../../providers/fault-count/fault-count';
 
 @IonicPage()
 @Component({
@@ -88,6 +88,7 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit {
     private store$: Store<StoreModel>,
     private logHelper: LogHelper,
     public questionProvider: QuestionProvider,
+    private faultCountProvider: FaultCountProvider,
   ) {
     super(platform, navController, authenticationProvider);
 
@@ -258,7 +259,7 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit {
       dangerousFaults: this.getDangerousFaults(),
       seriousFaults: this.getSeriousFaults(),
       drivingFaults: this.getDrivingFaults(),
-      drivingFaultCount: getDrivingFaultSummaryCount(this.testResult.testData),
+      drivingFaultCount: this.faultCountProvider.getDrivingFaultSummaryCount(this.testResult.testData),
     };
   }
 

--- a/src/providers/fault-count/__tests__/fault-count.spec.ts
+++ b/src/providers/fault-count/__tests__/fault-count.spec.ts
@@ -1,0 +1,137 @@
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
+import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
+import { FaultCountProvider } from '../fault-count';
+import { TestBed } from '@angular/core/testing';
+
+describe('FaultCountProvider', () => {
+
+  let faultCountProvider: FaultCountProvider;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        FaultCountProvider,
+      ],
+    });
+
+    faultCountProvider = TestBed.get(FaultCountProvider);
+  });
+
+  const state: CatBUniqueTypes.TestData = {
+    drivingFaults: {
+      controlsGears: 1,
+    },
+    seriousFaults: {
+      awarenessPlanning: true,
+    },
+    dangerousFaults: {
+      useOfSpeed: true,
+    },
+    testRequirements: {
+      normalStart1: true,
+      normalStart2: true,
+      angledStart: true,
+      hillStart: true,
+    },
+    ETA: {
+      physical: false,
+      verbal: false,
+    },
+    eco: {
+      adviceGivenControl: false,
+      adviceGivenPlanning: false,
+    },
+    manoeuvres: {
+      forwardPark: {
+        selected: true,
+        controlFault: CompetencyOutcome.DF,
+      },
+    },
+    controlledStop: {
+      selected: true,
+    },
+    vehicleChecks: {
+      tellMeQuestion: {
+        outcome: CompetencyOutcome.DF,
+      },
+      showMeQuestion: {
+        outcome: CompetencyOutcome.P,
+      },
+    },
+    eyesightTest: {
+      complete: true,
+      seriousFault: false,
+    },
+  };
+
+  describe('getDrivingFaultSummaryCount', () => {
+    it('should return the driving fault count correctly', () => {
+      expect(faultCountProvider.getDrivingFaultSummaryCount(state)).toBe(3);
+    });
+  });
+
+  describe('getSeriousFaultSummaryCount', () => {
+    it('should return the serious faults count', () => {
+      expect(faultCountProvider.getSeriousFaultSummaryCount(state)).toBe(1);
+    });
+    it('should return the correct count of serious faults', () => {
+      const failedState: CatBUniqueTypes.TestData = {
+        ...state,
+        manoeuvres: {
+          forwardPark: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+        controlledStop: {
+          selected: true,
+          fault: CompetencyOutcome.S,
+        },
+        vehicleChecks: {
+          tellMeQuestion: {
+            outcome: CompetencyOutcome.DF,
+          },
+          showMeQuestion: {
+            outcome: CompetencyOutcome.S,
+          },
+        },
+        eyesightTest: {
+          complete: true,
+          seriousFault: true,
+        },
+      };
+      expect(faultCountProvider.getSeriousFaultSummaryCount(failedState)).toBe(5);
+    });
+  });
+
+  describe('getDangerousFaultSummaryCount', () => {
+    it('should return the dangerous faults count', () => {
+      expect(faultCountProvider.getDangerousFaultSummaryCount(state)).toBe(1);
+    });
+    it('should return the correct number of dangerous faults', () => {
+      const failedState: CatBUniqueTypes.TestData = {
+        ...state,
+        manoeuvres: {
+          forwardPark: {
+            selected: true,
+            controlFault: CompetencyOutcome.D,
+          },
+        },
+        controlledStop: {
+          selected: true,
+          fault: CompetencyOutcome.D,
+        },
+        vehicleChecks: {
+          tellMeQuestion: {
+            outcome: CompetencyOutcome.DF,
+          },
+          showMeQuestion: {
+            outcome: CompetencyOutcome.D,
+          },
+        },
+      };
+      expect(faultCountProvider.getDangerousFaultSummaryCount(failedState)).toBe(4);
+    });
+  });
+
+});

--- a/src/providers/fault-count/fault-count.ts
+++ b/src/providers/fault-count/fault-count.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@angular/core';
+import { pickBy, endsWith, sumBy } from 'lodash';
+
+import { CompetencyOutcome } from '../../shared/models/competency-outcome';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
+
+@Injectable()
+export class FaultCountProvider {
+
+  getDrivingFaultSummaryCount = (data: CatBUniqueTypes.TestData): number => {
+
+    // The way how we store the driving faults differs for certain competencies
+    // Because of this we need to pay extra attention on summing up all of them
+    const { drivingFaults, manoeuvres, controlledStop, vehicleChecks } = data;
+
+    const drivingFaultSumOfSimpleCompetencies =
+      Object.values(drivingFaults).reduce((acc, numberOfFaults) => acc + numberOfFaults, 0);
+
+    const controlledStopHasDrivingFault = (controlledStop && controlledStop.fault === CompetencyOutcome.DF) ? 1 : 0;
+
+    const result =
+      drivingFaultSumOfSimpleCompetencies +
+      this.sumManoeuvreFaults(manoeuvres, CompetencyOutcome.DF) +
+      this.sumVehicleCheckFaults(vehicleChecks) +
+      controlledStopHasDrivingFault;
+
+    return result;
+  }
+
+  getSeriousFaultSummaryCount = (data: CatBUniqueTypes.TestData): number => {
+
+    // The way how we store serious faults differs for certain competencies
+    // Because of this we need to pay extra attention on summing up all of them
+    const { seriousFaults, manoeuvres, controlledStop, vehicleChecks, eyesightTest } = data;
+
+    const seriousFaultSumOfSimpleCompetencies = Object.keys(pickBy(seriousFaults)).length;
+    const vehicleCheckSeriousFaults = vehicleChecks.showMeQuestion.outcome === CompetencyOutcome.S ? 1 : 0;
+    const controlledStopSeriousFaults = (controlledStop && controlledStop.fault === CompetencyOutcome.S) ? 1 : 0;
+    const eyesightTestSeriousFaults = (eyesightTest && eyesightTest.seriousFault) ? 1 : 0;
+
+    const result =
+      seriousFaultSumOfSimpleCompetencies +
+      this.sumManoeuvreFaults(manoeuvres, CompetencyOutcome.S) +
+      vehicleCheckSeriousFaults +
+      controlledStopSeriousFaults +
+      eyesightTestSeriousFaults;
+
+    return result;
+  }
+
+  getDangerousFaultSummaryCount = (data: CatBUniqueTypes.TestData): number => {
+
+    // The way how we store serious faults differs for certain competencies
+    // Because of this we need to pay extra attention on summing up all of them
+    const { dangerousFaults, manoeuvres, controlledStop, vehicleChecks } = data;
+
+    const dangerousFaultSumOfSimpleCompetencies = Object.keys(pickBy(dangerousFaults)).length;
+    const vehicleCheckDangerousFaults = vehicleChecks.showMeQuestion.outcome === CompetencyOutcome.D ? 1 : 0;
+    const controlledStopDangerousFaults = (controlledStop && controlledStop.fault === CompetencyOutcome.D) ? 1 : 0;
+
+    const result =
+      dangerousFaultSumOfSimpleCompetencies +
+      this.sumManoeuvreFaults(manoeuvres, CompetencyOutcome.D) +
+      vehicleCheckDangerousFaults +
+      controlledStopDangerousFaults;
+
+    return result;
+  }
+
+  sumVehicleCheckFaults = (vehicleChecks: CatBUniqueTypes.VehicleChecks): number => {
+    const { showMeQuestion, tellMeQuestion } = vehicleChecks;
+
+    if (showMeQuestion.outcome === CompetencyOutcome.S || showMeQuestion.outcome === CompetencyOutcome.D) {
+      return 0;
+    }
+
+    if (showMeQuestion.outcome === CompetencyOutcome.DF || tellMeQuestion.outcome === CompetencyOutcome.DF) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  sumManoeuvreFaults = (manoeuvres: CatBUniqueTypes.Manoeuvres, faultType: CompetencyOutcome): number => {
+    const manoeuvresCollection = Object.values(manoeuvres);
+    return sumBy(manoeuvresCollection, (manoeuvre) => {
+      if (manoeuvre.selected) {
+        const dFkeys = pickBy(manoeuvre, (val, key) => endsWith(key, 'Fault') && val === faultType);
+        return Object.keys(dFkeys).length;
+      }
+    });
+  }
+
+}

--- a/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
+++ b/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { TestReportValidatorProvider } from '../test-report-validator';
 import { CatBLegalRequirements } from '../../../modules/tests/test-data/test-data.models';
+import { FaultCountProvider } from '../../fault-count/fault-count';
 
 describe('TestReportValidator', () => {
 
@@ -10,6 +11,7 @@ describe('TestReportValidator', () => {
     TestBed.configureTestingModule({
       providers: [
         TestReportValidatorProvider,
+        FaultCountProvider,
       ],
     });
 

--- a/src/providers/test-report-validator/test-report-validator.ts
+++ b/src/providers/test-report-validator/test-report-validator.ts
@@ -3,17 +3,14 @@ import { CatBLegalRequirements } from '../../modules/tests/test-data/test-data.m
 import { Observable } from 'rxjs/Observable';
 import { of } from 'rxjs/observable/of';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
-import {
-  getDangerousFaultSummaryCount,
-  getSeriousFaultSummaryCount,
-} from '../../modules/tests/test-data/test-data.selector';
+import { FaultCountProvider } from '../fault-count/fault-count';
 
 @Injectable()
 // TODO: This provider has tight coupling to category B
 // When introducing B+E functionality this will need to adjust its typing
 export class TestReportValidatorProvider {
 
-  constructor() { }
+  constructor(private faultCountProvider: FaultCountProvider) { }
 
   validateCatBLegalRequirements = (results: CatBLegalRequirements): Observable<boolean> =>
     of(results.normalStart1 &&
@@ -30,8 +27,8 @@ export class TestReportValidatorProvider {
 
     return of(
       noEtaFaults ||
-      getDangerousFaultSummaryCount(testData) !== 0 ||
-      getSeriousFaultSummaryCount(testData) !== 0,
+      this.faultCountProvider.getDangerousFaultSummaryCount(testData) !== 0 ||
+      this.faultCountProvider.getSeriousFaultSummaryCount(testData) !== 0,
     );
   }
 }

--- a/src/providers/test-result/__tests__/test-result.spec.ts
+++ b/src/providers/test-result/__tests__/test-result.spec.ts
@@ -3,6 +3,7 @@ import { TestResultProvider } from '../test-result';
 import { ActivityCodes } from '../../../shared/models/activity-codes';
 import { DrivingFaults } from '@dvsa/mes-test-schema/categories/Common';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
+import { FaultCountProvider } from '../../fault-count/fault-count';
 
 // TODO: This test has tight coupling with category B
 // We will need to adjust it when we introduce new categories
@@ -53,6 +54,7 @@ describe('TestResultCalculatorProvider', () => {
     TestBed.configureTestingModule({
       providers: [
         TestResultProvider,
+        FaultCountProvider,
       ],
     });
 

--- a/src/providers/test-result/test-result.ts
+++ b/src/providers/test-result/test-result.ts
@@ -2,25 +2,28 @@ import { Injectable } from '@angular/core';
 import { ActivityCode } from '@dvsa/mes-test-schema/categories/Common';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { ActivityCodes } from '../../shared/models/activity-codes';
-import { getDrivingFaultSummaryCount, getSeriousFaultSummaryCount, getDangerousFaultSummaryCount }
-  from '../../modules/tests/test-data/test-data.selector';
 import { Observable } from 'rxjs/Observable';
 import { of } from 'rxjs/observable/of';
+import { FaultCountProvider } from '../fault-count/fault-count';
 
 @Injectable()
 export class TestResultProvider {
 
+  constructor(
+    private faultCountProvider: FaultCountProvider,
+  ) {}
+
   calculateCatBTestResult = (testData: CatBUniqueTypes.TestData): Observable<ActivityCode> => {
 
-    if (getDangerousFaultSummaryCount(testData) > 0) {
+    if (this.faultCountProvider.getDangerousFaultSummaryCount(testData) > 0) {
       return of(ActivityCodes.FAIL);
     }
 
-    if (getSeriousFaultSummaryCount(testData) > 0) {
+    if (this.faultCountProvider.getSeriousFaultSummaryCount(testData) > 0) {
       return of(ActivityCodes.FAIL);
     }
 
-    if (getDrivingFaultSummaryCount(testData) > 15) {
+    if (this.faultCountProvider.getDrivingFaultSummaryCount(testData) > 15) {
       return of(ActivityCodes.FAIL);
     }
 


### PR DESCRIPTION
## Description
- Refactors getDrivingFaultSummaryCount selector and corresponding selectors for serious and dangerous faults into a provider.
- Injects provider into appropriate components
- Uses provider as a mapper in the ngrx page state retrieval area
- Updates debrief, office, view test result and test result calculator to use the new provider

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
