### PR TITLE
Feature mes 3950 improve debrief selectors

### DIFF
--- a/src/components/common/end-test-link/__tests__/end-test-link.spec.ts
+++ b/src/components/common/end-test-link/__tests__/end-test-link.spec.ts
@@ -3,7 +3,7 @@ import { EndTestLinkComponent } from '../end-test-link';
 import { IonicModule, ModalController, NavController } from 'ionic-angular';
 import { ModalControllerMock, NavControllerMock } from 'ionic-mocks';
 import { AppModule } from '../../../../app/app.module';
-import { CAT_B } from '../../../../pages/page-names.constants';
+import { CAT_B, CAT_BE } from '../../../../pages/page-names.constants';
 
 describe('EndTestLinkComponent', () => {
   let fixture: ComponentFixture<EndTestLinkComponent>;
@@ -50,13 +50,23 @@ describe('EndTestLinkComponent', () => {
 
   describe('Class', () => {
     describe('onTerminate', () => {
-      it('should dismiss the dialog termination confirmation dialog and navigate to the debrief', () => {
+      it('should dismiss the dialog termination confirmation dialog and navigate to CAT B debrief', () => {
+        component.category = 'B';
         component.terminateTestModal = jasmine.createSpyObj('terminateTestModal', ['dismiss']);
         component.onTerminate();
         expect(component.terminateTestModal.dismiss).toHaveBeenCalled();
         const { calls } = navController.push as jasmine.Spy;
         expect(calls.argsFor(0)[0]).toBe(CAT_B.DEBRIEF_PAGE);
       });
+      it('should dismiss the dialog termination confirmation dialog and navigate to CAT BE debrief', () => {
+        component.category = 'B+E';
+        component.terminateTestModal = jasmine.createSpyObj('terminateTestModal', ['dismiss']);
+        component.onTerminate();
+        expect(component.terminateTestModal.dismiss).toHaveBeenCalled();
+        const { calls } = navController.push as jasmine.Spy;
+        expect(calls.argsFor(0)[0]).toBe(CAT_BE.DEBRIEF_PAGE);
+      });
+
     });
   });
 });

--- a/src/components/common/end-test-link/end-test-link.ts
+++ b/src/components/common/end-test-link/end-test-link.ts
@@ -33,11 +33,13 @@ export class EndTestLinkComponent {
 
   onTerminate = () => {
     this.terminateTestModal.dismiss();
-    if (this.category === TestCategory.BE) {
-      this.navController.push(CAT_BE.DEBRIEF_PAGE);
-    } else {
-      this.navController.push(CAT_B.DEBRIEF_PAGE);
+    switch (this.category) {
+      case TestCategory.BE:
+        this.navController.push(CAT_BE.DEBRIEF_PAGE);
+        break;
+      case TestCategory.B:
+        this.navController.push(CAT_B.DEBRIEF_PAGE);
+        break;
     }
-
   }
 }

--- a/src/components/common/end-test-link/end-test-link.ts
+++ b/src/components/common/end-test-link/end-test-link.ts
@@ -1,12 +1,17 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { ModalController, Modal, NavController } from 'ionic-angular';
-import { CAT_B } from '../../../pages/page-names.constants';
+import { CAT_BE, CAT_B } from '../../../pages/page-names.constants';
+import { TestCategory } from '../../../shared/models/test-category';
 
 @Component({
   selector: 'end-test-link',
   templateUrl: 'end-test-link.html',
 })
 export class EndTestLinkComponent {
+
+  @Input()
+  category: string;
+
   constructor(
     public modalController: ModalController,
     public navController: NavController,
@@ -28,6 +33,11 @@ export class EndTestLinkComponent {
 
   onTerminate = () => {
     this.terminateTestModal.dismiss();
-    this.navController.push(CAT_B.DEBRIEF_PAGE);
+    if (this.category === TestCategory.BE) {
+      this.navController.push(CAT_BE.DEBRIEF_PAGE);
+    } else {
+      this.navController.push(CAT_B.DEBRIEF_PAGE);
+    }
+
   }
 }

--- a/src/pages/communication-page/cat-b/communication.cat-b.page.html
+++ b/src/pages/communication-page/cat-b/communication.cat-b.page.html
@@ -3,7 +3,7 @@
   <ion-navbar>
     <ion-title>{{ 'communication.title' | translate }} - {{pageState.candidateUntitledName$ | async}}</ion-title>
     <ion-buttons end>
-      <end-test-link></end-test-link>
+      <end-test-link category="B"></end-test-link>
     </ion-buttons>
   </ion-navbar>
 </ion-header>

--- a/src/pages/communication-page/cat-be/communication.cat-be.page.html
+++ b/src/pages/communication-page/cat-be/communication.cat-be.page.html
@@ -2,7 +2,7 @@
   <ion-navbar>
     <ion-title>{{ 'communication.title' | translate }} - {{pageState.candidateUntitledName$ | async}}</ion-title>
     <ion-buttons end>
-      <end-test-link></end-test-link>
+      <end-test-link category="B+E"></end-test-link>
     </ion-buttons>
   </ion-navbar>
 </ion-header>

--- a/src/pages/debrief/cat-be/__tests__/debrief.cat-be.page.spec.ts
+++ b/src/pages/debrief/cat-be/__tests__/debrief.cat-be.page.spec.ts
@@ -15,13 +15,11 @@ import { StoreModule, Store } from '@ngrx/store';
 import { AddDangerousFault } from '../../../../modules/tests/test-data/dangerous-faults/dangerous-faults.actions';
 import { AddSeriousFault } from '../../../../modules/tests/test-data/serious-faults/serious-faults.actions';
 import { AddDrivingFault } from '../../../../modules/tests/test-data/driving-faults/driving-faults.actions';
-import { ToggleETA } from '../../../../modules/tests/test-data/eta/eta.actions';
-import { TogglePlanningEco, ToggleControlEco } from '../../../../modules/tests/test-data/eco/eco.actions';
 import {
   EyesightTestFailed,
   EyesightTestPassed,
 } from '../../../../modules/tests/test-data/eyesight-test/eyesight-test.actions';
-import { Competencies, ExaminerActions } from '../../../../modules/tests/test-data/test-data.constants';
+import { Competencies } from '../../../../modules/tests/test-data/test-data.constants';
 import { DebriefComponentsModule } from '../../components/debrief-components.module';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
@@ -34,7 +32,7 @@ import { PopulateTestSlotAttributes }
   from '../../../../modules/tests/journal-data/test-slot-attributes/test-slot-attributes.actions';
 import { EndDebrief } from '../../debrief.actions';
 import * as welshTranslations from '../../../../assets/i18n/cy.json';
-import { CAT_B } from '../../../page-names.constants';
+import { CAT_BE } from '../../../page-names.constants';
 import { Language } from '../../../../modules/tests/communication-preferences/communication-preferences.model';
 import { configureI18N } from '../../../../shared/helpers/translation.helpers';
 import { TestCategory } from '../../../../shared/models/test-category';
@@ -161,241 +159,100 @@ describe('DebriefCatBEPage', () => {
       expect(fixture.debugElement.query(By.css('.failed'))).toBeNull();
     });
 
-    describe('displaying ETAs', () => {
-      it('should not display ETA fault container if there are no ETA faults', () => {
-        fixture.detectChanges();
-        expect(fixture.debugElement.query(By.css('#ETA'))).toBeNull();
-      });
-      it('should display the ETA faults if there are any', () => {
-        store$.dispatch(new ToggleETA(ExaminerActions.physical));
-        fixture.detectChanges();
-        expect(fixture.debugElement.query(By.css('#ETA'))).not.toBeNull();
-        expect(fixture.debugElement.query(By.css('#etaFaults'))).not.toBeNull();
-      });
-      describe('single ETA', () => {
-        describe('physical ETAs', () => {
-          it('should display in English', () => {
-            store$.dispatch(new ToggleETA(ExaminerActions.physical));
-            fixture.detectChanges();
-            expect(fixture.debugElement.query(By.css('#etaFaults')).nativeElement.innerHTML).toBe('Physical');
-          });
-          it('should display in Welsh for a Welsh test', (done) => {
-            fixture.detectChanges();
-            translate.use('cy').subscribe(() => {
-              store$.dispatch(new ToggleETA(ExaminerActions.physical));
-              fixture.detectChanges();
-              const expectedTranslation = (<any>welshTranslations).debrief.etaPhysical;
-              const { debugElement } = fixture;
-              expect(debugElement.query(By.css('#etaFaults')).nativeElement.innerHTML).toBe(expectedTranslation);
-              done();
-            });
-          });
-        });
-        describe('verbal ETAs', () => {
-          it('should display in English', () => {
-            store$.dispatch(new ToggleETA(ExaminerActions.verbal));
-            fixture.detectChanges();
-            expect(fixture.debugElement.query(By.css('#etaFaults')).nativeElement.innerHTML).toBe('Verbal');
-          });
-          it('should display in Welsh for a Welsh test', (done) => {
-            fixture.detectChanges();
-            translate.use('cy').subscribe(() => {
-              store$.dispatch(new ToggleETA(ExaminerActions.verbal));
-              fixture.detectChanges();
-              const expectedTranslation = (<any>welshTranslations).debrief.etaVerbal;
-              const { debugElement } = fixture;
-              expect(debugElement.query(By.css('#etaFaults')).nativeElement.innerHTML).toBe(expectedTranslation);
-              done();
-            });
-          });
-        });
-      });
-      describe('both ETAs', () => {
-        it('should display in English', () => {
-          store$.dispatch(new ToggleETA(ExaminerActions.verbal));
-          store$.dispatch(new ToggleETA(ExaminerActions.physical));
-          fixture.detectChanges();
-          expect(fixture.debugElement.query(By.css('#etaFaults')).nativeElement.innerHTML).toBe('Physical and Verbal');
-        });
-        it('should display in Welsh for a Welsh test', (done) => {
-          fixture.detectChanges();
-          translate.use('cy').subscribe(() => {
-            store$.dispatch(new ToggleETA(ExaminerActions.verbal));
-            store$.dispatch(new ToggleETA(ExaminerActions.physical));
-            fixture.detectChanges();
-            const expectedTranslation = (<any>welshTranslations).debrief.etaBoth;
-            expect(fixture.debugElement.query(By.css('#etaFaults')).nativeElement.innerHTML).toBe(expectedTranslation);
-            done();
-          });
-        });
-      });
-    });
+  });
 
-    describe('displaying results of eco driving', () => {
-      it('should display the eco faults if there are any', () => {
-        store$.dispatch(new TogglePlanningEco());
-        fixture.detectChanges();
-        expect(fixture.debugElement.query(By.css('#eco'))).not.toBeNull();
-        expect(fixture.debugElement.query(By.css('#ecoFaults'))).not.toBeNull();
-      });
-      it('should not display eco fault container if there are no eco faults', () => {
-        fixture.detectChanges();
-        expect(fixture.debugElement.query(By.css('#eco'))).toBeNull();
-      });
-      describe('single ECO element', () => {
-        describe('ECO planning', () => {
-          it('should display in English', () => {
-            store$.dispatch(new TogglePlanningEco());
-            fixture.detectChanges();
-            expect(fixture.debugElement.query(By.css('#ecoFaults')).nativeElement.innerHTML.trim()).toBe('Planning');
-          });
-          it('should display in Welsh for a Welsh test', (done) => {
-            fixture.detectChanges();
-            translate.use('cy').subscribe(() => {
-              store$.dispatch(new TogglePlanningEco());
-              fixture.detectChanges();
-              const expectedTranslation = (<any>welshTranslations).debrief.ecoPlanning;
-              const { debugElement } = fixture;
-              expect(debugElement.query(By.css('#ecoFaults')).nativeElement.innerHTML.trim()).toBe(expectedTranslation);
-              done();
-            });
-          });
-        });
-        describe('ECO control', () => {
-          it('should display in English', () => {
-            store$.dispatch(new ToggleControlEco());
-            fixture.detectChanges();
-            expect(fixture.debugElement.query(By.css('#ecoFaults')).nativeElement.innerHTML.trim()).toBe('Control');
-          });
-          it('should display in Welsh for a Welsh test', (done) => {
-            fixture.detectChanges();
-            translate.use('cy').subscribe(() => {
-              store$.dispatch(new ToggleControlEco());
-              fixture.detectChanges();
-              const expectedTranslation = (<any>welshTranslations).debrief.ecoControl;
-              const { debugElement } = fixture;
-              expect(debugElement.query(By.css('#ecoFaults')).nativeElement.innerHTML.trim()).toBe(expectedTranslation);
-              done();
-            });
-          });
-        });
-      });
-      describe('Both ECO elements', () => {
-        it('should display in English', () => {
-          store$.dispatch(new TogglePlanningEco());
-          store$.dispatch(new ToggleControlEco());
-          fixture.detectChanges();
-          expect(fixture.debugElement.query(By.css('#ecoFaults')).nativeElement.innerHTML.trim())
-            .toBe('Control and Planning');
-        });
-        it('should display in Welsh for a Welsh test', (done) => {
-          fixture.detectChanges();
-          translate.use('cy').subscribe(() => {
-            store$.dispatch(new TogglePlanningEco());
-            store$.dispatch(new ToggleControlEco());
-            fixture.detectChanges();
-            const expectedTranslation = (<any>welshTranslations).debrief.ecoBoth;
-            expect(fixture.debugElement.query(By.css('#ecoFaults')).nativeElement.innerHTML.trim())
-              .toBe(expectedTranslation);
-            done();
-          });
-        });
-      });
-    });
+  it('should not display dangerous faults container if there are no dangerous faults', () => {
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#dangerous-fault'))).toBeNull();
+  });
 
-    it('should not display dangerous faults container if there are no dangerous faults', () => {
+  it('should not display serious faults container if there are no serious faults', () => {
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#serious-fault'))).toBeNull();
+  });
+
+  it('should not display driving faults container if there are no driving faults', () => {
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#driving-fault'))).toBeNull();
+  });
+
+  it('should display dangerous faults container if there are dangerous faults', () => {
+    store$.dispatch(new AddDangerousFault(Competencies.controlsClutch));
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#dangerous-fault'))).not.toBeNull();
+  });
+
+  it('should display serious faults container if there are serious faults', () => {
+    store$.dispatch(new AddSeriousFault(Competencies.controlsClutch));
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#serious-fault'))).not.toBeNull();
+  });
+
+  it('should display driving faults container if there are driving faults', () => {
+    store$.dispatch(new AddDrivingFault({ competency: Competencies.controlsClutch, newFaultCount: 1 }));
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#driving-fault'))).not.toBeNull();
+  });
+
+  describe('endDebrief', () => {
+    it('should dispatch the PersistTests action', () => {
+      component.endDebrief();
+      expect(store$.dispatch).toHaveBeenCalledWith(new EndDebrief);
+    });
+    it('should navigate to PassFinalisationPage when outcome = pass', () => {
+      component.outcome = 'Pass';
+      component.endDebrief();
+      expect(navController.push).toHaveBeenCalledWith(CAT_BE.PASS_FINALISATION_PAGE);
+    });
+    it('should navigate to BackToOfficePage when outcome = fail', () => {
+      component.outcome = 'Fail';
+      component.endDebrief();
+      expect(navController.push).toHaveBeenCalledWith(CAT_BE.POST_DEBRIEF_HOLDING_PAGE);
+    });
+    it('should navigate to the BackToOfficePage when outcomes = terminated', () => {
+      component.outcome = 'Terminated';
+      component.endDebrief();
+      expect(navController.push).toHaveBeenCalledWith(CAT_BE.POST_DEBRIEF_HOLDING_PAGE);
+    });
+  });
+
+  describe('translation of fault competencies', () => {
+    it('should display fault competencies in English by default', () => {
+      store$.dispatch(new AddDrivingFault({ competency: Competencies.moveOffSafety, newFaultCount: 1 }));
+      store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsSignalling));
+      store$.dispatch(new AddDangerousFault(Competencies.useOfMirrorsChangeDirection));
       fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('#dangerous-fault'))).toBeNull();
-    });
+      const drivingFaultLabel = fixture.debugElement.query(By.css('#driving-fault .counter-label')).nativeElement;
+      const seriousLabel = fixture.debugElement.query(By.css('#serious-fault .counter-label')).nativeElement;
+      const dangerousLabel = fixture.debugElement.query(By.css('#dangerous-fault .counter-label')).nativeElement;
 
-    it('should not display serious faults container if there are no serious faults', () => {
+      expect(drivingFaultLabel.innerHTML).toBe(fullCompetencyLabels.moveOffSafety);
+      expect(seriousLabel.innerHTML).toBe(fullCompetencyLabels.useOfMirrorsSignalling);
+      expect(dangerousLabel.innerHTML).toBe(fullCompetencyLabels.useOfMirrorsChangeDirection);
+    });
+    it('should display fault competencies in Welsh for a Welsh test', (done) => {
+      store$.dispatch(new AddDrivingFault({ competency: Competencies.moveOffSafety, newFaultCount: 1 }));
+      store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsSignalling));
+      store$.dispatch(new AddDangerousFault(Competencies.useOfMirrorsChangeDirection));
       fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('#serious-fault'))).toBeNull();
-    });
-
-    it('should not display driving faults container if there are no driving faults', () => {
-      fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('#driving-fault'))).toBeNull();
-    });
-
-    it('should display dangerous faults container if there are dangerous faults', () => {
-      store$.dispatch(new AddDangerousFault(Competencies.controlsClutch));
-      fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('#dangerous-fault'))).not.toBeNull();
-    });
-
-    it('should display serious faults container if there are serious faults', () => {
-      store$.dispatch(new AddSeriousFault(Competencies.controlsClutch));
-      fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('#serious-fault'))).not.toBeNull();
-    });
-
-    it('should display driving faults container if there are driving faults', () => {
-      store$.dispatch(new AddDrivingFault({ competency: Competencies.controlsClutch, newFaultCount: 1 }));
-      fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('#driving-fault'))).not.toBeNull();
-    });
-
-    describe('endDebrief', () => {
-      it('should dispatch the PersistTests action', () => {
-        component.endDebrief();
-        expect(store$.dispatch).toHaveBeenCalledWith(new EndDebrief);
-      });
-      it('should navigate to PassFinalisationPage when outcome = pass', () => {
-        component.outcome = 'Pass';
-        component.endDebrief();
-        expect(navController.push).toHaveBeenCalledWith(CAT_B.PASS_FINALISATION_PAGE);
-      });
-      it('should navigate to BackToOfficePage when outcome = fail', () => {
-        component.outcome = 'Fail';
-        component.endDebrief();
-        expect(navController.push).toHaveBeenCalledWith(CAT_B.POST_DEBRIEF_HOLDING_PAGE);
-      });
-      it('should navigate to the BackToOfficePage when outcomes = terminated', () => {
-        component.outcome = 'Terminated';
-        component.endDebrief();
-        expect(navController.push).toHaveBeenCalledWith(CAT_B.POST_DEBRIEF_HOLDING_PAGE);
-      });
-    });
-
-    describe('translation of fault competencies', () => {
-      it('should display fault competencies in English by default', () => {
-        store$.dispatch(new AddDrivingFault({ competency: Competencies.moveOffSafety, newFaultCount: 1 }));
-        store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsSignalling));
-        store$.dispatch(new AddDangerousFault(Competencies.useOfMirrorsChangeDirection));
+      configureI18N(Language.CYMRAEG, translate);
+      translate.onLangChange.subscribe(() => {
         fixture.detectChanges();
         const drivingFaultLabel = fixture.debugElement.query(By.css('#driving-fault .counter-label')).nativeElement;
         const seriousLabel = fixture.debugElement.query(By.css('#serious-fault .counter-label')).nativeElement;
         const dangerousLabel = fixture.debugElement.query(By.css('#dangerous-fault .counter-label')).nativeElement;
 
-        expect(drivingFaultLabel.innerHTML).toBe(fullCompetencyLabels.moveOffSafety);
-        expect(seriousLabel.innerHTML).toBe(fullCompetencyLabels.useOfMirrorsSignalling);
-        expect(dangerousLabel.innerHTML).toBe(fullCompetencyLabels.useOfMirrorsChangeDirection);
-      });
-      it('should display fault competencies in Welsh for a Welsh test', (done) => {
-        store$.dispatch(new AddDrivingFault({ competency: Competencies.moveOffSafety, newFaultCount: 1 }));
-        store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsSignalling));
-        store$.dispatch(new AddDangerousFault(Competencies.useOfMirrorsChangeDirection));
-        fixture.detectChanges();
-        configureI18N(Language.CYMRAEG, translate);
-        translate.onLangChange.subscribe(() => {
-          fixture.detectChanges();
-          const drivingFaultLabel = fixture.debugElement.query(By.css('#driving-fault .counter-label')).nativeElement;
-          const seriousLabel = fixture.debugElement.query(By.css('#serious-fault .counter-label')).nativeElement;
-          const dangerousLabel = fixture.debugElement.query(By.css('#dangerous-fault .counter-label')).nativeElement;
-
-          const expectedDrivingFaultTranslation = (<any>welshTranslations).debrief.competencies.moveOffSafety;
-          const expectedSeriousFaultTranslation = (<any>welshTranslations).debrief.competencies.useOfMirrorsSignalling;
-          const expectedDangerousFaultTranslation =
+        const expectedDrivingFaultTranslation = (<any>welshTranslations).debrief.competencies.moveOffSafety;
+        const expectedSeriousFaultTranslation = (<any>welshTranslations).debrief.competencies.useOfMirrorsSignalling;
+        const expectedDangerousFaultTranslation =
             (<any>welshTranslations).debrief.competencies.useOfMirrorsChangeDirection;
 
-          expect(drivingFaultLabel.innerHTML).toBe(expectedDrivingFaultTranslation);
-          expect(seriousLabel.innerHTML).toBe(expectedSeriousFaultTranslation);
-          expect(dangerousLabel.innerHTML).toBe(expectedDangerousFaultTranslation);
-          done();
-        });
-        store$.dispatch(new PopulateTestSlotAttributes({ ...testSlotAttributes, welshTest: true }));
+        expect(drivingFaultLabel.innerHTML).toBe(expectedDrivingFaultTranslation);
+        expect(seriousLabel.innerHTML).toBe(expectedSeriousFaultTranslation);
+        expect(dangerousLabel.innerHTML).toBe(expectedDangerousFaultTranslation);
+        done();
       });
