### PR TITLE
Refactored displayDrivingFaultComments for Cat B

### DIFF
--- a/src/pages/debrief/cat-b/__tests__/debrief.cat-b.selector.spec.ts
+++ b/src/pages/debrief/cat-b/__tests__/debrief.cat-b.selector.spec.ts
@@ -1,101 +1,11 @@
-import {
-    SeriousFaults,
-    DangerousFaults,
-    DrivingFaults,
-  } from '@dvsa/mes-test-schema/categories/Common';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import {
-    displayDrivingFaultComments,
     getManoeuvreFaults,
   } from '../debrief.cat-b.selector';
 import { CompetencyOutcome } from '../../../../shared/models/competency-outcome';
 
 describe('debriefSelector', () => {
   const manoeuvres: CatBUniqueTypes.Manoeuvres = {};
-
-  describe('displayDrivingFaultComments', () => {
-    let localDangerousFaults: DangerousFaults = {};
-    let localSeriousFaults: SeriousFaults = {};
-    let localDrivingFaults: DrivingFaults = {};
-
-    it('should return false if there are less than 16 driving faults', () => {
-      localDangerousFaults = {};
-      localSeriousFaults = {};
-      localDrivingFaults.ancillaryControls = 1;
-      const testData: CatBUniqueTypes.TestData = {
-        dangerousFaults: localDangerousFaults,
-        seriousFaults: localSeriousFaults,
-        drivingFaults: localDrivingFaults,
-      };
-      const result = displayDrivingFaultComments(testData);
-      expect(result).toEqual(false);
-    });
-
-    it('should return true if there are more than 15 driving faults and no serious or dangerous faults', () => {
-      localDrivingFaults = {
-        controlsAccelerator: 2,
-        controlsClutch: 3,
-        controlsGears: 1,
-        controlsFootbrake: 4,
-        controlsParkingBrake: 3,
-        controlsSteering: 2,
-        precautions: 1,
-      };
-      const testData: CatBUniqueTypes.TestData = {
-        dangerousFaults: localDangerousFaults,
-        seriousFaults: localSeriousFaults,
-        drivingFaults: localDrivingFaults,
-      };
-      const result = displayDrivingFaultComments(testData);
-      expect(result).toEqual(true);
-    });
-
-    it('should return false if there are more than 15 driving faults and a serious fault', () => {
-      localDangerousFaults = {};
-      localDrivingFaults = {
-        controlsAccelerator: 2,
-        controlsClutch: 3,
-        controlsGears: 1,
-        controlsFootbrake: 4,
-        controlsParkingBrake: 3,
-        controlsSteering: 2,
-        precautions: 1,
-      };
-      localSeriousFaults.useOfSpeed = true;
-      localSeriousFaults.controlsSteering = true;
-      const testData: CatBUniqueTypes.TestData = {
-        dangerousFaults: localDangerousFaults,
-        seriousFaults: localSeriousFaults,
-        drivingFaults: localDrivingFaults,
-      };
-      const result = displayDrivingFaultComments(testData);
-      expect(result).toEqual(false);
-    });
-
-    it('should return false if there are more than 15 driving faults and a dangerous fault', () => {
-      localSeriousFaults = {};
-      localDrivingFaults = {
-        controlsAccelerator: 2,
-        controlsClutch: 3,
-        controlsGears: 1,
-        controlsFootbrake: 4,
-        controlsParkingBrake: 3,
-        controlsSteering: 2,
-        precautions: 1,
-      };
-      localDangerousFaults.useOfSpeed = true;
-      localDangerousFaults.controlsSteering = true;
-      const testData: CatBUniqueTypes.TestData = {
-        dangerousFaults: localDangerousFaults,
-        seriousFaults: localSeriousFaults,
-        drivingFaults: localDrivingFaults,
-      };
-      const result = displayDrivingFaultComments(testData);
-      expect(result).toEqual(false);
-
-    });
-
-  });
 
   describe('getManoeuvreFaults', () => {
     it('should return an empty array if there are no manoeuvre driving faults', () => {

--- a/src/pages/office/cat-b/__tests__/office.cat-b.page.spec.ts
+++ b/src/pages/office/cat-b/__tests__/office.cat-b.page.spec.ts
@@ -66,12 +66,14 @@ import { NavigationStateProviderMock } from '../../../../providers/navigation-st
 import { SetActivityCode } from '../../../../modules/tests/activity-code/activity-code.actions';
 import { VehicleChecksQuestion } from '../../../../providers/question/vehicle-checks-question.model';
 import { TestCategory } from '../../../../shared/models/test-category';
+import { FaultCountProvider } from '../../../providers/fault-count/fault-count';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficeCatBPage>;
   let component: OfficeCatBPage;
   let navController: NavController;
   let store$: Store<StoreModel>;
+  let faultCountProvider: FaultCountProvider;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -146,6 +148,7 @@ describe('OfficePage', () => {
         { provide: AlertController, useClass: AlertControllerMock },
         { provide: ToastController, useClass: ToastControllerMock },
         { provide: NavigationStateProvider, useClass: NavigationStateProviderMock },
+        { provide: FaultCountProvider, useClass: FaultCountProvider },
       ],
     })
       .compileComponents()
@@ -156,6 +159,7 @@ describe('OfficePage', () => {
       });
     store$ = TestBed.get(Store);
     spyOn(store$, 'dispatch');
+    faultCountProvider = TestBed.get(FaultCountProvider);
   }));
 
   describe('Class', () => {
@@ -195,6 +199,41 @@ describe('OfficePage', () => {
         component.completeTest();
 
         expect(store$.dispatch).not.toHaveBeenCalledWith(new CompleteTest());
+      });
+    });
+
+    describe('shouldDisplayDrivingFaultComments', () => {
+      it('should return false if there are less than 16 driving faults', () => {
+        spyOn(faultCountProvider, 'getDrivingFaultSumCount').and.returnValue(15);
+        spyOn(faultCountProvider, 'getSeriousFaultSumCount').and.returnValue(0);
+        spyOn(faultCountProvider, 'getDangerousFaultSumCount').and.returnValue(0);
+
+        const result = component.shouldDisplayDrivingFaultComments({});
+        expect(result).toEqual(false);
+      });
+      it('should return true if there are more than 15 driving faults and no serious or dangerous faults', () => {
+        spyOn(faultCountProvider, 'getDrivingFaultSumCount').and.returnValue(16);
+        spyOn(faultCountProvider, 'getSeriousFaultSumCount').and.returnValue(0);
+        spyOn(faultCountProvider, 'getDangerousFaultSumCount').and.returnValue(0);
+
+        const result = component.shouldDisplayDrivingFaultComments({});
+        expect(result).toEqual(true);
+      });
+      it('should return false if there are more than 15 driving faults and a serious fault', () => {
+        spyOn(faultCountProvider, 'getDrivingFaultSumCount').and.returnValue(16);
+        spyOn(faultCountProvider, 'getSeriousFaultSumCount').and.returnValue(1);
+        spyOn(faultCountProvider, 'getDangerousFaultSumCount').and.returnValue(0);
+
+        const result = component.shouldDisplayDrivingFaultComments({});
+        expect(result).toEqual(false);
+      });
+      it('should return false if there are more than 15 driving faults and a dangerous fault', () => {
+        spyOn(faultCountProvider, 'getDrivingFaultSumCount').and.returnValue(16);
+        spyOn(faultCountProvider, 'getSeriousFaultSumCount').and.returnValue(0);
+        spyOn(faultCountProvider, 'getDangerousFaultSumCount').and.returnValue(1);
+
+        const result = component.shouldDisplayDrivingFaultComments({});
+        expect(result).toEqual(false);
       });
     });
   });

