### PR TITLE
Mes 3856 4156 warning banners transmission d255

### DIFF
--- a/src/components/common/common-components.module.ts
+++ b/src/components/common/common-components.module.ts
@@ -22,6 +22,7 @@ import { TabComponent } from './tab/tab';
 import { TabsComponent } from './tabs/tabs';
 import { ActivityCodeComponent } from '../../pages/office/components/activity-code/activity-code';
 import { IncompleteTestsBanner } from './incomplete-tests-banner/incomplete-tests-banner';
+import { WarningBannerComponent } from './warning-banner/warning-banner';
 
 @NgModule({
   declarations: [
@@ -43,6 +44,7 @@ import { IncompleteTestsBanner } from './incomplete-tests-banner/incomplete-test
     TabsComponent,
     ActivityCodeComponent,
     IncompleteTestsBanner,
+    WarningBannerComponent,
   ],
   imports: [
     SignaturePadModule,
@@ -70,6 +72,7 @@ import { IncompleteTestsBanner } from './incomplete-tests-banner/incomplete-test
     TabsComponent,
     ActivityCodeComponent,
     IncompleteTestsBanner,
+    WarningBannerComponent,
   ],
 })
 export class ComponentsModule { }

--- a/src/components/common/warning-banner/__tests__/warning-banner.spec.ts
+++ b/src/components/common/warning-banner/__tests__/warning-banner.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed, async, ComponentFixture } from '@angular/core/testing';
+import { IonicModule, Config } from 'ionic-angular';
+import { ConfigMock } from 'ionic-mocks';
+import { By } from '@angular/platform-browser';
+import { WarningBannerComponent } from '../warning-banner';
+
+describe('WarningBanner', () => {
+  let fixture: ComponentFixture<WarningBannerComponent>;
+  let component: WarningBannerComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [WarningBannerComponent],
+      imports: [
+        IonicModule,
+      ],
+      providers: [
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(WarningBannerComponent);
+        component = fixture.componentInstance;
+      });
+  }));
+
+  describe('DOM', () => {
+    it('should display the warning message', () => {
+      const warningText = 'This is the warning text';
+      component.warningText = warningText;
+
+      fixture.detectChanges();
+      const rendered = fixture.debugElement.query(By.css('span#warning_text')).nativeElement.innerHTML;
+      expect(rendered).toBe(warningText);
+    });
+  });
+});

--- a/src/components/common/warning-banner/warning-banner.html
+++ b/src/components/common/warning-banner/warning-banner.html
@@ -1,0 +1,6 @@
+<div>
+  <img src="/assets/imgs/exclamation-black.png" />
+  <label>
+    <span id="warning_text">{{warningText}}</span>
+  </label>
+</div>

--- a/src/components/common/warning-banner/warning-banner.scss
+++ b/src/components/common/warning-banner/warning-banner.scss
@@ -1,0 +1,36 @@
+warning-banner {
+  div {
+    display: flex;
+    align-items: center;
+    justify-content: left;
+    padding-left: 28px;
+    background: map-get($colors, mes-light-yellow);
+    height: 80px;
+    border-left: 10px solid map-get($colors-gds, gds-yellow);
+    span {
+      margin-left: 8px;
+      font-size: 40px;
+      font-weight: normal;
+      height: 28px;
+      letter-spacing: 0.39px;
+      width: 333px;
+    }
+    img {
+      padding-right: 10px;
+      height: 30px;
+      vertical-align: middle;
+    }
+    animation-name: expand;
+    animation-duration: 0.1s;
+  }
+}
+
+@keyframes expand {
+  from {
+    margin-top: -70px;
+  }
+
+  to {
+    margin-top: 0px;
+  }
+}

--- a/src/components/common/warning-banner/warning-banner.ts
+++ b/src/components/common/warning-banner/warning-banner.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'warning-banner',
+  templateUrl: 'warning-banner.html',
+})
+
+export class WarningBannerComponent {
+  @Input()
+  warningText: string;
+
+  constructor() {
+
+  }
+
+}

