### PR TITLE
MES-4161 & MES-4162: D255 + Transmission banners

### DIFF
--- a/src/pages/pass-finalisation/cat-b/_tests_/pass-finalisation.cat-b.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-b/_tests_/pass-finalisation.cat-b.page.spec.ts
@@ -30,6 +30,7 @@ import { CandidateChoseToProceedWithTestInWelsh, CandidateChoseToProceedWithTest
 import { PassCertificateNumberComponent } from '../../components/pass-certificate-number/pass-certificate-number';
 import { LicenseProvidedComponent } from '../../components/license-provided/license-provided';
 import { TransmissionComponent } from '../../../../components/test-finalisation/transmission/transmission';
+import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
 
 describe('PassFinalisationCatBPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatBPage>;
@@ -48,6 +49,7 @@ describe('PassFinalisationCatBPage', () => {
         MockComponent(DebriefWitnessedComponent),
         MockComponent(FinalisationHeaderComponent),
         MockComponent(LanguagePreferencesComponent),
+        MockComponent(WarningBannerComponent),
       ],
       imports: [IonicModule, AppModule],
       providers: [

--- a/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.html
+++ b/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.html
@@ -27,11 +27,13 @@
           (licenseNotReceived)="provisionalLicenseNotReceived()"> </license-provided>
 
         <transmission [form]="form" (gearBoxCategoryChange)="transmissionChanged($event)"></transmission>
+        <warning-banner *ngIf="pageState.transmissionAutomaticRadioChecked$ | async" warningText="An automatic licence will be issued."></warning-banner>
 
         <pass-certificate-number [form]="form" (passCertificateNumberChange)="passCertificateNumberChanged($event)"></pass-certificate-number>
 
         <d255 [display]=true [d255]="pageState.d255$ | async" [outcome]="testOutcome" [formGroup]="form"
           (d255Change)="d255Changed($event)"></d255>
+        <warning-banner *ngIf="pageState.d255$ | async" warningText="By selecting Yes you are confirming a D255 is required."></warning-banner>
 
         <language-preferences [formGroup]="form" [isWelsh]="(pageState.conductedLanguage$ | async) === 'Cymraeg'"
           (welshChanged)="isWelshChanged($event)"></language-preferences>

--- a/src/pages/pass-finalisation/cat-be/_tests_/pass-finalisation.cat-be.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-be/_tests_/pass-finalisation.cat-be.page.spec.ts
@@ -31,6 +31,7 @@ import { CandidateChoseToProceedWithTestInWelsh, CandidateChoseToProceedWithTest
   '../../../../modules/tests/communication-preferences/communication-preferences.actions';
 import { PassFinalisationCatBEPage } from '../pass-finalisation.cat-be.page';
 import { Code78Component } from '../components/code-78/code-78';
+import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
 
 describe('PassFinalisationCatBEPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatBEPage>;
@@ -50,6 +51,7 @@ describe('PassFinalisationCatBEPage', () => {
         MockComponent(FinalisationHeaderComponent),
         MockComponent(LanguagePreferencesComponent),
         MockComponent(Code78Component),
+        MockComponent(WarningBannerComponent),
       ],
       imports: [IonicModule, AppModule],
       providers: [

--- a/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.html
+++ b/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.html
@@ -33,6 +33,7 @@
 
         <d255 [display]=true [d255]="pageState.d255$ | async" [outcome]="testOutcome" [formGroup]="form"
           (d255Change)="d255Changed($event)"></d255>
+        <warning-banner *ngIf="pageState.d255$ | async" warningText="By selecting Yes you are confirming a D255 is required."></warning-banner>
 
         <language-preferences [formGroup]="form" [isWelsh]="(pageState.conductedLanguage$ | async) === 'Cymraeg'"
           (welshChanged)="isWelshChanged($event)"></language-preferences>

--- a/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.scss
+++ b/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.scss
@@ -1,4 +1,4 @@
-page-pass-finalisation-cat-be-page {
+pass-finalisation-cat-be-page {
   ion-content > div {
     background-color: map-get($colors, "mes-white");
   }


### PR DESCRIPTION
## Description
- Adds warning banners for transmission + D255 for category B
- Adds warning banner for D255 for category B+E (Transmission banner is covered by the Code78 work #930)
- Fixes the background colour on the B+E pass finalisation page 

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
