### PR TITLE
MES-4237: Adding reverse left to label constants

### DIFF
--- a/src/shared/constants/competencies/catb-manoeuvres.ts
+++ b/src/shared/constants/competencies/catb-manoeuvres.ts
@@ -1,4 +1,5 @@
 export enum manoeuvreTypeLabels {
+  reverseLeft = 'Reverse left',
   reverseRight = 'Reverse right',
   reverseParkRoad = 'Reverse park (road)',
   reverseParkCarpark = 'Reverse park (car park)',


### PR DESCRIPTION
## Description

Adding Reverse left to Manoeuvre labels enum

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
