### PR TITLE
Add ng-bullet for unit testing performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1051,8 +1051,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1073,14 +1072,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1095,20 +1092,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1225,8 +1219,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1238,7 +1231,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1253,7 +1245,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -1261,14 +1252,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -1287,7 +1276,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1368,8 +1356,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1381,7 +1368,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -1467,8 +1453,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -1504,7 +1489,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -1524,7 +1508,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1568,14 +1551,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -8475,7 +8456,6 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -8652,8 +8632,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -12711,8 +12690,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -12733,14 +12711,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12755,20 +12731,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -12885,8 +12858,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -12898,7 +12870,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -12913,7 +12884,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -12921,14 +12891,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -12947,7 +12915,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -13028,8 +12995,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -13041,7 +13007,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -13127,8 +13092,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -13164,7 +13128,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -13184,7 +13147,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -13228,14 +13190,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -13811,8 +13771,7 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -13990,7 +13949,6 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -14001,7 +13959,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -14053,7 +14010,6 @@
       "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
-      "optional": true,
       "requires": {
         "httpreq": ">=0.4.22",
         "underscore": "~1.7.0"
@@ -14063,8 +14019,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
       "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "https-browserify": {
       "version": "1.0.0",
@@ -14764,8 +14719,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -16096,15 +16050,13 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
       "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "libmime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/libmime/-/libmime-3.0.0.tgz",
       "integrity": "sha1-UaGp50SOy9Ms2lRCFnW7IbwJPaY=",
       "dev": true,
-      "optional": true,
       "requires": {
         "iconv-lite": "0.4.15",
         "libbase64": "0.1.0",
@@ -16115,8 +16067,7 @@
           "version": "0.4.15",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
           "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -16124,8 +16075,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "license-webpack-plugin": {
       "version": "1.5.0",
@@ -17161,6 +17111,15 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "ng-bullet": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ng-bullet/-/ng-bullet-1.0.3.tgz",
+      "integrity": "sha512-qacsE/w/pLlBxebort1rkrE2B4Vc3idutcpe7tYiHVarz0V6Q5SN8E3d6NUp4UFBMOucpHlCpaASp7qEOsxM1Q==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "ng-mocks": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/ng-mocks/-/ng-mocks-7.1.3.tgz",
@@ -17413,15 +17372,13 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
       "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nodemailer-shared": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
       "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
       "dev": true,
-      "optional": true,
       "requires": {
         "nodemailer-fetch": "1.6.0"
       }
@@ -17454,8 +17411,7 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz",
       "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nopt": {
       "version": "3.0.6",
@@ -22662,15 +22618,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
       "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "smtp-connection": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
       "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
       "dev": true,
-      "optional": true,
       "requires": {
         "httpntlm": "1.6.1",
         "nodemailer-shared": "1.1.0"
@@ -22911,7 +22865,6 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.2.3.tgz",
       "integrity": "sha512-+2r83WaRT3PXYoO/1z+RDEBE7Z2f9YcdQnJ0K/ncXXbV5gJ6wYfNAebYFYiiUjM6E4JyXnPY8cimwyvFYHVUUA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "ip": "^1.1.5",
         "smart-buffer": "4.0.2"
@@ -22922,7 +22875,6 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "agent-base": "~4.2.0",
         "socks": "~2.2.0"
@@ -25173,8 +25125,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "unherit": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "^2.0.13",
+    "ng-bullet": "^1.0.3",
     "ng-mocks": "^7.1.3",
     "npm-run-all": "^4.1.3",
     "null-loader": "^0.1.1",

--- a/src/components/common/dangerous-fault-badge/__tests__/dangerous-fault-badge.spec.ts
+++ b/src/components/common/dangerous-fault-badge/__tests__/dangerous-fault-badge.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DangerousFaultBadgeComponent } from '../dangerous-fault-badge';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('DangerousFaultBadgeComponenet', () => {
   let fixture: ComponentFixture<DangerousFaultBadgeComponent>;
@@ -12,7 +12,7 @@ describe('DangerousFaultBadgeComponenet', () => {
       declarations: [
         DangerousFaultBadgeComponent,
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/components/common/dangerous-fault-badge/__tests__/dangerous-fault-badge.spec.ts
+++ b/src/components/common/dangerous-fault-badge/__tests__/dangerous-fault-badge.spec.ts
@@ -16,8 +16,8 @@ describe('DangerousFaultBadgeComponenet', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(DangerousFaultBadgeComponent);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(DangerousFaultBadgeComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('DOM', () => {

--- a/src/components/common/dangerous-fault-badge/__tests__/dangerous-fault-badge.spec.ts
+++ b/src/components/common/dangerous-fault-badge/__tests__/dangerous-fault-badge.spec.ts
@@ -1,22 +1,23 @@
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DangerousFaultBadgeComponent } from '../dangerous-fault-badge';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('DangerousFaultBadgeComponenet', () => {
   let fixture: ComponentFixture<DangerousFaultBadgeComponent>;
   let component: DangerousFaultBadgeComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         DangerousFaultBadgeComponent,
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(DangerousFaultBadgeComponent);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('DOM', () => {

--- a/src/components/common/display-address/__tests__/display-address.spec.ts
+++ b/src/components/common/display-address/__tests__/display-address.spec.ts
@@ -1,22 +1,23 @@
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DisplayAddressComponent } from '../display-address';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('DisplayAddressComponent', () => {
   let fixture: ComponentFixture<DisplayAddressComponent>;
   let component: DisplayAddressComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         DisplayAddressComponent,
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(DisplayAddressComponent);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('DOM', () => {

--- a/src/components/common/display-address/__tests__/display-address.spec.ts
+++ b/src/components/common/display-address/__tests__/display-address.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DisplayAddressComponent } from '../display-address';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('DisplayAddressComponent', () => {
   let fixture: ComponentFixture<DisplayAddressComponent>;
@@ -12,8 +12,8 @@ describe('DisplayAddressComponent', () => {
       declarations: [
         DisplayAddressComponent,
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(DisplayAddressComponent);

--- a/src/components/common/display-address/__tests__/display-address.spec.ts
+++ b/src/components/common/display-address/__tests__/display-address.spec.ts
@@ -16,8 +16,8 @@ describe('DisplayAddressComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(DisplayAddressComponent);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(DisplayAddressComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('DOM', () => {

--- a/src/components/common/driving-faults-badge/__tests__/driving-faults-badge.spec.ts
+++ b/src/components/common/driving-faults-badge/__tests__/driving-faults-badge.spec.ts
@@ -16,8 +16,8 @@ describe('DrivingFaultsBadgeComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(DrivingFaultsBadgeComponent);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(DrivingFaultsBadgeComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('DOM', () => {

--- a/src/components/common/driving-faults-badge/__tests__/driving-faults-badge.spec.ts
+++ b/src/components/common/driving-faults-badge/__tests__/driving-faults-badge.spec.ts
@@ -1,7 +1,7 @@
 import { DrivingFaultsBadgeComponent } from '../driving-faults-badge';
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('DrivingFaultsBadgeComponent', () => {
   let fixture: ComponentFixture<DrivingFaultsBadgeComponent>;
@@ -12,8 +12,8 @@ describe('DrivingFaultsBadgeComponent', () => {
       declarations: [
         DrivingFaultsBadgeComponent,
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(DrivingFaultsBadgeComponent);

--- a/src/components/common/driving-faults-badge/__tests__/driving-faults-badge.spec.ts
+++ b/src/components/common/driving-faults-badge/__tests__/driving-faults-badge.spec.ts
@@ -1,22 +1,23 @@
 import { DrivingFaultsBadgeComponent } from '../driving-faults-badge';
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('DrivingFaultsBadgeComponent', () => {
   let fixture: ComponentFixture<DrivingFaultsBadgeComponent>;
   let component: DrivingFaultsBadgeComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         DrivingFaultsBadgeComponent,
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(DrivingFaultsBadgeComponent);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('DOM', () => {

--- a/src/components/common/end-test-link/__tests__/end-test-link.spec.ts
+++ b/src/components/common/end-test-link/__tests__/end-test-link.spec.ts
@@ -4,7 +4,7 @@ import { IonicModule, ModalController, NavController } from 'ionic-angular';
 import { ModalControllerMock, NavControllerMock } from 'ionic-mocks';
 import { AppModule } from '../../../../app/app.module';
 import { CAT_B, CAT_BE } from '../../../../pages/page-names.constants';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('EndTestLinkComponent', () => {
   let fixture: ComponentFixture<EndTestLinkComponent>;
@@ -20,8 +20,8 @@ describe('EndTestLinkComponent', () => {
         { provide: ModalController, useFactory: () => ModalControllerMock.instance() },
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(EndTestLinkComponent);

--- a/src/components/common/end-test-link/__tests__/end-test-link.spec.ts
+++ b/src/components/common/end-test-link/__tests__/end-test-link.spec.ts
@@ -4,6 +4,7 @@ import { IonicModule, ModalController, NavController } from 'ionic-angular';
 import { ModalControllerMock, NavControllerMock } from 'ionic-mocks';
 import { AppModule } from '../../../../app/app.module';
 import { CAT_B, CAT_BE } from '../../../../pages/page-names.constants';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('EndTestLinkComponent', () => {
   let fixture: ComponentFixture<EndTestLinkComponent>;
@@ -11,7 +12,7 @@ describe('EndTestLinkComponent', () => {
   let modalController: ModalController;
   let navController: NavController;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [EndTestLinkComponent],
       imports: [IonicModule, AppModule],
@@ -20,13 +21,13 @@ describe('EndTestLinkComponent', () => {
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(EndTestLinkComponent);
         component = fixture.componentInstance;
         modalController = TestBed.get(ModalController);
         navController = TestBed.get(NavController);
-      });
   }));
 
   describe('DOM', () => {

--- a/src/components/common/end-test-link/__tests__/end-test-link.spec.ts
+++ b/src/components/common/end-test-link/__tests__/end-test-link.spec.ts
@@ -24,10 +24,10 @@ describe('EndTestLinkComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(EndTestLinkComponent);
-        component = fixture.componentInstance;
-        modalController = TestBed.get(ModalController);
-        navController = TestBed.get(NavController);
+    fixture = TestBed.createComponent(EndTestLinkComponent);
+    component = fixture.componentInstance;
+    modalController = TestBed.get(ModalController);
+    navController = TestBed.get(NavController);
   }));
 
   describe('DOM', () => {

--- a/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.selector.spec.ts
+++ b/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.selector.spec.ts
@@ -10,7 +10,7 @@ import { AppConfigProvider } from '../../../../providers/app-config/app-config';
 import { AppConfigProviderMock } from '../../../../providers/app-config/__mocks__/app-config.mock';
 import { DateTimeProvider } from '../../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../../providers/date-time/__mocks__/date-time.mock';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 class MockStore { }
 

--- a/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.selector.spec.ts
+++ b/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.selector.spec.ts
@@ -10,13 +10,14 @@ import { AppConfigProvider } from '../../../../providers/app-config/app-config';
 import { AppConfigProviderMock } from '../../../../providers/app-config/__mocks__/app-config.mock';
 import { DateTimeProvider } from '../../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../../providers/date-time/__mocks__/date-time.mock';
+import { configureTestSuite } from 'ng-bullet'
 
 class MockStore { }
 
 describe('IncompleteTestsBannerSelector', () => {
   let slotProvider: SlotProvider;
 
-  beforeEach(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       providers: [
         { provide: SlotProvider, useClass: SlotProvider },

--- a/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.selector.spec.ts
+++ b/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.selector.spec.ts
@@ -12,7 +12,8 @@ import { DateTimeProvider } from '../../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../../providers/date-time/__mocks__/date-time.mock';
 import { configureTestSuite } from 'ng-bullet';
 
-class MockStore { }
+class MockStore {
+}
 
 describe('IncompleteTestsBannerSelector', () => {
   let slotProvider: SlotProvider;
@@ -63,7 +64,7 @@ describe('IncompleteTestsBannerSelector', () => {
                   },
                   candidate: null,
                   previousCancellation: null,
-                  business:null,
+                  business: null,
                 },
               },
             },
@@ -91,7 +92,7 @@ describe('IncompleteTestsBannerSelector', () => {
                   },
                   candidate: null,
                   previousCancellation: null,
-                  business:null,
+                  business: null,
                 },
               },
             },
@@ -121,7 +122,7 @@ describe('IncompleteTestsBannerSelector', () => {
                   },
                   candidate: null,
                   previousCancellation: null,
-                  business:null,
+                  business: null,
                 },
               },
             },
@@ -151,7 +152,7 @@ describe('IncompleteTestsBannerSelector', () => {
                   },
                   candidate: null,
                   previousCancellation: null,
-                  business:null,
+                  business: null,
                 },
               },
             },

--- a/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.spec.ts
+++ b/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.spec.ts
@@ -38,8 +38,8 @@ describe('IncompleteTestsBanner', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(IncompleteTestsBanner);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(IncompleteTestsBanner);
+    component = fixture.componentInstance;
   }));
 
   describe('DOM', () => {

--- a/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.spec.ts
+++ b/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.spec.ts
@@ -12,7 +12,7 @@ import { journalReducer } from '../../../../modules/journal/journal.reducer';
 import { SlotProvider } from '../../../../providers/slot/slot';
 import { AppConfigProvider } from '../../../../providers/app-config/app-config';
 import { AppConfigProviderMock } from '../../../../providers/app-config/__mocks__/app-config.mock';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('IncompleteTestsBanner', () => {
   let fixture: ComponentFixture<IncompleteTestsBanner>;
@@ -34,7 +34,7 @@ describe('IncompleteTestsBanner', () => {
         { provide: SlotProvider, useClass: SlotProvider },
         { provide: AppConfigProvider, useClass: AppConfigProviderMock },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.spec.ts
+++ b/src/components/common/incomplete-tests-banner/__tests__/incomplete-tests-banner.spec.ts
@@ -12,12 +12,13 @@ import { journalReducer } from '../../../../modules/journal/journal.reducer';
 import { SlotProvider } from '../../../../providers/slot/slot';
 import { AppConfigProvider } from '../../../../providers/app-config/app-config';
 import { AppConfigProviderMock } from '../../../../providers/app-config/__mocks__/app-config.mock';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('IncompleteTestsBanner', () => {
   let fixture: ComponentFixture<IncompleteTestsBanner>;
   let component: IncompleteTestsBanner;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [IncompleteTestsBanner],
       imports: [
@@ -34,11 +35,11 @@ describe('IncompleteTestsBanner', () => {
         { provide: AppConfigProvider, useClass: AppConfigProviderMock },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(IncompleteTestsBanner);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('DOM', () => {

--- a/src/components/common/practice-mode-banner/__tests__/practice-mode-banner.spec.ts
+++ b/src/components/common/practice-mode-banner/__tests__/practice-mode-banner.spec.ts
@@ -21,9 +21,9 @@ describe('PracticeModeBanner', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(PracticeModeBanner);
-        component = fixture.componentInstance;
-        navController = TestBed.get(NavController);
+    fixture = TestBed.createComponent(PracticeModeBanner);
+    component = fixture.componentInstance;
+    navController = TestBed.get(NavController);
   }));
 
   describe('Class', () => {

--- a/src/components/common/practice-mode-banner/__tests__/practice-mode-banner.spec.ts
+++ b/src/components/common/practice-mode-banner/__tests__/practice-mode-banner.spec.ts
@@ -2,13 +2,14 @@ import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { PracticeModeBanner } from '../practice-mode-banner';
 import { NavController, IonicModule, Config } from 'ionic-angular';
 import { NavControllerMock, ConfigMock } from 'ionic-mocks';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('PracticeModeBanner', () => {
   let fixture: ComponentFixture<PracticeModeBanner>;
   let component: PracticeModeBanner;
   let navController: NavController;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [PracticeModeBanner],
       imports: [IonicModule],
@@ -17,13 +18,14 @@ describe('PracticeModeBanner', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(PracticeModeBanner);
         component = fixture.componentInstance;
         navController = TestBed.get(NavController);
-      });
   }));
+
   describe('Class', () => {
     describe('exitPracticeMode', () => {
       it('should take the user back to the root page', () => {

--- a/src/components/common/practice-mode-banner/__tests__/practice-mode-banner.spec.ts
+++ b/src/components/common/practice-mode-banner/__tests__/practice-mode-banner.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { PracticeModeBanner } from '../practice-mode-banner';
 import { NavController, IonicModule, Config } from 'ionic-angular';
 import { NavControllerMock, ConfigMock } from 'ionic-mocks';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('PracticeModeBanner', () => {
   let fixture: ComponentFixture<PracticeModeBanner>;
@@ -17,7 +17,7 @@ describe('PracticeModeBanner', () => {
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/components/common/screen-lock-indicator/__tests__/screen-lock-indicator.spec.ts
+++ b/src/components/common/screen-lock-indicator/__tests__/screen-lock-indicator.spec.ts
@@ -2,12 +2,13 @@ import { LockScreenIndicator } from '../lock-screen-indicator';
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from 'ng2-translate';
 import { translateServiceMock } from '../../../../shared/__mocks__/translate';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('LockScreenIndicator', () => {
   let fixture: ComponentFixture<LockScreenIndicator>;
   let component: LockScreenIndicator;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         LockScreenIndicator,
@@ -19,11 +20,11 @@ describe('LockScreenIndicator', () => {
         { provide: TranslateService, useValue: translateServiceMock },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(LockScreenIndicator);
         component = fixture.componentInstance;
-      });
   }));
   describe('Class', () => {
     // Unit tests for the components TypeScript class

--- a/src/components/common/screen-lock-indicator/__tests__/screen-lock-indicator.spec.ts
+++ b/src/components/common/screen-lock-indicator/__tests__/screen-lock-indicator.spec.ts
@@ -23,8 +23,8 @@ describe('LockScreenIndicator', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(LockScreenIndicator);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(LockScreenIndicator);
+    component = fixture.componentInstance;
   }));
   describe('Class', () => {
     // Unit tests for the components TypeScript class

--- a/src/components/common/screen-lock-indicator/__tests__/screen-lock-indicator.spec.ts
+++ b/src/components/common/screen-lock-indicator/__tests__/screen-lock-indicator.spec.ts
@@ -2,7 +2,7 @@ import { LockScreenIndicator } from '../lock-screen-indicator';
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from 'ng2-translate';
 import { translateServiceMock } from '../../../../shared/__mocks__/translate';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('LockScreenIndicator', () => {
   let fixture: ComponentFixture<LockScreenIndicator>;
@@ -19,7 +19,7 @@ describe('LockScreenIndicator', () => {
       providers: [
         { provide: TranslateService, useValue: translateServiceMock },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/components/common/serious-fault-badge/__tests__/serious-fault-badge.spec.ts
+++ b/src/components/common/serious-fault-badge/__tests__/serious-fault-badge.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SeriousFaultBadgeComponent } from '../serious-fault-badge';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('SeriousFaultBadgeComponenet', () => {
   let fixture: ComponentFixture<SeriousFaultBadgeComponent>;
@@ -12,8 +12,8 @@ describe('SeriousFaultBadgeComponenet', () => {
       declarations: [
         SeriousFaultBadgeComponent,
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(SeriousFaultBadgeComponent);

--- a/src/components/common/serious-fault-badge/__tests__/serious-fault-badge.spec.ts
+++ b/src/components/common/serious-fault-badge/__tests__/serious-fault-badge.spec.ts
@@ -16,8 +16,8 @@ describe('SeriousFaultBadgeComponenet', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(SeriousFaultBadgeComponent);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(SeriousFaultBadgeComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('DOM', () => {

--- a/src/components/common/serious-fault-badge/__tests__/serious-fault-badge.spec.ts
+++ b/src/components/common/serious-fault-badge/__tests__/serious-fault-badge.spec.ts
@@ -1,22 +1,23 @@
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SeriousFaultBadgeComponent } from '../serious-fault-badge';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('SeriousFaultBadgeComponenet', () => {
   let fixture: ComponentFixture<SeriousFaultBadgeComponent>;
   let component: SeriousFaultBadgeComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         SeriousFaultBadgeComponent,
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(SeriousFaultBadgeComponent);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('DOM', () => {

--- a/src/components/common/signature-area/__tests__/signature-area.spec.ts
+++ b/src/components/common/signature-area/__tests__/signature-area.spec.ts
@@ -6,7 +6,10 @@ import { Store } from '@ngrx/store';
 import { MockComponent } from 'ng-mocks';
 import { IonicModule } from 'ionic-angular';
 import { configureTestSuite } from 'ng-bullet';
-class TestStore { }
+
+class TestStore {
+}
+
 describe('SignatureAreaComponent', () => {
   let fixture: ComponentFixture<SignatureAreaComponent>;
   let component: SignatureAreaComponent;
@@ -27,8 +30,8 @@ describe('SignatureAreaComponent', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(SignatureAreaComponent);
-      component = fixture.componentInstance;
+    fixture = TestBed.createComponent(SignatureAreaComponent);
+    component = fixture.componentInstance;
   }));
   describe('Class', () => {
     describe('signature', () => {

--- a/src/components/common/signature-area/__tests__/signature-area.spec.ts
+++ b/src/components/common/signature-area/__tests__/signature-area.spec.ts
@@ -5,11 +5,13 @@ import { By } from '@angular/platform-browser';
 import { Store } from '@ngrx/store';
 import { MockComponent } from 'ng-mocks';
 import { IonicModule } from 'ionic-angular';
+import { configureTestSuite } from 'ng-bullet'
 class TestStore { }
 describe('SignatureAreaComponent', () => {
   let fixture: ComponentFixture<SignatureAreaComponent>;
   let component: SignatureAreaComponent;
-  beforeEach(async(() => {
+
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         SignatureAreaComponent,
@@ -21,10 +23,12 @@ describe('SignatureAreaComponent', () => {
       providers: [
         { provide: Store, useClass: TestStore },
       ],
-    }).compileComponents().then(() => {
+    })
+  })
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(SignatureAreaComponent);
       component = fixture.componentInstance;
-    });
   }));
   describe('Class', () => {
     describe('signature', () => {

--- a/src/components/common/signature-area/__tests__/signature-area.spec.ts
+++ b/src/components/common/signature-area/__tests__/signature-area.spec.ts
@@ -5,7 +5,7 @@ import { By } from '@angular/platform-browser';
 import { Store } from '@ngrx/store';
 import { MockComponent } from 'ng-mocks';
 import { IonicModule } from 'ionic-angular';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 class TestStore { }
 describe('SignatureAreaComponent', () => {
   let fixture: ComponentFixture<SignatureAreaComponent>;
@@ -23,8 +23,8 @@ describe('SignatureAreaComponent', () => {
       providers: [
         { provide: Store, useClass: TestStore },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
       fixture = TestBed.createComponent(SignatureAreaComponent);

--- a/src/components/common/terminate-test-modal/__tests__/terminate-test-modal.spec.ts
+++ b/src/components/common/terminate-test-modal/__tests__/terminate-test-modal.spec.ts
@@ -12,7 +12,7 @@ import { By } from '@angular/platform-browser';
 import { DeviceAuthenticationProvider } from '../../../../providers/device-authentication/device-authentication';
 // tslint:disable-next-line:max-line-length
 import { DeviceAuthenticationProviderMock } from '../../../../providers/device-authentication/__mocks__/device-authentication.mock';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('TerminateTestModal', () => {
   let fixture: ComponentFixture<TerminateTestModal>;
@@ -32,7 +32,7 @@ describe('TerminateTestModal', () => {
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
         { provide: DeviceAuthenticationProvider, useClass: DeviceAuthenticationProviderMock },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/components/common/terminate-test-modal/__tests__/terminate-test-modal.spec.ts
+++ b/src/components/common/terminate-test-modal/__tests__/terminate-test-modal.spec.ts
@@ -36,11 +36,11 @@ describe('TerminateTestModal', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(TerminateTestModal);
-        component = fixture.componentInstance;
-        deviceAuthenticationProvider = TestBed.get(DeviceAuthenticationProvider);
-        component.onTerminate = jasmine.createSpy('onTerminate');
-        component.onCancel = jasmine.createSpy('onCancel');
+    fixture = TestBed.createComponent(TerminateTestModal);
+    component = fixture.componentInstance;
+    deviceAuthenticationProvider = TestBed.get(DeviceAuthenticationProvider);
+    component.onTerminate = jasmine.createSpy('onTerminate');
+    component.onCancel = jasmine.createSpy('onCancel');
   }));
 
   describe('DOM', () => {

--- a/src/components/common/terminate-test-modal/__tests__/terminate-test-modal.spec.ts
+++ b/src/components/common/terminate-test-modal/__tests__/terminate-test-modal.spec.ts
@@ -12,13 +12,14 @@ import { By } from '@angular/platform-browser';
 import { DeviceAuthenticationProvider } from '../../../../providers/device-authentication/device-authentication';
 // tslint:disable-next-line:max-line-length
 import { DeviceAuthenticationProviderMock } from '../../../../providers/device-authentication/__mocks__/device-authentication.mock';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('TerminateTestModal', () => {
   let fixture: ComponentFixture<TerminateTestModal>;
   let component: TerminateTestModal;
   let deviceAuthenticationProvider: DeviceAuthenticationProvider;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [TerminateTestModal],
       imports: [IonicModule, AppModule],
@@ -32,14 +33,14 @@ describe('TerminateTestModal', () => {
         { provide: DeviceAuthenticationProvider, useClass: DeviceAuthenticationProviderMock },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(TerminateTestModal);
         component = fixture.componentInstance;
         deviceAuthenticationProvider = TestBed.get(DeviceAuthenticationProvider);
         component.onTerminate = jasmine.createSpy('onTerminate');
         component.onCancel = jasmine.createSpy('onCancel');
-      });
   }));
 
   describe('DOM', () => {

--- a/src/components/common/tick-indicator/__tests__/tick-indicator.spec.ts
+++ b/src/components/common/tick-indicator/__tests__/tick-indicator.spec.ts
@@ -3,7 +3,7 @@ import { Config, IonicModule } from 'ionic-angular';
 import { ConfigMock } from 'ionic-mocks';
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('TickIndicatorComponent', () => {
   let fixture: ComponentFixture<TickIndicatorComponent>;
@@ -20,8 +20,8 @@ describe('TickIndicatorComponent', () => {
       imports: [
         IonicModule,
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(TickIndicatorComponent);

--- a/src/components/common/tick-indicator/__tests__/tick-indicator.spec.ts
+++ b/src/components/common/tick-indicator/__tests__/tick-indicator.spec.ts
@@ -24,8 +24,8 @@ describe('TickIndicatorComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(TickIndicatorComponent);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(TickIndicatorComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('DOM', () => {

--- a/src/components/common/tick-indicator/__tests__/tick-indicator.spec.ts
+++ b/src/components/common/tick-indicator/__tests__/tick-indicator.spec.ts
@@ -3,12 +3,13 @@ import { Config, IonicModule } from 'ionic-angular';
 import { ConfigMock } from 'ionic-mocks';
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('TickIndicatorComponent', () => {
   let fixture: ComponentFixture<TickIndicatorComponent>;
   let component: TickIndicatorComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         TickIndicatorComponent,
@@ -20,11 +21,11 @@ describe('TickIndicatorComponent', () => {
         IonicModule,
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(TickIndicatorComponent);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('DOM', () => {

--- a/src/components/test-slot/candidate-link/__tests__/candidate-link.spec.ts
+++ b/src/components/test-slot/candidate-link/__tests__/candidate-link.spec.ts
@@ -22,6 +22,7 @@ import { CANDIDATE_DETAILS_PAGE, FAKE_CANDIDATE_DETAILS_PAGE } from '../../../..
 import { App } from '../../../../app/app.component';
 import { MockAppComponent } from '../../../../app/__mocks__/app.component.mock';
 import { bookedTestSlotMock } from '../../../../shared/mocks/test-slot-data.mock';
+import { configureTestSuite } from 'ng-bullet'
 
 class MockStore { }
 
@@ -31,7 +32,7 @@ describe('CandidateLinkComponent', () => {
 
   const modalControllerMock = ModalControllerMock.instance();
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [CandidateLinkComponent],
       imports: [IonicModule.forRoot(CandidateLinkComponent)],
@@ -45,8 +46,9 @@ describe('CandidateLinkComponent', () => {
         { provide: TranslateService, useValue: translateServiceMock },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(CandidateLinkComponent);
         component = fixture.componentInstance;
         component.name = { title: '', firstName: '', lastName: '' };
@@ -56,7 +58,6 @@ describe('CandidateLinkComponent', () => {
         component.slot = bookedTestSlotMock;
         component.slotChanged = false;
         component.isPortrait = true;
-      });
   }));
 
   describe('Class', () => {

--- a/src/components/test-slot/candidate-link/__tests__/candidate-link.spec.ts
+++ b/src/components/test-slot/candidate-link/__tests__/candidate-link.spec.ts
@@ -24,7 +24,8 @@ import { MockAppComponent } from '../../../../app/__mocks__/app.component.mock';
 import { bookedTestSlotMock } from '../../../../shared/mocks/test-slot-data.mock';
 import { configureTestSuite } from 'ng-bullet';
 
-class MockStore { }
+class MockStore {
+}
 
 describe('CandidateLinkComponent', () => {
   let component: CandidateLinkComponent;
@@ -49,15 +50,15 @@ describe('CandidateLinkComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(CandidateLinkComponent);
-        component = fixture.componentInstance;
-        component.name = { title: '', firstName: '', lastName: '' };
-        component.name.title = 'Mr';
-        component.name.firstName = 'Joe';
-        component.name.lastName = 'Bloggs';
-        component.slot = bookedTestSlotMock;
-        component.slotChanged = false;
-        component.isPortrait = true;
+    fixture = TestBed.createComponent(CandidateLinkComponent);
+    component = fixture.componentInstance;
+    component.name = { title: '', firstName: '', lastName: '' };
+    component.name.title = 'Mr';
+    component.name.firstName = 'Joe';
+    component.name.lastName = 'Bloggs';
+    component.slot = bookedTestSlotMock;
+    component.slotChanged = false;
+    component.isPortrait = true;
   }));
 
   describe('Class', () => {

--- a/src/components/test-slot/candidate-link/__tests__/candidate-link.spec.ts
+++ b/src/components/test-slot/candidate-link/__tests__/candidate-link.spec.ts
@@ -22,7 +22,7 @@ import { CANDIDATE_DETAILS_PAGE, FAKE_CANDIDATE_DETAILS_PAGE } from '../../../..
 import { App } from '../../../../app/app.component';
 import { MockAppComponent } from '../../../../app/__mocks__/app.component.mock';
 import { bookedTestSlotMock } from '../../../../shared/mocks/test-slot-data.mock';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 class MockStore { }
 
@@ -45,8 +45,8 @@ describe('CandidateLinkComponent', () => {
         { provide: DataStoreProvider, useClass: DataStoreProviderMock },
         { provide: TranslateService, useValue: translateServiceMock },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(CandidateLinkComponent);

--- a/src/components/test-slot/indicators/__tests__/indicators.spec.ts
+++ b/src/components/test-slot/indicators/__tests__/indicators.spec.ts
@@ -3,19 +3,22 @@ import { IndicatorsComponent } from '../indicators';
 import { IonicModule } from 'ionic-angular';
 import { By } from '@angular/platform-browser';
 import { TestStatus } from '../../../../modules/tests/test-status/test-status.model';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('IndicatorsComponent', () => {
   let component: IndicatorsComponent;
   let fixture: ComponentFixture<IndicatorsComponent>;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [IndicatorsComponent],
       imports: [IonicModule],
-    }).compileComponents().then(() => {
+    })
+  })
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(IndicatorsComponent);
       component = fixture.componentInstance;
-    });
   }));
 
   describe('DOM', () => {

--- a/src/components/test-slot/indicators/__tests__/indicators.spec.ts
+++ b/src/components/test-slot/indicators/__tests__/indicators.spec.ts
@@ -17,8 +17,8 @@ describe('IndicatorsComponent', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(IndicatorsComponent);
-      component = fixture.componentInstance;
+    fixture = TestBed.createComponent(IndicatorsComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('DOM', () => {

--- a/src/components/test-slot/indicators/__tests__/indicators.spec.ts
+++ b/src/components/test-slot/indicators/__tests__/indicators.spec.ts
@@ -3,7 +3,7 @@ import { IndicatorsComponent } from '../indicators';
 import { IonicModule } from 'ionic-angular';
 import { By } from '@angular/platform-browser';
 import { TestStatus } from '../../../../modules/tests/test-status/test-status.model';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('IndicatorsComponent', () => {
   let component: IndicatorsComponent;
@@ -13,8 +13,8 @@ describe('IndicatorsComponent', () => {
     TestBed.configureTestingModule({
       declarations: [IndicatorsComponent],
       imports: [IonicModule],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
       fixture = TestBed.createComponent(IndicatorsComponent);

--- a/src/components/test-slot/language/__tests__/language.spec.ts
+++ b/src/components/test-slot/language/__tests__/language.spec.ts
@@ -16,8 +16,8 @@ describe('LanguageComponent', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(LanguageComponent);
-      component = fixture.componentInstance;
+    fixture = TestBed.createComponent(LanguageComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('DOM', () => {

--- a/src/components/test-slot/language/__tests__/language.spec.ts
+++ b/src/components/test-slot/language/__tests__/language.spec.ts
@@ -2,19 +2,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LanguageComponent } from '../language';
 import { IonicModule } from 'ionic-angular';
 import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('LanguageComponent', () => {
   let component: LanguageComponent;
   let fixture: ComponentFixture<LanguageComponent>;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [LanguageComponent],
       imports: [IonicModule],
-    }).compileComponents().then(() => {
+    })
+  })
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(LanguageComponent);
       component = fixture.componentInstance;
-    });
   }));
 
   describe('DOM', () => {

--- a/src/components/test-slot/language/__tests__/language.spec.ts
+++ b/src/components/test-slot/language/__tests__/language.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LanguageComponent } from '../language';
 import { IonicModule } from 'ionic-angular';
 import { By } from '@angular/platform-browser';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('LanguageComponent', () => {
   let component: LanguageComponent;
@@ -12,8 +12,8 @@ describe('LanguageComponent', () => {
     TestBed.configureTestingModule({
       declarations: [LanguageComponent],
       imports: [IonicModule],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
       fixture = TestBed.createComponent(LanguageComponent);

--- a/src/components/test-slot/location/__tests__/location.spec.ts
+++ b/src/components/test-slot/location/__tests__/location.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LocationComponent } from '../location';
 import { IonicModule } from 'ionic-angular';
 import { By } from '@angular/platform-browser';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('LocationComponent', () => {
   let component: LocationComponent;
@@ -13,8 +13,8 @@ describe('LocationComponent', () => {
       declarations: [LocationComponent],
       imports: [IonicModule.forRoot(LocationComponent)],
       providers: [],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
       fixture = TestBed.createComponent(LocationComponent);

--- a/src/components/test-slot/location/__tests__/location.spec.ts
+++ b/src/components/test-slot/location/__tests__/location.spec.ts
@@ -2,21 +2,24 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LocationComponent } from '../location';
 import { IonicModule } from 'ionic-angular';
 import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('LocationComponent', () => {
   let component: LocationComponent;
   let fixture: ComponentFixture<LocationComponent>;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [LocationComponent],
       imports: [IonicModule.forRoot(LocationComponent)],
       providers: [],
-    }).compileComponents().then(() => {
+    })
+  })
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(LocationComponent);
       component = fixture.componentInstance;
       component.location = 'Example Test Centre';
-    });
   }));
 
   describe('DOM', () => {

--- a/src/components/test-slot/location/__tests__/location.spec.ts
+++ b/src/components/test-slot/location/__tests__/location.spec.ts
@@ -17,9 +17,9 @@ describe('LocationComponent', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(LocationComponent);
-      component = fixture.componentInstance;
-      component.location = 'Example Test Centre';
+    fixture = TestBed.createComponent(LocationComponent);
+    component = fixture.componentInstance;
+    component.location = 'Example Test Centre';
   }));
 
   describe('DOM', () => {

--- a/src/components/test-slot/progressive-access/__tests__/progressive-access.spec.ts
+++ b/src/components/test-slot/progressive-access/__tests__/progressive-access.spec.ts
@@ -16,8 +16,8 @@ describe('ProgressiveAccessComponent', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(ProgressiveAccessComponent);
-      component = fixture.componentInstance;
+    fixture = TestBed.createComponent(ProgressiveAccessComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('DOM', () => {

--- a/src/components/test-slot/progressive-access/__tests__/progressive-access.spec.ts
+++ b/src/components/test-slot/progressive-access/__tests__/progressive-access.spec.ts
@@ -2,19 +2,22 @@ import { ProgressiveAccessComponent } from '../progressive-access';
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { IonicModule } from 'ionic-angular';
 import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('ProgressiveAccessComponent', () => {
   let component: ProgressiveAccessComponent;
   let fixture: ComponentFixture<ProgressiveAccessComponent>;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [ProgressiveAccessComponent],
       imports: [IonicModule],
-    }).compileComponents().then(() => {
+    })
+  })
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(ProgressiveAccessComponent);
       component = fixture.componentInstance;
-    });
   }));
 
   describe('DOM', () => {

--- a/src/components/test-slot/progressive-access/__tests__/progressive-access.spec.ts
+++ b/src/components/test-slot/progressive-access/__tests__/progressive-access.spec.ts
@@ -2,7 +2,7 @@ import { ProgressiveAccessComponent } from '../progressive-access';
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { IonicModule } from 'ionic-angular';
 import { By } from '@angular/platform-browser';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('ProgressiveAccessComponent', () => {
   let component: ProgressiveAccessComponent;
@@ -12,8 +12,8 @@ describe('ProgressiveAccessComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ProgressiveAccessComponent],
       imports: [IonicModule],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
       fixture = TestBed.createComponent(ProgressiveAccessComponent);

--- a/src/components/test-slot/submission-status/__tests__/submission-status.spec.ts
+++ b/src/components/test-slot/submission-status/__tests__/submission-status.spec.ts
@@ -3,7 +3,7 @@ import { IonicModule } from 'ionic-angular';
 import { AppModule } from '../../../../app/app.module';
 import { SubmissionStatusComponent } from '../submission-status';
 import { TestStatus } from '../../../../modules/tests/test-status/test-status.model';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('PracticeTestModal', () => {
   let fixture: ComponentFixture<SubmissionStatusComponent>;
@@ -18,8 +18,8 @@ describe('PracticeTestModal', () => {
         AppModule,
         IonicModule,
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(SubmissionStatusComponent);

--- a/src/components/test-slot/submission-status/__tests__/submission-status.spec.ts
+++ b/src/components/test-slot/submission-status/__tests__/submission-status.spec.ts
@@ -3,12 +3,13 @@ import { IonicModule } from 'ionic-angular';
 import { AppModule } from '../../../../app/app.module';
 import { SubmissionStatusComponent } from '../submission-status';
 import { TestStatus } from '../../../../modules/tests/test-status/test-status.model';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('PracticeTestModal', () => {
   let fixture: ComponentFixture<SubmissionStatusComponent>;
   let component: SubmissionStatusComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         SubmissionStatusComponent,
@@ -18,11 +19,11 @@ describe('PracticeTestModal', () => {
         IonicModule,
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(SubmissionStatusComponent);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('Class', () => {

--- a/src/components/test-slot/submission-status/__tests__/submission-status.spec.ts
+++ b/src/components/test-slot/submission-status/__tests__/submission-status.spec.ts
@@ -22,8 +22,8 @@ describe('PracticeTestModal', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(SubmissionStatusComponent);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(SubmissionStatusComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('Class', () => {

--- a/src/components/test-slot/test-category/__tests__/test-category.spec.ts
+++ b/src/components/test-slot/test-category/__tests__/test-category.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { IonicModule } from 'ionic-angular';
 import { TestCategoryComponent } from '../test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('TestCategoryComponent', () => {
   let fixture: ComponentFixture<TestCategoryComponent>;
@@ -14,8 +14,8 @@ describe('TestCategoryComponent', () => {
       ],
       imports: [IonicModule],
 
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
       fixture = TestBed.createComponent(TestCategoryComponent);

--- a/src/components/test-slot/test-category/__tests__/test-category.spec.ts
+++ b/src/components/test-slot/test-category/__tests__/test-category.spec.ts
@@ -1,22 +1,25 @@
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { IonicModule } from 'ionic-angular';
 import { TestCategoryComponent } from '../test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('TestCategoryComponent', () => {
   let fixture: ComponentFixture<TestCategoryComponent>;
   let component: TestCategoryComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         TestCategoryComponent,
       ],
       imports: [IonicModule],
 
-    }).compileComponents().then(() => {
+    })
+  })
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(TestCategoryComponent);
       component = fixture.componentInstance;
-    });
   }));
 
   describe('Class', () => {

--- a/src/components/test-slot/test-category/__tests__/test-category.spec.ts
+++ b/src/components/test-slot/test-category/__tests__/test-category.spec.ts
@@ -18,8 +18,8 @@ describe('TestCategoryComponent', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(TestCategoryComponent);
-      component = fixture.componentInstance;
+    fixture = TestBed.createComponent(TestCategoryComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('Class', () => {

--- a/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
@@ -67,11 +67,11 @@ describe('Test Outcome', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(TestOutcomeComponent);
-        component = fixture.componentInstance;
-        navController = TestBed.get(NavController);
-        store$ = TestBed.get(Store);
-        spyOn(store$, 'dispatch');
+    fixture = TestBed.createComponent(TestOutcomeComponent);
+    component = fixture.componentInstance;
+    navController = TestBed.get(NavController);
+    store$ = TestBed.get(Store);
+    spyOn(store$, 'dispatch');
   }));
 
   describe('Class', () => {

--- a/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
@@ -15,6 +15,7 @@ import { JournalModel } from '../../../../modules/journal/journal.model';
 import { LogHelper } from '../../../../providers/logs/logsHelper';
 import { LogHelperMock } from '../../../../providers/logs/__mocks__/logsHelper.mock';
 import { TestCategory } from '../../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Test Outcome', () => {
   let fixture: ComponentFixture<TestOutcomeComponent>;
@@ -36,7 +37,7 @@ describe('Test Outcome', () => {
     examiner: { staffNumber: '123', individualId: 456 },
   };
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [TestOutcomeComponent],
       imports: [
@@ -63,12 +64,12 @@ describe('Test Outcome', () => {
         { provide: LogHelper, useClass: LogHelperMock },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(TestOutcomeComponent);
         component = fixture.componentInstance;
         navController = TestBed.get(NavController);
-      });
     store$ = TestBed.get(Store);
     spyOn(store$, 'dispatch');
   }));

--- a/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
@@ -15,7 +15,7 @@ import { JournalModel } from '../../../../modules/journal/journal.model';
 import { LogHelper } from '../../../../providers/logs/logsHelper';
 import { LogHelperMock } from '../../../../providers/logs/__mocks__/logsHelper.mock';
 import { TestCategory } from '../../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Test Outcome', () => {
   let fixture: ComponentFixture<TestOutcomeComponent>;
@@ -63,15 +63,15 @@ describe('Test Outcome', () => {
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
         { provide: LogHelper, useClass: LogHelperMock },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(TestOutcomeComponent);
         component = fixture.componentInstance;
         navController = TestBed.get(NavController);
-    store$ = TestBed.get(Store);
-    spyOn(store$, 'dispatch');
+        store$ = TestBed.get(Store);
+        spyOn(store$, 'dispatch');
   }));
 
   describe('Class', () => {

--- a/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
+++ b/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
@@ -33,7 +33,7 @@ import { SpecialNeedsCode } from '../../../../shared/helpers/get-slot-type';
 import { LocationComponent } from '../../location/location';
 import { SlotProvider } from '../../../../providers/slot/slot';
 import { TestCategory } from '../../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('TestSlotComponent', () => {
   let fixture: ComponentFixture<TestSlotComponent>;
@@ -126,8 +126,8 @@ describe('TestSlotComponent', () => {
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
         { provide: SlotProvider, useClass: SlotProvider },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
       fixture = TestBed.createComponent(TestSlotComponent);

--- a/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
+++ b/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
@@ -130,11 +130,11 @@ describe('TestSlotComponent', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(TestSlotComponent);
-      component = fixture.componentInstance;
-      component.slot = cloneDeep(mockSlot);
-      component.showLocation = true;
-      store$ = TestBed.get(Store);
+    fixture = TestBed.createComponent(TestSlotComponent);
+    component = fixture.componentInstance;
+    component.slot = cloneDeep(mockSlot);
+    component.showLocation = true;
+    store$ = TestBed.get(Store);
   }));
 
   describe('Class', () => {

--- a/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
+++ b/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
@@ -33,6 +33,7 @@ import { SpecialNeedsCode } from '../../../../shared/helpers/get-slot-type';
 import { LocationComponent } from '../../location/location';
 import { SlotProvider } from '../../../../providers/slot/slot';
 import { TestCategory } from '../../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('TestSlotComponent', () => {
   let fixture: ComponentFixture<TestSlotComponent>;
@@ -97,7 +98,7 @@ describe('TestSlotComponent', () => {
     },
   };
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         TestSlotComponent,
@@ -125,13 +126,15 @@ describe('TestSlotComponent', () => {
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
         { provide: SlotProvider, useClass: SlotProvider },
       ],
-    }).compileComponents().then(() => {
+    })
+  })
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(TestSlotComponent);
       component = fixture.componentInstance;
       component.slot = cloneDeep(mockSlot);
       component.showLocation = true;
       store$ = TestBed.get(Store);
-    });
   }));
 
   describe('Class', () => {

--- a/src/components/test-slot/time/__tests__/time.spec.ts
+++ b/src/components/test-slot/time/__tests__/time.spec.ts
@@ -5,7 +5,7 @@ import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { LogHelper } from '../../../../providers/logs/logsHelper';
 import { LogHelperMock } from '../../../../providers/logs/__mocks__/logsHelper.mock';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('TimeComponent', () => {
   let component: TimeComponent;
@@ -18,8 +18,8 @@ describe('TimeComponent', () => {
       providers: [
         { provide: LogHelper, useClass: LogHelperMock },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(TimeComponent);

--- a/src/components/test-slot/time/__tests__/time.spec.ts
+++ b/src/components/test-slot/time/__tests__/time.spec.ts
@@ -5,12 +5,13 @@ import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { LogHelper } from '../../../../providers/logs/logsHelper';
 import { LogHelperMock } from '../../../../providers/logs/__mocks__/logsHelper.mock';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('TimeComponent', () => {
   let component: TimeComponent;
   let fixture: ComponentFixture<TimeComponent>;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [TimeComponent],
       imports: [IonicModule],
@@ -18,13 +19,13 @@ describe('TimeComponent', () => {
         { provide: LogHelper, useClass: LogHelperMock },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(TimeComponent);
         component = fixture.componentInstance;
         component.time =  '2018-12-10T10:04:00+00:00';
         component.testComplete = true;
-      });
   }));
 
   describe('DOM', () => {

--- a/src/components/test-slot/time/__tests__/time.spec.ts
+++ b/src/components/test-slot/time/__tests__/time.spec.ts
@@ -22,10 +22,10 @@ describe('TimeComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(TimeComponent);
-        component = fixture.componentInstance;
-        component.time =  '2018-12-10T10:04:00+00:00';
-        component.testComplete = true;
+    fixture = TestBed.createComponent(TimeComponent);
+    component = fixture.componentInstance;
+    component.time = '2018-12-10T10:04:00+00:00';
+    component.testComplete = true;
   }));
 
   describe('DOM', () => {

--- a/src/components/test-slot/vehicle-details/__tests__/vehicle-details.spec.ts
+++ b/src/components/test-slot/vehicle-details/__tests__/vehicle-details.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { IonicModule } from 'ionic-angular';
 import { VehicleDetailsComponent } from '../vehicle-details';
 import { By } from '@angular/platform-browser';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('VehicleDetailsComponent', () => {
   let fixture: ComponentFixture<VehicleDetailsComponent>;
@@ -14,8 +14,8 @@ describe('VehicleDetailsComponent', () => {
         VehicleDetailsComponent,
       ],
       imports: [IonicModule],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
       fixture = TestBed.createComponent(VehicleDetailsComponent);

--- a/src/components/test-slot/vehicle-details/__tests__/vehicle-details.spec.ts
+++ b/src/components/test-slot/vehicle-details/__tests__/vehicle-details.spec.ts
@@ -18,8 +18,8 @@ describe('VehicleDetailsComponent', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(VehicleDetailsComponent);
-      component = fixture.componentInstance;
+    fixture = TestBed.createComponent(VehicleDetailsComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('DOM', () => {

--- a/src/components/test-slot/vehicle-details/__tests__/vehicle-details.spec.ts
+++ b/src/components/test-slot/vehicle-details/__tests__/vehicle-details.spec.ts
@@ -2,21 +2,24 @@ import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { IonicModule } from 'ionic-angular';
 import { VehicleDetailsComponent } from '../vehicle-details';
 import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('VehicleDetailsComponent', () => {
   let fixture: ComponentFixture<VehicleDetailsComponent>;
   let component: VehicleDetailsComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         VehicleDetailsComponent,
       ],
       imports: [IonicModule],
-    }).compileComponents().then(() => {
+    })
+  })
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(VehicleDetailsComponent);
       component = fixture.componentInstance;
-    });
   }));
 
   describe('DOM', () => {

--- a/src/modules/journal/__tests__/journal.effects.spec.ts
+++ b/src/modules/journal/__tests__/journal.effects.spec.ts
@@ -31,6 +31,7 @@ import { Device } from '@ionic-native/device';
 import { LogHelperMock } from '../../../providers/logs/__mocks__/logsHelper.mock';
 import { HttpErrorResponse } from '@angular/common/http';
 import { defer } from 'rxjs/observable/defer';
+import { configureTestSuite } from 'ng-bullet'
 
 export class TestActions extends Actions {
   constructor() {
@@ -52,9 +53,7 @@ describe('Journal Effects', () => {
   let networkStateProvider: NetworkStateProvider;
   let appConfigProvider: AppConfigProvider;
 
-  beforeEach(() => {
-    // ARRANGE
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -79,6 +78,11 @@ describe('Journal Effects', () => {
         Device,
       ],
     });
+  });
+
+  beforeEach(() => {
+    // ARRANGE
+    actions$ = new ReplaySubject(1);
     journalProvider = TestBed.get(JournalProvider);
     effects = TestBed.get(JournalEffects);
     slotProvider = TestBed.get(SlotProvider);

--- a/src/modules/journal/__tests__/journal.effects.spec.ts
+++ b/src/modules/journal/__tests__/journal.effects.spec.ts
@@ -31,7 +31,7 @@ import { Device } from '@ionic-native/device';
 import { LogHelperMock } from '../../../providers/logs/__mocks__/logsHelper.mock';
 import { HttpErrorResponse } from '@angular/common/http';
 import { defer } from 'rxjs/observable/defer';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 export class TestActions extends Actions {
   constructor() {

--- a/src/modules/journal/__tests__/journal.selector.spec.ts
+++ b/src/modules/journal/__tests__/journal.selector.spec.ts
@@ -15,7 +15,7 @@ import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/dat
 import { Store } from '@ngrx/store';
 import { cloneDeep } from 'lodash';
 import { baseJournalData } from '../__mocks__/journal-slots-data.mock';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 class MockStore { }
 

--- a/src/modules/journal/__tests__/journal.selector.spec.ts
+++ b/src/modules/journal/__tests__/journal.selector.spec.ts
@@ -15,13 +15,14 @@ import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/dat
 import { Store } from '@ngrx/store';
 import { cloneDeep } from 'lodash';
 import { baseJournalData } from '../__mocks__/journal-slots-data.mock';
+import { configureTestSuite } from 'ng-bullet'
 
 class MockStore { }
 
 describe('JournalSelector', () => {
   let slotProvider: SlotProvider;
 
-  beforeEach(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       providers: [
         SlotProvider,

--- a/src/modules/logs/__tests__/logs.effects.spec.ts
+++ b/src/modules/logs/__tests__/logs.effects.spec.ts
@@ -22,7 +22,7 @@ import { of } from 'rxjs/observable/of';
 import { DateTime, Duration } from '../../../shared/helpers/date-time';
 import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 export class TestActions extends Actions {
   constructor() {
@@ -60,7 +60,7 @@ describe('Logs Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     // ARRANGE

--- a/src/modules/logs/__tests__/logs.effects.spec.ts
+++ b/src/modules/logs/__tests__/logs.effects.spec.ts
@@ -22,6 +22,7 @@ import { of } from 'rxjs/observable/of';
 import { DateTime, Duration } from '../../../shared/helpers/date-time';
 import { DateTimeProvider } from '../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../providers/date-time/__mocks__/date-time.mock';
+import { configureTestSuite } from 'ng-bullet'
 
 export class TestActions extends Actions {
   constructor() {
@@ -41,9 +42,7 @@ describe('Logs Effects', () => {
   let appConfigProviderMock: AppConfigProvider;
   let dataStoreMock: DataStoreProvider;
 
-  beforeEach(() => {
-    // ARRANGE
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -61,6 +60,11 @@ describe('Logs Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    // ARRANGE
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(LogsEffects);
     appConfigProviderMock = TestBed.get(AppConfigProvider);
     cacheDays = appConfigProviderMock.getAppConfig().daysToCacheLogs;

--- a/src/modules/tests/__tests__/tests.analytics.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.analytics.effects.spec.ts
@@ -26,6 +26,7 @@ import { NavigationStateProviderMock } from '../../../providers/navigation-state
 import { NavigationStateProvider } from '../../../providers/navigation-state/navigation-state';
 import { candidateMock } from '../__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Tests Analytics Effects', () => {
 
@@ -40,8 +41,7 @@ describe('Tests Analytics Effects', () => {
     checkDigit: 9,
   };
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -56,6 +56,10 @@ describe('Tests Analytics Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(TestsAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     navigationStateProviderMock = TestBed.get(NavigationStateProvider);

--- a/src/modules/tests/__tests__/tests.analytics.effects.spec.ts
+++ b/src/modules/tests/__tests__/tests.analytics.effects.spec.ts
@@ -26,7 +26,7 @@ import { NavigationStateProviderMock } from '../../../providers/navigation-state
 import { NavigationStateProvider } from '../../../providers/navigation-state/navigation-state';
 import { candidateMock } from '../__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Tests Analytics Effects', () => {
 
@@ -56,7 +56,7 @@ describe('Tests Analytics Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/modules/tests/examiner-booked/__tests__/examiner-booked.effects.spec.ts
+++ b/src/modules/tests/examiner-booked/__tests__/examiner-booked.effects.spec.ts
@@ -10,6 +10,7 @@ import { SetChangeMarker } from '../../change-marker/change-marker.actions';
 import { StartTest } from '../../tests.actions';
 import { SetExaminerConducted } from '../../examiner-conducted/examiner-conducted.actions';
 import { TestCategory } from '../../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Examiner Booked Effects', () => {
 
@@ -17,8 +18,7 @@ describe('Examiner Booked Effects', () => {
   let actions$: any;
   let store$: Store<StoreModel>;
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -31,6 +31,10 @@ describe('Examiner Booked Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(ExaminerBookedEffects);
     store$ = TestBed.get(Store);
   });

--- a/src/modules/tests/examiner-booked/__tests__/examiner-booked.effects.spec.ts
+++ b/src/modules/tests/examiner-booked/__tests__/examiner-booked.effects.spec.ts
@@ -10,7 +10,7 @@ import { SetChangeMarker } from '../../change-marker/change-marker.actions';
 import { StartTest } from '../../tests.actions';
 import { SetExaminerConducted } from '../../examiner-conducted/examiner-conducted.actions';
 import { TestCategory } from '../../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Examiner Booked Effects', () => {
 
@@ -31,7 +31,7 @@ describe('Examiner Booked Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.effects.spec.ts
+++ b/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.effects.spec.ts
@@ -11,6 +11,7 @@ import { StartTest } from '../../tests.actions';
 import { SetExaminerBooked } from '../../examiner-booked/examiner-booked.actions';
 import { journalReducer } from '../../../journal/journal.reducer';
 import { TestCategory } from '../../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Examiner Conducted Effects', () => {
 
@@ -18,8 +19,7 @@ describe('Examiner Conducted Effects', () => {
   let actions$: any;
   let store$: Store<StoreModel>;
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -33,6 +33,10 @@ describe('Examiner Conducted Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(ExaminerConductedEffects);
     store$ = TestBed.get(Store);
   });

--- a/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.effects.spec.ts
+++ b/src/modules/tests/examiner-conducted/__tests__/examiner-conducted.effects.spec.ts
@@ -11,7 +11,7 @@ import { StartTest } from '../../tests.actions';
 import { SetExaminerBooked } from '../../examiner-booked/examiner-booked.actions';
 import { journalReducer } from '../../../journal/journal.reducer';
 import { TestCategory } from '../../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Examiner Conducted Effects', () => {
 
@@ -33,7 +33,7 @@ describe('Examiner Conducted Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/modules/tests/test-data/__tests__/test-data.effects.spec.ts
+++ b/src/modules/tests/test-data/__tests__/test-data.effects.spec.ts
@@ -11,6 +11,7 @@ import { StoreModel } from '../../../../shared/models/store.model';
 import { Competencies } from '../test-data.constants';
 import { FaultPayload } from '../test-data.models';
 import { TestCategory } from '../../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Test Data Effects', () => {
 
@@ -18,8 +19,7 @@ describe('Test Data Effects', () => {
   let actions$: any;
   let store$: Store<StoreModel>;
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -32,6 +32,10 @@ describe('Test Data Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(TestDataEffects);
     store$ = TestBed.get(Store);
   });

--- a/src/modules/tests/test-data/__tests__/test-data.effects.spec.ts
+++ b/src/modules/tests/test-data/__tests__/test-data.effects.spec.ts
@@ -11,7 +11,7 @@ import { StoreModel } from '../../../../shared/models/store.model';
 import { Competencies } from '../test-data.constants';
 import { FaultPayload } from '../test-data.models';
 import { TestCategory } from '../../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Test Data Effects', () => {
 
@@ -32,7 +32,7 @@ describe('Test Data Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/pages/back-to-office/__tests__/back-to-office.analytics.effects.spec.ts
+++ b/src/pages/back-to-office/__tests__/back-to-office.analytics.effects.spec.ts
@@ -26,6 +26,7 @@ import * as applicationReferenceActions
 import * as activityCodeActions from '../../../modules/tests/activity-code/activity-code.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Back To Office Analytics Effects', () => {
 
@@ -41,8 +42,7 @@ describe('Back To Office Analytics Effects', () => {
     checkDigit: 9,
   };
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -56,6 +56,10 @@ describe('Back To Office Analytics Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(BackToOfficeAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     store$ = TestBed.get(Store);

--- a/src/pages/back-to-office/__tests__/back-to-office.analytics.effects.spec.ts
+++ b/src/pages/back-to-office/__tests__/back-to-office.analytics.effects.spec.ts
@@ -26,7 +26,7 @@ import * as applicationReferenceActions
 import * as activityCodeActions from '../../../modules/tests/activity-code/activity-code.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Back To Office Analytics Effects', () => {
 
@@ -56,7 +56,7 @@ describe('Back To Office Analytics Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/pages/back-to-office/cat-b/_tests_/back-to-office.cat-b.page.spec.ts
+++ b/src/pages/back-to-office/cat-b/_tests_/back-to-office.cat-b.page.spec.ts
@@ -20,6 +20,7 @@ import { MockComponent } from 'ng-mocks';
 import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { By } from '@angular/platform-browser';
 import { of } from 'rxjs/observable/of';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('BackToOfficePage', () => {
   let fixture: ComponentFixture<BackToOfficeCatBPage>;
@@ -30,7 +31,7 @@ describe('BackToOfficePage', () => {
   let insomnia: Insomnia;
   let deviceProvider: DeviceProvider;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         BackToOfficeCatBPage,
@@ -96,8 +97,9 @@ describe('BackToOfficePage', () => {
         { provide: DeviceProvider, useClass: DeviceProviderMock },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(BackToOfficeCatBPage);
         component = fixture.componentInstance;
         navController = TestBed.get(NavController);
@@ -106,7 +108,6 @@ describe('BackToOfficePage', () => {
         deviceProvider = TestBed.get(DeviceProvider);
         store$ = TestBed.get(Store);
         spyOn(store$, 'dispatch');
-      });
   }));
 
   describe('Class', () => {

--- a/src/pages/back-to-office/cat-b/_tests_/back-to-office.cat-b.page.spec.ts
+++ b/src/pages/back-to-office/cat-b/_tests_/back-to-office.cat-b.page.spec.ts
@@ -20,7 +20,7 @@ import { MockComponent } from 'ng-mocks';
 import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { By } from '@angular/platform-browser';
 import { of } from 'rxjs/observable/of';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('BackToOfficePage', () => {
   let fixture: ComponentFixture<BackToOfficeCatBPage>;
@@ -96,8 +96,8 @@ describe('BackToOfficePage', () => {
         { provide: Insomnia, useClass: InsomniaMock },
         { provide: DeviceProvider, useClass: DeviceProviderMock },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(BackToOfficeCatBPage);

--- a/src/pages/back-to-office/cat-b/_tests_/back-to-office.cat-b.page.spec.ts
+++ b/src/pages/back-to-office/cat-b/_tests_/back-to-office.cat-b.page.spec.ts
@@ -100,14 +100,14 @@ describe('BackToOfficePage', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(BackToOfficeCatBPage);
-        component = fixture.componentInstance;
-        navController = TestBed.get(NavController);
-        screenOrientation = TestBed.get(ScreenOrientation);
-        insomnia = TestBed.get(Insomnia);
-        deviceProvider = TestBed.get(DeviceProvider);
-        store$ = TestBed.get(Store);
-        spyOn(store$, 'dispatch');
+    fixture = TestBed.createComponent(BackToOfficeCatBPage);
+    component = fixture.componentInstance;
+    navController = TestBed.get(NavController);
+    screenOrientation = TestBed.get(ScreenOrientation);
+    insomnia = TestBed.get(Insomnia);
+    deviceProvider = TestBed.get(DeviceProvider);
+    store$ = TestBed.get(Store);
+    spyOn(store$, 'dispatch');
   }));
 
   describe('Class', () => {

--- a/src/pages/back-to-office/cat-be/_tests_/back-to-office.cat-be.page.spec.ts
+++ b/src/pages/back-to-office/cat-be/_tests_/back-to-office.cat-be.page.spec.ts
@@ -100,14 +100,14 @@ describe('BackToOfficePage', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(BackToOfficeCatBEPage);
-        component = fixture.componentInstance;
-        navController = TestBed.get(NavController);
-        screenOrientation = TestBed.get(ScreenOrientation);
-        insomnia = TestBed.get(Insomnia);
-        deviceProvider = TestBed.get(DeviceProvider);
-        store$ = TestBed.get(Store);
-        spyOn(store$, 'dispatch');
+    fixture = TestBed.createComponent(BackToOfficeCatBEPage);
+    component = fixture.componentInstance;
+    navController = TestBed.get(NavController);
+    screenOrientation = TestBed.get(ScreenOrientation);
+    insomnia = TestBed.get(Insomnia);
+    deviceProvider = TestBed.get(DeviceProvider);
+    store$ = TestBed.get(Store);
+    spyOn(store$, 'dispatch');
   }));
 
   describe('Class', () => {

--- a/src/pages/back-to-office/cat-be/_tests_/back-to-office.cat-be.page.spec.ts
+++ b/src/pages/back-to-office/cat-be/_tests_/back-to-office.cat-be.page.spec.ts
@@ -20,7 +20,7 @@ import { MockComponent } from 'ng-mocks';
 import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { By } from '@angular/platform-browser';
 import { of } from 'rxjs/observable/of';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('BackToOfficePage', () => {
   let fixture: ComponentFixture<BackToOfficeCatBEPage>;
@@ -96,8 +96,8 @@ describe('BackToOfficePage', () => {
         { provide: Insomnia, useClass: InsomniaMock },
         { provide: DeviceProvider, useClass: DeviceProviderMock },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(BackToOfficeCatBEPage);

--- a/src/pages/back-to-office/cat-be/_tests_/back-to-office.cat-be.page.spec.ts
+++ b/src/pages/back-to-office/cat-be/_tests_/back-to-office.cat-be.page.spec.ts
@@ -20,6 +20,7 @@ import { MockComponent } from 'ng-mocks';
 import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { By } from '@angular/platform-browser';
 import { of } from 'rxjs/observable/of';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('BackToOfficePage', () => {
   let fixture: ComponentFixture<BackToOfficeCatBEPage>;
@@ -30,7 +31,7 @@ describe('BackToOfficePage', () => {
   let insomnia: Insomnia;
   let deviceProvider: DeviceProvider;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         BackToOfficeCatBEPage,
@@ -96,8 +97,9 @@ describe('BackToOfficePage', () => {
         { provide: DeviceProvider, useClass: DeviceProviderMock },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(BackToOfficeCatBEPage);
         component = fixture.componentInstance;
         navController = TestBed.get(NavController);
@@ -106,7 +108,6 @@ describe('BackToOfficePage', () => {
         deviceProvider = TestBed.get(DeviceProvider);
         store$ = TestBed.get(Store);
         spyOn(store$, 'dispatch');
-      });
   }));
 
   describe('Class', () => {

--- a/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
@@ -25,6 +25,7 @@ import * as applicationReferenceActions
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
 import { PopulateTestCategory } from '../../../modules/tests/category/category.actions';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Communication Analytics Effects', () => {
 
@@ -40,8 +41,7 @@ describe('Communication Analytics Effects', () => {
     checkDigit: 9,
   };
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -55,6 +55,10 @@ describe('Communication Analytics Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(CommunicationAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     store$ = TestBed.get(Store);

--- a/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.analytics.effects.spec.ts
@@ -25,7 +25,7 @@ import * as applicationReferenceActions
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
 import { PopulateTestCategory } from '../../../modules/tests/category/category.actions';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Communication Analytics Effects', () => {
 
@@ -55,7 +55,7 @@ describe('Communication Analytics Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/pages/communication-page/__tests__/communication.effects.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.effects.spec.ts
@@ -6,7 +6,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import * as communicationActions from '../communication.actions';
 import * as testStatusActions from '../../../modules/tests/test-status/test-status.actions';
 import * as testsActions from '../../../modules/tests/tests.actions';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Communication Effects', () => {
 
@@ -34,7 +34,7 @@ describe('Communication Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/pages/communication-page/__tests__/communication.effects.spec.ts
+++ b/src/pages/communication-page/__tests__/communication.effects.spec.ts
@@ -6,6 +6,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import * as communicationActions from '../communication.actions';
 import * as testStatusActions from '../../../modules/tests/test-status/test-status.actions';
 import * as testsActions from '../../../modules/tests/tests.actions';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Communication Effects', () => {
 
@@ -14,8 +15,7 @@ describe('Communication Effects', () => {
 
   const currentSlotId = '1234';
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -34,6 +34,10 @@ describe('Communication Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(CommunicationEffects);
   });
 

--- a/src/pages/communication-page/components/privacy-notice/__tests__/privacy-notice.spec.ts
+++ b/src/pages/communication-page/components/privacy-notice/__tests__/privacy-notice.spec.ts
@@ -27,8 +27,8 @@ describe('PrivacyNoticeComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(PrivacyNoticeComponent);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(PrivacyNoticeComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('Class', () => {

--- a/src/pages/communication-page/components/privacy-notice/__tests__/privacy-notice.spec.ts
+++ b/src/pages/communication-page/components/privacy-notice/__tests__/privacy-notice.spec.ts
@@ -4,7 +4,7 @@ import { PrivacyNoticeComponent } from '../privacy-notice';
 import { TranslateService, TranslateModule } from 'ng2-translate';
 import { translateServiceMock } from '../../../../../shared/__mocks__/translate';
 import { ConfigMock } from 'ionic-mocks';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('PrivacyNoticeComponent', () => {
   let fixture: ComponentFixture<PrivacyNoticeComponent>;
@@ -23,8 +23,8 @@ describe('PrivacyNoticeComponent', () => {
         { provide: TranslateService, useValue: translateServiceMock },
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(PrivacyNoticeComponent);

--- a/src/pages/communication-page/components/privacy-notice/__tests__/privacy-notice.spec.ts
+++ b/src/pages/communication-page/components/privacy-notice/__tests__/privacy-notice.spec.ts
@@ -4,12 +4,13 @@ import { PrivacyNoticeComponent } from '../privacy-notice';
 import { TranslateService, TranslateModule } from 'ng2-translate';
 import { translateServiceMock } from '../../../../../shared/__mocks__/translate';
 import { ConfigMock } from 'ionic-mocks';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('PrivacyNoticeComponent', () => {
   let fixture: ComponentFixture<PrivacyNoticeComponent>;
   let component: PrivacyNoticeComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         PrivacyNoticeComponent,
@@ -23,11 +24,11 @@ describe('PrivacyNoticeComponent', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(PrivacyNoticeComponent);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('Class', () => {

--- a/src/pages/communication-page/components/provided-email/__tests__/provided-email.spec.ts
+++ b/src/pages/communication-page/components/provided-email/__tests__/provided-email.spec.ts
@@ -7,13 +7,14 @@ import { TranslateService, TranslateModule, TranslateLoader } from 'ng2-translat
 import * as welshTranslations from '../../../../../assets/i18n/cy.json';
 import { createTranslateLoader } from '../../../../../app/app.module';
 import { Http } from '@angular/http';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('ProvidedEmailComponent', () => {
   let fixture: ComponentFixture<ProvidedEmailComponent>;
   let component: ProvidedEmailComponent;
   let translate: TranslateService;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         ProvidedEmailComponent,
@@ -27,8 +28,9 @@ describe('ProvidedEmailComponent', () => {
         }),
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(ProvidedEmailComponent);
         component = fixture.componentInstance;
         component.formGroup = new FormGroup({});
@@ -37,7 +39,6 @@ describe('ProvidedEmailComponent', () => {
         component.isProvidedEmailAddressChosen = true;
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
-      });
   }));
 
   describe('DOM', () => {

--- a/src/pages/communication-page/components/provided-email/__tests__/provided-email.spec.ts
+++ b/src/pages/communication-page/components/provided-email/__tests__/provided-email.spec.ts
@@ -7,7 +7,7 @@ import { TranslateService, TranslateModule, TranslateLoader } from 'ng2-translat
 import * as welshTranslations from '../../../../../assets/i18n/cy.json';
 import { createTranslateLoader } from '../../../../../app/app.module';
 import { Http } from '@angular/http';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('ProvidedEmailComponent', () => {
   let fixture: ComponentFixture<ProvidedEmailComponent>;
@@ -27,8 +27,8 @@ describe('ProvidedEmailComponent', () => {
           deps: [Http],
         }),
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(ProvidedEmailComponent);

--- a/src/pages/communication-page/components/provided-email/__tests__/provided-email.spec.ts
+++ b/src/pages/communication-page/components/provided-email/__tests__/provided-email.spec.ts
@@ -31,14 +31,14 @@ describe('ProvidedEmailComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(ProvidedEmailComponent);
-        component = fixture.componentInstance;
-        component.formGroup = new FormGroup({});
-        component.formGroup.addControl('radioCtrl', new FormControl());
-        component.shouldRender = true;
-        component.isProvidedEmailAddressChosen = true;
-        translate = TestBed.get(TranslateService);
-        translate.setDefaultLang('en');
+    fixture = TestBed.createComponent(ProvidedEmailComponent);
+    component = fixture.componentInstance;
+    component.formGroup = new FormGroup({});
+    component.formGroup.addControl('radioCtrl', new FormControl());
+    component.shouldRender = true;
+    component.isProvidedEmailAddressChosen = true;
+    translate = TestBed.get(TranslateService);
+    translate.setDefaultLang('en');
   }));
 
   describe('DOM', () => {

--- a/src/pages/dashboard/__tests__/dashboard.analytics.effects.spec.ts
+++ b/src/pages/dashboard/__tests__/dashboard.analytics.effects.spec.ts
@@ -7,6 +7,7 @@ import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/an
 import { AnalyticsScreenNames } from '../../../providers/analytics/analytics.model';
 import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
 import * as dashboardActions from '../dashboard.actions';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Dashboard Analytics Effects', () => {
 
@@ -15,8 +16,7 @@ describe('Dashboard Analytics Effects', () => {
   let actions$: any;
   const screenName = AnalyticsScreenNames.DASHBOARD;
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       providers: [
         DashboardAnalyticsEffects,
@@ -24,6 +24,10 @@ describe('Dashboard Analytics Effects', () => {
         provideMockActions(() => actions$),
       ],
     });
+  });
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(DashboardAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
   });

--- a/src/pages/dashboard/__tests__/dashboard.spec.ts
+++ b/src/pages/dashboard/__tests__/dashboard.spec.ts
@@ -26,13 +26,14 @@ import { ComponentsModule } from '../../../components/common/common-components.m
 import { testsReducer } from '../../../modules/tests/tests.reducer';
 import { journalReducer } from '../../../modules/journal/journal.reducer';
 import { SlotProvider } from '../../../providers/slot/slot';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('DashboardPage', () => {
   let fixture: ComponentFixture<DashboardPage>;
   let component: DashboardPage;
   let store$: Store<StoreModel>;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [DashboardPage],
       imports: [
@@ -59,15 +60,14 @@ describe('DashboardPage', () => {
         { provide: SlotProvider, useClass: SlotProvider },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(DashboardPage);
         component = fixture.componentInstance;
         component.subscription = new Subscription();
         store$ = TestBed.get(Store);
         spyOn(store$, 'dispatch');
-      });
-
   }));
 
   describe('DOM', () => {

--- a/src/pages/dashboard/__tests__/dashboard.spec.ts
+++ b/src/pages/dashboard/__tests__/dashboard.spec.ts
@@ -59,7 +59,7 @@ describe('DashboardPage', () => {
         { provide: App, useClass: MockAppComponent },
         { provide: SlotProvider, useClass: SlotProvider },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/dashboard/__tests__/dashboard.spec.ts
+++ b/src/pages/dashboard/__tests__/dashboard.spec.ts
@@ -63,11 +63,11 @@ describe('DashboardPage', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(DashboardPage);
-        component = fixture.componentInstance;
-        component.subscription = new Subscription();
-        store$ = TestBed.get(Store);
-        spyOn(store$, 'dispatch');
+    fixture = TestBed.createComponent(DashboardPage);
+    component = fixture.componentInstance;
+    component.subscription = new Subscription();
+    store$ = TestBed.get(Store);
+    spyOn(store$, 'dispatch');
   }));
 
   describe('DOM', () => {

--- a/src/pages/dashboard/components/go-to-journal-card/__tests__/go-to-journal-card.spec.ts
+++ b/src/pages/dashboard/components/go-to-journal-card/__tests__/go-to-journal-card.spec.ts
@@ -3,24 +3,27 @@ import { IonicModule, NavController } from 'ionic-angular';
 import { GoToJournalCardComponent } from '../go-to-journal-card';
 import { NavControllerMock } from 'ionic-mocks';
 import { JOURNAL_PAGE } from '../../../../page-names.constants';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('GoToJournalCard ', () => {
   let component: GoToJournalCardComponent;
   let fixture: ComponentFixture<GoToJournalCardComponent>;
   let navContoller: NavController;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [GoToJournalCardComponent],
       imports: [IonicModule.forRoot(GoToJournalCardComponent)],
       providers: [
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
       ],
-    }).compileComponents().then(() => {
+    })
+  });
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(GoToJournalCardComponent);
       component = fixture.componentInstance;
       navContoller = TestBed.get(NavController);
-    });
   }));
 
   describe('Class', () => {

--- a/src/pages/dashboard/components/go-to-journal-card/__tests__/go-to-journal-card.spec.ts
+++ b/src/pages/dashboard/components/go-to-journal-card/__tests__/go-to-journal-card.spec.ts
@@ -17,7 +17,7 @@ describe('GoToJournalCard ', () => {
       providers: [
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/dashboard/components/go-to-journal-card/__tests__/go-to-journal-card.spec.ts
+++ b/src/pages/dashboard/components/go-to-journal-card/__tests__/go-to-journal-card.spec.ts
@@ -21,9 +21,9 @@ describe('GoToJournalCard ', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(GoToJournalCardComponent);
-      component = fixture.componentInstance;
-      navContoller = TestBed.get(NavController);
+    fixture = TestBed.createComponent(GoToJournalCardComponent);
+    component = fixture.componentInstance;
+    navContoller = TestBed.get(NavController);
   }));
 
   describe('Class', () => {

--- a/src/pages/dashboard/components/practice-end-to-end-card/__tests__/practice-end-to-end-card.spec.ts
+++ b/src/pages/dashboard/components/practice-end-to-end-card/__tests__/practice-end-to-end-card.spec.ts
@@ -21,9 +21,9 @@ describe('PracticeEndToEndCard ', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(PracticeEndToEndCardComponent);
-      component = fixture.componentInstance;
-      navContoller = TestBed.get(NavController);
+    fixture = TestBed.createComponent(PracticeEndToEndCardComponent);
+    component = fixture.componentInstance;
+    navContoller = TestBed.get(NavController);
   }));
 
   describe('Class', () => {

--- a/src/pages/dashboard/components/practice-end-to-end-card/__tests__/practice-end-to-end-card.spec.ts
+++ b/src/pages/dashboard/components/practice-end-to-end-card/__tests__/practice-end-to-end-card.spec.ts
@@ -17,7 +17,7 @@ describe('PracticeEndToEndCard ', () => {
       providers: [
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/dashboard/components/practice-end-to-end-card/__tests__/practice-end-to-end-card.spec.ts
+++ b/src/pages/dashboard/components/practice-end-to-end-card/__tests__/practice-end-to-end-card.spec.ts
@@ -3,24 +3,27 @@ import { IonicModule, NavController } from 'ionic-angular';
 import { PracticeEndToEndCardComponent } from '../practice-end-to-end-card';
 import { NavControllerMock } from 'ionic-mocks';
 import { FAKE_JOURNAL_PAGE } from '../../../../page-names.constants';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('PracticeEndToEndCard ', () => {
   let component: PracticeEndToEndCardComponent;
   let fixture: ComponentFixture<PracticeEndToEndCardComponent>;
   let navContoller: NavController;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [PracticeEndToEndCardComponent],
       imports: [IonicModule.forRoot(PracticeEndToEndCardComponent)],
       providers: [
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
       ],
-    }).compileComponents().then(() => {
+    })
+  });
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(PracticeEndToEndCardComponent);
       component = fixture.componentInstance;
       navContoller = TestBed.get(NavController);
-    });
   }));
 
   describe('Class', () => {

--- a/src/pages/dashboard/components/practice-test-modal/__tests__/practice-test-modal.spec.ts
+++ b/src/pages/dashboard/components/practice-test-modal/__tests__/practice-test-modal.spec.ts
@@ -27,11 +27,14 @@ describe('PracticeTestModal', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(PracticeTestModal);
-        component = fixture.componentInstance;
-        component.onCancel = () => {};
-        component.onNoFault = () => {};
-        component.onFault = () => {};
+    fixture = TestBed.createComponent(PracticeTestModal);
+    component = fixture.componentInstance;
+    component.onCancel = () => {
+    };
+    component.onNoFault = () => {
+    };
+    component.onFault = () => {
+    };
   }));
 
   describe('DOM', () => {

--- a/src/pages/dashboard/components/practice-test-modal/__tests__/practice-test-modal.spec.ts
+++ b/src/pages/dashboard/components/practice-test-modal/__tests__/practice-test-modal.spec.ts
@@ -4,12 +4,13 @@ import { IonicModule, NavParams, ViewController } from 'ionic-angular';
 import { NavParamsMock, ViewControllerMock } from 'ionic-mocks';
 import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('PracticeTestModal', () => {
   let fixture: ComponentFixture<PracticeTestModal>;
   let component: PracticeTestModal;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         PracticeTestModal,
@@ -22,15 +23,15 @@ describe('PracticeTestModal', () => {
         { provide: NavParams, useFactory: () => NavParamsMock.instance() },
         { provide: ViewController, useFactory: () => ViewControllerMock.instance() },
       ],
-    })
-      .compileComponents()
-      .then(() => {
+    });
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(PracticeTestModal);
         component = fixture.componentInstance;
         component.onCancel = () => {};
         component.onNoFault = () => {};
         component.onFault = () => {};
-      });
   }));
 
   describe('DOM', () => {

--- a/src/pages/dashboard/components/practice-test-report-card/__tests__/practice-test-report-card.spec.ts
+++ b/src/pages/dashboard/components/practice-test-report-card/__tests__/practice-test-report-card.spec.ts
@@ -4,12 +4,13 @@ import { PracticeTestReportCardComponent } from '../practice-test-report-card';
 import { NavControllerMock, AlertControllerMock, ModalControllerMock } from 'ionic-mocks';
 import { journalReducer } from '../../../../../modules/journal/journal.reducer';
 import { StoreModule } from '@ngrx/store';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('PracticeTestReportCard ', () => {
   let component: PracticeTestReportCardComponent;
   let fixture: ComponentFixture<PracticeTestReportCardComponent>;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [PracticeTestReportCardComponent],
       imports: [
@@ -23,10 +24,12 @@ describe('PracticeTestReportCard ', () => {
         { provide: AlertController, useFactory: () => AlertControllerMock.instance() },
         { provide: ModalController, useFactory: () => ModalControllerMock.instance() },
       ],
-    }).compileComponents().then(() => {
+    })
+  });
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(PracticeTestReportCardComponent);
       component = fixture.componentInstance;
-    });
   }));
 
   describe('Class', () => {

--- a/src/pages/dashboard/components/practice-test-report-card/__tests__/practice-test-report-card.spec.ts
+++ b/src/pages/dashboard/components/practice-test-report-card/__tests__/practice-test-report-card.spec.ts
@@ -28,8 +28,8 @@ describe('PracticeTestReportCard ', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(PracticeTestReportCardComponent);
-      component = fixture.componentInstance;
+    fixture = TestBed.createComponent(PracticeTestReportCardComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('Class', () => {

--- a/src/pages/dashboard/components/practice-test-report-card/__tests__/practice-test-report-card.spec.ts
+++ b/src/pages/dashboard/components/practice-test-report-card/__tests__/practice-test-report-card.spec.ts
@@ -24,7 +24,7 @@ describe('PracticeTestReportCard ', () => {
         { provide: AlertController, useFactory: () => AlertControllerMock.instance() },
         { provide: ModalController, useFactory: () => ModalControllerMock.instance() },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/dashboard/components/rekey-search-card/__tests__/rekey-search-card.spec.ts
+++ b/src/pages/dashboard/components/rekey-search-card/__tests__/rekey-search-card.spec.ts
@@ -21,9 +21,9 @@ describe('RekeySearchCard ', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(RekeySearchCardComponent);
-      component = fixture.componentInstance;
-      navContoller = TestBed.get(NavController);
+    fixture = TestBed.createComponent(RekeySearchCardComponent);
+    component = fixture.componentInstance;
+    navContoller = TestBed.get(NavController);
   }));
 
   describe('Class', () => {

--- a/src/pages/dashboard/components/rekey-search-card/__tests__/rekey-search-card.spec.ts
+++ b/src/pages/dashboard/components/rekey-search-card/__tests__/rekey-search-card.spec.ts
@@ -17,7 +17,7 @@ describe('RekeySearchCard ', () => {
       providers: [
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/dashboard/components/rekey-search-card/__tests__/rekey-search-card.spec.ts
+++ b/src/pages/dashboard/components/rekey-search-card/__tests__/rekey-search-card.spec.ts
@@ -3,24 +3,27 @@ import { IonicModule, NavController } from 'ionic-angular';
 import { RekeySearchCardComponent } from '../rekey-search-card';
 import { NavControllerMock } from 'ionic-mocks';
 import { REKEY_SEARCH_PAGE } from '../../../../page-names.constants';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('RekeySearchCard ', () => {
   let component: RekeySearchCardComponent;
   let fixture: ComponentFixture<RekeySearchCardComponent>;
   let navContoller: NavController;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [RekeySearchCardComponent],
       imports: [IonicModule.forRoot(RekeySearchCardComponent)],
       providers: [
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
       ],
-    }).compileComponents().then(() => {
+    })
+  });
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(RekeySearchCardComponent);
       component = fixture.componentInstance;
       navContoller = TestBed.get(NavController);
-    });
   }));
 
   describe('Class', () => {

--- a/src/pages/dashboard/components/test-results-search-card/__tests__/test-results-search-card.spec.ts
+++ b/src/pages/dashboard/components/test-results-search-card/__tests__/test-results-search-card.spec.ts
@@ -3,24 +3,27 @@ import { IonicModule, NavController } from 'ionic-angular';
 import { TestResultsSearchCardComponent } from '../test-results-search-card';
 import { NavControllerMock } from 'ionic-mocks';
 import { TEST_RESULTS_SEARCH_PAGE } from '../../../../page-names.constants';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('TestResultsSearchCard ', () => {
   let component: TestResultsSearchCardComponent;
   let fixture: ComponentFixture<TestResultsSearchCardComponent>;
   let navContoller: NavController;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [TestResultsSearchCardComponent],
       imports: [IonicModule.forRoot(TestResultsSearchCardComponent)],
       providers: [
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
       ],
-    }).compileComponents().then(() => {
+    })
+  });
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(TestResultsSearchCardComponent);
       component = fixture.componentInstance;
       navContoller = TestBed.get(NavController);
-    });
   }));
 
   describe('Class', () => {

--- a/src/pages/dashboard/components/test-results-search-card/__tests__/test-results-search-card.spec.ts
+++ b/src/pages/dashboard/components/test-results-search-card/__tests__/test-results-search-card.spec.ts
@@ -17,7 +17,7 @@ describe('TestResultsSearchCard ', () => {
       providers: [
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/dashboard/components/test-results-search-card/__tests__/test-results-search-card.spec.ts
+++ b/src/pages/dashboard/components/test-results-search-card/__tests__/test-results-search-card.spec.ts
@@ -21,9 +21,9 @@ describe('TestResultsSearchCard ', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(TestResultsSearchCardComponent);
-      component = fixture.componentInstance;
-      navContoller = TestBed.get(NavController);
+    fixture = TestBed.createComponent(TestResultsSearchCardComponent);
+    component = fixture.componentInstance;
+    navContoller = TestBed.get(NavController);
   }));
 
   describe('Class', () => {

--- a/src/pages/debrief/__tests__/debrief.analytics.effects.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.analytics.effects.spec.ts
@@ -19,6 +19,7 @@ import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions
 import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
 import { ActivityCodes } from '../../../shared/models/activity-codes';
 import { TestCategory } from '../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Debrief Analytics Effects', () => {
 
@@ -31,8 +32,7 @@ describe('Debrief Analytics Effects', () => {
   const screenNamePracticeModePass = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.PASS_DEBRIEF}`;
   const screenNamePracticeModeFail = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.FAIL_DEBRIEF}`;
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -46,6 +46,10 @@ describe('Debrief Analytics Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(DebriefAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     store$ = TestBed.get(Store);

--- a/src/pages/debrief/__tests__/debrief.analytics.effects.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.analytics.effects.spec.ts
@@ -19,7 +19,7 @@ import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions
 import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
 import { ActivityCodes } from '../../../shared/models/activity-codes';
 import { TestCategory } from '../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Debrief Analytics Effects', () => {
 
@@ -46,7 +46,7 @@ describe('Debrief Analytics Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/pages/debrief/components/dangerous-faults-debrief-card/__tests__/dangerous-faults-debrief-card.spec.ts
+++ b/src/pages/debrief/components/dangerous-faults-debrief-card/__tests__/dangerous-faults-debrief-card.spec.ts
@@ -11,13 +11,14 @@ import { Language } from '../../../../../modules/tests/communication-preferences
 import { configureI18N } from '../../../../../shared/helpers/translation.helpers';
 import * as welshTranslations from '../../../../../assets/i18n/cy.json';
 import { Competencies } from '../../../../../modules/tests/test-data/test-data.constants';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('DangerousFaultsDebriefCardComponent', () => {
   let fixture: ComponentFixture<DangerousFaultsDebriefCardComponent>;
   let component: DangerousFaultsDebriefCardComponent;
   let translate: TranslateService;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [DangerousFaultsDebriefCardComponent],
       imports: [
@@ -29,13 +30,13 @@ describe('DangerousFaultsDebriefCardComponent', () => {
         TranslateModule,
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(DangerousFaultsDebriefCardComponent);
         component = fixture.componentInstance;
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
-      });
   }));
 
   describe('DOM', () => {

--- a/src/pages/debrief/components/dangerous-faults-debrief-card/__tests__/dangerous-faults-debrief-card.spec.ts
+++ b/src/pages/debrief/components/dangerous-faults-debrief-card/__tests__/dangerous-faults-debrief-card.spec.ts
@@ -11,7 +11,7 @@ import { Language } from '../../../../../modules/tests/communication-preferences
 import { configureI18N } from '../../../../../shared/helpers/translation.helpers';
 import * as welshTranslations from '../../../../../assets/i18n/cy.json';
 import { Competencies } from '../../../../../modules/tests/test-data/test-data.constants';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('DangerousFaultsDebriefCardComponent', () => {
   let fixture: ComponentFixture<DangerousFaultsDebriefCardComponent>;
@@ -29,8 +29,8 @@ describe('DangerousFaultsDebriefCardComponent', () => {
         }),
         TranslateModule,
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(DangerousFaultsDebriefCardComponent);

--- a/src/pages/debrief/components/dangerous-faults-debrief-card/__tests__/dangerous-faults-debrief-card.spec.ts
+++ b/src/pages/debrief/components/dangerous-faults-debrief-card/__tests__/dangerous-faults-debrief-card.spec.ts
@@ -25,18 +25,17 @@ describe('DangerousFaultsDebriefCardComponent', () => {
         IonicModule,
         AppModule,
         ComponentsModule,
-        StoreModule.forRoot({
-        }),
+        StoreModule.forRoot({}),
         TranslateModule,
       ],
     });
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(DangerousFaultsDebriefCardComponent);
-        component = fixture.componentInstance;
-        translate = TestBed.get(TranslateService);
-        translate.setDefaultLang('en');
+    fixture = TestBed.createComponent(DangerousFaultsDebriefCardComponent);
+    component = fixture.componentInstance;
+    translate = TestBed.get(TranslateService);
+    translate.setDefaultLang('en');
   }));
 
   describe('DOM', () => {

--- a/src/pages/debrief/components/driving-faults-debrief-card/__tests__/driving-faults-debrief-card.spec.ts
+++ b/src/pages/debrief/components/driving-faults-debrief-card/__tests__/driving-faults-debrief-card.spec.ts
@@ -11,13 +11,14 @@ import { DrivingFaultsDebriefCardComponent } from '../driving-faults-debrief-car
 import { FaultSummary } from '../../../../../shared/models/fault-marking.model';
 import { configureI18N } from '../../../../../shared/helpers/translation.helpers';
 import { Language } from '../../../../../modules/tests/communication-preferences/communication-preferences.model';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('DrivingFaultsDebriefCardComponent', () => {
   let fixture: ComponentFixture<DrivingFaultsDebriefCardComponent>;
   let component: DrivingFaultsDebriefCardComponent;
   let translate: TranslateService;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [DrivingFaultsDebriefCardComponent],
       imports: [
@@ -29,13 +30,13 @@ describe('DrivingFaultsDebriefCardComponent', () => {
         TranslateModule,
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(DrivingFaultsDebriefCardComponent);
         component = fixture.componentInstance;
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
-      });
   }));
 
   describe('DOM', () => {

--- a/src/pages/debrief/components/driving-faults-debrief-card/__tests__/driving-faults-debrief-card.spec.ts
+++ b/src/pages/debrief/components/driving-faults-debrief-card/__tests__/driving-faults-debrief-card.spec.ts
@@ -11,7 +11,7 @@ import { DrivingFaultsDebriefCardComponent } from '../driving-faults-debrief-car
 import { FaultSummary } from '../../../../../shared/models/fault-marking.model';
 import { configureI18N } from '../../../../../shared/helpers/translation.helpers';
 import { Language } from '../../../../../modules/tests/communication-preferences/communication-preferences.model';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('DrivingFaultsDebriefCardComponent', () => {
   let fixture: ComponentFixture<DrivingFaultsDebriefCardComponent>;
@@ -29,8 +29,8 @@ describe('DrivingFaultsDebriefCardComponent', () => {
         }),
         TranslateModule,
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(DrivingFaultsDebriefCardComponent);

--- a/src/pages/debrief/components/driving-faults-debrief-card/__tests__/driving-faults-debrief-card.spec.ts
+++ b/src/pages/debrief/components/driving-faults-debrief-card/__tests__/driving-faults-debrief-card.spec.ts
@@ -25,18 +25,17 @@ describe('DrivingFaultsDebriefCardComponent', () => {
         IonicModule,
         AppModule,
         ComponentsModule,
-        StoreModule.forRoot({
-        }),
+        StoreModule.forRoot({}),
         TranslateModule,
       ],
     });
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(DrivingFaultsDebriefCardComponent);
-        component = fixture.componentInstance;
-        translate = TestBed.get(TranslateService);
-        translate.setDefaultLang('en');
+    fixture = TestBed.createComponent(DrivingFaultsDebriefCardComponent);
+    component = fixture.componentInstance;
+    translate = TestBed.get(TranslateService);
+    translate.setDefaultLang('en');
   }));
 
   describe('DOM', () => {

--- a/src/pages/debrief/components/eco-debrief-card/__tests__/eco-debrief-card.spec.ts
+++ b/src/pages/debrief/components/eco-debrief-card/__tests__/eco-debrief-card.spec.ts
@@ -7,13 +7,14 @@ import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
 import { ComponentsModule } from '../../../../../components/common/common-components.module';
 import { EcoDebriefCardComponent } from '../eco-debrief-card';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('EcoDebriefCardComponent', () => {
   let fixture: ComponentFixture<EcoDebriefCardComponent>;
   let component: EcoDebriefCardComponent;
   let translate: TranslateService;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [EcoDebriefCardComponent],
       imports: [
@@ -25,13 +26,13 @@ describe('EcoDebriefCardComponent', () => {
         TranslateModule,
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(EcoDebriefCardComponent);
         component = fixture.componentInstance;
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
-      });
   }));
 
   describe('DOM', () => {

--- a/src/pages/debrief/components/eco-debrief-card/__tests__/eco-debrief-card.spec.ts
+++ b/src/pages/debrief/components/eco-debrief-card/__tests__/eco-debrief-card.spec.ts
@@ -7,7 +7,7 @@ import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
 import { ComponentsModule } from '../../../../../components/common/common-components.module';
 import { EcoDebriefCardComponent } from '../eco-debrief-card';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('EcoDebriefCardComponent', () => {
   let fixture: ComponentFixture<EcoDebriefCardComponent>;
@@ -25,8 +25,8 @@ describe('EcoDebriefCardComponent', () => {
         }),
         TranslateModule,
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(EcoDebriefCardComponent);

--- a/src/pages/debrief/components/eco-debrief-card/__tests__/eco-debrief-card.spec.ts
+++ b/src/pages/debrief/components/eco-debrief-card/__tests__/eco-debrief-card.spec.ts
@@ -21,18 +21,17 @@ describe('EcoDebriefCardComponent', () => {
         IonicModule,
         AppModule,
         ComponentsModule,
-        StoreModule.forRoot({
-        }),
+        StoreModule.forRoot({}),
         TranslateModule,
       ],
     });
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(EcoDebriefCardComponent);
-        component = fixture.componentInstance;
-        translate = TestBed.get(TranslateService);
-        translate.setDefaultLang('en');
+    fixture = TestBed.createComponent(EcoDebriefCardComponent);
+    component = fixture.componentInstance;
+    translate = TestBed.get(TranslateService);
+    translate.setDefaultLang('en');
   }));
 
   describe('DOM', () => {

--- a/src/pages/debrief/components/eta-debrief-card/__tests__/eta-debrief-card.spec.ts
+++ b/src/pages/debrief/components/eta-debrief-card/__tests__/eta-debrief-card.spec.ts
@@ -21,18 +21,17 @@ describe('EtaDebriefCardComponent', () => {
         IonicModule,
         AppModule,
         ComponentsModule,
-        StoreModule.forRoot({
-        }),
+        StoreModule.forRoot({}),
         TranslateModule,
       ],
     });
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(EtaDebriefCardComponent);
-        component = fixture.componentInstance;
-        translate = TestBed.get(TranslateService);
-        translate.setDefaultLang('en');
+    fixture = TestBed.createComponent(EtaDebriefCardComponent);
+    component = fixture.componentInstance;
+    translate = TestBed.get(TranslateService);
+    translate.setDefaultLang('en');
   }));
 
   describe('DOM', () => {

--- a/src/pages/debrief/components/eta-debrief-card/__tests__/eta-debrief-card.spec.ts
+++ b/src/pages/debrief/components/eta-debrief-card/__tests__/eta-debrief-card.spec.ts
@@ -7,7 +7,7 @@ import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
 import { ComponentsModule } from '../../../../../components/common/common-components.module';
 import { EtaDebriefCardComponent } from '../eta-debrief-card';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('EtaDebriefCardComponent', () => {
   let fixture: ComponentFixture<EtaDebriefCardComponent>;
@@ -25,8 +25,8 @@ describe('EtaDebriefCardComponent', () => {
         }),
         TranslateModule,
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(EtaDebriefCardComponent);

--- a/src/pages/debrief/components/eta-debrief-card/__tests__/eta-debrief-card.spec.ts
+++ b/src/pages/debrief/components/eta-debrief-card/__tests__/eta-debrief-card.spec.ts
@@ -7,13 +7,14 @@ import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
 import { ComponentsModule } from '../../../../../components/common/common-components.module';
 import { EtaDebriefCardComponent } from '../eta-debrief-card';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('EtaDebriefCardComponent', () => {
   let fixture: ComponentFixture<EtaDebriefCardComponent>;
   let component: EtaDebriefCardComponent;
   let translate: TranslateService;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [EtaDebriefCardComponent],
       imports: [
@@ -25,13 +26,13 @@ describe('EtaDebriefCardComponent', () => {
         TranslateModule,
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(EtaDebriefCardComponent);
         component = fixture.componentInstance;
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
-      });
   }));
 
   describe('DOM', () => {

--- a/src/pages/debrief/components/serious-faults-debrief-card/__tests__/serious-faults-debrief-card.spec.ts
+++ b/src/pages/debrief/components/serious-faults-debrief-card/__tests__/serious-faults-debrief-card.spec.ts
@@ -11,13 +11,14 @@ import { configureI18N } from '../../../../../shared/helpers/translation.helpers
 import { Language } from '../../../../../modules/tests/communication-preferences/communication-preferences.model';
 import { SeriousFaultsDebriefCardComponent } from '../serious-faults-debrief-card';
 import { Competencies } from '../../../../../modules/tests/test-data/test-data.constants';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('SeriousFaultsDebriefCardComponent', () => {
   let fixture: ComponentFixture<SeriousFaultsDebriefCardComponent>;
   let component: SeriousFaultsDebriefCardComponent;
   let translate: TranslateService;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [SeriousFaultsDebriefCardComponent],
       imports: [
@@ -29,13 +30,13 @@ describe('SeriousFaultsDebriefCardComponent', () => {
         TranslateModule,
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(SeriousFaultsDebriefCardComponent);
         component = fixture.componentInstance;
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
-      });
   }));
 
   describe('DOM', () => {

--- a/src/pages/debrief/components/serious-faults-debrief-card/__tests__/serious-faults-debrief-card.spec.ts
+++ b/src/pages/debrief/components/serious-faults-debrief-card/__tests__/serious-faults-debrief-card.spec.ts
@@ -11,7 +11,7 @@ import { configureI18N } from '../../../../../shared/helpers/translation.helpers
 import { Language } from '../../../../../modules/tests/communication-preferences/communication-preferences.model';
 import { SeriousFaultsDebriefCardComponent } from '../serious-faults-debrief-card';
 import { Competencies } from '../../../../../modules/tests/test-data/test-data.constants';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('SeriousFaultsDebriefCardComponent', () => {
   let fixture: ComponentFixture<SeriousFaultsDebriefCardComponent>;
@@ -29,8 +29,8 @@ describe('SeriousFaultsDebriefCardComponent', () => {
         }),
         TranslateModule,
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(SeriousFaultsDebriefCardComponent);

--- a/src/pages/debrief/components/serious-faults-debrief-card/__tests__/serious-faults-debrief-card.spec.ts
+++ b/src/pages/debrief/components/serious-faults-debrief-card/__tests__/serious-faults-debrief-card.spec.ts
@@ -25,18 +25,17 @@ describe('SeriousFaultsDebriefCardComponent', () => {
         IonicModule,
         AppModule,
         ComponentsModule,
-        StoreModule.forRoot({
-        }),
+        StoreModule.forRoot({}),
         TranslateModule,
       ],
     });
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(SeriousFaultsDebriefCardComponent);
-        component = fixture.componentInstance;
-        translate = TestBed.get(TranslateService);
-        translate.setDefaultLang('en');
+    fixture = TestBed.createComponent(SeriousFaultsDebriefCardComponent);
+    component = fixture.componentInstance;
+    translate = TestBed.get(TranslateService);
+    translate.setDefaultLang('en');
   }));
 
   describe('DOM', () => {

--- a/src/pages/debrief/components/vehicle-checks-card/__tests__/vehicle-checks-card.spec.ts
+++ b/src/pages/debrief/components/vehicle-checks-card/__tests__/vehicle-checks-card.spec.ts
@@ -20,7 +20,7 @@ import { createTranslateLoader } from '../../../../../app/app.module';
 import { Http } from '@angular/http';
 import * as welshTranslations from '../../../../../assets/i18n/cy.json';
 import { TestCategory } from '../../../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('VehicleChecksCardComponent', () => {
   let fixture: ComponentFixture<VehicleChecksCardComponent>;
@@ -44,8 +44,8 @@ describe('VehicleChecksCardComponent', () => {
       providers: [
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(VehicleChecksCardComponent);

--- a/src/pages/debrief/components/vehicle-checks-card/__tests__/vehicle-checks-card.spec.ts
+++ b/src/pages/debrief/components/vehicle-checks-card/__tests__/vehicle-checks-card.spec.ts
@@ -20,13 +20,14 @@ import { createTranslateLoader } from '../../../../../app/app.module';
 import { Http } from '@angular/http';
 import * as welshTranslations from '../../../../../assets/i18n/cy.json';
 import { TestCategory } from '../../../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('VehicleChecksCardComponent', () => {
   let fixture: ComponentFixture<VehicleChecksCardComponent>;
   let store$: Store<StoreModel>;
   let translate: TranslateService;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         VehicleChecksCardComponent,
@@ -44,14 +45,14 @@ describe('VehicleChecksCardComponent', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(VehicleChecksCardComponent);
         store$ = TestBed.get(Store);
         store$.dispatch(new StartTest(105, TestCategory.B));
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
-      });
   }));
 
   describe('DOM', () => {

--- a/src/pages/debrief/components/vehicle-checks-card/__tests__/vehicle-checks-card.spec.ts
+++ b/src/pages/debrief/components/vehicle-checks-card/__tests__/vehicle-checks-card.spec.ts
@@ -48,11 +48,11 @@ describe('VehicleChecksCardComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(VehicleChecksCardComponent);
-        store$ = TestBed.get(Store);
-        store$.dispatch(new StartTest(105, TestCategory.B));
-        translate = TestBed.get(TranslateService);
-        translate.setDefaultLang('en');
+    fixture = TestBed.createComponent(VehicleChecksCardComponent);
+    store$ = TestBed.get(Store);
+    store$.dispatch(new StartTest(105, TestCategory.B));
+    translate = TestBed.get(TranslateService);
+    translate.setDefaultLang('en');
   }));
 
   describe('DOM', () => {

--- a/src/pages/error-page/__tests__/error.spec.ts
+++ b/src/pages/error-page/__tests__/error.spec.ts
@@ -29,7 +29,7 @@ describe('ErrorPage', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
         { provide: Platform, useFactory: () => PlatformMock.instance() },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/error-page/__tests__/error.spec.ts
+++ b/src/pages/error-page/__tests__/error.spec.ts
@@ -33,8 +33,8 @@ describe('ErrorPage', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(ErrorPage);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(ErrorPage);
+    component = fixture.componentInstance;
   }));
 
   it('should navigation back to the last page in the stack', () => {

--- a/src/pages/error-page/__tests__/error.spec.ts
+++ b/src/pages/error-page/__tests__/error.spec.ts
@@ -7,12 +7,13 @@ import { MockComponent } from 'ng-mocks';
 import { ErrorPage } from './../error';
 import { ErrorMessageComponent } from '../../../components/common/error-message/error-message';
 import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('ErrorPage', () => {
   let fixture: ComponentFixture<ErrorPage>;
   let component: ErrorPage;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         ErrorPage,
@@ -29,11 +30,11 @@ describe('ErrorPage', () => {
         { provide: Platform, useFactory: () => PlatformMock.instance() },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(ErrorPage);
         component = fixture.componentInstance;
-      });
   }));
 
   it('should navigation back to the last page in the stack', () => {

--- a/src/pages/health-declaration/__tests__/health-declaration.analytics.effects.spec.ts
+++ b/src/pages/health-declaration/__tests__/health-declaration.analytics.effects.spec.ts
@@ -19,6 +19,7 @@ import { PopulateCandidateDetails } from '../../../modules/tests/journal-data/ca
 import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Health Declaration Analytics Effects', () => {
 
@@ -30,8 +31,7 @@ describe('Health Declaration Analytics Effects', () => {
   // tslint:disable-next-line:max-line-length
   const screenNamePracticeMode = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.HEALTH_DECLARATION}`;
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -45,6 +45,10 @@ describe('Health Declaration Analytics Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(HealthDeclarationAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     store$ = TestBed.get(Store);

--- a/src/pages/health-declaration/__tests__/health-declaration.analytics.effects.spec.ts
+++ b/src/pages/health-declaration/__tests__/health-declaration.analytics.effects.spec.ts
@@ -19,7 +19,7 @@ import { PopulateCandidateDetails } from '../../../modules/tests/journal-data/ca
 import { end2endPracticeSlotId } from '../../../shared/mocks/test-slot-ids.mock';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Health Declaration Analytics Effects', () => {
 
@@ -45,7 +45,7 @@ describe('Health Declaration Analytics Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/pages/health-declaration/__tests__/health-declaration.effects.spec.ts
+++ b/src/pages/health-declaration/__tests__/health-declaration.effects.spec.ts
@@ -6,6 +6,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import * as healthDeclarationActions from '../health-declaration.actions';
 import * as testStatusActions from '../../../modules/tests/test-status/test-status.actions';
 import * as testsActions from '../../../modules/tests/tests.actions';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Health Declaration Effects', () => {
 
@@ -14,8 +15,7 @@ describe('Health Declaration Effects', () => {
 
   const currentSlotId = '1234';
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -34,6 +34,10 @@ describe('Health Declaration Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(HealthDeclarationEffects);
   });
 

--- a/src/pages/health-declaration/__tests__/health-declaration.effects.spec.ts
+++ b/src/pages/health-declaration/__tests__/health-declaration.effects.spec.ts
@@ -6,7 +6,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import * as healthDeclarationActions from '../health-declaration.actions';
 import * as testStatusActions from '../../../modules/tests/test-status/test-status.actions';
 import * as testsActions from '../../../modules/tests/tests.actions';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Health Declaration Effects', () => {
 
@@ -34,7 +34,7 @@ describe('Health Declaration Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/pages/journal/__tests__/journal.analytics.effects.spec.ts
+++ b/src/pages/journal/__tests__/journal.analytics.effects.spec.ts
@@ -16,6 +16,7 @@ import * as journalActions from '../../../modules/journal/journal.actions';
 import { Store, StoreModule } from '@ngrx/store';
 import { journalReducer } from '../../../modules/journal/journal.reducer';
 import * as slotActions from '../../../providers/slot/slot.actions';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Journal Analytics Effects', () => {
 
@@ -24,8 +25,7 @@ describe('Journal Analytics Effects', () => {
   let actions$: any;
   const screenName = AnalyticsScreenNames.JOURNAL;
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -39,6 +39,10 @@ describe('Journal Analytics Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(JournalAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
   });

--- a/src/pages/journal/__tests__/journal.analytics.effects.spec.ts
+++ b/src/pages/journal/__tests__/journal.analytics.effects.spec.ts
@@ -16,7 +16,7 @@ import * as journalActions from '../../../modules/journal/journal.actions';
 import { Store, StoreModule } from '@ngrx/store';
 import { journalReducer } from '../../../modules/journal/journal.reducer';
 import * as slotActions from '../../../providers/slot/slot.actions';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Journal Analytics Effects', () => {
 
@@ -39,7 +39,7 @@ describe('Journal Analytics Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/pages/journal/components/journal-force-check-modal/journal-force-check-modal.spec.ts
+++ b/src/pages/journal/components/journal-force-check-modal/journal-force-check-modal.spec.ts
@@ -29,9 +29,10 @@ describe('JournalForceCheckModal', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(JournalForceCheckModal);
-        component = fixture.componentInstance;
-        component.onCancel = () => { };
+    fixture = TestBed.createComponent(JournalForceCheckModal);
+    component = fixture.componentInstance;
+    component.onCancel = () => {
+    };
   }));
 
   describe('Class', () => {

--- a/src/pages/journal/components/journal-force-check-modal/journal-force-check-modal.spec.ts
+++ b/src/pages/journal/components/journal-force-check-modal/journal-force-check-modal.spec.ts
@@ -5,12 +5,13 @@ import { IonicModule, NavParams, ViewController } from 'ionic-angular';
 import { NavParamsMock, ViewControllerMock } from 'ionic-mocks';
 import { By } from '@angular/platform-browser';
 import { ComponentsModule } from '../../../../components/common/common-components.module';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('JournalForceCheckModal', () => {
   let fixture: ComponentFixture<JournalForceCheckModal>;
   let component: JournalForceCheckModal;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         JournalForceCheckModal,
@@ -24,13 +25,13 @@ describe('JournalForceCheckModal', () => {
         { provide: NavParams, useFactory: () => NavParamsMock.instance() },
         { provide: ViewController, useFactory: () => ViewControllerMock.instance() },
       ],
-    })
-      .compileComponents()
-      .then(() => {
+    });
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(JournalForceCheckModal);
         component = fixture.componentInstance;
         component.onCancel = () => { };
-      });
   }));
 
   describe('Class', () => {

--- a/src/pages/journal/journal-rekey-modal/journal-rekey-modal.spec.ts
+++ b/src/pages/journal/journal-rekey-modal/journal-rekey-modal.spec.ts
@@ -9,12 +9,13 @@ import { DeviceProvider } from '../../../providers/device/device';
 import { DeviceProviderMock } from '../../../providers/device/__mocks__/device.mock';
 import { LogHelper } from '../../../providers/logs/logsHelper';
 import { LogHelperMock } from '../../../providers/logs/__mocks__/logsHelper.mock';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('JournalRekeyModal', () => {
   let fixture: ComponentFixture<JournalRekeyModal>;
   let component: JournalRekeyModal;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         JournalRekeyModal,
@@ -31,14 +32,14 @@ describe('JournalRekeyModal', () => {
         { provide: LogHelper, useClass: LogHelperMock },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(JournalRekeyModal);
         component = fixture.componentInstance;
         component.onStartTest = () => { };
         component.onRekeyTest = () => { };
         component.onCancel = () => { };
-      });
   }));
 
   describe('DOM', () => {

--- a/src/pages/journal/journal-rekey-modal/journal-rekey-modal.spec.ts
+++ b/src/pages/journal/journal-rekey-modal/journal-rekey-modal.spec.ts
@@ -35,11 +35,14 @@ describe('JournalRekeyModal', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(JournalRekeyModal);
-        component = fixture.componentInstance;
-        component.onStartTest = () => { };
-        component.onRekeyTest = () => { };
-        component.onCancel = () => { };
+    fixture = TestBed.createComponent(JournalRekeyModal);
+    component = fixture.componentInstance;
+    component.onStartTest = () => {
+    };
+    component.onRekeyTest = () => {
+    };
+    component.onCancel = () => {
+    };
   }));
 
   describe('DOM', () => {

--- a/src/pages/journal/journal-rekey-modal/journal-rekey-modal.spec.ts
+++ b/src/pages/journal/journal-rekey-modal/journal-rekey-modal.spec.ts
@@ -31,7 +31,7 @@ describe('JournalRekeyModal', () => {
         { provide: DeviceProvider, useClass: DeviceProviderMock },
         { provide: LogHelper, useClass: LogHelperMock },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/journal/personal-commitment/personal-commitment.spec.ts
+++ b/src/pages/journal/personal-commitment/personal-commitment.spec.ts
@@ -40,8 +40,8 @@ describe('PersonalCommitmentSlotComponent', () => {
   });
 
   beforeEach(async(() => {
-      fixture = TestBed.createComponent(PersonalCommitmentSlotComponent);
-      component = fixture.componentInstance;
+    fixture = TestBed.createComponent(PersonalCommitmentSlotComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('Class', () => {

--- a/src/pages/journal/personal-commitment/personal-commitment.spec.ts
+++ b/src/pages/journal/personal-commitment/personal-commitment.spec.ts
@@ -36,7 +36,7 @@ describe('PersonalCommitmentSlotComponent', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
       imports: [IonicModule],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/journal/personal-commitment/personal-commitment.spec.ts
+++ b/src/pages/journal/personal-commitment/personal-commitment.spec.ts
@@ -8,6 +8,7 @@ import { ConfigMock } from 'ionic-mocks';
 import { MockComponent } from 'ng-mocks';
 import { TimeComponent } from '../../../components/test-slot/time/time';
 import { LocationComponent } from '../../../components/test-slot/location/location';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('PersonalCommitmentSlotComponent', () => {
   let fixture: ComponentFixture<PersonalCommitmentSlotComponent>;
@@ -23,7 +24,7 @@ describe('PersonalCommitmentSlotComponent', () => {
     activityDescription: 'Annual Leave',
   };
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         PersonalCommitmentSlotComponent,
@@ -35,10 +36,12 @@ describe('PersonalCommitmentSlotComponent', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
       imports: [IonicModule],
-    }).compileComponents().then(() => {
+    })
+  });
+
+  beforeEach(async(() => {
       fixture = TestBed.createComponent(PersonalCommitmentSlotComponent);
       component = fixture.componentInstance;
-    });
   }));
 
   describe('Class', () => {

--- a/src/pages/office/__tests__/office.analytics.effects.spec.ts
+++ b/src/pages/office/__tests__/office.analytics.effects.spec.ts
@@ -28,6 +28,7 @@ import * as applicationReferenceActions
 import * as activityCodeActions from '../../../modules/tests/activity-code/activity-code.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Office Analytics Effects', () => {
 
@@ -47,8 +48,7 @@ describe('Office Analytics Effects', () => {
     checkDigit: 9,
   };
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -62,6 +62,10 @@ describe('Office Analytics Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(OfficeAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     store$ = TestBed.get(Store);

--- a/src/pages/office/__tests__/office.analytics.effects.spec.ts
+++ b/src/pages/office/__tests__/office.analytics.effects.spec.ts
@@ -28,7 +28,7 @@ import * as applicationReferenceActions
 import * as activityCodeActions from '../../../modules/tests/activity-code/activity-code.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Office Analytics Effects', () => {
 
@@ -62,7 +62,7 @@ describe('Office Analytics Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/pages/office/cat-be/__tests__/office.cat-be.page.spec.ts
+++ b/src/pages/office/cat-be/__tests__/office.cat-be.page.spec.ts
@@ -64,6 +64,7 @@ import { NavigationStateProviderMock } from '../../../../providers/navigation-st
 import { SetActivityCode } from '../../../../modules/tests/activity-code/activity-code.actions';
 import { TestCategory } from '../../../../shared/models/test-category';
 import { FaultSummaryProvider } from '../../../../providers/fault-summary/fault-summary';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficeCatBEPage>;
@@ -71,7 +72,7 @@ describe('OfficePage', () => {
   let navController: NavController;
   let store$: Store<StoreModel>;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         OfficeCatBEPage,
@@ -147,12 +148,12 @@ describe('OfficePage', () => {
         { provide: FaultSummaryProvider, useClass: FaultSummaryProvider },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(OfficeCatBEPage);
         component = fixture.componentInstance;
         navController = TestBed.get(NavController);
-      });
     store$ = TestBed.get(Store);
     spyOn(store$, 'dispatch');
   }));

--- a/src/pages/office/cat-be/__tests__/office.cat-be.page.spec.ts
+++ b/src/pages/office/cat-be/__tests__/office.cat-be.page.spec.ts
@@ -64,7 +64,7 @@ import { NavigationStateProviderMock } from '../../../../providers/navigation-st
 import { SetActivityCode } from '../../../../modules/tests/activity-code/activity-code.actions';
 import { TestCategory } from '../../../../shared/models/test-category';
 import { FaultSummaryProvider } from '../../../../providers/fault-summary/fault-summary';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('OfficePage', () => {
   let fixture: ComponentFixture<OfficeCatBEPage>;
@@ -147,15 +147,15 @@ describe('OfficePage', () => {
         { provide: NavigationStateProvider, useClass: NavigationStateProviderMock },
         { provide: FaultSummaryProvider, useClass: FaultSummaryProvider },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(OfficeCatBEPage);
         component = fixture.componentInstance;
         navController = TestBed.get(NavController);
-    store$ = TestBed.get(Store);
-    spyOn(store$, 'dispatch');
+        store$ = TestBed.get(Store);
+        spyOn(store$, 'dispatch');
   }));
 
   describe('Class', () => {

--- a/src/pages/office/cat-be/__tests__/office.cat-be.page.spec.ts
+++ b/src/pages/office/cat-be/__tests__/office.cat-be.page.spec.ts
@@ -151,11 +151,11 @@ describe('OfficePage', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(OfficeCatBEPage);
-        component = fixture.componentInstance;
-        navController = TestBed.get(NavController);
-        store$ = TestBed.get(Store);
-        spyOn(store$, 'dispatch');
+    fixture = TestBed.createComponent(OfficeCatBEPage);
+    component = fixture.componentInstance;
+    navController = TestBed.get(NavController);
+    store$ = TestBed.get(Store);
+    spyOn(store$, 'dispatch');
   }));
 
   describe('Class', () => {

--- a/src/pages/office/components/candidate-description/__tests__/candidate-description.spec.ts
+++ b/src/pages/office/components/candidate-description/__tests__/candidate-description.spec.ts
@@ -27,10 +27,10 @@ describe('CandidateDescriptionComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(CandidateDescriptionComponent);
-        behaviourMapProvider = TestBed.get(OutcomeBehaviourMapProvider);
-        behaviourMapProvider.setBehaviourMap(behaviourMap);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(CandidateDescriptionComponent);
+    behaviourMapProvider = TestBed.get(OutcomeBehaviourMapProvider);
+    behaviourMapProvider.setBehaviourMap(behaviourMap);
+    component = fixture.componentInstance;
   }));
 
   describe('class', () => {

--- a/src/pages/office/components/candidate-description/__tests__/candidate-description.spec.ts
+++ b/src/pages/office/components/candidate-description/__tests__/candidate-description.spec.ts
@@ -4,12 +4,14 @@ import { IonicModule } from 'ionic-angular';
 import { AppModule } from '../../../../../app/app.module';
 import { OutcomeBehaviourMapProvider } from '../../../../../providers/outcome-behaviour-map/outcome-behaviour-map';
 import { behaviourMap } from '../../../../../pages/office/office-behaviour-map';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('CandidateDescriptionComponent', () => {
   let fixture: ComponentFixture<CandidateDescriptionComponent>;
   let component: CandidateDescriptionComponent;
   let behaviourMapProvider: OutcomeBehaviourMapProvider;
-  beforeEach(async(() => {
+
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         CandidateDescriptionComponent,
@@ -22,13 +24,13 @@ describe('CandidateDescriptionComponent', () => {
         { provide: OutcomeBehaviourMapProvider, useClass: OutcomeBehaviourMapProvider },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(CandidateDescriptionComponent);
         behaviourMapProvider = TestBed.get(OutcomeBehaviourMapProvider);
         behaviourMapProvider.setBehaviourMap(behaviourMap);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('class', () => {

--- a/src/pages/office/components/candidate-description/__tests__/candidate-description.spec.ts
+++ b/src/pages/office/components/candidate-description/__tests__/candidate-description.spec.ts
@@ -23,7 +23,7 @@ describe('CandidateDescriptionComponent', () => {
       providers: [
         { provide: OutcomeBehaviourMapProvider, useClass: OutcomeBehaviourMapProvider },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/office/components/route-number/__tests__/route-number.spec.ts
+++ b/src/pages/office/components/route-number/__tests__/route-number.spec.ts
@@ -27,10 +27,10 @@ describe('RouteNumberComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(RouteNumberComponent);
-        behaviourMapProvider = TestBed.get(OutcomeBehaviourMapProvider);
-        behaviourMapProvider.setBehaviourMap(behaviourMap);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(RouteNumberComponent);
+    behaviourMapProvider = TestBed.get(OutcomeBehaviourMapProvider);
+    behaviourMapProvider.setBehaviourMap(behaviourMap);
+    component = fixture.componentInstance;
   }));
 
   describe('class', () => {

--- a/src/pages/office/components/route-number/__tests__/route-number.spec.ts
+++ b/src/pages/office/components/route-number/__tests__/route-number.spec.ts
@@ -4,12 +4,14 @@ import { IonicModule } from 'ionic-angular';
 import { AppModule } from '../../../../../app/app.module';
 import { OutcomeBehaviourMapProvider } from '../../../../../providers/outcome-behaviour-map/outcome-behaviour-map';
 import { behaviourMap } from '../../../../../pages/office/office-behaviour-map';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('RouteNumberComponent', () => {
   let fixture: ComponentFixture<RouteNumberComponent>;
   let component: RouteNumberComponent;
   let behaviourMapProvider: OutcomeBehaviourMapProvider;
-  beforeEach(async(() => {
+
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         RouteNumberComponent,
@@ -22,13 +24,13 @@ describe('RouteNumberComponent', () => {
         { provide: OutcomeBehaviourMapProvider, useClass: OutcomeBehaviourMapProvider },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(RouteNumberComponent);
         behaviourMapProvider = TestBed.get(OutcomeBehaviourMapProvider);
         behaviourMapProvider.setBehaviourMap(behaviourMap);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('class', () => {

--- a/src/pages/office/components/route-number/__tests__/route-number.spec.ts
+++ b/src/pages/office/components/route-number/__tests__/route-number.spec.ts
@@ -23,7 +23,7 @@ describe('RouteNumberComponent', () => {
       providers: [
         { provide: OutcomeBehaviourMapProvider, useClass: OutcomeBehaviourMapProvider },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/pass-finalisation/cat-b/_tests_/pass-finalisation.cat-b.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-b/_tests_/pass-finalisation.cat-b.page.spec.ts
@@ -61,7 +61,7 @@ describe('PassFinalisationCatBPage', () => {
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/pass-finalisation/cat-b/_tests_/pass-finalisation.cat-b.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-b/_tests_/pass-finalisation.cat-b.page.spec.ts
@@ -14,19 +14,19 @@ import { MockComponent } from 'ng-mocks';
 import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { D255Component } from '../../../../components/test-finalisation/d255/d255';
 import { DebriefWitnessedComponent } from
-  '../../../../components/test-finalisation/debrief-witnessed/debrief-witnessed';
+    '../../../../components/test-finalisation/debrief-witnessed/debrief-witnessed';
 import { LanguagePreferencesComponent } from
-  '../../../../components/test-finalisation/language-preference/language-preferences';
+    '../../../../components/test-finalisation/language-preference/language-preferences';
 import { FinalisationHeaderComponent } from
-  '../../../../components/test-finalisation/finalisation-header/finalisation-header';
+    '../../../../components/test-finalisation/finalisation-header/finalisation-header';
 import { PassFinalisationViewDidEnter } from '../../pass-finalisation.actions';
 import { ProvisionalLicenseReceived, ProvisionalLicenseNotReceived, PassCertificateNumberChanged } from
-  '../../../../modules/tests/pass-completion/pass-completion.actions';
+    '../../../../modules/tests/pass-completion/pass-completion.actions';
 import { GearboxCategoryChanged } from '../../../../modules/tests/vehicle-details/vehicle-details.actions';
 import { D255Yes, D255No, DebriefWitnessed, DebriefUnwitnessed } from
-  '../../../../modules/tests/test-summary/test-summary.actions';
+    '../../../../modules/tests/test-summary/test-summary.actions';
 import { CandidateChoseToProceedWithTestInWelsh, CandidateChoseToProceedWithTestInEnglish } from
-  '../../../../modules/tests/communication-preferences/communication-preferences.actions';
+    '../../../../modules/tests/communication-preferences/communication-preferences.actions';
 import { PassCertificateNumberComponent } from '../../components/pass-certificate-number/pass-certificate-number';
 import { LicenseProvidedComponent } from '../../components/license-provided/license-provided';
 import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
@@ -65,10 +65,10 @@ describe('PassFinalisationCatBPage', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(PassFinalisationCatBPage);
-        component = fixture.componentInstance;
-        store$ = TestBed.get(Store);
-        spyOn(store$, 'dispatch');
+    fixture = TestBed.createComponent(PassFinalisationCatBPage);
+    component = fixture.componentInstance;
+    store$ = TestBed.get(Store);
+    spyOn(store$, 'dispatch');
   }));
 
   describe('Class', () => {

--- a/src/pages/pass-finalisation/cat-b/_tests_/pass-finalisation.cat-b.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-b/_tests_/pass-finalisation.cat-b.page.spec.ts
@@ -31,13 +31,14 @@ import { PassCertificateNumberComponent } from '../../components/pass-certificat
 import { LicenseProvidedComponent } from '../../components/license-provided/license-provided';
 import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
 import { TransmissionComponent } from '../../../../components/common/transmission/transmission';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('PassFinalisationCatBPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatBPage>;
   let component: PassFinalisationCatBPage;
   let store$: Store<StoreModel>;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         PassFinalisationCatBPage,
@@ -61,13 +62,13 @@ describe('PassFinalisationCatBPage', () => {
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(PassFinalisationCatBPage);
         component = fixture.componentInstance;
         store$ = TestBed.get(Store);
         spyOn(store$, 'dispatch');
-      });
   }));
 
   describe('Class', () => {

--- a/src/pages/post-debrief-holding/__tests__/post-debrief-holding.analytics.spec.ts
+++ b/src/pages/post-debrief-holding/__tests__/post-debrief-holding.analytics.spec.ts
@@ -16,6 +16,7 @@ import { PostDebriefHoldingAnalyticsEffects } from '../post-debrief-holding.anal
 import * as postDebriefHoldingActions from '../post-debrief-holding.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Post Debrief Holding Analytics Effects', () => {
 
@@ -26,8 +27,7 @@ describe('Post Debrief Holding Analytics Effects', () => {
   const screenName = AnalyticsScreenNames.POST_DEBRIEF_HOLDING;
   const practiceScreenName = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.POST_DEBRIEF_HOLDING}`;
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -41,6 +41,10 @@ describe('Post Debrief Holding Analytics Effects', () => {
         Store,
       ],
     });
+  });
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(PostDebriefHoldingAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     store$ = TestBed.get(Store);

--- a/src/pages/rekey-reason/__tests__/rekey-reason.analytics.effects.spec.ts
+++ b/src/pages/rekey-reason/__tests__/rekey-reason.analytics.effects.spec.ts
@@ -16,6 +16,7 @@ import * as testsActions from '../../../modules/tests/tests.actions';
 import * as candidateActions from '../../../modules/tests/journal-data/candidate/candidate.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Rekey Reason Analytics Effects', () => {
 
@@ -25,8 +26,7 @@ describe('Rekey Reason Analytics Effects', () => {
   const screenName = AnalyticsScreenNames.REKEY_REASON;
   let store$: Store<StoreModel>;
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -40,6 +40,10 @@ describe('Rekey Reason Analytics Effects', () => {
         Store,
       ],
     });
+  });
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(RekeyReasonAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     store$ = TestBed.get(Store);

--- a/src/pages/rekey-reason/__tests__/rekey-reason.analytics.effects.spec.ts
+++ b/src/pages/rekey-reason/__tests__/rekey-reason.analytics.effects.spec.ts
@@ -16,7 +16,7 @@ import * as testsActions from '../../../modules/tests/tests.actions';
 import * as candidateActions from '../../../modules/tests/journal-data/candidate/candidate.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Rekey Reason Analytics Effects', () => {
 

--- a/src/pages/rekey-reason/__tests__/rekey-reason.effects.spec.ts
+++ b/src/pages/rekey-reason/__tests__/rekey-reason.effects.spec.ts
@@ -16,7 +16,7 @@ import { SetExaminerConducted } from '../../../modules/tests/examiner-conducted/
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { defer } from 'rxjs/observable/defer';
 import { TestCategory } from '../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Rekey Reason Effects', () => {
   let effects: RekeyReasonEffects;

--- a/src/pages/rekey-reason/__tests__/rekey-reason.effects.spec.ts
+++ b/src/pages/rekey-reason/__tests__/rekey-reason.effects.spec.ts
@@ -16,6 +16,7 @@ import { SetExaminerConducted } from '../../../modules/tests/examiner-conducted/
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { defer } from 'rxjs/observable/defer';
 import { TestCategory } from '../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Rekey Reason Effects', () => {
   let effects: RekeyReasonEffects;
@@ -23,8 +24,7 @@ describe('Rekey Reason Effects', () => {
   let findUserProvider: FindUserProvider;
   let store$: Store<StoreModel>;
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -40,6 +40,10 @@ describe('Rekey Reason Effects', () => {
         Store,
       ],
     });
+  });
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(RekeyReasonEffects);
     store$ = TestBed.get(Store);
     findUserProvider = TestBed.get(FindUserProvider);

--- a/src/pages/rekey-reason/components/ipad-issue/__tests__/ipad-issue.spec.ts
+++ b/src/pages/rekey-reason/components/ipad-issue/__tests__/ipad-issue.spec.ts
@@ -4,11 +4,13 @@ import { IonicModule } from 'ionic-angular';
 import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
 import { FormGroup } from '@angular/forms';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('IpadIssueComponent', () => {
   let fixture: ComponentFixture<IpadIssueComponent>;
   let component: IpadIssueComponent;
-  beforeEach(async(() => {
+
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         IpadIssueComponent,
@@ -19,13 +21,13 @@ describe('IpadIssueComponent', () => {
       ],
       providers: [],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(IpadIssueComponent);
         component = fixture.componentInstance;
         component.formGroup = new FormGroup({});
         component.ngOnChanges();
-      });
   }));
 
   describe('class', () => {

--- a/src/pages/rekey-reason/components/ipad-issue/__tests__/ipad-issue.spec.ts
+++ b/src/pages/rekey-reason/components/ipad-issue/__tests__/ipad-issue.spec.ts
@@ -4,7 +4,7 @@ import { IonicModule } from 'ionic-angular';
 import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
 import { FormGroup } from '@angular/forms';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('IpadIssueComponent', () => {
   let fixture: ComponentFixture<IpadIssueComponent>;
@@ -20,7 +20,7 @@ describe('IpadIssueComponent', () => {
         AppModule,
       ],
       providers: [],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/rekey-reason/components/ipad-issue/__tests__/ipad-issue.spec.ts
+++ b/src/pages/rekey-reason/components/ipad-issue/__tests__/ipad-issue.spec.ts
@@ -24,10 +24,10 @@ describe('IpadIssueComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(IpadIssueComponent);
-        component = fixture.componentInstance;
-        component.formGroup = new FormGroup({});
-        component.ngOnChanges();
+    fixture = TestBed.createComponent(IpadIssueComponent);
+    component = fixture.componentInstance;
+    component.formGroup = new FormGroup({});
+    component.ngOnChanges();
   }));
 
   describe('class', () => {

--- a/src/pages/rekey-reason/components/other-reason/__tests__/other-reason.spec.ts
+++ b/src/pages/rekey-reason/components/other-reason/__tests__/other-reason.spec.ts
@@ -4,11 +4,13 @@ import { IonicModule } from 'ionic-angular';
 import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
 import { FormGroup } from '@angular/forms';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('OtherReasonComponent', () => {
   let fixture: ComponentFixture<OtherReasonComponent>;
   let component: OtherReasonComponent;
-  beforeEach(async(() => {
+
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         OtherReasonComponent,
@@ -19,13 +21,13 @@ describe('OtherReasonComponent', () => {
       ],
       providers: [],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(OtherReasonComponent);
         component = fixture.componentInstance;
         component.formGroup = new FormGroup({});
         component.ngOnChanges();
-      });
   }));
 
   describe('class', () => {

--- a/src/pages/rekey-reason/components/other-reason/__tests__/other-reason.spec.ts
+++ b/src/pages/rekey-reason/components/other-reason/__tests__/other-reason.spec.ts
@@ -24,10 +24,10 @@ describe('OtherReasonComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(OtherReasonComponent);
-        component = fixture.componentInstance;
-        component.formGroup = new FormGroup({});
-        component.ngOnChanges();
+    fixture = TestBed.createComponent(OtherReasonComponent);
+    component = fixture.componentInstance;
+    component.formGroup = new FormGroup({});
+    component.ngOnChanges();
   }));
 
   describe('class', () => {

--- a/src/pages/rekey-reason/components/other-reason/__tests__/other-reason.spec.ts
+++ b/src/pages/rekey-reason/components/other-reason/__tests__/other-reason.spec.ts
@@ -4,7 +4,7 @@ import { IonicModule } from 'ionic-angular';
 import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
 import { FormGroup } from '@angular/forms';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('OtherReasonComponent', () => {
   let fixture: ComponentFixture<OtherReasonComponent>;
@@ -20,7 +20,7 @@ describe('OtherReasonComponent', () => {
         AppModule,
       ],
       providers: [],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/rekey-reason/components/transfer/__tests__/transfer.spec.ts
+++ b/src/pages/rekey-reason/components/transfer/__tests__/transfer.spec.ts
@@ -4,11 +4,13 @@ import { IonicModule } from 'ionic-angular';
 import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
 import { FormGroup } from '@angular/forms';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('TransferComponent', () => {
   let fixture: ComponentFixture<TransferComponent>;
   let component: TransferComponent;
-  beforeEach(async(() => {
+
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         TransferComponent,
@@ -19,13 +21,13 @@ describe('TransferComponent', () => {
       ],
       providers: [],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(TransferComponent);
         component = fixture.componentInstance;
         component.formGroup = new FormGroup({});
         component.ngOnChanges();
-      });
   }));
 
   describe('class', () => {

--- a/src/pages/rekey-reason/components/transfer/__tests__/transfer.spec.ts
+++ b/src/pages/rekey-reason/components/transfer/__tests__/transfer.spec.ts
@@ -24,10 +24,10 @@ describe('TransferComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(TransferComponent);
-        component = fixture.componentInstance;
-        component.formGroup = new FormGroup({});
-        component.ngOnChanges();
+    fixture = TestBed.createComponent(TransferComponent);
+    component = fixture.componentInstance;
+    component.formGroup = new FormGroup({});
+    component.ngOnChanges();
   }));
 
   describe('class', () => {

--- a/src/pages/rekey-reason/components/transfer/__tests__/transfer.spec.ts
+++ b/src/pages/rekey-reason/components/transfer/__tests__/transfer.spec.ts
@@ -4,7 +4,7 @@ import { IonicModule } from 'ionic-angular';
 import { AppModule } from '../../../../../app/app.module';
 import { By } from '@angular/platform-browser';
 import { FormGroup } from '@angular/forms';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('TransferComponent', () => {
   let fixture: ComponentFixture<TransferComponent>;
@@ -20,7 +20,7 @@ describe('TransferComponent', () => {
         AppModule,
       ],
       providers: [],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/rekey-reason/components/upload-rekey-modal/__tests__/upload-rekey-modal.spec.ts
+++ b/src/pages/rekey-reason/components/upload-rekey-modal/__tests__/upload-rekey-modal.spec.ts
@@ -23,10 +23,12 @@ describe('UploadRekeyModal', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(UploadRekeyModal);
-        component = fixture.componentInstance;
-        component.onCancel = () => {};
-        component.onUpload = () => {};
+    fixture = TestBed.createComponent(UploadRekeyModal);
+    component = fixture.componentInstance;
+    component.onCancel = () => {
+    };
+    component.onUpload = () => {
+    };
   }));
 
   describe('DOM', () => {

--- a/src/pages/rekey-reason/components/upload-rekey-modal/__tests__/upload-rekey-modal.spec.ts
+++ b/src/pages/rekey-reason/components/upload-rekey-modal/__tests__/upload-rekey-modal.spec.ts
@@ -5,12 +5,13 @@ import { NavParamsMock, ViewControllerMock } from 'ionic-mocks';
 import { AppModule } from '../../../../../app/app.module';
 import { UploadRekeyModal } from '../upload-rekey-modal';
 import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('UploadRekeyModal', () => {
   let fixture: ComponentFixture<UploadRekeyModal>;
   let component: UploadRekeyModal;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [UploadRekeyModal],
       imports: [IonicModule, AppModule],
@@ -19,13 +20,13 @@ describe('UploadRekeyModal', () => {
         { provide: ViewController, useFactory: () => ViewControllerMock.instance() },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(UploadRekeyModal);
         component = fixture.componentInstance;
         component.onCancel = () => {};
         component.onUpload = () => {};
-      });
   }));
 
   describe('DOM', () => {

--- a/src/pages/rekey-reason/components/upload-rekey-modal/__tests__/upload-rekey-modal.spec.ts
+++ b/src/pages/rekey-reason/components/upload-rekey-modal/__tests__/upload-rekey-modal.spec.ts
@@ -19,7 +19,7 @@ describe('UploadRekeyModal', () => {
         { provide: NavParams, useFactory: () => NavParamsMock.instance() },
         { provide: ViewController, useFactory: () => ViewControllerMock.instance() },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/rekey-upload-outcome/__tests__/rekey-upload-outcome.spec.ts
+++ b/src/pages/rekey-upload-outcome/__tests__/rekey-upload-outcome.spec.ts
@@ -20,6 +20,7 @@ import { testsReducer } from '../../../modules/tests/tests.reducer';
 import { rekeyReasonReducer } from '../../rekey-reason/rekey-reason.reducer';
 import { of } from 'rxjs/observable/of';
 import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('RekeyUploadOutcomePage', () => {
   let fixture: ComponentFixture<RekeyUploadOutcomePage>;
@@ -30,7 +31,7 @@ describe('RekeyUploadOutcomePage', () => {
   let insomnia: Insomnia;
   let deviceProvider: DeviceProvider;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         RekeyUploadOutcomePage,
@@ -55,8 +56,9 @@ describe('RekeyUploadOutcomePage', () => {
         { provide: DeviceProvider, useClass: DeviceProviderMock },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(RekeyUploadOutcomePage);
         component = fixture.componentInstance;
         navController = TestBed.get(NavController);
@@ -65,7 +67,6 @@ describe('RekeyUploadOutcomePage', () => {
         deviceProvider = TestBed.get(DeviceProvider);
         store$ = TestBed.get(Store);
         spyOn(store$, 'dispatch');
-      });
   }));
 
   describe('Class', () => {

--- a/src/pages/rekey-upload-outcome/__tests__/rekey-upload-outcome.spec.ts
+++ b/src/pages/rekey-upload-outcome/__tests__/rekey-upload-outcome.spec.ts
@@ -55,7 +55,7 @@ describe('RekeyUploadOutcomePage', () => {
         { provide: Insomnia, useClass: InsomniaMock },
         { provide: DeviceProvider, useClass: DeviceProviderMock },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/rekey-upload-outcome/__tests__/rekey-upload-outcome.spec.ts
+++ b/src/pages/rekey-upload-outcome/__tests__/rekey-upload-outcome.spec.ts
@@ -59,14 +59,14 @@ describe('RekeyUploadOutcomePage', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(RekeyUploadOutcomePage);
-        component = fixture.componentInstance;
-        navController = TestBed.get(NavController);
-        screenOrientation = TestBed.get(ScreenOrientation);
-        insomnia = TestBed.get(Insomnia);
-        deviceProvider = TestBed.get(DeviceProvider);
-        store$ = TestBed.get(Store);
-        spyOn(store$, 'dispatch');
+    fixture = TestBed.createComponent(RekeyUploadOutcomePage);
+    component = fixture.componentInstance;
+    navController = TestBed.get(NavController);
+    screenOrientation = TestBed.get(ScreenOrientation);
+    insomnia = TestBed.get(Insomnia);
+    deviceProvider = TestBed.get(DeviceProvider);
+    store$ = TestBed.get(Store);
+    spyOn(store$, 'dispatch');
   }));
 
   describe('Class', () => {

--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -45,6 +45,7 @@ import * as uncoupleRecoupleActions
   from '../../../modules/tests/test-data/cat-be/uncouple-recouple/uncouple-recouple.actions';
 import * as reverseLeftActions
   from '../cat-be/components/reverse-left/reverse-left.actions';
+import { configureTestSuite } from 'ng-bullet';
 import { configureTestSuite } from 'ng-bullet'
 import * as catBEManoeuversActions
   from '../../../modules/tests/test-data/cat-be/manoeuvres/manoeuvres.cat-be.actions';
@@ -70,7 +71,7 @@ describe('Test Report Analytics Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -46,7 +46,6 @@ import * as uncoupleRecoupleActions
 import * as reverseLeftActions
   from '../cat-be/components/reverse-left/reverse-left.actions';
 import { configureTestSuite } from 'ng-bullet';
-import { configureTestSuite } from 'ng-bullet'
 import * as catBEManoeuversActions
   from '../../../modules/tests/test-data/cat-be/manoeuvres/manoeuvres.cat-be.actions';
 

--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -45,6 +45,7 @@ import * as uncoupleRecoupleActions
   from '../../../modules/tests/test-data/cat-be/uncouple-recouple/uncouple-recouple.actions';
 import * as reverseLeftActions
   from '../cat-be/components/reverse-left/reverse-left.actions';
+import { configureTestSuite } from 'ng-bullet'
 import * as catBEManoeuversActions
   from '../../../modules/tests/test-data/cat-be/manoeuvres/manoeuvres.cat-be.actions';
 
@@ -55,8 +56,7 @@ describe('Test Report Analytics Effects', () => {
   let analyticsProviderMock;
   let store$: Store<StoreModel>;
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -70,6 +70,10 @@ describe('Test Report Analytics Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(TestReportAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     store$ = TestBed.get(Store);

--- a/src/pages/test-report/components/eta-invalid-modal/__tests__/eta-invalid-modal.spec.ts
+++ b/src/pages/test-report/components/eta-invalid-modal/__tests__/eta-invalid-modal.spec.ts
@@ -29,9 +29,10 @@ describe('LegalRequirementsModal', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(EtaInvalidModal);
-        component = fixture.componentInstance;
-        component.onCancel = () => {};
+    fixture = TestBed.createComponent(EtaInvalidModal);
+    component = fixture.componentInstance;
+    component.onCancel = () => {
+    };
   }));
 
   describe('DOM', () => {

--- a/src/pages/test-report/components/eta-invalid-modal/__tests__/eta-invalid-modal.spec.ts
+++ b/src/pages/test-report/components/eta-invalid-modal/__tests__/eta-invalid-modal.spec.ts
@@ -25,8 +25,8 @@ describe('LegalRequirementsModal', () => {
         { provide: NavParams, useFactory: () => NavParamsMock.instance() },
         { provide: ViewController, useFactory: () => ViewControllerMock.instance() },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(EtaInvalidModal);

--- a/src/pages/test-report/components/eta-invalid-modal/__tests__/eta-invalid-modal.spec.ts
+++ b/src/pages/test-report/components/eta-invalid-modal/__tests__/eta-invalid-modal.spec.ts
@@ -5,12 +5,13 @@ import { AppModule } from '../../../../../app/app.module';
 import { EtaInvalidModal } from '../eta-invalid-modal';
 import { By } from '@angular/platform-browser';
 import { ComponentsModule } from '../../../../../components/common/common-components.module';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('LegalRequirementsModal', () => {
   let fixture: ComponentFixture<EtaInvalidModal>;
   let component: EtaInvalidModal;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         EtaInvalidModal,
@@ -25,12 +26,12 @@ describe('LegalRequirementsModal', () => {
         { provide: ViewController, useFactory: () => ViewControllerMock.instance() },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(EtaInvalidModal);
         component = fixture.componentInstance;
         component.onCancel = () => {};
-      });
   }));
 
   describe('DOM', () => {

--- a/src/pages/test-results-search/__tests__/test-results-search.analytics.effects.spec.ts
+++ b/src/pages/test-results-search/__tests__/test-results-search.analytics.effects.spec.ts
@@ -11,6 +11,7 @@ import {
 import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
 import { TestResultsSearchAnalyticsEffects } from '../test-results-search.analytics.effects';
 import * as testResultSearchActions from '../test-results-search.actions';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Test Results Search Analytics Effects', () => {
 
@@ -19,8 +20,7 @@ describe('Test Results Search Analytics Effects', () => {
   let actions$: any;
   const screenName = AnalyticsScreenNames.TEST_RESULTS_SEARCH;
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       providers: [
         TestResultsSearchAnalyticsEffects,
@@ -28,6 +28,10 @@ describe('Test Results Search Analytics Effects', () => {
         provideMockActions(() => actions$),
       ],
     });
+  });
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(TestResultsSearchAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
   });

--- a/src/pages/test-results-search/__tests__/test-results-search.spec.ts
+++ b/src/pages/test-results-search/__tests__/test-results-search.spec.ts
@@ -45,7 +45,7 @@ describe('TestResultsSearchPage', () => {
         { provide: AppConfigProvider, useClass: AppConfigProviderMock },
         { provide: App, useClass: MockAppComponent },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/test-results-search/__tests__/test-results-search.spec.ts
+++ b/src/pages/test-results-search/__tests__/test-results-search.spec.ts
@@ -49,10 +49,10 @@ describe('TestResultsSearchPage', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(TestResultsSearchPage);
-        component = fixture.componentInstance;
-        modalController = TestBed.get(ModalController);
-        appConfigProviderMock = TestBed.get(AppConfigProvider);
+    fixture = TestBed.createComponent(TestResultsSearchPage);
+    component = fixture.componentInstance;
+    modalController = TestBed.get(ModalController);
+    appConfigProviderMock = TestBed.get(AppConfigProvider);
   }));
 
   describe('DOM', () => {

--- a/src/pages/test-results-search/__tests__/test-results-search.spec.ts
+++ b/src/pages/test-results-search/__tests__/test-results-search.spec.ts
@@ -15,6 +15,7 @@ import { ExaminerRole } from '../../../providers/app-config/constants/examiner-r
 import { App } from '../../../app/app.component';
 import { MockAppComponent } from '../../../app/__mocks__/app.component.mock';
 import { ComponentsModule } from '../../../components/common/common-components.module';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('TestResultsSearchPage', () => {
   let fixture: ComponentFixture<TestResultsSearchPage>;
@@ -22,7 +23,7 @@ describe('TestResultsSearchPage', () => {
   let modalController: ModalController;
   let appConfigProviderMock: AppConfigProvider;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         TestResultsSearchPage,
@@ -45,13 +46,13 @@ describe('TestResultsSearchPage', () => {
         { provide: App, useClass: MockAppComponent },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(TestResultsSearchPage);
         component = fixture.componentInstance;
         modalController = TestBed.get(ModalController);
         appConfigProviderMock = TestBed.get(AppConfigProvider);
-      });
   }));
 
   describe('DOM', () => {

--- a/src/pages/test-results-search/components/search-result/__tests__/search-result.spec.ts
+++ b/src/pages/test-results-search/components/search-result/__tests__/search-result.spec.ts
@@ -26,8 +26,8 @@ describe('SearchResultComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(SearchResultComponent);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(SearchResultComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('Class', () => {

--- a/src/pages/test-results-search/components/search-result/__tests__/search-result.spec.ts
+++ b/src/pages/test-results-search/components/search-result/__tests__/search-result.spec.ts
@@ -22,7 +22,7 @@ describe('SearchResultComponent', () => {
       providers: [
         { provide: App, useClass: MockAppComponent },
       ],
-    })
+    });
   });
 
   beforeEach(async(() => {

--- a/src/pages/test-results-search/components/search-result/__tests__/search-result.spec.ts
+++ b/src/pages/test-results-search/components/search-result/__tests__/search-result.spec.ts
@@ -4,12 +4,13 @@ import { IonicModule } from 'ionic-angular';
 import { SearchResultComponent } from '../search-result';
 import { App } from '../../../../../app/app.component';
 import { MockAppComponent } from '../../../../../app/__mocks__/app.component.mock';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('SearchResultComponent', () => {
   let fixture: ComponentFixture<SearchResultComponent>;
   let component: SearchResultComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         SearchResultComponent,
@@ -22,11 +23,11 @@ describe('SearchResultComponent', () => {
         { provide: App, useClass: MockAppComponent },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  });
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(SearchResultComponent);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('Class', () => {

--- a/src/pages/view-test-result/cat-b/components/debrief-card/__tests__/debrief-card.spec.ts
+++ b/src/pages/view-test-result/cat-b/components/debrief-card/__tests__/debrief-card.spec.ts
@@ -1,4 +1,3 @@
-
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { IonicModule, Config } from 'ionic-angular';
 import { DebriefCardComponent } from '../debrief-card';
@@ -16,12 +15,13 @@ import {
 } from '../../../../../../components/common/driving-faults-badge/driving-faults-badge';
 import { DataRowComponent } from '../../../../components/data-row/data-row';
 import { DataRowCustomComponent } from '../../../../components/data-row-custom/data-row-custom';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('DebriefCardComponent', () => {
   let fixture: ComponentFixture<DebriefCardComponent>;
   let component: DebriefCardComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         DebriefCardComponent,
@@ -38,12 +38,12 @@ describe('DebriefCardComponent', () => {
       providers: [
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
-    })
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(DebriefCardComponent);
-        component = fixture.componentInstance;
-      });
+    });
+  });
+
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(DebriefCardComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('Class', () => {

--- a/src/pages/view-test-result/cat-b/components/view-test-header/__tests__/view-test-header.spec.ts
+++ b/src/pages/view-test-result/cat-b/components/view-test-header/__tests__/view-test-header.spec.ts
@@ -4,12 +4,13 @@ import { IonicModule, Config } from 'ionic-angular';
 import { ConfigMock } from 'ionic-mocks';
 import { ViewTestHeaderComponent } from '../view-test-header';
 import { TestOutcome } from '../../../../../../modules/tests/tests.constants';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('ViewTestHeaderComponent', () => {
   let fixture: ComponentFixture<ViewTestHeaderComponent>;
   let component: ViewTestHeaderComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         ViewTestHeaderComponent,
@@ -21,11 +22,11 @@ describe('ViewTestHeaderComponent', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(ViewTestHeaderComponent);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('Class', () => {

--- a/src/pages/view-test-result/cat-b/components/view-test-header/__tests__/view-test-header.spec.ts
+++ b/src/pages/view-test-result/cat-b/components/view-test-header/__tests__/view-test-header.spec.ts
@@ -1,4 +1,3 @@
-
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { IonicModule, Config } from 'ionic-angular';
 import { ConfigMock } from 'ionic-mocks';
@@ -25,24 +24,24 @@ describe('ViewTestHeaderComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(ViewTestHeaderComponent);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(ViewTestHeaderComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('Class', () => {
     describe('isPassed', () => {
-      it('should return true for activity code 1', ()  => {
+      it('should return true for activity code 1', () => {
         component.data = {
-          activityCode: '1' ,
+          activityCode: '1',
           candidateDriverNumber: '',
           candidateName: '',
           testOutcome: TestOutcome.Passed,
         };
         expect(component.isPassed()).toBe(true);
       });
-      it('should return false for an activity code that is not 1', ()  => {
+      it('should return false for an activity code that is not 1', () => {
         component.data = {
-          activityCode: '5' ,
+          activityCode: '5',
           candidateDriverNumber: '',
           candidateName: '',
           testOutcome: TestOutcome.Passed,

--- a/src/pages/view-test-result/cat-b/components/view-test-header/__tests__/view-test-header.spec.ts
+++ b/src/pages/view-test-result/cat-b/components/view-test-header/__tests__/view-test-header.spec.ts
@@ -4,7 +4,7 @@ import { IonicModule, Config } from 'ionic-angular';
 import { ConfigMock } from 'ionic-mocks';
 import { ViewTestHeaderComponent } from '../view-test-header';
 import { TestOutcome } from '../../../../../../modules/tests/tests.constants';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('ViewTestHeaderComponent', () => {
   let fixture: ComponentFixture<ViewTestHeaderComponent>;
@@ -21,8 +21,8 @@ describe('ViewTestHeaderComponent', () => {
       providers: [
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(ViewTestHeaderComponent);

--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
@@ -25,6 +25,7 @@ import * as applicationReferenceActions
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
 import { PopulateTestCategory } from '../../../modules/tests/category/category.actions';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Waiting Room To Car Analytics Effects', () => {
 
@@ -41,8 +42,7 @@ describe('Waiting Room To Car Analytics Effects', () => {
     checkDigit: 9,
   };
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -56,6 +56,10 @@ describe('Waiting Room To Car Analytics Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(WaitingRoomToCarAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     store$ = TestBed.get(Store);

--- a/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
+++ b/src/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
@@ -25,7 +25,7 @@ import * as applicationReferenceActions
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
 import { PopulateTestCategory } from '../../../modules/tests/category/category.actions';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Waiting Room To Car Analytics Effects', () => {
 
@@ -56,7 +56,7 @@ describe('Waiting Room To Car Analytics Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks-question/__tests__/vehicle-checks-question.spec.ts
+++ b/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks-question/__tests__/vehicle-checks-question.spec.ts
@@ -6,6 +6,7 @@ import { AppModule } from '../../../../../../app/app.module';
 import { VehicleChecksQuestion } from '../../../../../../providers/question/vehicle-checks-question.model';
 import { EventEmitter } from '@angular/core';
 import { QuestionResult } from '@dvsa/mes-test-schema/categories/BE/partial';
+import { configureTestSuite } from 'ng-bullet'
 
 const vehicleChecksQuestion: VehicleChecksQuestion = {
   code: 'S04',
@@ -17,7 +18,7 @@ describe('VehicleChecksQuestionComponent', () => {
   let fixture: ComponentFixture<VehicleChecksQuestionComponent>;
   let component: VehicleChecksQuestionComponent;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         VehicleChecksQuestionComponent,
@@ -27,11 +28,11 @@ describe('VehicleChecksQuestionComponent', () => {
         AppModule,
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(VehicleChecksQuestionComponent);
         component = fixture.componentInstance;
-      });
   }));
 
   describe('Class', () => {

--- a/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks-question/__tests__/vehicle-checks-question.spec.ts
+++ b/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks-question/__tests__/vehicle-checks-question.spec.ts
@@ -1,4 +1,3 @@
-
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { IonicModule } from 'ionic-angular';
 import { VehicleChecksQuestionComponent } from '../vehicle-checks-question';
@@ -31,22 +30,22 @@ describe('VehicleChecksQuestionComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(VehicleChecksQuestionComponent);
-        component = fixture.componentInstance;
+    fixture = TestBed.createComponent(VehicleChecksQuestionComponent);
+    component = fixture.componentInstance;
   }));
 
   describe('Class', () => {
     describe('isOptionDisabled', () => {
       it(`should return true if the question is in the list of questions to disable
           and not equal to the currently selected question`,
-      () => {
-        component.questionResult = { code: 'S03' };
-        component.questionsToDisable = [
-          vehicleChecksQuestion,
-        ];
-        const result = component.isOptionDisabled({ code: 'S04', description: '', shortName: '' });
-        expect(result).toEqual(true);
-      });
+        () => {
+          component.questionResult = { code: 'S03' };
+          component.questionsToDisable = [
+            vehicleChecksQuestion,
+          ];
+          const result = component.isOptionDisabled({ code: 'S04', description: '', shortName: '' });
+          expect(result).toEqual(true);
+        });
       it('should return false if the question is not in the list of questions to disable', () => {
         component.questionResult = { code: 'S04' };
         component.questionsToDisable = [];
@@ -55,12 +54,12 @@ describe('VehicleChecksQuestionComponent', () => {
       });
       it(`should return false if the question is not in the list of questions to disable
           and is equal to the currently selected question`,
-       () => {
-         component.questionResult = { code: 'S05' };
-         component.questionsToDisable = [{ code: 'S04' }];
-         const result = component.isOptionDisabled({ code: 'S05', description: '', shortName: '' });
-         expect(result).toEqual(false);
-       });
+        () => {
+          component.questionResult = { code: 'S05' };
+          component.questionsToDisable = [{ code: 'S04' }];
+          const result = component.isOptionDisabled({ code: 'S05', description: '', shortName: '' });
+          expect(result).toEqual(false);
+        });
     });
     describe('vehicleChecksQuestionChanged', () => {
       it('should emit the correct event', () => {

--- a/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks-question/__tests__/vehicle-checks-question.spec.ts
+++ b/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks-question/__tests__/vehicle-checks-question.spec.ts
@@ -6,7 +6,7 @@ import { AppModule } from '../../../../../../app/app.module';
 import { VehicleChecksQuestion } from '../../../../../../providers/question/vehicle-checks-question.model';
 import { EventEmitter } from '@angular/core';
 import { QuestionResult } from '@dvsa/mes-test-schema/categories/BE/partial';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 const vehicleChecksQuestion: VehicleChecksQuestion = {
   code: 'S04',
@@ -27,8 +27,8 @@ describe('VehicleChecksQuestionComponent', () => {
         IonicModule,
         AppModule,
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(VehicleChecksQuestionComponent);

--- a/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
+++ b/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
@@ -42,9 +42,9 @@ describe('VehicleChecksCatBEComponent', () => {
   });
 
   beforeEach(async(() => {
-        fixture = TestBed.createComponent(VehicleChecksCatBEComponent);
-        component = fixture.componentInstance;
-        modalController = TestBed.get(ModalController);
+    fixture = TestBed.createComponent(VehicleChecksCatBEComponent);
+    component = fixture.componentInstance;
+    modalController = TestBed.get(ModalController);
   }));
 
   describe('Class', () => {

--- a/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
+++ b/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
@@ -12,6 +12,7 @@ import { SeriousFaultBadgeComponent }
 import { DrivingFaultsBadgeComponent }
   from '../../../../../../components/common/driving-faults-badge/driving-faults-badge';
 import { TickIndicatorComponent } from '../../../../../../components/common/tick-indicator/tick-indicator';
+import { configureTestSuite } from 'ng-bullet'
 
 class MockStore { }
 
@@ -20,7 +21,7 @@ describe('VehicleChecksCatBEComponent', () => {
   let component: VehicleChecksCatBEComponent;
   let modalController: ModalController;
 
-  beforeEach(async(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
         VehicleChecksCatBEComponent,
@@ -38,12 +39,12 @@ describe('VehicleChecksCatBEComponent', () => {
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
     })
-      .compileComponents()
-      .then(() => {
+  })
+
+  beforeEach(async(() => {
         fixture = TestBed.createComponent(VehicleChecksCatBEComponent);
         component = fixture.componentInstance;
         modalController = TestBed.get(ModalController);
-      });
   }));
 
   describe('Class', () => {

--- a/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
+++ b/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
@@ -12,7 +12,7 @@ import { SeriousFaultBadgeComponent }
 import { DrivingFaultsBadgeComponent }
   from '../../../../../../components/common/driving-faults-badge/driving-faults-badge';
 import { TickIndicatorComponent } from '../../../../../../components/common/tick-indicator/tick-indicator';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 class MockStore { }
 
@@ -38,8 +38,8 @@ describe('VehicleChecksCatBEComponent', () => {
         { provide: Store, useClass: MockStore },
         { provide: Config, useFactory: () => ConfigMock.instance() },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async(() => {
         fixture = TestBed.createComponent(VehicleChecksCatBEComponent);

--- a/src/pages/waiting-room/__tests__/waiting-room.analytics.effects.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.analytics.effects.spec.ts
@@ -25,7 +25,7 @@ import * as applicationReferenceActions
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
 import { PopulateTestCategory } from '../../../modules/tests/category/category.actions';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Waiting Room Analytics Effects', () => {
 
@@ -55,7 +55,7 @@ describe('Waiting Room Analytics Effects', () => {
         Store,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
     actions$ = new ReplaySubject(1);

--- a/src/pages/waiting-room/__tests__/waiting-room.analytics.effects.spec.ts
+++ b/src/pages/waiting-room/__tests__/waiting-room.analytics.effects.spec.ts
@@ -25,6 +25,7 @@ import * as applicationReferenceActions
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '../../../shared/models/test-category';
 import { PopulateTestCategory } from '../../../modules/tests/category/category.actions';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Waiting Room Analytics Effects', () => {
 
@@ -40,8 +41,7 @@ describe('Waiting Room Analytics Effects', () => {
     checkDigit: 9,
   };
 
-  beforeEach(() => {
-    actions$ = new ReplaySubject(1);
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
@@ -55,6 +55,10 @@ describe('Waiting Room Analytics Effects', () => {
         Store,
       ],
     });
+  })
+
+  beforeEach(() => {
+    actions$ = new ReplaySubject(1);
     effects = TestBed.get(WaitingRoomAnalyticsEffects);
     analyticsProviderMock = TestBed.get(AnalyticsProvider);
     store$ = TestBed.get(Store);

--- a/src/providers/analytics/__tests__/analytics.spec.ts
+++ b/src/providers/analytics/__tests__/analytics.spec.ts
@@ -9,13 +9,14 @@ import { GoogleAnalytics } from '@ionic-native/google-analytics';
 import { Platform } from 'ionic-angular';
 import { DeviceProvider } from '../../device/device';
 import { AuthenticationProvider } from '../../authentication/authentication';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Analytics Provider', () => {
 
   let analyticsProvider: AnalyticsProvider;
   let googleAnalyticsMock: GoogleAnalyticsMock;
 
-  beforeEach(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       providers: [
         AnalyticsProvider,
@@ -26,7 +27,9 @@ describe('Analytics Provider', () => {
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
       ],
     });
+  });
 
+  beforeEach(() => {
     analyticsProvider = TestBed.get(AnalyticsProvider);
     googleAnalyticsMock = TestBed.get(GoogleAnalytics);
 

--- a/src/providers/compression/__tests__/compression.spec.ts
+++ b/src/providers/compression/__tests__/compression.spec.ts
@@ -2,18 +2,21 @@ import { TestBed } from '@angular/core/testing';
 import { CompressionProvider } from '../compression';
 import { gzipSync } from 'zlib';
 import { categoryBTestResultMock } from '../../../shared/mocks/cat-b-test-result.mock';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Compression Provider', () => {
 
   let compressionProvider: CompressionProvider;
 
-  beforeEach(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       providers: [
         CompressionProvider,
       ],
     });
+  });
 
+  beforeEach(() => {
     compressionProvider = TestBed.get(CompressionProvider);
   });
 

--- a/src/providers/fault-count/__tests__/fault-count.spec.ts
+++ b/src/providers/fault-count/__tests__/fault-count.spec.ts
@@ -5,17 +5,22 @@ import { TestBed } from '@angular/core/testing';
 import { catBTestDataStateObject } from '../__mocks__/cat-B-test-data-state-object';
 import { catBETestDataStateObject } from '../__mocks__/cat-BE-test-data-state-object';
 import { TestCategory } from '../../../shared/models/test-category';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('FaultCountProvider', () => {
 
   let faultCountProvider: FaultCountProvider;
 
-  beforeEach(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       providers: [
         FaultCountProvider,
       ],
     });
+  })
+
+  beforeEach(() => {
+
 
     faultCountProvider = TestBed.get(FaultCountProvider);
 

--- a/src/providers/fault-count/__tests__/fault-count.spec.ts
+++ b/src/providers/fault-count/__tests__/fault-count.spec.ts
@@ -5,7 +5,7 @@ import { TestBed } from '@angular/core/testing';
 import { catBTestDataStateObject } from '../__mocks__/cat-B-test-data-state-object';
 import { catBETestDataStateObject } from '../__mocks__/cat-BE-test-data-state-object';
 import { TestCategory } from '../../../shared/models/test-category';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('FaultCountProvider', () => {
 
@@ -17,10 +17,9 @@ describe('FaultCountProvider', () => {
         FaultCountProvider,
       ],
     });
-  })
+  });
 
   beforeEach(() => {
-
 
     faultCountProvider = TestBed.get(FaultCountProvider);
 

--- a/src/providers/find-user/__tests__/find-user.spec.ts
+++ b/src/providers/find-user/__tests__/find-user.spec.ts
@@ -5,13 +5,14 @@ import { UrlProviderMock } from '../../url/__mocks__/url.mock';
 import { AppConfigProvider } from '../../app-config/app-config';
 import { AppConfigProviderMock } from '../../app-config/__mocks__/app-config.mock';
 import { FindUserProvider } from '../find-user';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('FindUserProvider', () => {
 
   let findUserProvider: FindUserProvider;
   let httpMock: HttpTestingController;
 
-  beforeEach(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
@@ -22,7 +23,9 @@ describe('FindUserProvider', () => {
         { provide: AppConfigProvider, useClass: AppConfigProviderMock },
       ],
     });
+  });
 
+  beforeEach(() => {
     httpMock = TestBed.get(HttpTestingController);
     findUserProvider = TestBed.get(FindUserProvider);
   });

--- a/src/providers/logs/__tests__/logs-helper.spec.ts
+++ b/src/providers/logs/__tests__/logs-helper.spec.ts
@@ -5,11 +5,12 @@ import { Store, StoreModule } from '@ngrx/store';
 import { DeviceMock } from '@ionic-native-mocks/device';
 import { LogHelper } from '../logsHelper';
 import { LogType } from '../../../shared/models/log.model';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('LogHelper', () => {
   let logHelper: LogHelper;
 
-  beforeEach(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
@@ -25,7 +26,9 @@ describe('LogHelper', () => {
         Store,
       ],
     });
+  });
 
+  beforeEach(() => {
     logHelper = TestBed.get(LogHelper);
   });
 

--- a/src/providers/navigation-state/__tests__/navigation-state.spec.ts
+++ b/src/providers/navigation-state/__tests__/navigation-state.spec.ts
@@ -5,13 +5,14 @@ import { REKEY_SEARCH_PAGE, JOURNAL_PAGE } from '../../../pages/page-names.const
 import { MockAppComponent } from '../../../app/__mocks__/app.component.mock';
 import { NavigationProvider } from '../../navigation/navigation';
 import { NavigationProviderMock } from '../../navigation/__mocks__/navigation.mock';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('NavigationStateProvider', () => {
   describe('isRekeySearch', () => {
     let navigationStateProvider: NavigationStateProvider;
     let navigation: NavigationProvider;
 
-    beforeEach(() => {
+    configureTestSuite(() => {
       TestBed.configureTestingModule({
         providers: [
           NavigationStateProvider,
@@ -19,7 +20,9 @@ describe('NavigationStateProvider', () => {
           { provide: NavigationProvider, useClass: NavigationProviderMock },
         ],
       });
+    });
 
+    beforeEach(() => {
       navigationStateProvider = TestBed.get(NavigationStateProvider);
       navigation = TestBed.get(NavigationProvider);
     });

--- a/src/providers/rekey-search/__tests__/rekey-search.spec.ts
+++ b/src/providers/rekey-search/__tests__/rekey-search.spec.ts
@@ -5,13 +5,14 @@ import { UrlProvider } from '../../url/url';
 import { UrlProviderMock } from '../../url/__mocks__/url.mock';
 import { AppConfigProvider } from '../../app-config/app-config';
 import { AppConfigProviderMock } from '../../app-config/__mocks__/app-config.mock';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('RekeySearchProvider', () => {
 
   let rekeySearchProvider: RekeySearchProvider;
   let httpMock: HttpTestingController;
 
-  beforeEach(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
@@ -22,7 +23,9 @@ describe('RekeySearchProvider', () => {
         { provide: AppConfigProvider, useClass: AppConfigProviderMock },
       ],
     });
+  });
 
+  beforeEach(() => {
     httpMock = TestBed.get(HttpTestingController);
     rekeySearchProvider = TestBed.get(RekeySearchProvider);
   });

--- a/src/providers/search/__tests__/search.spec.ts
+++ b/src/providers/search/__tests__/search.spec.ts
@@ -6,13 +6,14 @@ import { SearchProvider } from '../search';
 import { AdvancedSearchParams } from '../search.models';
 import { AppConfigProvider } from '../../app-config/app-config';
 import { AppConfigProviderMock } from '../../app-config/__mocks__/app-config.mock';
+import { configureTestSuite } from 'ng-bullet';
 
 describe('SearchProvider', () => {
 
   let searchProvider: SearchProvider;
   let httpMock: HttpTestingController;
 
-  beforeEach(() => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
@@ -23,7 +24,9 @@ describe('SearchProvider', () => {
         { provide: AppConfigProvider, useClass: AppConfigProviderMock },
       ],
     });
+  });
 
+  beforeEach(() => {
     httpMock = TestBed.get(HttpTestingController);
     searchProvider = TestBed.get(SearchProvider);
   });

--- a/src/shared/classes/__tests__/base-page.spec.ts
+++ b/src/shared/classes/__tests__/base-page.spec.ts
@@ -5,6 +5,7 @@ import { AuthenticationProvider } from '../../../providers/authentication/authen
 import { AuthenticationProviderMock } from '../../../providers/authentication/__mocks__/authentication.mock';
 import { BasePageComponent } from '../base-page';
 import { LOGIN_PAGE } from '../../../pages/page-names.constants';
+import { configureTestSuite } from 'ng-bullet'
 
 describe('Base Page', () => {
 
@@ -14,14 +15,17 @@ describe('Base Page', () => {
 
   let basePageComponent: BasePageComponent;
 
-  beforeEach(async () => {
+  configureTestSuite(() => {
     TestBed.configureTestingModule({
       providers: [
         { provide: Platform, useFactory: () => PlatformMock.instance() },
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
       ],
-    }).compileComponents();
+    })
+  })
+
+  beforeEach(async () => {
 
     platform = TestBed.get(Platform);
     navController = TestBed.get(NavController);

--- a/src/shared/classes/__tests__/base-page.spec.ts
+++ b/src/shared/classes/__tests__/base-page.spec.ts
@@ -5,7 +5,7 @@ import { AuthenticationProvider } from '../../../providers/authentication/authen
 import { AuthenticationProviderMock } from '../../../providers/authentication/__mocks__/authentication.mock';
 import { BasePageComponent } from '../base-page';
 import { LOGIN_PAGE } from '../../../pages/page-names.constants';
-import { configureTestSuite } from 'ng-bullet'
+import { configureTestSuite } from 'ng-bullet';
 
 describe('Base Page', () => {
 
@@ -22,8 +22,8 @@ describe('Base Page', () => {
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
       ],
-    })
-  })
+    });
+  });
 
   beforeEach(async () => {
 


### PR DESCRIPTION
## Description
- Add ng-bullet library to increase speed of execution for unit tests
- re-work existing unit tests to use library's configureTestModule function call

Further Info:
https://medium.com/angular-in-depth/angular-unit-testing-performance-34363b7345ba
https://www.npmjs.com/package/ng-bullet

## Checklist

- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots
baseline unit test run:
![Screenshot 2019-12-04 at 12 43 57](https://user-images.githubusercontent.com/33055124/70143523-c8051000-1693-11ea-8091-bf847997ab03.png)

with ng-bullet:
![Screenshot 2019-12-04 at 12 36 24](https://user-images.githubusercontent.com/33055124/70143137-c0913700-1692-11ea-8393-e11e3e87edfb.png)

