### PR TITLE
MES-609: Additional cat be manoeuvre analytics

### DIFF
--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -45,6 +45,8 @@ import * as uncoupleRecoupleActions
   from '../../../modules/tests/test-data/cat-be/uncouple-recouple/uncouple-recouple.actions';
 import * as reverseLeftActions
   from '../cat-be/components/reverse-left/reverse-left.actions';
+import * as catBEManoeuversActions
+  from '../../../modules/tests/test-data/cat-be/manoeuvres/manoeuvres.cat-be.actions';
 
 describe('Test Report Analytics Effects', () => {
 
@@ -1046,6 +1048,7 @@ describe('Test Report Analytics Effects', () => {
         done();
       });
     });
+
     it('should call logEvent for selected manoeuvre', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
@@ -1059,6 +1062,25 @@ describe('Test Report Analytics Effects', () => {
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.TOGGLE_LEGAL_REQUIREMENT,
           `${legalRequirementsLabels['manoeuvre']} - ${legalRequirementToggleValues.completed}`,
+        );
+        done();
+      });
+    });
+
+    it('should call logEvent for deselected manoeuvre', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
+      actions$.next(new manoeuvresActions.RecordManoeuvresSelection(ManoeuvreTypes.reverseParkRoad));
+      // ACT
+      actions$.next(new catBEManoeuversActions.DeselectReverseLeftManoeuvre());
+      // ASSERT
+      effects.deselectReverseLeftManoeuvreEffect$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.TOGGLE_LEGAL_REQUIREMENT,
+          `${legalRequirementsLabels['manoeuvre']} - ${legalRequirementToggleValues.uncompleted}`,
         );
         done();
       });

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -37,6 +37,8 @@ import { Eco, TestRequirements } from '@dvsa/mes-test-schema/categories/Common';
 import * as uncoupleRecoupleActions
   from '../../modules/tests/test-data/cat-be/uncouple-recouple/uncouple-recouple.actions';
 import * as reverseLeftActions from './cat-be/components/reverse-left/reverse-left.actions';
+import * as catBEManoeuversActions
+  from '../../modules/tests/test-data/cat-be/manoeuvres/manoeuvres.cat-be.actions';
 
 @Injectable()
 export class TestReportAnalyticsEffects {
@@ -636,6 +638,26 @@ export class TestReportAnalyticsEffects {
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
         formatAnalyticsText(AnalyticsEvents.TOGGLE_LEGAL_REQUIREMENT, tests),
         `${legalRequirementsLabels['manoeuvre']} - ${legalRequirementToggleValues.completed}`,
+      );
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  deselectReverseLeftManoeuvreEffect$ = this.actions$.pipe(
+    ofType(catBEManoeuversActions.DESELECT_REVERSE_LEFT_MANOEUVRE),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    switchMap(([action, tests]: [catBEManoeuversActions.DeselectReverseLeftManoeuvre, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.TOGGLE_LEGAL_REQUIREMENT, tests),
+        `${legalRequirementsLabels['manoeuvre']} - ${legalRequirementToggleValues.uncompleted}`,
       );
       return of(new AnalyticRecorded());
     }),


### PR DESCRIPTION
## Description

Adding analytics for DeselectReverseLeftManoeuvre action

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
