### PR TITLE
Feature mes 3874 behaviour map cat be

### DIFF
--- a/src/pages/non-pass-finalisation/cat-be/non-pass-finalisation.cat-be.page.ts
+++ b/src/pages/non-pass-finalisation/cat-be/non-pass-finalisation.cat-be.page.ts
@@ -35,7 +35,7 @@ import {
 import { FormGroup } from '@angular/forms';
 import { PersistTests } from '../../../modules/tests/tests.actions';
 import { OutcomeBehaviourMapProvider } from '../../../providers/outcome-behaviour-map/outcome-behaviour-map';
-import { behaviourMap } from '../../office/office-behaviour-map';
+import { behaviourMap } from '../../office/office-behaviour-map.cat-be';
 import {
   DebriefWitnessed,
   DebriefUnwitnessed,

--- a/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.ts
+++ b/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.ts
@@ -55,7 +55,7 @@ import {
   DebriefUnwitnessed,
 } from '../../../modules/tests/test-summary/test-summary.actions';
 import { OutcomeBehaviourMapProvider } from '../../../providers/outcome-behaviour-map/outcome-behaviour-map';
-import { behaviourMap } from '../../office/office-behaviour-map';
+import { behaviourMap } from '../../office/office-behaviour-map.cat-be';
 import { ActivityCodes } from '../../../shared/models/activity-codes';
 import {
   CandidateChoseToProceedWithTestInWelsh,


### PR DESCRIPTION
Amend Cat BE pages that make use of the Outcome behaviour provider to use the new BE behaviour map instead.  There is no functional difference currently, as the mappings for most form fields are the same, but this may diverge in the future.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number