+      store$.dispatch(new PopulateTestSlotAttributes({ ...testSlotAttributes, welshTest: true }));
     });
   });
 

--- a/src/pages/debrief/cat-be/debrief.cat-be.page.html
+++ b/src/pages/debrief/cat-be/debrief.cat-be.page.html
@@ -5,144 +5,16 @@
       <button ion-button (click)="logout()">Sign Out</button>
     </ion-buttons>
   </ion-navbar>
-  <div id="test-outcome-background" [ngSwitch]="outcome">
-    <div class="test-outcome-container passed" *ngSwitchCase="'Pass'">
-      <h4>{{ 'debrief.outcomeHeader' | translate }}</h4>
-      <h1>{{ 'debrief.passStatus' | translate }}</h1>
-    </div>
-    <div class="test-outcome-container failed" *ngSwitchCase="'Fail'">
-      <h4>{{ 'debrief.outcomeHeader' | translate }}</h4>
-      <h1>{{ 'debrief.failStatus' | translate }}</h1>
-    </div>
-    <div class="test-outcome-container terminated" *ngSwitchCase="'Terminated'">
-      <h4>{{ 'debrief.outcomeHeader' | translate }}</h4>
-      <h1>{{ 'debrief.terminatedStatus' | translate }}</h1>
-    </div>
-  </div>
+  <test-outcome-debrief-card [outcome]="outcome"></test-outcome-debrief-card>
 </ion-header>
 
 <ion-content>
