### PR TITLE
MES-628 - Moves "ticked" logic to parent pages, making legal requirements component category agnostic

### DIFF
--- a/src/pages/test-report/cat-b/test-report.cat-b.page.html
+++ b/src/pages/test-report/cat-b/test-report.cat-b.page.html
@@ -30,21 +30,21 @@
         </ion-row>
         <ion-row>
           <ion-col>
-            <legal-requirement [legalRequirement]="legalRequirements.normalStart1">
+            <legal-requirement [legalRequirement]="legalRequirements.normalStart1" [ticked]="isLegalRequirementTicked(legalRequirements.normalStart1, (pageState.catBLegalRequirements$ | async))">
             </legal-requirement>
           </ion-col>
           <ion-col>
-            <legal-requirement [legalRequirement]="legalRequirements.normalStart2">
+            <legal-requirement [legalRequirement]="legalRequirements.normalStart2" [ticked]="isLegalRequirementTicked(legalRequirements.normalStart2, (pageState.catBLegalRequirements$ | async))">
             </legal-requirement>
           </ion-col>
         </ion-row>
         <ion-row>
           <ion-col>
-            <legal-requirement [legalRequirement]="legalRequirements.angledStart">
+            <legal-requirement [legalRequirement]="legalRequirements.angledStart" [ticked]="isLegalRequirementTicked(legalRequirements.angledStart, (pageState.catBLegalRequirements$ | async))">
             </legal-requirement>
           </ion-col>
           <ion-col>
-            <legal-requirement [legalRequirement]="legalRequirements.hillStart">
+            <legal-requirement [legalRequirement]="legalRequirements.hillStart" [ticked]="isLegalRequirementTicked(legalRequirements.hillStart, (pageState.catBLegalRequirements$ | async))">
             </legal-requirement>
           </ion-col>
         </ion-row>

--- a/src/pages/test-report/cat-b/test-report.cat-b.page.html
+++ b/src/pages/test-report/cat-b/test-report.cat-b.page.html
@@ -30,21 +30,33 @@
         </ion-row>
         <ion-row>
           <ion-col>
-            <legal-requirement [legalRequirement]="legalRequirements.normalStart1" [ticked]="isLegalRequirementTicked(legalRequirements.normalStart1, (pageState.catBLegalRequirements$ | async))">
+            <legal-requirement 
+              [legalRequirement]="legalRequirements.normalStart1"
+              [ticked]="(pageState.catBLegalRequirements$ | async)[legalRequirements.normalStart1]"
+            >
             </legal-requirement>
           </ion-col>
           <ion-col>
-            <legal-requirement [legalRequirement]="legalRequirements.normalStart2" [ticked]="isLegalRequirementTicked(legalRequirements.normalStart2, (pageState.catBLegalRequirements$ | async))">
+            <legal-requirement
+              [legalRequirement]="legalRequirements.normalStart2"
+              [ticked]="(pageState.catBLegalRequirements$ | async)[legalRequirements.normalStart2]"
+            >
             </legal-requirement>
           </ion-col>
         </ion-row>
         <ion-row>
           <ion-col>
-            <legal-requirement [legalRequirement]="legalRequirements.angledStart" [ticked]="isLegalRequirementTicked(legalRequirements.angledStart, (pageState.catBLegalRequirements$ | async))">
+            <legal-requirement
+              [legalRequirement]="legalRequirements.angledStart"
+              [ticked]="(pageState.catBLegalRequirements$ | async)[legalRequirements.angledStart]"
+            >
             </legal-requirement>
           </ion-col>
           <ion-col>
-            <legal-requirement [legalRequirement]="legalRequirements.hillStart" [ticked]="isLegalRequirementTicked(legalRequirements.hillStart, (pageState.catBLegalRequirements$ | async))">
+            <legal-requirement
+              [legalRequirement]="legalRequirements.hillStart"
+              [ticked]="(pageState.catBLegalRequirements$ | async)[legalRequirements.hillStart]"
+            >
             </legal-requirement>
           </ion-col>
         </ion-row>

--- a/src/pages/test-report/cat-b/test-report.cat-b.page.ts
+++ b/src/pages/test-report/cat-b/test-report.cat-b.page.ts
@@ -226,13 +226,6 @@ export class TestReportCatBPage extends PracticeableBasePageComponent {
       ),
     ).subscribe();
   }
