### PR TITLE
Mes-4175-eco-and-eta-are-not-displayed-on-the-office-page

### DIFF
--- a/src/pages/office/office.ts
+++ b/src/pages/office/office.ts
@@ -312,7 +312,7 @@ export class OfficePage extends PracticeableBasePageComponent {
       displayEco$: currentTest$.pipe(
         select(getTestOutcome),
         withLatestFrom(currentTest$.pipe(
-          select(getTestSummary),
+          select(getTestData),
           select(getEco))),
         map(([outcome, eco]) =>
           this.outcomeBehaviourProvider.isVisible(outcome, 'eco', eco)),
@@ -320,7 +320,7 @@ export class OfficePage extends PracticeableBasePageComponent {
       displayEta$: currentTest$.pipe(
         select(getTestOutcome),
         withLatestFrom(currentTest$.pipe(
-          select(getTestSummary),
+          select(getTestData),
           select(getETA))),
         map(([outcome, eta]) =>
           this.outcomeBehaviourProvider.isVisible(outcome, 'eta', eta)),


### PR DESCRIPTION
Mes-4175 Changed get test summary to get test data for eco and eta requirements on office page. Eco and Eta now displayed on the office page.

## Checklist

- [x] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="495" alt="Screenshot 2019-11-25 at 16 50 16" src="https://user-images.githubusercontent.com/23356214/69561056-a70e3200-0fa4-11ea-814f-20a59fb60c04.png">