-
-  <ion-card id="ETA" *ngIf="hasPhysicalEta || hasVerbalEta">
-    <ion-card-content>
-      <ion-grid>
-        <ion-row align-items-start class="mes-data">
-          <ion-col col-3></ion-col>
-          <ion-col col-34>
-            <h4 class="fault-heading">{{ 'debrief.etaHeader' | translate }}</h4>
-          </ion-col>
-          <ion-col align-self-start>
-            <span id="etaFaults" *ngIf="hasPhysicalEta && !hasVerbalEta">{{ 'debrief.etaPhysical' | translate }}</span>
-            <span id="etaFaults" *ngIf="!hasPhysicalEta && hasVerbalEta">{{ 'debrief.etaVerbal' | translate }}</span>
-            <span id="etaFaults" *ngIf="hasPhysicalEta && hasVerbalEta">{{ 'debrief.etaBoth' | translate }}</span>
-          </ion-col>
-        </ion-row>
-      </ion-grid>
-    </ion-card-content>
-  </ion-card>
-
-  <ion-card id="dangerous-fault" *ngIf="(pageState.dangerousFaults$ | async).length > 0">
-    <ion-card-header>
-      <ion-card-title>
-        <h1 class="fault-heading">{{(pageState.dangerousFaults$ | async).length}}</h1>
-        <h4 class="fault-heading">{{ 'debrief.dangerousFaultsCardDescription' | translate }}</h4>
-      </ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <ion-grid>
-        <ion-row align-items-center *ngFor="let dangerousFault of (pageState.dangerousFaults$ | async)" class="mes-data">
-          <ion-col col-32 no-padding></ion-col>
-          <ion-col col-2 no-padding align-self-start>
-            <div class="counter-icon">
-              <dangerous-fault-badge [showBadge]="true"></dangerous-fault-badge>
-            </div>
-          </ion-col>
-          <ion-col col-3 no-padding></ion-col>
-          <ion-col no-padding>
-            <div class="counter-label">{{ 'debrief.competencies.' + dangerousFault | translate }}</div>
-          </ion-col>
-        </ion-row>
-      </ion-grid>
-    </ion-card-content>
-  </ion-card>
-
-  <ion-card id="serious-fault" *ngIf="(pageState.seriousFaults$ | async).length > 0">
-    <ion-card-header>
-      <ion-card-title>
-        <h1 class="fault-heading">{{(pageState.seriousFaults$ | async).length}}</h1>
-        <h4 class="fault-heading">{{ 'debrief.seriousFaultsCardDescription' | translate }}</h4>
-      </ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <ion-grid>
-        <ion-row align-items-center *ngFor="let seriousFault of (pageState.seriousFaults$ | async)" class="mes-data">
-          <ion-col col-32 no-padding></ion-col>
-          <ion-col col-2 no-padding align-self-start>
-            <div class="counter-icon">
-              <serious-fault-badge [showBadge]="true"></serious-fault-badge>
-            </div>
-          </ion-col>
-          <ion-col col-3 no-padding></ion-col>
-          <ion-col no-padding>
-            <div class="counter-label">{{ 'debrief.competencies.' + seriousFault | translate }}</div>
-          </ion-col>
-        </ion-row>
-      </ion-grid>
-    </ion-card-content>
-  </ion-card>
-
-  <ion-card id="driving-fault" *ngIf="(pageState.drivingFaultCount$ | async) > 0 || (pageState.drivingFaults$ | async).length > 0">
-    <ion-card-header>
-      <ion-card-title>
-        <h1 class="fault-heading">{{pageState.drivingFaultCount$ | async}}</h1>
-        <h4 class="fault-heading">{{ 'debrief.drivingFaultsCardDescription' | translate }}</h4>
-      </ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <ion-grid>
-        <ion-row align-items-center *ngFor="let drivingFault of (pageState.drivingFaults$ | async)" class="mes-data">
-          <ion-col col-32 no-padding></ion-col>
-          <ion-col col-2 no-padding align-self-start>
-            <div class="counter-icon">
-              <driving-faults-badge class="counter driving-faults" [count]="drivingFault.faultCount">
-              </driving-faults-badge>
-            </div>
-          </ion-col>
-          <ion-col col-3 no-padding></ion-col>
-          <ion-col no-padding>
-            <div class="counter-label">{{'debrief.competencies.' + drivingFault.competencyIdentifier | translate}}</div>
-          </ion-col>
-        </ion-row>
-      </ion-grid>
-    </ion-card-content>
-  </ion-card>
-
-  <ion-card id="eco" *ngIf="adviceGivenControl || adviceGivenPlanning">
-    <ion-card-content>
-      <ion-grid>
-        <ion-row align-items-start class="mes-data">
-          <ion-col col-3></ion-col>
-          <ion-col col-34>
-            <h4 class="fault-heading">{{ 'debrief.ecoHeader' | translate }}</h4>
-          </ion-col>
-          <ion-col align-self-start>
-            <div id="ecoFaults" *ngIf="adviceGivenControl && !adviceGivenPlanning">
-              {{ 'debrief.ecoControl' | translate }}
-            </div>
-            <div id="ecoFaults" *ngIf="!adviceGivenControl && adviceGivenPlanning">
-              {{ 'debrief.ecoPlanning' | translate }}
-            </div>
-            <div id="ecoFaults" *ngIf="adviceGivenControl && adviceGivenPlanning">
-              {{ 'debrief.ecoBoth' | translate }}
-            </div>
-          </ion-col>
-        </ion-row>
-      </ion-grid>
-    </ion-card-content>
-  </ion-card>
-
+  <eta-debrief-card [hasPhysicalEta]="hasPhysicalEta" [hasVerbalEta]="hasVerbalEta"></eta-debrief-card>
+  <dangerous-faults-debrief-card [dangerousFaults]="pageState.dangerousFaults$ | async"></dangerous-faults-debrief-card>
+  <serious-faults-debrief-card [seriousFaults]="pageState.seriousFaults$ | async"></serious-faults-debrief-card>
+  <driving-faults-debrief-card [drivingFaults]="pageState.drivingFaults$ | async" [drivingFaultCount]="pageState.drivingFaultCount$ | async"></driving-faults-debrief-card>
+  <eco-debrief-card [adviceGivenControl]="adviceGivenControl" [adviceGivenPlanning]="adviceGivenPlanning"></eco-debrief-card>
   <vehicle-checks-card></vehicle-checks-card>
