### PR TITLE
MES-3833: Implementing Analytics for opening and closing reverse left overlay

### DIFF
--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -43,6 +43,8 @@ import { legalRequirementsLabels, legalRequirementToggleValues }
 import { TestCategory } from '../../../shared/models/test-category';
 import * as uncoupleRecoupleActions
   from '../../../modules/tests/test-data/cat-be/uncouple-recouple/uncouple-recouple.actions';
+import * as reverseLeftActions
+  from '../cat-be/components/reverse-left/reverse-left.actions';
 
 describe('Test Report Analytics Effects', () => {
 
@@ -1252,6 +1254,44 @@ describe('Test Report Analytics Effects', () => {
           `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.ADD_DANGEROUS_FAULT}`,
           'Uncouple recouple',
           1,
+        );
+        done();
+      });
+    });
+  });
+
+  describe('reverseLeftPopoverOpened', () => {
+    it('should call logEvent with the correct parameters', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions$.next(new reverseLeftActions.ReverseLeftPopoverOpened());
+      // ASSERT
+      effects.reverseLeftPopoverOpened$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REVERSE_LEFT_POPOVER_OPENED}`,
+        );
+        done();
+      });
+    });
+  });
+
+  describe('reverseLeftPopoverClosed', () => {
+    it('should call logEvent with the correct parameters', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions$.next(new reverseLeftActions.ReverseLeftPopoverClosed());
+      // ASSERT
+      effects.reverseLeftPopoverClosed$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REVERSE_LEFT_POPOVER_CLOSED}`,
         );
         done();
       });

--- a/src/pages/test-report/cat-be/components/reverse-left/reverse-left.ts
+++ b/src/pages/test-report/cat-be/components/reverse-left/reverse-left.ts
@@ -11,6 +11,7 @@ import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
 import { TestCategory } from '../../../../../shared/models/test-category';
 import { CompetencyOutcome } from '../../../../../shared/models/competency-outcome';
 import { OverlayCallback } from '../../../test-report.model';
+import { ReverseLeftPopoverOpened, ReverseLeftPopoverClosed } from './reverse-left.actions';
 
 @Component({
   selector: 'reverse-left',
@@ -71,7 +72,13 @@ export class ReverseLeftComponent implements OnInit, OnDestroy  {
   }
 
   togglePopoverDisplay = (): void => {
-    this.displayPopover = !this.displayPopover;
+    if (this.displayPopover) {
+      this.store$.dispatch(new ReverseLeftPopoverClosed());
+      this.displayPopover = false;
+    } else {
+      this.store$.dispatch(new ReverseLeftPopoverOpened());
+      this.displayPopover = true;
+    }
     this.toggleOverlay();
   }
 

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -36,6 +36,7 @@ import { getEco, getTestRequirements } from '../../modules/tests/test-data/commo
 import { Eco, TestRequirements } from '@dvsa/mes-test-schema/categories/Common';
 import * as uncoupleRecoupleActions
   from '../../modules/tests/test-data/cat-be/uncouple-recouple/uncouple-recouple.actions';
+import * as reverseLeftActions from './cat-be/components/reverse-left/reverse-left.actions';
 
 @Injectable()
 export class TestReportAnalyticsEffects {
@@ -752,6 +753,24 @@ export class TestReportAnalyticsEffects {
         'Uncouple recouple',
         1,
       );
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  reverseLeftPopoverOpened$ = this.actions$.pipe(
+    ofType(reverseLeftActions.REVERSE_LEFT_POPOVER_OPENED),
+    concatMap((action: reverseLeftActions.ReverseLeftPopoverOpened) => {
+      this.analytics.logEvent(AnalyticsEventCategories.TEST_REPORT, AnalyticsEvents.REVERSE_LEFT_POPOVER_OPENED);
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  reverseLeftPopoverClosed$ = this.actions$.pipe(
+    ofType(reverseLeftActions.REVERSE_LEFT_POPOVER_CLOSED),
+    concatMap((action: reverseLeftActions.ReverseLeftPopoverClosed) => {
+      this.analytics.logEvent(AnalyticsEventCategories.TEST_REPORT, AnalyticsEvents.REVERSE_LEFT_POPOVER_CLOSED);
       return of(new AnalyticRecorded());
     }),
   );

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -760,8 +760,18 @@ export class TestReportAnalyticsEffects {
   @Effect()
   reverseLeftPopoverOpened$ = this.actions$.pipe(
     ofType(reverseLeftActions.REVERSE_LEFT_POPOVER_OPENED),
-    concatMap((action: reverseLeftActions.ReverseLeftPopoverOpened) => {
-      this.analytics.logEvent(AnalyticsEventCategories.TEST_REPORT, AnalyticsEvents.REVERSE_LEFT_POPOVER_OPENED);
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    concatMap(([action, tests]: [reverseLeftActions.ReverseLeftPopoverOpened, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.REVERSE_LEFT_POPOVER_OPENED, tests),
+        );
       return of(new AnalyticRecorded());
     }),
   );
@@ -769,8 +779,18 @@ export class TestReportAnalyticsEffects {
   @Effect()
   reverseLeftPopoverClosed$ = this.actions$.pipe(
     ofType(reverseLeftActions.REVERSE_LEFT_POPOVER_CLOSED),
-    concatMap((action: reverseLeftActions.ReverseLeftPopoverClosed) => {
-      this.analytics.logEvent(AnalyticsEventCategories.TEST_REPORT, AnalyticsEvents.REVERSE_LEFT_POPOVER_CLOSED);
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    concatMap(([action, tests]: [reverseLeftActions.ReverseLeftPopoverClosed, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.REVERSE_LEFT_POPOVER_CLOSED, tests),
+      );
       return of(new AnalyticRecorded());
     }),
   );

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -94,6 +94,8 @@ export enum AnalyticsEvents {
   TOGGLE_LEGAL_REQUIREMENT = 'toggle legal requirement',
   TEST_OUTCOME_CHANGED = 'test outcome changed',
   TEST_BOOKING_SEARCH = 'perform test booking search',
+  REVERSE_LEFT_POPOVER_OPENED = 'open reversing manoeuvre',
+  REVERSE_LEFT_POPOVER_CLOSED = 'close reversing manoevure',
 }
 
 export enum AnalyticsLabels {


### PR DESCRIPTION
## Description

Dispatching analytics events when reverse left overlay opens/closes.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
