### PR TITLE
MES 4190 uncouple recouple analytics

### DIFF
--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -41,7 +41,7 @@ import { legalRequirementsLabels, legalRequirementToggleValues }
 import { TestCategory } from '../../../shared/models/test-category';
 import * as uncoupleRecoupleActions from '../../../modules/tests/test-data/uncouple-recouple/uncouple-recouple.actions';
 
-fdescribe('Test Report Analytics Effects', () => {
+describe('Test Report Analytics Effects', () => {
 
   let effects: TestReportAnalyticsEffects;
   let actions$: ReplaySubject<any>;

--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -39,8 +39,9 @@ import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions
 import { legalRequirementsLabels, legalRequirementToggleValues }
   from '../../../shared/constants/legal-requirements/catb-legal-requirements';
 import { TestCategory } from '../../../shared/models/test-category';
+import * as uncoupleRecoupleActions from '../../../modules/tests/test-data/uncouple-recouple/uncouple-recouple.actions';
 
-describe('Test Report Analytics Effects', () => {
+fdescribe('Test Report Analytics Effects', () => {
 
   let effects: TestReportAnalyticsEffects;
   let actions$: ReplaySubject<any>;
@@ -1131,6 +1132,123 @@ describe('Test Report Analytics Effects', () => {
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.TOGGLE_LEGAL_REQUIREMENT,
           `${legalRequirementsLabels['vehicleChecks']} - ${legalRequirementToggleValues.uncompleted}`,
+        );
+        done();
+      });
+    });
+  });
+
+  describe('uncoupleRecoupleAddDrivingFault', () => {
+    it('should call logEvent for this competency', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.BE));
+      // ACT
+      actions$.next(new uncoupleRecoupleActions.UncoupleRecoupleAddDrivingFault());
+      // ASSERT
+      effects.uncoupleRecoupleAddDrivingFault$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DRIVING_FAULT,
+          'Uncouple recouple',
+          1,
+        );
+        done();
+      });
+    });
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions$.next(new uncoupleRecoupleActions.UncoupleRecoupleAddDrivingFault());
+      // ASSERT
+      effects.uncoupleRecoupleAddDrivingFault$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_DRIVING_FAULT}`,
+          'Uncouple recouple',
+          1,
+        );
+        done();
+      });
+    });
+  });
+
+  describe('uncoupleRecoupleAddSeriousFault', () => {
+    it('should call logEvent for this competency', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.BE));
+      // ACT
+      actions$.next(new uncoupleRecoupleActions.UncoupleRecoupleAddSeriousFault());
+      // ASSERT
+      effects.uncoupleRecoupleAddSeriousFault$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_SERIOUS_FAULT,
+          'Uncouple recouple',
+          1,
+        );
+        done();
+      });
+    });
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions$.next(new uncoupleRecoupleActions.UncoupleRecoupleAddSeriousFault());
+      // ASSERT
+      effects.uncoupleRecoupleAddSeriousFault$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_SERIOUS_FAULT}`,
+          'Uncouple recouple',
+          1,
+        );
+        done();
+      });
+    });
+  });
+
+  describe('uncoupleRecoupleAddDangerousFault', () => {
+    it('should call logEvent for this competency', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.BE));
+      // ACT
+      actions$.next(new uncoupleRecoupleActions.UncoupleRecoupleAddDangerousFault());
+      // ASSERT
+      effects.uncoupleRecoupleAddDangerousFault$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.ADD_DANGEROUS_FAULT,
+          'Uncouple recouple',
+          1,
+        );
+        done();
+      });
+    });
+    it('should call logEvent for this competency, prefixed with practice test', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions$.next(new uncoupleRecoupleActions.UncoupleRecoupleAddDangerousFault());
+      // ASSERT
+      effects.uncoupleRecoupleAddDangerousFault$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_DANGEROUS_FAULT}`,
+          'Uncouple recouple',
+          1,
         );
         done();
       });

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -32,6 +32,7 @@ import { getCurrentTest } from '../../modules/tests/tests.selector';
 import { getTestData } from '../../modules/tests/test-data/test-data.reducer';
 import { getEco, getTestRequirements } from '../../modules/tests/test-data/test-data.selector';
 import { Eco, TestRequirements } from '@dvsa/mes-test-schema/categories/Common';
+import * as uncoupleRecoupleActions from '../../modules/tests/test-data/uncouple-recouple/uncouple-recouple.actions';
 
 @Injectable()
 export class TestReportAnalyticsEffects {
@@ -678,6 +679,75 @@ export class TestReportAnalyticsEffects {
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
         formatAnalyticsText(AnalyticsEvents.TOGGLE_LEGAL_REQUIREMENT, tests),
         `${legalRequirementsLabels['vehicleChecks']} - ${legalRequirementToggleValues.uncompleted}`,
+      );
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  uncoupleRecoupleAddDrivingFault$ = this.actions$.pipe(
+    ofType(
+      uncoupleRecoupleActions.UNCOUPLE_RECOUPLE_ADD_DRIVING_FAULT,
+    ),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    concatMap(([action, tests]: [uncoupleRecoupleActions.UncoupleRecoupleAddDrivingFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_DRIVING_FAULT, tests),
+        'Uncouple recouple',
+        1,
+      );
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  uncoupleRecoupleAddSeriousFault$ = this.actions$.pipe(
+    ofType(
+      uncoupleRecoupleActions.UNCOUPLE_RECOUPLE_ADD_SERIOUS_FAULT,
+    ),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    concatMap(([action, tests]: [uncoupleRecoupleActions.UncoupleRecoupleAddSeriousFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_SERIOUS_FAULT, tests),
+        'Uncouple recouple',
+        1,
+      );
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  uncoupleRecoupleAddDangerousFault$ = this.actions$.pipe(
+    ofType(
+      uncoupleRecoupleActions.UNCOUPLE_RECOUPLE_ADD_DANGEROUS_FAULT,
+    ),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    concatMap(([action, tests]: [uncoupleRecoupleActions.UncoupleRecoupleAddDangerousFault, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.ADD_DANGEROUS_FAULT, tests),
+        'Uncouple recouple',
+        1,
       );
       return of(new AnalyticRecorded());
     }),


### PR DESCRIPTION
## Description
- Added analytics effects for test report uncouple recouple driving faults
- Unit testing for analytics effects

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
