### PR TITLE
MES-4027 Only hide provisional licence field when value isn't set (#936)

### DIFF
--- a/src/pages/view-test-result/components/test-summary-card/__tests__/test-summary-card.spec.ts
+++ b/src/pages/view-test-result/components/test-summary-card/__tests__/test-summary-card.spec.ts
@@ -40,8 +40,21 @@ describe('TestSummaryCardComponent', () => {
     });
   });
 
-  describe('DOM', () => {
+  describe('shouldDisplayLicenceProvided', () => {
+    it('should return a true when data supplied has a value of true', () => {
+      const result: boolean = component.shouldDisplayLicenceProvided(true);
+      expect(result).toBeTruthy();
+    });
 
+    it('should return a true when data supplied has a value of false', () => {
+      const result: boolean = component.shouldDisplayLicenceProvided(false);
+      expect(result).toBeTruthy();
+    });
+
+    it('should return a false when data passed in is not a boolean', () => {
+      const result: boolean = component.shouldDisplayLicenceProvided(undefined);
+      expect(result).toBeFalsy();
+    });
   });
 
 });

--- a/src/pages/view-test-result/components/test-summary-card/test-summary-card.html
+++ b/src/pages/view-test-result/components/test-summary-card/test-summary-card.html
@@ -13,7 +13,7 @@
           <span class="mes-data">{{ getFlattenArray(data.accompaniment) }}</span>
         </ion-col>
       </ion-row>
-      <ion-row class="mes-data-row-with-separator" *ngIf="data.provisionalLicenceProvided">
+      <ion-row class="mes-data-row-with-separator" *ngIf="shouldDisplayLicenceProvided(data.provisionalLicenceProvided)">
         <ion-col col-40>
           <label>Licence provided</label>
         </ion-col>

--- a/src/pages/view-test-result/components/test-summary-card/test-summary-card.ts
+++ b/src/pages/view-test-result/components/test-summary-card/test-summary-card.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { TestSummaryCardModel } from './test-summary-card-model';
 import { convertBooleanToString, flattenArray } from '../../view-test-result-helpers';
+import { isBoolean } from 'lodash';
 
 @Component({
   selector: 'test-summary-card',
@@ -31,4 +32,5 @@ export class TestSummaryCardComponent {
 
   getFlattenArray = (data: string[]): string => flattenArray(data);
 
+  shouldDisplayLicenceProvided = (data: boolean): boolean => isBoolean(data);
 }


### PR DESCRIPTION
## Description
Cherry-pick of https://github.com/dvsa/mes-mobile-app/pull/936
## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