-
 </ion-content>
 <ion-footer>
   <div id="end-debrief-background">

--- a/src/pages/debrief/cat-be/debrief.cat-be.page.ts
+++ b/src/pages/debrief/cat-be/debrief.cat-be.page.ts
@@ -131,7 +131,8 @@ export class DebriefCatBEPage extends BasePageComponent {
       ),
       drivingFaults$: currentTest$.pipe(
         select(getTestData),
-        map((data) => {
+        withLatestFrom(category$),
+        map(([data, category]) => {
           return [
             ...getDrivingFaults(data.drivingFaults),
             ...getManoeuvreFaults(data.manoeuvres, CompetencyOutcome.DF).map(
@@ -149,8 +150,8 @@ export class DebriefCatBEPage extends BasePageComponent {
                 source: result.source,
               })),
             ...getVehicleCheckDrivingFaults(data.vehicleChecks).map(
-              (result: CommentedCompetency): MultiFaultAssignableCompetency => ({
-                faultCount: 1,
+              (result: CommentedCompetency & MultiFaultAssignableCompetency): MultiFaultAssignableCompetency => ({
+                faultCount: this.faultCountProvider.getDrivingFaultSumCount(category as TestCategory, data),
                 competencyDisplayName: result.competencyDisplayName,
                 competencyIdentifier: result.competencyIdentifier,
                 source: result.source,

--- a/src/pages/debrief/cat-be/debrief.cat-be.page.ts
+++ b/src/pages/debrief/cat-be/debrief.cat-be.page.ts
@@ -43,7 +43,7 @@ import {
 } from '../../../modules/tests/communication-preferences/communication-preferences.reducer';
 import { getConductedLanguage } from
   '../../../modules/tests/communication-preferences/communication-preferences.selector';
-import { CAT_B } from '../../page-names.constants';
+import { CAT_BE } from '../../page-names.constants';
 import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
 import { configureI18N } from '../../../shared/helpers/translation.helpers';
 import { BasePageComponent } from '../../../shared/classes/base-page';
@@ -218,15 +218,15 @@ export class DebriefCatBEPage extends BasePageComponent {
   endDebrief(): void {
     this.store$.dispatch(new EndDebrief());
     if (this.outcome === 'Pass') {
-      this.navController.push(CAT_B.PASS_FINALISATION_PAGE);
+      this.navController.push(CAT_BE.PASS_FINALISATION_PAGE);
       return;
     }
-    this.navController.push(CAT_B.POST_DEBRIEF_HOLDING_PAGE).then(() => {
-      const testReportPage = this.navController.getViews().find(view => view.id === CAT_B.TEST_REPORT_PAGE);
+    this.navController.push(CAT_BE.POST_DEBRIEF_HOLDING_PAGE).then(() => {
+      const testReportPage = this.navController.getViews().find(view => view.id === CAT_BE.TEST_REPORT_PAGE);
       if (testReportPage) {
         this.navController.removeView(testReportPage);
       }
-      const debriefPage = this.navController.getViews().find(view => view.id === CAT_B.DEBRIEF_PAGE);
+      const debriefPage = this.navController.getViews().find(view => view.id === CAT_BE.DEBRIEF_PAGE);
       if (debriefPage) {
         this.navController.removeView(debriefPage);
       }

--- a/src/pages/debrief/cat-be/debrief.cat-be.page.ts
+++ b/src/pages/debrief/cat-be/debrief.cat-be.page.ts
@@ -25,7 +25,6 @@ import {
   getManoeuvreFaults,
   getUncoupleRecoupleFault,
   getVehicleCheckSeriousFaults,
-  getVehicleCheckDangerousFaults,
   getVehicleCheckDrivingFaults,
   getUncoupleRecoupleFaultAndComment,
 } from '../cat-be/debrief.cat-be.selector';
@@ -125,7 +124,6 @@ export class DebriefCatBEPage extends BasePageComponent {
             ...getSeriousOrDangerousFaults(data.dangerousFaults),
             ...getManoeuvreFaults(data.manoeuvres, CompetencyOutcome.D).map(fault => fault.competencyIdentifier),
             ...getUncoupleRecoupleFault(data.uncoupleRecouple, CompetencyOutcome.D),
-            ...getVehicleCheckDangerousFaults(data.vehicleChecks).map(fault => fault.competencyIdentifier),
           ];
         }),
       ),

--- a/src/pages/debrief/cat-be/debrief.cat-be.selector.ts
+++ b/src/pages/debrief/cat-be/debrief.cat-be.selector.ts
@@ -78,28 +78,6 @@ export const getManoeuvreFaultsCount = (
 };
 
 // TODO move methods that return a count and comments into a FaultSummaryProvider
-export const getVehicleCheckDangerousFaults =
-  (vehicleChecks: CatBEUniqueTypes.VehicleChecks): (CommentedCompetency & MultiFaultAssignableCompetency)[] => {
-    const result: (CommentedCompetency & MultiFaultAssignableCompetency)[] = [];
-
-    if (!vehicleChecks) {
-      return result;
-    }
-    const faults = vehicleChecks.showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.D);
-
-    const competency: CommentedCompetency & MultiFaultAssignableCompetency = {
-      comment: vehicleChecks.showMeTellMeComments || '',
-      competencyIdentifier: CommentSource.VEHICLE_CHECKS,
-      competencyDisplayName: CompetencyDisplayName.SHOW_ME_TELL_ME,
-      source: CommentSource.VEHICLE_CHECKS,
-      faultCount: faults.length,
-
-    };
-    faults.length > 0  && result.push(competency);
-
-    return result;
-  };
-
 export const getVehicleCheckSeriousFaults =
   (vehicleChecks: CatBEUniqueTypes.VehicleChecks): (CommentedCompetency & MultiFaultAssignableCompetency)[] => {
     const result: (CommentedCompetency & MultiFaultAssignableCompetency)[] = [];
@@ -198,10 +176,6 @@ export const anySeriousFaults = (data: CatBEUniqueTypes.TestData): boolean => {
 export const anyDangerousFaults = (data: CatBEUniqueTypes.TestData): boolean => {
   const dangerousFaults = getSeriousOrDangerousFaults(data.dangerousFaults);
   if (dangerousFaults.length > 0) {
-    return true;
-  }
-  const vehicleCheckDangerousFaults = getVehicleCheckDangerousFaults(data.vehicleChecks);
-  if (vehicleCheckDangerousFaults.length > 0) {
     return true;
   }
   const uncoupleRecoupleDangerousFault = getUncoupleRecoupleFault(data.uncoupleRecouple, CompetencyOutcome.D);

--- a/src/pages/debrief/cat-be/debrief.cat-be.selector.ts
+++ b/src/pages/debrief/cat-be/debrief.cat-be.selector.ts
@@ -77,6 +77,7 @@ export const getManoeuvreFaultsCount = (
   return faultCount;
 };
 
+// TODO move methods that return a count and comments into a FaultSummaryProvider
 export const getVehicleCheckDangerousFaults =
   (vehicleChecks: CatBEUniqueTypes.VehicleChecks): (CommentedCompetency & MultiFaultAssignableCompetency)[] => {
     const result: (CommentedCompetency & MultiFaultAssignableCompetency)[] = [];
@@ -145,7 +146,6 @@ export const getVehicleCheckDrivingFaults =
         competencyDisplayName: CompetencyDisplayName.SHOW_ME_TELL_ME,
         source: CommentSource.VEHICLE_CHECKS,
         faultCount: showMeDFFault.length + tellMeDFFault.length,
-        // TODO REVIEW LOGIC AND CALCULATE FAULT COUNT from show me tell me colletcions
       };
       result.push(competency);
     }
@@ -226,16 +226,15 @@ export const displayDrivingFaultComments = (data: CatBEUniqueTypes.TestData): bo
     drivingFaultCount = drivingFaultCount + 1;
   }
   if (data.vehicleChecks) {
-      // TODO may need to sum up the driving fault counts.... plus look at logic of serious fault
     const checks = data.vehicleChecks;
-    if (checks.showMeQuestions &&
-        checks.showMeQuestions.findIndex(fault => fault.outcome === CompetencyOutcome.DF) >= 0) {
-      drivingFaultCount = drivingFaultCount + 1;
-    }
-    if (checks.tellMeQuestions &&
-        checks.tellMeQuestions.findIndex(fault => fault.outcome === CompetencyOutcome.DF) >= 0) {
-      drivingFaultCount = drivingFaultCount + 1;
-    }
+    const showMeFaultCount = checks.showMeQuestions.filter((check) => {
+      check.outcome === CompetencyOutcome.DF;
+    });
+    const tellMeFaultCount = checks.tellMeQuestions.filter((check) => {
+      check.outcome === CompetencyOutcome.DF;
+    });
+
+    drivingFaultCount = drivingFaultCount + showMeFaultCount.length + tellMeFaultCount.length;
   }
 
   drivingFaultCount = drivingFaultCount + getManoeuvreFaultsCount(data.manoeuvres, CompetencyOutcome.DF);

--- a/src/pages/debrief/cat-be/debrief.cat-be.selector.ts
+++ b/src/pages/debrief/cat-be/debrief.cat-be.selector.ts
@@ -106,16 +106,18 @@ export const getVehicleCheckSeriousFaults =
     if (!vehicleChecks) {
       return result;
     }
-    const faults = vehicleChecks.showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.S);
+    const showMeFaults = vehicleChecks.showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.DF);
+    const tellMeFaults = vehicleChecks.tellMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.DF);
 
+    const seriousFaultCount = showMeFaults.length + tellMeFaults.length === 5 ? 1 : 0;
     const competency: CommentedCompetency & MultiFaultAssignableCompetency = {
       comment: vehicleChecks.showMeTellMeComments || '',
       competencyIdentifier: CommentSource.VEHICLE_CHECKS,
       competencyDisplayName: CompetencyDisplayName.SHOW_ME_TELL_ME,
       source: CommentSource.VEHICLE_CHECKS,
-      faultCount: faults.length,
+      faultCount: seriousFaultCount,
     };
-    faults.length > 0  && result.push(competency);
+    seriousFaultCount > 0  && result.push(competency);
 
     return result;
   };

--- a/src/pages/debrief/cat-be/debrief.cat-be.selector.ts
+++ b/src/pages/debrief/cat-be/debrief.cat-be.selector.ts
@@ -84,16 +84,17 @@ export const getVehicleCheckDangerousFaults =
     if (!vehicleChecks) {
       return result;
     }
+    const faults = vehicleChecks.showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.D);
+
     const competency: CommentedCompetency & MultiFaultAssignableCompetency = {
       comment: vehicleChecks.showMeTellMeComments || '',
       competencyIdentifier: CommentSource.VEHICLE_CHECKS,
       competencyDisplayName: CompetencyDisplayName.SHOW_ME_TELL_ME,
       source: CommentSource.VEHICLE_CHECKS,
-      faultCount: 1,
+      faultCount: faults.length,
 
     };
-    const faultIndex = vehicleChecks.showMeQuestions.findIndex(fault => fault.outcome === CompetencyOutcome.D);
-    faultIndex >= 0  && result.push(competency);
+    faults.length > 0  && result.push(competency);
 
     return result;
   };
@@ -105,42 +106,44 @@ export const getVehicleCheckSeriousFaults =
     if (!vehicleChecks) {
       return result;
     }
+    const faults = vehicleChecks.showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.S);
+
     const competency: CommentedCompetency & MultiFaultAssignableCompetency = {
       comment: vehicleChecks.showMeTellMeComments || '',
       competencyIdentifier: CommentSource.VEHICLE_CHECKS,
       competencyDisplayName: CompetencyDisplayName.SHOW_ME_TELL_ME,
       source: CommentSource.VEHICLE_CHECKS,
-      faultCount: 1,
+      faultCount: faults.length,
     };
-    const faultIndex = vehicleChecks.showMeQuestions.findIndex(fault => fault.outcome === CompetencyOutcome.S);
-    faultIndex >= 0  && result.push(competency);
+    faults.length > 0  && result.push(competency);
 
     return result;
   };
-
 export const getVehicleCheckDrivingFaults =
   (vehicleChecks: CatBEUniqueTypes.VehicleChecks): (CommentedCompetency & MultiFaultAssignableCompetency)[] => {
     const result: (CommentedCompetency & MultiFaultAssignableCompetency)[] = [];
     if (!vehicleChecks || !vehicleChecks.showMeQuestions || !vehicleChecks.tellMeQuestions) {
       return result;
     }
-    const dangerousFaultIndex = vehicleChecks.showMeQuestions.findIndex(fault => fault.outcome === CompetencyOutcome.D);
-    const seriousFaultIndex = vehicleChecks.showMeQuestions.findIndex(fault => fault.outcome === CompetencyOutcome.S);
 
-    if (dangerousFaultIndex >= 0 || seriousFaultIndex >= 0) {
+    const dangerousFaults = vehicleChecks.showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.D);
+    const seriousFaults = vehicleChecks.showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.S);
+
+    if (dangerousFaults.length > 0 || seriousFaults.length > 0) {
       return result;
     }
 
-    const showMeDFFault = vehicleChecks.showMeQuestions.findIndex(fault => fault.outcome === CompetencyOutcome.DF);
-    const tellMeDFFault = vehicleChecks.tellMeQuestions.findIndex(fault => fault.outcome === CompetencyOutcome.DF);
-    if (showMeDFFault >= 0
-      || tellMeDFFault >= 0) {
+    const showMeDFFault = vehicleChecks.showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.DF);
+    const tellMeDFFault = vehicleChecks.tellMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.DF);
+    if (showMeDFFault.length > 0
+      || tellMeDFFault.length > 0) {
       const competency: CommentedCompetency & MultiFaultAssignableCompetency = {
         comment: vehicleChecks.showMeTellMeComments || '',
         competencyIdentifier: CommentSource.VEHICLE_CHECKS,
         competencyDisplayName: CompetencyDisplayName.SHOW_ME_TELL_ME,
         source: CommentSource.VEHICLE_CHECKS,
-        faultCount: 1, // TODO REVIEW LOGIC AND CALCULATE FAULT COUNT from show me tell me colletcions
+        faultCount: showMeDFFault.length + tellMeDFFault.length,
+        // TODO REVIEW LOGIC AND CALCULATE FAULT COUNT from show me tell me colletcions
       };
       result.push(competency);
     }

--- a/src/pages/test-report/__tests__/test-report.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.effects.spec.ts
@@ -309,7 +309,6 @@ describe('Test Report Effects', () => {
     beforeEach(() => {
       store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       store$.dispatch(new PopulateTestCategory(TestCategory.B));
-      console.log('dispatched start test');
     });
 
     it('should dispatch an action containing the correct result for a test', (done) => {

--- a/src/pages/test-report/__tests__/test-report.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.effects.spec.ts
@@ -30,6 +30,7 @@ import {
 } from '../../../modules/tests/test-data/test-data.constants';
 import { TestCategory } from '../../../shared/models/test-category';
 import { FaultCountProvider } from '../../../providers/fault-count/fault-count';
+import { PopulateTestCategory } from '../../../modules/tests/category/category.actions';
 
 export class TestActions extends Actions {
   constructor() {
@@ -307,6 +308,8 @@ describe('Test Report Effects', () => {
 
     beforeEach(() => {
       store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
+      store$.dispatch(new PopulateTestCategory(TestCategory.B));
+      console.log('dispatched start test');
     });
 
     it('should dispatch an action containing the correct result for a test', (done) => {

--- a/src/pages/test-report/cat-be/test-report.cat-be.page.ts
+++ b/src/pages/test-report/cat-be/test-report.cat-be.page.ts
@@ -29,7 +29,7 @@ import {
   LegalRequirements,
   ExaminerActions,
 } from '../../../modules/tests/test-data/test-data.constants';
-import { getTestData } from '../../../modules/tests/test-data/test-data.reducer';
+import { getTestData } from '../../../modules/tests/test-data/test-data.cat-be.reducer';
 import { getTests } from '../../../modules/tests/tests.reducer';
 import { getTestReportState } from '../test-report.reducer';
 import {
@@ -42,7 +42,7 @@ import { TestReportValidatorProvider } from '../../../providers/test-report-vali
 import { CatBLegalRequirements } from '../../../modules/tests/test-data/test-data.models';
 import {
   hasManoeuvreBeenCompleted,
-} from '../../../modules/tests/test-data/cat-b/test-data.cat-b.selector';
+} from '../../../modules/tests/test-data/cat-be/test-data.cat-be.selector';
 import { ModalEvent } from '../test-report.constants';
 import { CAT_BE } from '../../page-names.constants';
 import { OverlayCallback } from '../test-report.model';

--- a/src/pages/test-report/test-report.effects.ts
+++ b/src/pages/test-report/test-report.effects.ts
@@ -22,7 +22,6 @@ import * as controlledStopActions from '../../modules/tests/test-data/controlled
 import * as activityCodeActions from '../../modules/tests/activity-code/activity-code.actions';
 import { TestResultProvider } from '../../providers/test-result/test-result';
 import { ActivityCode } from '@dvsa/mes-test-schema/categories/Common';
-import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { of } from 'rxjs/observable/of';
 import { isEmpty } from 'lodash';
 
@@ -118,7 +117,7 @@ export class TestReportEffects {
       ),
     )),
     switchMap(([action, currentTest]) => {
-      return this.testResultProvider.calculateCatBTestResult(currentTest.testData as CatBUniqueTypes.TestData)
+      return this.testResultProvider.calculateTestResult(currentTest.category, currentTest.testData)
         .pipe(
           switchMap((result: ActivityCode) => {
 

--- a/src/pages/waiting-room-to-car/cat-b/waiting-room-to-car.cat-b.page.html
+++ b/src/pages/waiting-room-to-car/cat-b/waiting-room-to-car.cat-b.page.html
@@ -3,7 +3,7 @@
   <ion-navbar hideBackButton>
     <ion-title>{{pageState.candidateName$ | async}}</ion-title>
     <ion-buttons end>
-      <end-test-link></end-test-link>
+      <end-test-link category="B"></end-test-link>
     </ion-buttons>
   </ion-navbar>
 </ion-header>

--- a/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.html
+++ b/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.html
@@ -2,7 +2,7 @@
   <ion-navbar hideBackButton>
     <ion-title>{{pageState.candidateName$ | async}}</ion-title>
     <ion-buttons end>
-      <end-test-link></end-test-link>
+      <end-test-link category="B+E"></end-test-link>
     </ion-buttons>
   </ion-navbar>
 </ion-header>

--- a/src/pages/waiting-room/cat-b/waiting-room.cat-b.page.html
+++ b/src/pages/waiting-room/cat-b/waiting-room.cat-b.page.html
@@ -3,7 +3,7 @@
   <ion-navbar>
     <ion-title>{{ 'waitingRoom.title' | translate }} - {{pageState.candidateUntitledName$ | async}}</ion-title>
     <ion-buttons end>
-      <end-test-link></end-test-link>
+      <end-test-link category="B"></end-test-link>
     </ion-buttons>
   </ion-navbar>
 </ion-header>

--- a/src/pages/waiting-room/cat-be/waiting-room.cat-be.page.html
+++ b/src/pages/waiting-room/cat-be/waiting-room.cat-be.page.html
@@ -2,7 +2,7 @@
   <ion-navbar>
     <ion-title>{{ 'waitingRoom.title' | translate }} - {{pageState.candidateUntitledName$ | async}}</ion-title>
     <ion-buttons end>
-      <end-test-link></end-test-link>
+      <end-test-link category="B+E"></end-test-link>
     </ion-buttons>
   </ion-navbar>
 </ion-header>

--- a/src/providers/fault-count/fault-count.ts
+++ b/src/providers/fault-count/fault-count.ts
@@ -141,21 +141,23 @@ export class FaultCountProvider {
       Object.values(drivingFaults).reduce((acc, numberOfFaults) => acc + numberOfFaults, 0);
 
     const result =
-      drivingFaultSumOfSimpleCompetencies +
-      this.sumManoeuvreFaults(manoeuvres, CompetencyOutcome.DF) +
-      this.getVehicleChecksFaultCountCatBE(vehicleChecks).drivingFaults;
+       drivingFaultSumOfSimpleCompetencies +
+       this.sumManoeuvreFaults(manoeuvres, CompetencyOutcome.DF) +
+       this.getVehicleChecksFaultCountCatBE(vehicleChecks).drivingFaults;
 
     return result;
   }
 
-  private getSeriousFaultSumCountCatBE = (data: CatBUniqueTypes.TestData): number => {
+  private getSeriousFaultSumCountCatBE = (data: CatBEUniqueTypes.TestData): number => {
 
     // The way how we store serious faults differs for certain competencies
     // Because of this we need to pay extra attention on summing up all of them
     const { seriousFaults, manoeuvres, vehicleChecks, eyesightTest } = data;
 
     const seriousFaultSumOfSimpleCompetencies = Object.keys(pickBy(seriousFaults)).length;
-    const vehicleCheckSeriousFaults = vehicleChecks.showMeQuestion.outcome === CompetencyOutcome.S ? 1 : 0;
+    const vehicleCheckSeriousFaults = vehicleChecks.showMeQuestions.filter((check) => {
+      check.outcome === CompetencyOutcome.S;
+    }).length;
     const eyesightTestSeriousFaults = (eyesightTest && eyesightTest.seriousFault) ? 1 : 0;
 
     const result =
@@ -167,14 +169,16 @@ export class FaultCountProvider {
     return result;
   }
 
-  private getDangerousFaultSumCountCatBE = (data: CatBUniqueTypes.TestData): number => {
+  private getDangerousFaultSumCountCatBE = (data: CatBEUniqueTypes.TestData): number => {
 
     // The way how we store serious faults differs for certain competencies
     // Because of this we need to pay extra attention on summing up all of them
     const { dangerousFaults, manoeuvres, vehicleChecks } = data;
 
     const dangerousFaultSumOfSimpleCompetencies = Object.keys(pickBy(dangerousFaults)).length;
-    const vehicleCheckDangerousFaults = vehicleChecks.showMeQuestion.outcome === CompetencyOutcome.D ? 1 : 0;
+    const vehicleCheckDangerousFaults = vehicleChecks.showMeQuestions.filter((check) => {
+      check.outcome === CompetencyOutcome.D;
+    }).length;
 
     const result =
       dangerousFaultSumOfSimpleCompetencies +
@@ -191,6 +195,7 @@ export class FaultCountProvider {
         const dFkeys = pickBy(manoeuvre, (val, key) => endsWith(key, 'Fault') && val === faultType);
         return Object.keys(dFkeys).length;
       }
+      return 0;
     });
   }
 

--- a/src/providers/test-result/test-result.ts
+++ b/src/providers/test-result/test-result.ts
@@ -17,11 +17,12 @@ export class TestResultProvider {
 
   calculateTestResult = (category: string,
                          testData: CatBUniqueTypes.TestData| CatBEUniqueTypes.TestData): Observable<ActivityCode> => {
-    if (category === TestCategory.B) {
-      return this.calculateCatBTestResult(testData as CatBUniqueTypes.TestData);
-    }
-    if (category === TestCategory.BE) {
-      return this.calculateCatBETestResult(testData as CatBEUniqueTypes.TestData);
+
+    switch (category) {
+      case TestCategory.B:
+        return this.calculateCatBTestResult(testData as CatBUniqueTypes.TestData);
+      case TestCategory.BE:
+        return this.calculateCatBETestResult(testData as CatBEUniqueTypes.TestData);
     }
   }
 

--- a/src/providers/test-result/test-result.ts
+++ b/src/providers/test-result/test-result.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs/Observable';
 import { of } from 'rxjs/observable/of';
 import { FaultCountProvider } from '../fault-count/fault-count';
 import { TestCategory } from '../../shared/models/test-category';
+import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
 
 @Injectable()
 export class TestResultProvider {
@@ -14,7 +15,18 @@ export class TestResultProvider {
     private faultCountProvider: FaultCountProvider,
   ) {}
 
-  calculateCatBTestResult = (testData: CatBUniqueTypes.TestData): Observable<ActivityCode> => {
+  calculateTestResult = (category: string,
+                         testData: CatBUniqueTypes.TestData| CatBEUniqueTypes.TestData): Observable<ActivityCode> => {
+    if (category === TestCategory.B) {
+      return this.calculateCatBTestResult(testData as CatBUniqueTypes.TestData);
+    }
+    if (category === TestCategory.BE) {
+      return this.calculateCatBETestResult(testData as CatBEUniqueTypes.TestData);
+    }
+  }
+
+  calculateCatBTestResult = (testData: CatBUniqueTypes.TestData |
+    CatBEUniqueTypes.TestData): Observable<ActivityCode> => {
 
     if (this.faultCountProvider.getDangerousFaultSumCount(TestCategory.B, testData) > 0) {
       return of(ActivityCodes.FAIL);
@@ -25,6 +37,22 @@ export class TestResultProvider {
     }
 
     if (this.faultCountProvider.getDrivingFaultSumCount(TestCategory.B, testData) > 15) {
+      return of(ActivityCodes.FAIL);
+    }
+
+    return of(ActivityCodes.PASS);
+  }
+  calculateCatBETestResult = (testData: CatBEUniqueTypes.TestData): Observable<ActivityCode> => {
+
+    if (this.faultCountProvider.getDangerousFaultSumCount(TestCategory.BE, testData) > 0) {
+      return of(ActivityCodes.FAIL);
+    }
+
+    if (this.faultCountProvider.getSeriousFaultSumCount(TestCategory.BE, testData) > 0) {
+      return of(ActivityCodes.FAIL);
+    }
+
+    if (this.faultCountProvider.getDrivingFaultSumCount(TestCategory.BE, testData) > 15) {
       return of(ActivityCodes.FAIL);
     }
 


### PR DESCRIPTION
Make end-test component Category aware.
Fix CatBE related counts in FaultCount provider
Fix unit tests.
Improve debrief selectors for serious faults.
