### PR TITLE
MES-4183: Examiner Conducted Id on Start Test

### DIFF
--- a/src/modules/tests/__tests__/tests.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.effects.spec.ts
@@ -214,7 +214,7 @@ describe('Tests Effects', () => {
       .subscribe(([res1, res2, res3, res4, res5, res6, res7, res8, res9, res10]) => {
         expect(res1).toEqual(new PopulateExaminer(examiner)),
         expect(res8).toEqual(new SetExaminerBooked(parseInt(examiner.staffNumber, 10))),
-        expect(res9).toEqual(new SetExaminerConducted(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
+        expect(res9).toEqual(new SetExaminerConducted(parseInt(examiner.staffNumber, 10))),
         expect(res10).toEqual(new SetExaminerKeyed(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
         done();
       });
@@ -242,7 +242,7 @@ describe('Tests Effects', () => {
       .subscribe(([res1, res2, res3, res4, res5, res6, res7, res8, res9, res10, res11, res12, res13]) => {
         expect(res1).toEqual(new PopulateExaminer(examiner)),
         expect(res8).toEqual(new SetExaminerBooked(parseInt(examiner.staffNumber, 10))),
-        expect(res9).toEqual(new SetExaminerConducted(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
+        expect(res9).toEqual(new SetExaminerConducted(parseInt(examiner.staffNumber, 10))),
         expect(res10).toEqual(new SetExaminerKeyed(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
         expect(res13).toEqual(new rekeyActions.MarkAsRekey()),
         done();
@@ -282,7 +282,7 @@ describe('Tests Effects', () => {
         expect(res2).toEqual(new PopulateApplicationReference(testSlot.booking.application)),
         expect(res3).toEqual(new PopulateCandidateDetails(testSlot.booking.candidate)),
         expect(res8).toEqual(new SetExaminerBooked(parseInt(staffNumber, 10))),
-        expect(res9).toEqual(new SetExaminerConducted(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
+        expect(res9).toEqual(new SetExaminerConducted(parseInt(staffNumber, 10))),
         expect(res10).toEqual(new SetExaminerKeyed(parseInt(authenticationProviderMock.getEmployeeId(), 10))),
         expect(res13).toEqual(new rekeyActions.MarkAsRekey()),
         done();

--- a/src/modules/tests/tests.effects.ts
+++ b/src/modules/tests/tests.effects.ts
@@ -135,9 +135,9 @@ export class TestsEffects {
       let slot: TestSlot;
       let examiner: Examiner;
 
-      let examinerBooked: string;
-      const examinerConducted: string = employeeId;
       const examinerKeyed: string = employeeId;
+
+      let examinerBooked: string;
 
       if (isRekeySearch) {
         examinerBooked = getStaffNumber(rekeySearch);
@@ -164,7 +164,7 @@ export class TestsEffects {
         new testStatusActions.SetTestStatusBooked(startTestAction.slotId.toString()),
         new PopulateTestCategory(slot.booking.application.testCategory),
         new SetExaminerBooked(parseInt(examinerBooked, 10) ? parseInt(examinerBooked, 10) : null),
-        new SetExaminerConducted(parseInt(examinerConducted, 10) ? parseInt(examinerConducted, 10) : null),
+        new SetExaminerConducted(parseInt(examinerBooked, 10) ? parseInt(examinerBooked, 10) : null),
         new SetExaminerKeyed(parseInt(examinerKeyed, 10) ? parseInt(examinerKeyed, 10) : null),
         new PopulateConductedLanguage(conductedLanguage),
         new PopulateTestSchemaVersion(version),


### PR DESCRIPTION
## Description

Setting the correct `examinerConductedId` when the Test Starts.
Previously it was set from the DE id who is logged in to the device, and this changes to get it from the booking.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

![Screenshot 2019-11-22 at 12 20 10](https://user-images.githubusercontent.com/7311745/69426221-a8312c00-0d24-11ea-9f2e-ac1d056b7973.png)
