### PR TITLE
fix issue with 16+ driving fault comments disappearing when one entered

### DIFF
--- a/src/pages/office/cat-be/office.cat-be.page.html
+++ b/src/pages/office/cat-be/office.cat-be.page.html
@@ -113,7 +113,7 @@
       </fault-comment-card>
 
       <fault-comment-card id="driving-fault-comment-card" [formGroup]="form" [faultComments]="pageState.drivingFaults$ | async"
-        [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && pageState.displayDrivingFault$ | async"
+        [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && (pageState.displayDrivingFault$ | async)"
         [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async"
         (faultCommentsChange)="drivingFaultCommentChanged($event)">
       </fault-comment-card>

--- a/src/pages/pass-finalisation/cat-be/components/code-78/code-78.ts
+++ b/src/pages/pass-finalisation/cat-be/components/code-78/code-78.ts
@@ -27,8 +27,8 @@ export class Code78Component implements OnChanges {
 
   formControl: FormControl;
   static readonly fieldName: string = 'code78Ctrl';
-  manualMessage: string = 'A <b><em>manual</em></b> license will be issued';
-  automaticMessage: string = 'An <b><em>automatic</em></b> license will be issued';
+  manualMessage: string = 'A <b><em>manual</em></b> licence will be issued';
+  automaticMessage: string = 'An <b><em>automatic</em></b> licence will be issued';
 
   ngOnChanges(): void {
     if (!this.formControl) {

--- a/src/providers/fault-count/fault-count.ts
+++ b/src/providers/fault-count/fault-count.ts
@@ -6,6 +6,7 @@ import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
 import { TestCategory } from '../../shared/models/test-category';
 import { VehicleChecksScore } from '../../shared/models/vehicle-checks-score.model';
+import { getCompetencyFaults } from '../../shared/helpers/competency';
 
 @Injectable()
 export class FaultCountProvider {
@@ -87,14 +88,13 @@ export class FaultCountProvider {
     // The way how we store the driving faults differs for certain competencies
     // Because of this we need to pay extra attention on summing up all of them
     const { drivingFaults, manoeuvres, controlledStop, vehicleChecks } = data;
-
-    const drivingFaultSumOfSimpleCompetencies = drivingFaults ?
-      Object.values(drivingFaults).reduce((acc, numberOfFaults) => acc + numberOfFaults, 0) : 0;
+    let faultTotal: number = 0;
+    getCompetencyFaults(drivingFaults).forEach(fault => faultTotal = faultTotal + fault.faultCount);
 
     const controlledStopHasDrivingFault = (controlledStop && controlledStop.fault === CompetencyOutcome.DF) ? 1 : 0;
 
     const result =
-      drivingFaultSumOfSimpleCompetencies +
+      faultTotal +
       this.sumManoeuvreFaults(manoeuvres, CompetencyOutcome.DF) +
       this.getVehicleChecksFaultCountCatB(vehicleChecks) +
       controlledStopHasDrivingFault;
@@ -150,17 +150,18 @@ export class FaultCountProvider {
     // Because of this we need to pay extra attention on summing up all of them
     const { drivingFaults, manoeuvres,  vehicleChecks, uncoupleRecouple } = data;
 
-    const drivingFaultSumOfSimpleCompetencies = drivingFaults ?
-      Object.values(drivingFaults).reduce((acc, numberOfFaults) => acc + numberOfFaults, 0) : 0;
+    let faultTotal: number = 0;
+    getCompetencyFaults(drivingFaults).forEach(fault => faultTotal = faultTotal + fault.faultCount);
     const uncoupleRecoupleHasDrivingFault =
       (uncoupleRecouple && uncoupleRecouple.fault === CompetencyOutcome.DF) ? 1 : 0;
 
     const result =
-       drivingFaultSumOfSimpleCompetencies +
+       faultTotal +
        this.sumManoeuvreFaults(manoeuvres, CompetencyOutcome.DF) +
        this.getVehicleChecksFaultCountCatBE(vehicleChecks).drivingFaults +
        uncoupleRecoupleHasDrivingFault;
 
+    console.log(`get driving fault sum count cat be ${result}`);
     return result;
   }
 

--- a/src/shared/helpers/__tests__/competency.spec.ts
+++ b/src/shared/helpers/__tests__/competency.spec.ts
@@ -1,0 +1,150 @@
+import { DrivingFaults, SeriousFaults, DangerousFaults } from '@dvsa/mes-test-schema/categories/Common';
+import { getCompetencyFaults, calculateFaultCount } from '../competency';
+// Driving Faults/ Serious Faults/ Dangerous faults
+
+describe('calculateFaultCount', () => {
+  it('should return count of 1 if boolean is passed', () => {
+    const result = calculateFaultCount(true);
+    expect(result).toBe(1);
+  });
+
+  it('should return value passed in if value is a mumber', () => {
+    const result = calculateFaultCount(4);
+    expect(result).toBe(4);
+  });
+  it('should return 0 if passed null', () => {
+    const result = calculateFaultCount(null);
+    expect(result).toBe(0);
+  });
+
+});
+describe('getCompetencyFaults', () => {
+  it('should return an empty FaultSummary when no driving faults', () => {
+    const drivingFaults: DrivingFaults = {};
+
+    const result = getCompetencyFaults(drivingFaults);
+    expect(result.length).toBe(0);
+  });
+
+  it('should return an empty FaultSummary when no serious faults', () => {
+    const seriousFaults: SeriousFaults = {};
+
+    const result = getCompetencyFaults(seriousFaults);
+    expect(result.length).toBe(0);
+  });
+  it('should return an empty FaultSummary when no dangerous faults', () => {
+    const dangerousFaults: DangerousFaults = {};
+
+    const result = getCompetencyFaults(dangerousFaults);
+    expect(result.length).toBe(0);
+  });
+
+  it('should return a FaultSummary containing the driving faults', () => {
+    const drivingFaults: DrivingFaults =
+      { controlsAccelerator: 4,
+        controlsClutch: 3,
+        ancillaryControls: 2,
+      };
+
+    const result = getCompetencyFaults(drivingFaults);
+
+    expect(result.length).toBe(3);
+    expect(result).toContain(
+      {
+        comment: null,
+        faultCount: 4,
+        competencyIdentifier: 'controlsAccelerator',
+        competencyDisplayName:'Controls - Accelerator',
+        source: 'simple',
+      });
+    expect(result).toContain(
+      {
+        comment: null,
+        faultCount: 3,
+        competencyIdentifier: 'controlsClutch',
+        competencyDisplayName:'Controls - Clutch',
+        source: 'simple',
+      });
+    expect(result).toContain(
+      {
+        comment: null,
+        faultCount: 2,
+        competencyIdentifier: 'ancillaryControls',
+        competencyDisplayName:'Ancillary Controls',
+        source: 'simple',
+      });
+  });
+
+  it('should return a FaultSummary containing the serious faults', () => {
+    const seriousFaults: SeriousFaults =
+      { controlsAccelerator: true,
+        controlsClutch: true,
+        ancillaryControls: true,
+      };
+
+    const result = getCompetencyFaults(seriousFaults);
+
+    expect(result.length).toBe(3);
+    expect(result).toContain(
+      {
+        comment: null,
+        faultCount: 1,
+        competencyIdentifier: 'controlsAccelerator',
+        competencyDisplayName:'Controls - Accelerator',
+        source: 'simple',
+      });
+    expect(result).toContain(
+      {
+        comment: null,
+        faultCount: 1,
+        competencyIdentifier: 'controlsClutch',
+        competencyDisplayName:'Controls - Clutch',
+        source: 'simple',
+      });
+    expect(result).toContain(
+      {
+        comment: null,
+        faultCount: 1,
+        competencyIdentifier: 'ancillaryControls',
+        competencyDisplayName:'Ancillary Controls',
+        source: 'simple',
+      });
+  });
+
+  it('should return a FaultSummary containing the dangerous faults', () => {
+    const dangerousFaults: DangerousFaults =
+      { controlsAccelerator: true,
+        controlsClutch: true,
+        ancillaryControls: true,
+      };
+
+    const result = getCompetencyFaults(dangerousFaults);
+
+    expect(result.length).toBe(3);
+    expect(result).toContain(
+      {
+        comment: null,
+        faultCount: 1,
+        competencyIdentifier: 'controlsAccelerator',
+        competencyDisplayName:'Controls - Accelerator',
+        source: 'simple',
+      });
+    expect(result).toContain(
+      {
+        comment: null,
+        faultCount: 1,
+        competencyIdentifier: 'controlsClutch',
+        competencyDisplayName:'Controls - Clutch',
+        source: 'simple',
+      });
+    expect(result).toContain(
+      {
+        comment: null,
+        faultCount: 1,
+        competencyIdentifier: 'ancillaryControls',
+        competencyDisplayName:'Ancillary Controls',
+        source: 'simple',
+      });
+  });
+
+});

--- a/src/shared/helpers/__tests__/competency.spec.ts
+++ b/src/shared/helpers/__tests__/competency.spec.ts
@@ -1,7 +1,10 @@
 import { DrivingFaults, SeriousFaults, DangerousFaults } from '@dvsa/mes-test-schema/categories/Common';
 import { getCompetencyFaults, calculateFaultCount } from '../competency';
-// Driving Faults/ Serious Faults/ Dangerous faults
+import { Competencies } from '../../../modules/tests/test-data/test-data.constants';
+import { fullCompetencyLabels } from '../../../shared/constants/competencies/catb-competencies';
 
+// note: although competency labels come from a file called catb-competencies, these are in fact
+// common to all competencies
 describe('calculateFaultCount', () => {
   it('should return count of 1 if boolean is passed', () => {
     const result = calculateFaultCount(true);
@@ -53,24 +56,24 @@ describe('getCompetencyFaults', () => {
       {
         comment: null,
         faultCount: 4,
-        competencyIdentifier: 'controlsAccelerator',
-        competencyDisplayName:'Controls - Accelerator',
+        competencyIdentifier: Competencies.controlsAccelerator,
+        competencyDisplayName: fullCompetencyLabels.controlsAccelerator,
         source: 'simple',
       });
     expect(result).toContain(
       {
         comment: null,
         faultCount: 3,
-        competencyIdentifier: 'controlsClutch',
-        competencyDisplayName:'Controls - Clutch',
+        competencyIdentifier: Competencies.controlsClutch,
+        competencyDisplayName: fullCompetencyLabels.controlsClutch,
         source: 'simple',
       });
     expect(result).toContain(
       {
         comment: null,
         faultCount: 2,
-        competencyIdentifier: 'ancillaryControls',
-        competencyDisplayName:'Ancillary Controls',
+        competencyIdentifier: Competencies.ancillaryControls,
+        competencyDisplayName: fullCompetencyLabels.ancillaryControls,
         source: 'simple',
       });
   });
@@ -89,24 +92,24 @@ describe('getCompetencyFaults', () => {
       {
         comment: null,
         faultCount: 1,
-        competencyIdentifier: 'controlsAccelerator',
-        competencyDisplayName:'Controls - Accelerator',
+        competencyIdentifier: Competencies.controlsAccelerator,
+        competencyDisplayName: fullCompetencyLabels.controlsAccelerator,
         source: 'simple',
       });
     expect(result).toContain(
       {
         comment: null,
         faultCount: 1,
-        competencyIdentifier: 'controlsClutch',
-        competencyDisplayName:'Controls - Clutch',
+        competencyIdentifier: Competencies.controlsClutch,
+        competencyDisplayName:fullCompetencyLabels.controlsClutch,
         source: 'simple',
       });
     expect(result).toContain(
       {
         comment: null,
         faultCount: 1,
-        competencyIdentifier: 'ancillaryControls',
-        competencyDisplayName:'Ancillary Controls',
+        competencyIdentifier: Competencies.ancillaryControls,
+        competencyDisplayName: fullCompetencyLabels.ancillaryControls,
         source: 'simple',
       });
   });
@@ -125,24 +128,24 @@ describe('getCompetencyFaults', () => {
       {
         comment: null,
         faultCount: 1,
-        competencyIdentifier: 'controlsAccelerator',
-        competencyDisplayName:'Controls - Accelerator',
+        competencyIdentifier: Competencies.controlsAccelerator,
+        competencyDisplayName: fullCompetencyLabels.controlsAccelerator,
         source: 'simple',
       });
     expect(result).toContain(
       {
         comment: null,
         faultCount: 1,
-        competencyIdentifier: 'controlsClutch',
-        competencyDisplayName:'Controls - Clutch',
+        competencyIdentifier: Competencies.controlsClutch,
+        competencyDisplayName: fullCompetencyLabels.controlsClutch,
         source: 'simple',
       });
     expect(result).toContain(
       {
         comment: null,
         faultCount: 1,
-        competencyIdentifier: 'ancillaryControls',
-        competencyDisplayName:'Ancillary Controls',
+        competencyIdentifier: Competencies.ancillaryControls,
+        competencyDisplayName: fullCompetencyLabels.ancillaryControls,
         source: 'simple',
       });
   });

--- a/src/shared/helpers/competency.ts
+++ b/src/shared/helpers/competency.ts
@@ -1,0 +1,37 @@
+import { DrivingFaults, SeriousFaults, DangerousFaults } from '@dvsa/mes-test-schema/categories/Common';
+import { CompetencyIdentifiers, FaultSummary, CommentSource } from '../../shared/models/fault-marking.model';
+import { competencyLabels } from '../../pages/test-report/components/competency/competency.constants';
+import { fullCompetencyLabels } from '../../shared/constants/competencies/catb-competencies';
+import { forOwn, isBoolean, isNumber } from 'lodash';
+
+export const getCompetencyFaults = (faults: DrivingFaults | SeriousFaults | DangerousFaults): FaultSummary[] => {
+  const faultsEncountered: FaultSummary[] = [];
+
+  forOwn(faults, (value: number, key: string, obj: DrivingFaults| SeriousFaults | DangerousFaults) => {
+    const faultCount = calculateFaultCount(value);
+    if (faultCount > 0  && !key.endsWith(CompetencyIdentifiers.COMMENTS_SUFFIX)) {
+      const label = key as keyof typeof competencyLabels;
+      const comment = obj[`${key}${CompetencyIdentifiers.COMMENTS_SUFFIX}`] || null;
+      const faultSummary: FaultSummary = {
+        comment,
+        faultCount,
+        competencyIdentifier: key,
+        competencyDisplayName: fullCompetencyLabels[label],
+        source: CommentSource.SIMPLE,
+      };
+      faultsEncountered.push(faultSummary);
+    }
+  });
+
+  return faultsEncountered.sort((a, b) => b.faultCount - a.faultCount);
+};
+
+export const calculateFaultCount = (value: number | boolean) : number => {
+  if (isBoolean(value)) {
+    return value ? 1 : 0;
+  }
+  if (isNumber(value)) {
+    return value;
+  }
+  return 0;
+};


### PR DESCRIPTION
Test failures with no serious or dangerous faults  but 16+ driving faults display comment fields to the user on the office page to enter details into. 

Upon entering details in to any of these comment fields all of them disappeared.

Tracked this down to code that used Object.values combined with reduce.
Essentially it would add up the driving faults - however it picked up the comment field value, added that to the accumulated value (which resulted in a string instead of a number) and so failed the logic of  the result being > 15.

e.g . instead of a number it was returning "4<commentvalue>010"    

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