--- a/src/pages/test-finalisation/pass-finalisation/__tests__/pass-finalisation.spec.ts
+++ b/src/pages/test-finalisation/pass-finalisation/__tests__/pass-finalisation.spec.ts
@@ -14,6 +14,7 @@ import { PersistTests } from '../../../../modules/tests/tests.actions';
 import { MockComponent } from 'ng-mocks';
 import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { TestFinalisationComponentsModule } from '../../components/test-finalisation.module';
+import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
 
 describe('PassFinalisationPage', () => {
   let fixture: ComponentFixture<PassFinalisationPage>;
@@ -25,6 +26,7 @@ describe('PassFinalisationPage', () => {
       declarations: [
         PassFinalisationPage,
         MockComponent(PracticeModeBanner),
+        MockComponent(WarningBannerComponent),
       ],
       imports: [IonicModule, AppModule, TestFinalisationComponentsModule],
       providers: [

--- a/src/pages/test-finalisation/pass-finalisation/pass-finalisation.html
+++ b/src/pages/test-finalisation/pass-finalisation/pass-finalisation.html
@@ -115,7 +115,7 @@
 
         <d255 [display]=true [d255]="pageState.d255$ | async" [outcome]="testOutcome" [formGroup]="form"
           (d255Change)="d255Changed($event)"></d255>
-        <warning-banner *ngIf="pageState.d255$ | async" warningText="You have selected yes to having a D255 form."></warning-banner>
+        <warning-banner *ngIf="pageState.d255$ | async" warningText="By selecting Yes you are confirming a D255 is required."></warning-banner>
 
         <language-preferences [formGroup]="form" [isWelsh]="(pageState.conductedLanguage$ | async) === 'Cymraeg'"
           (welshChanged)="isWelshChanged($event)"></language-preferences>

--- a/src/pages/test-finalisation/pass-finalisation/pass-finalisation.html
+++ b/src/pages/test-finalisation/pass-finalisation/pass-finalisation.html
@@ -87,6 +87,7 @@
             </ion-row>
           </ion-col>
         </ion-row>
+        <warning-banner *ngIf="pageState.transmissionAutomaticRadioChecked$ | async" warningText="An automatic licence will be issued."></warning-banner>
 
         <ion-row class="mes-validated-row mes-row-separator" id="provisional-license-card">
           <div class="validation-bar" [class.ng-invalid]="isCtrlDirtyAndInvalid('passCertificateNumberCtrl') ||
@@ -114,6 +115,7 @@
 
         <d255 [display]=true [d255]="pageState.d255$ | async" [outcome]="testOutcome" [formGroup]="form"
           (d255Change)="d255Changed($event)"></d255>
+        <warning-banner *ngIf="pageState.d255$ | async" warningText="You have selected yes to having a D255 form."></warning-banner>
 
         <language-preferences [formGroup]="form" [isWelsh]="(pageState.conductedLanguage$ | async) === 'Cymraeg'"
           (welshChanged)="isWelshChanged($event)"></language-preferences>

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -37,6 +37,7 @@ $colors: (
   nonTestActivitySlotBackground: rgba(198, 236, 233, 0.1),
   travelSlotBackground: #eef8e5,
   mes-validation-error: #b12025,
+  mes-light-yellow: #F8E8CE,
 );
 
 $colors-gds: (


### PR DESCRIPTION
## Description
Story links -
https://jira.dvsacloud.uk/browse/MES-4156
https://jira.dvsacloud.uk/browse/MES-3856
Copies over banners from the B+E journey in the develop branch and re-purposes them to notify DE's of the implications of choosing Automatic transmission and answering 'Yes' to the D255 input. 

**The copy for the D255 banner is subject to change**

## Checklist

- [x] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/33695049/68952258-7b769500-07b7-11ea-9ea2-21ccb944e52a.png)