-  // TODO: Needs unit tests
-  isLegalRequirementTicked(
-    legalRequirement: LegalRequirements,
-    catBLegalRequirements: CatBUniqueTypes.TestRequirements,
-  ): boolean {
-    return catBLegalRequirements[legalRequirement];
-  }
 
   onEndTestClick = (): void => {
     const options = { cssClass: 'mes-modal-alert text-zoom-regular' };

--- a/src/pages/test-report/cat-b/test-report.cat-b.page.ts
+++ b/src/pages/test-report/cat-b/test-report.cat-b.page.ts
@@ -54,6 +54,7 @@ import { Insomnia } from '@ionic-native/insomnia';
 import { StatusBar } from '@ionic-native/status-bar';
 import { CAT_B } from '../../page-names.constants';
 import { OverlayCallback } from '../test-report.model';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 
 interface TestReportPageState {
   candidateUntitledName$: Observable<string>;
@@ -87,7 +88,7 @@ export class TestReportCatBPage extends PracticeableBasePageComponent {
   isEtaValid: boolean = true;
 
   modal: Modal;
-  catBLegalRequirements: CatBLegalRequirements;
+  catBLegalRequirements: CatBUniqueTypes.TestRequirements;
 
   constructor(
     store$: Store<StoreModel>,
@@ -224,6 +225,13 @@ export class TestReportCatBPage extends PracticeableBasePageComponent {
         map(result => (this.catBLegalRequirements = result)),
       ),
     ).subscribe();
+  }
+  // TODO: Needs unit tests
+  isLegalRequirementTicked(
+    legalRequirement: LegalRequirements,
+    catBLegalRequirements: CatBUniqueTypes.TestRequirements,
+  ): boolean {
+    return catBLegalRequirements[legalRequirement];
   }
 
   onEndTestClick = (): void => {

--- a/src/pages/test-report/cat-be/test-report.cat-be.page.html
+++ b/src/pages/test-report/cat-be/test-report.cat-be.page.html
@@ -31,25 +31,40 @@
         </ion-row>
         <ion-row>
           <ion-col>
-            <legal-requirement [legalRequirement]="legalRequirements.normalStart1">
+            <legal-requirement 
+              [legalRequirement]="legalRequirements.normalStart1"
+              [ticked]="isLegalRequirementTicked(legalRequirements.normalStart1, (pageState.catBELegalRequirements$ | async))"
+            >
             </legal-requirement>
           </ion-col>
           <ion-col>
-            <legal-requirement [legalRequirement]="legalRequirements.normalStart2">
+            <legal-requirement 
+              [legalRequirement]="legalRequirements.normalStart2"
+              [ticked]="isLegalRequirementTicked(legalRequirements.normalStart2, (pageState.catBELegalRequirements$ | async))"
+            >
             </legal-requirement>
           </ion-col>
         </ion-row>
         <ion-row>
           <ion-col col-28>
-            <legal-requirement [legalRequirement]="legalRequirements.uphillStart">
+            <legal-requirement 
+              [legalRequirement]="legalRequirements.uphillStart"
+              [ticked]="isLegalRequirementTicked(legalRequirements.uphillStart, (pageState.catBELegalRequirements$ | async))"
+            >
             </legal-requirement>
           </ion-col>
           <ion-col col-28>
-            <legal-requirement [legalRequirement]="legalRequirements.downhillStart">
+            <legal-requirement 
+              [legalRequirement]="legalRequirements.downhillStart"
+              [ticked]="isLegalRequirementTicked(legalRequirements.downhillStart, (pageState.catBELegalRequirements$ | async))"
+            >
             </legal-requirement>
           </ion-col>
           <ion-col col-40>
-            <legal-requirement [legalRequirement]="legalRequirements.angledStartControlledStop">
+            <legal-requirement 
+              [legalRequirement]="legalRequirements.angledStartControlledStop"
+              [ticked]="isLegalRequirementTicked(legalRequirements.angledStartControlledStop, (pageState.catBELegalRequirements$ | async))"
+            >
             </legal-requirement>
           </ion-col>
         </ion-row>

--- a/src/pages/test-report/cat-be/test-report.cat-be.page.html
+++ b/src/pages/test-report/cat-be/test-report.cat-be.page.html
@@ -13,7 +13,7 @@
 </ion-header>
 
 <ion-content no-padding no-bounce>
-  <!-- <toolbar></toolbar> -->
+  <toolbar></toolbar>
   <ion-grid no-padding class="grid-layout" [ngClass]="{
       'remove-mode': isRemoveFaultMode,
       'add-mode': !isRemoveFaultMode,

--- a/src/pages/test-report/cat-be/test-report.cat-be.page.html
+++ b/src/pages/test-report/cat-be/test-report.cat-be.page.html
@@ -33,14 +33,14 @@
           <ion-col>
             <legal-requirement 
               [legalRequirement]="legalRequirements.normalStart1"
-              [ticked]="isLegalRequirementTicked(legalRequirements.normalStart1, (pageState.catBELegalRequirements$ | async))"
+              [ticked]="(pageState.catBELegalRequirements$ | async)[legalRequirements.normalStart1]"
             >
             </legal-requirement>
           </ion-col>
           <ion-col>
             <legal-requirement 
               [legalRequirement]="legalRequirements.normalStart2"
-              [ticked]="isLegalRequirementTicked(legalRequirements.normalStart2, (pageState.catBELegalRequirements$ | async))"
+              [ticked]="(pageState.catBELegalRequirements$ | async)[legalRequirements.normalStart2]"
             >
             </legal-requirement>
           </ion-col>
@@ -49,21 +49,21 @@
           <ion-col col-28>
             <legal-requirement 
               [legalRequirement]="legalRequirements.uphillStart"
-              [ticked]="isLegalRequirementTicked(legalRequirements.uphillStart, (pageState.catBELegalRequirements$ | async))"
+              [ticked]="(pageState.catBELegalRequirements$ | async)[legalRequirements.uphillStart]"
             >
             </legal-requirement>
           </ion-col>
           <ion-col col-28>
             <legal-requirement 
               [legalRequirement]="legalRequirements.downhillStart"
-              [ticked]="isLegalRequirementTicked(legalRequirements.downhillStart, (pageState.catBELegalRequirements$ | async))"
+              [ticked]="(pageState.catBELegalRequirements$ | async)[legalRequirements.downhillStart]"
             >
             </legal-requirement>
           </ion-col>
           <ion-col col-40>
             <legal-requirement 
               [legalRequirement]="legalRequirements.angledStartControlledStop"
-              [ticked]="isLegalRequirementTicked(legalRequirements.angledStartControlledStop, (pageState.catBELegalRequirements$ | async))"
+              [ticked]="(pageState.catBELegalRequirements$ | async)[legalRequirements.angledStartControlledStop]"
             >
             </legal-requirement>
           </ion-col>

--- a/src/pages/test-report/cat-be/test-report.cat-be.page.ts
+++ b/src/pages/test-report/cat-be/test-report.cat-be.page.ts
@@ -50,7 +50,6 @@ import { AddDrivingFault } from '../../../modules/tests/test-data/driving-faults
 import { AddSeriousFault } from '../../../modules/tests/test-data/serious-faults/serious-faults.actions';
 import { AddDangerousFault } from '../../../modules/tests/test-data/dangerous-faults/dangerous-faults.actions';
 import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
-import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 
 interface TestReportPageState {
   candidateUntitledName$: Observable<string>;
@@ -83,7 +82,7 @@ export class TestReportCatBEPage extends BasePageComponent {
   isEtaValid: boolean = true;
 
   modal: Modal;
-  catBELegalRequirements: CatBUniqueTypes.TestRequirements;
+  catBELegalRequirements: CatBEUniqueTypes.TestRequirements;
 
   constructor(
     public store$: Store<StoreModel>,

--- a/src/pages/test-report/cat-be/test-report.cat-be.page.ts
+++ b/src/pages/test-report/cat-be/test-report.cat-be.page.ts
@@ -163,13 +163,6 @@ export class TestReportCatBEPage extends BasePageComponent {
   toggleReportOverlay(): void {
     this.displayOverlay = !this.displayOverlay;
   }
-  // TODO: Needs unit tests
-  isLegalRequirementTicked(
-    legalRequirement: LegalRequirements,
-    catBELegalRequirements: CatBEUniqueTypes.TestRequirements,
-  ): boolean {
-    return catBELegalRequirements[legalRequirement];
-  }
 
   ionViewDidLeave(): void {
     if (this.subscription) {

--- a/src/pages/test-report/cat-be/test-report.cat-be.page.ts
+++ b/src/pages/test-report/cat-be/test-report.cat-be.page.ts
@@ -39,9 +39,8 @@ import {
   isEtaValid,
 } from '../test-report.selector';
 import { TestReportValidatorProvider } from '../../../providers/test-report-validator/test-report-validator';
-import { CatBLegalRequirements } from '../../../modules/tests/test-data/test-data.models';
 import {
-  hasManoeuvreBeenCompleted,
+  hasManoeuvreBeenCompleted, getCatBELegalRequirements,
 } from '../../../modules/tests/test-data/cat-be/test-data.cat-be.selector';
 import { ModalEvent } from '../test-report.constants';
 import { CAT_BE } from '../../page-names.constants';
@@ -50,6 +49,8 @@ import { BasePageComponent } from '../../../shared/classes/base-page';
 import { AddDrivingFault } from '../../../modules/tests/test-data/driving-faults/driving-faults.actions';
 import { AddSeriousFault } from '../../../modules/tests/test-data/serious-faults/serious-faults.actions';
 import { AddDangerousFault } from '../../../modules/tests/test-data/dangerous-faults/dangerous-faults.actions';
+import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 
 interface TestReportPageState {
   candidateUntitledName$: Observable<string>;
@@ -59,7 +60,7 @@ interface TestReportPageState {
   manoeuvres$: Observable<boolean>;
   // isLegalRequirementsValid$: Observable<boolean>;
   isEtaValid$: Observable<boolean>;
-  // catBLegalRequirements$: Observable<CatBLegalRequirements>;
+  catBELegalRequirements$: Observable<CatBEUniqueTypes.TestRequirements>;
 }
 
 @IonicPage()
@@ -74,7 +75,6 @@ export class TestReportCatBEPage extends BasePageComponent {
   legalRequirements = LegalRequirements;
   eta = ExaminerActions;
   displayOverlay: boolean;
-
   isRemoveFaultMode: boolean = false;
   isSeriousMode: boolean = false;
   isDangerousMode: boolean = false;
@@ -83,7 +83,7 @@ export class TestReportCatBEPage extends BasePageComponent {
   isEtaValid: boolean = true;
 
   modal: Modal;
-  catBLegalRequirements: CatBLegalRequirements;
+  catBELegalRequirements: CatBUniqueTypes.TestRequirements;
 
   constructor(
     public store$: Store<StoreModel>,
@@ -106,10 +106,14 @@ export class TestReportCatBEPage extends BasePageComponent {
     };
   }
   ngOnInit(): void {
+
+    const currentTest$ = this.store$.pipe(
+      select(getTests),
+      select(getCurrentTest),
+    );
+
     this.pageState = {
-      candidateUntitledName$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      candidateUntitledName$: currentTest$.pipe(
         select(getJournalData),
         select(getCandidate),
         select(getUntitledCandidateName),
@@ -126,9 +130,7 @@ export class TestReportCatBEPage extends BasePageComponent {
         select(getTestReportState),
         select(isDangerousMode),
       ),
-      manoeuvres$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
+      manoeuvres$: currentTest$.pipe(
         select(getTestData),
         select(hasManoeuvreBeenCompleted),
       ),
@@ -140,12 +142,10 @@ export class TestReportCatBEPage extends BasePageComponent {
         select(getTestReportState),
         select(isEtaValid),
       ),
-      // catBLegalRequirements$: this.store$.pipe(
-      //   select(getTests),
-      //   select(getCurrentTest),
-      //   select(getTestData),
-      //   select(getCatBLegalRequirements),
-      // ),
+      catBELegalRequirements$: currentTest$.pipe(
+        select(getTestData),
+        select(getCatBELegalRequirements),
+      ),
     };
     this.setupSubscription();
 
@@ -163,12 +163,20 @@ export class TestReportCatBEPage extends BasePageComponent {
   toggleReportOverlay(): void {
     this.displayOverlay = !this.displayOverlay;
   }
+  // TODO: Needs unit tests
+  isLegalRequirementTicked(
+    legalRequirement: LegalRequirements,
+    catBELegalRequirements: CatBEUniqueTypes.TestRequirements,
+  ): boolean {
+    return catBELegalRequirements[legalRequirement];
+  }
 
   ionViewDidLeave(): void {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
   }
+
   setupSubscription() {
     const {
       candidateUntitledName$,
@@ -178,7 +186,7 @@ export class TestReportCatBEPage extends BasePageComponent {
       manoeuvres$,
       // isLegalRequirementsValid$,
       isEtaValid$,
-      // catBLegalRequirements$,
+      catBELegalRequirements$,
     } = this.pageState;
 
     this.subscription = merge(
@@ -191,9 +199,9 @@ export class TestReportCatBEPage extends BasePageComponent {
       //   map(result => (this.isLegalRequirementsValid = result)),
       // ),
       isEtaValid$.pipe(map(result => (this.isEtaValid = result))),
-      // catBLegalRequirements$.pipe(
-      //   map(result => (this.catBLegalRequirements = result)),
-      // ),
+      catBELegalRequirements$.pipe(
+        map(result => (this.catBELegalRequirements = result)),
+      ),
     ).subscribe();
   }
 
@@ -203,7 +211,7 @@ export class TestReportCatBEPage extends BasePageComponent {
       this.modal = this.modalController.create(
         'LegalRequirementsModal',
         {
-          legalRequirements: this.catBLegalRequirements,
+          legalRequirements: this.catBELegalRequirements,
         },
         options,
       );

--- a/src/pages/test-report/components/legal-requirement/legal-requirement.html
+++ b/src/pages/test-report/components/legal-requirement/legal-requirement.html
@@ -3,11 +3,11 @@
   [onPress]="toggleLegalRequirement"
   [ripple]="false"
   [ngClass]="{
-    'complete': componentState.ticked$ | async
+    'complete': ticked
   }"
 >
   <div class="tickwrapper">
-    <tick-indicator [ticked]="componentState.ticked$ | async"></tick-indicator>
+    <tick-indicator [ticked]="ticked"></tick-indicator>
   </div>
   <div [ngClass]="getLegalRequirementClass()">  
     <span class='competency-label'>{{ getLabel() }}</span>

--- a/src/pages/test-report/components/legal-requirement/legal-requirement.ts
+++ b/src/pages/test-report/components/legal-requirement/legal-requirement.ts
@@ -1,30 +1,12 @@
 import { Component, Input } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
-import { Subscription } from 'rxjs/Subscription';
-import { Store, select } from '@ngrx/store';
+import { Store } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
-import { getCurrentTest } from '../../../../modules/tests/tests.selector';
-import { getTests } from '../../../../modules/tests/tests.reducer';
-import { getTestData } from '../../../../modules/tests/test-data/test-data.reducer';
-import {
-  getTestRequirements,
-} from '../../../../modules/tests/test-data/test-data.selector';
-import {
-  hasLegalRequirementBeenCompleted,
-} from '../../../../modules/tests/test-data/cat-b/test-data.cat-b.selector';
 import {
   ToggleLegalRequirement,
 } from '../../../../modules/tests/test-data/test-requirements/test-requirements.actions';
 import { LegalRequirements } from '../../../../modules/tests/test-data/test-data.constants';
 import { legalRequirementLabels } from './legal-requirement.constants';
 
-interface LegalRequirementComponentState {
-  ticked$: Observable<boolean>;
-}
-// TODO: Look into making this component category agnostic by using @Input's to pass down
-// the data it is interested in, instead of using selectors that are category specific.
-// The parent page (test-report) should be responsible for passing down the correct info
-// and it is already aware of the category of the current test.
 @Component({
   selector: 'legal-requirement',
   templateUrl: 'legal-requirement.html',
@@ -33,26 +15,12 @@ export class LegalRequirementComponent {
 
   @Input()
   legalRequirement: LegalRequirements;
-
-  componentState: LegalRequirementComponentState;
-  subscription: Subscription;
+  @Input()
+  ticked: boolean;
 
   constructor(
     private store$: Store<StoreModel>,
   ) {}
-
-  ngOnInit(): void {
-
-    this.componentState = {
-      ticked$: this.store$.pipe(
-        select(getTests),
-        select(getCurrentTest),
-        select(getTestData),
-        select(getTestRequirements),
-        select(testrequirements => hasLegalRequirementBeenCompleted(testrequirements, this.legalRequirement)),
-      ),
-    };
-  }
 
   getLabel = (): string => legalRequirementLabels[this.legalRequirement];
 


### PR DESCRIPTION
## Description

- Previously the legal requirements component was responsible for figuring out whether it was ticked or not by accessing the store. This coupled it to category B because of the usage of selectors.
- Now this logic has been moved to the parent pages that utilise the legal requirements component and the `ticked` boolean is passed down as an `Input`.
- Also adds the toolbar back onto the B+E test report screen.

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
