### PR TITLE
MES 4180 Add candidate name to debrief page

### DIFF
--- a/src/pages/debrief/__tests__/debrief.spec.ts
+++ b/src/pages/debrief/__tests__/debrief.spec.ts
@@ -36,6 +36,7 @@ import { EndDebrief } from '../debrief.actions';
 import * as welshTranslations from '../../../assets/i18n/cy.json';
 import { PASS_FINALISATION_PAGE, POST_DEBRIEF_HOLDING_PAGE } from '../../page-names.constants';
 import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
+import { of } from 'rxjs/observable/of';
 
 describe('DebriefPage', () => {
   let fixture: ComponentFixture<DebriefPage>;
@@ -148,6 +149,13 @@ describe('DebriefPage', () => {
   });
 
   describe('DOM', () => {
+    it('should display the candidate name in the title', () => {
+      fixture.detectChanges();
+      component.pageState.candidateName$ = of('John Doe');
+      fixture.detectChanges();
+      const title = fixture.debugElement.query(By.css('ion-title'));
+      expect(title.nativeElement.textContent).toEqual('Debrief - John Doe');
+    });
     it('should display passed container if outcome is `passed`', () => {
       fixture.detectChanges();
       component.outcome = 'Pass';

--- a/src/pages/debrief/debrief.html
+++ b/src/pages/debrief/debrief.html
@@ -1,7 +1,7 @@
 <ion-header>
   <practice-mode-banner *ngIf="isPracticeMode"></practice-mode-banner>
   <ion-navbar>
-    <ion-title>{{ 'debrief.title' | translate }}</ion-title>
+    <ion-title>{{ 'debrief.title' | translate }} - {{pageState.candidateName$ | async}}</ion-title>
     <ion-buttons end *ngIf="authenticationProvider.logoutEnabled()">
       <button ion-button (click)="logout()">Sign Out</button>
     </ion-buttons>

--- a/src/pages/debrief/debrief.ts
+++ b/src/pages/debrief/debrief.ts
@@ -3,7 +3,7 @@ import { PracticeableBasePageComponent } from '../../shared/classes/practiceable
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { AuthenticationProvider } from '../../providers/authentication/authentication';
-import { getCurrentTest } from '../../modules/tests/tests.selector';
+import { getCurrentTest, getJournalData } from '../../modules/tests/tests.selector';
 import { DebriefViewDidEnter, EndDebrief } from '../../pages/debrief/debrief.actions';
 import { Observable } from 'rxjs/Observable';
 import { getTests } from '../../modules/tests/tests.reducer';
@@ -50,6 +50,8 @@ import {
   DASHBOARD_PAGE,
 } from '../page-names.constants';
 import { Language } from '../../modules/tests/communication-preferences/communication-preferences.model';
+import { getCandidate } from '../../modules/tests/candidate/candidate.reducer';
+import { getUntitledCandidateName } from '../../modules/tests/candidate/candidate.selector';
 
 interface DebriefPageState {
   seriousFaults$: Observable<string[]>;
@@ -60,6 +62,7 @@ interface DebriefPageState {
   ecoFaults$: Observable<Eco>;
   testResult$: Observable<string>;
   conductedLanguage$: Observable<string>;
+  candidateName$: Observable<string>;
 }
 
 @IonicPage()
@@ -174,6 +177,11 @@ export class DebriefPage extends PracticeableBasePageComponent {
       conductedLanguage$: currentTest$.pipe(
         select(getCommunicationPreference),
         select(getConductedLanguage),
+      ),
+      candidateName$: currentTest$.pipe(
+        select(getJournalData),
+        select(getCandidate),
+        select(getUntitledCandidateName),
       ),
     };
 


### PR DESCRIPTION
## Description
- Adds candidate name to Cat B Debrief page
- Manual pick of changes from https://github.com/dvsa/mes-mobile-app/pull/982 onto release branch

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