--- a/src/pages/office/cat-b/__tests__/office.cat-b.page.spec.ts
+++ b/src/pages/office/cat-b/__tests__/office.cat-b.page.spec.ts
@@ -66,7 +66,7 @@ import { NavigationStateProviderMock } from '../../../../providers/navigation-st
 import { SetActivityCode } from '../../../../modules/tests/activity-code/activity-code.actions';
 import { VehicleChecksQuestion } from '../../../../providers/question/vehicle-checks-question.model';
 import { TestCategory } from '../../../../shared/models/test-category';
-import { FaultCountProvider } from '../../../providers/fault-count/fault-count';
+import { FaultCountProvider } from '../../../../providers/fault-count/fault-count';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficeCatBPage>;

--- a/src/pages/office/cat-b/office.cat-b.page.ts
+++ b/src/pages/office/cat-b/office.cat-b.page.ts
@@ -82,7 +82,6 @@ import {
 } from '../../debrief/debrief.selector';
 
 import {
-  displayDrivingFaultComments,
   getManoeuvreFaults,
   getVehicleCheckDrivingFaults,
   getControlledStopFaultAndComment,
@@ -125,6 +124,7 @@ import { VehicleChecksQuestion } from '../../../providers/question/vehicle-check
 import { TestCategory } from '../../../shared/models/test-category';
 import { FaultCountProvider } from '../../../providers/fault-count/fault-count';
 import { getTestCategory } from '../../../modules/tests/category/category.reducer';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 
 interface OfficePageState {
   activityCode$: Observable<ActivityCodeModel>;
@@ -447,7 +447,7 @@ export class OfficeCatBPage extends PracticeableBasePageComponent {
       ),
       displayDrivingFaultComments$: currentTest$.pipe(
         select(getTestData),
-        map(data => displayDrivingFaultComments(data)),
+        map(data => this.shouldDisplayDrivingFaultComments(data)),
       ),
       weatherConditions$: currentTest$.pipe(
         select(getTestSummary),
@@ -658,4 +658,12 @@ export class OfficeCatBPage extends PracticeableBasePageComponent {
       source: result.source,
       comment: result.comment,
     })
+
+  shouldDisplayDrivingFaultComments = (data: CatBUniqueTypes.TestData): boolean => {
+    const drivingFaultCount: number = this.faultCountProvider.getDrivingFaultSumCount(TestCategory.B, data);
+    const seriousFaultCount: number = this.faultCountProvider.getSeriousFaultSumCount(TestCategory.B, data);
+    const dangerousFaultCount: number = this.faultCountProvider.getDangerousFaultSumCount(TestCategory.B, data);
+
+    return dangerousFaultCount === 0 && seriousFaultCount === 0 && drivingFaultCount > 15;
+  }
 }

--- a/src/pages/office/cat-be/office.cat-be.page.ts
+++ b/src/pages/office/cat-be/office.cat-be.page.ts
@@ -82,7 +82,6 @@ import {
 } from '../../debrief/debrief.selector';
 
 import {
-  displayDrivingFaultComments,
   getManoeuvreFaults,
   getVehicleCheckDrivingFaults,
   getControlledStopFaultAndComment,
@@ -446,7 +445,8 @@ export class OfficeCatBEPage extends BasePageComponent {
       ),
       displayDrivingFaultComments$: currentTest$.pipe(
         select(getTestData),
-        map(data => displayDrivingFaultComments(data)),
+        // TODO - needs to be refactored
+        map(data => true),
       ),
       weatherConditions$: currentTest$.pipe(
         select(getTestSummary),


### PR DESCRIPTION
## Description
- Moved the logic for the 'displayDrivingFaultComments' function to the office page where it's used and rewrote it to use the new faults count provider.

## Checklist

- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
