### PR TITLE
MES 4243 cat B+E update reverse left label

### DIFF
--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -70,8 +70,8 @@
       "controlledStop": "Stopio dan Reolaeth",
       "eyesightTest": "Prawf Golwg",
       "uncoupleRecouple": "Uncouple / Adennill",
-      "reverseLeftControl": "Bacio – dan reolaeth’",
-      "reverseLeftObservation": "Bacio – gwyliadwriaeth’"
+      "reverseLeftControl": "Bacio – dan reolaeth",
+      "reverseLeftObservation": "Bacio – gwyliadwriaeth"
     },
     "dangerousFault": "Nam peryglus",
     "dangerousFaultsCardDescription": "Namau peryglus",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -70,8 +70,8 @@
       "controlledStop": "Stopio dan Reolaeth",
       "eyesightTest": "Prawf Golwg",
       "uncoupleRecouple": "Uncouple / Adennill",
-      "reverseLeftControl": "[CY] Reverse left - Control",
-      "reverseLeftObservation": "[CY] Reverse left - Observation"
+      "reverseLeftControl": "[CY] Reverse - Control",
+      "reverseLeftObservation": "[CY] Reverse - Observation"
     },
     "dangerousFault": "Nam peryglus",
     "dangerousFaultsCardDescription": "Namau peryglus",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -70,8 +70,8 @@
       "controlledStop": "Stopio dan Reolaeth",
       "eyesightTest": "Prawf Golwg",
       "uncoupleRecouple": "Uncouple / Adennill",
-      "reverseLeftControl": "[CY] Reverse - Control",
-      "reverseLeftObservation": "[CY] Reverse - Observation"
+      "reverseLeftControl": "Bacio – dan reolaeth’",
+      "reverseLeftObservation": "Bacio – gwyliadwriaeth’"
     },
     "dangerousFault": "Nam peryglus",
     "dangerousFaultsCardDescription": "Namau peryglus",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -69,8 +69,8 @@
       "controlledStop": "Controlled stop",
       "eyesightTest": "Eyesight test",
       "uncoupleRecouple": "Uncouple / Recouple",
-      "reverseLeftControl": "Reverse left - Control",
-      "reverseLeftObservation": "Reverse left - Observation"
+      "reverseLeftControl": "Reverse - Control",
+      "reverseLeftObservation": "Reverse - Observation"
     },
     "dangerousFault": "Dangerous fault",
     "dangerousFaultsCardDescription": "dangerous faults",

--- a/src/pages/test-report/cat-be/components/reverse-left/reverse-left.html
+++ b/src/pages/test-report/cat-be/components/reverse-left/reverse-left.html
@@ -27,7 +27,7 @@
 
       <div class="label-wrapper">
         <ion-icon class="popover-arrow" [class.arrow-down]="displayPopover" name="md-arrow-dropright"></ion-icon>
-        <span id='reverse-left-label'>Reverse left</span>
+        <span id='reverse-left-label'>Reverse</span>
       </div>
 
       <div class="fault-wrapper">

--- a/src/pages/view-test-result/cat-be/__tests__/view-test-result.cat-be.page.spec.ts
+++ b/src/pages/view-test-result/cat-be/__tests__/view-test-result.cat-be.page.spec.ts
@@ -357,7 +357,7 @@ describe('ViewTestResultCatBEPage', () => {
           },
           {
             faultCount: 1,
-            competencyDisplayName: 'Reverse left - Observation',
+            competencyDisplayName: 'Reverse - Observation',
             competencyIdentifier: 'reverseLeftObservation',
             source: 'Manoeuvres-reverseLeft-Observation',
             comment: 'mock-observation-fault-comments',

--- a/src/pages/view-test-result/cat-be/components/debrief-card/__tests__/debrief-card.spec.ts
+++ b/src/pages/view-test-result/cat-be/components/debrief-card/__tests__/debrief-card.spec.ts
@@ -1,4 +1,3 @@
-
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { IonicModule, Config } from 'ionic-angular';
 import { DebriefCardComponent } from '../debrief-card';

--- a/src/pages/view-test-result/cat-be/components/debrief-card/debrief-card.ts
+++ b/src/pages/view-test-result/cat-be/components/debrief-card/debrief-card.ts
@@ -8,7 +8,7 @@ import {
   ViewTestResultLabels,
   TestRequirementsLabels,
 } from '../../../components/data-row-with-list/data-list-with-row.model';
-import { manoeuvreTypeLabels } from '../../../../../shared/constants/competencies/catb-manoeuvres';
+import { manoeuvreTypeLabels } from '../../../../../shared/constants/competencies/catbe-manoeuvres'
 import { FaultSummary } from '../../../../../shared/models/fault-marking.model';
 import { FaultSummaryProvider } from '../../../../../providers/fault-summary/fault-summary';
 import { FaultCountProvider } from '../../../../../providers/fault-count/fault-count';

--- a/src/pages/view-test-result/cat-be/components/debrief-card/debrief-card.ts
+++ b/src/pages/view-test-result/cat-be/components/debrief-card/debrief-card.ts
@@ -8,7 +8,7 @@ import {
   ViewTestResultLabels,
   TestRequirementsLabels,
 } from '../../../components/data-row-with-list/data-list-with-row.model';
-import { manoeuvreTypeLabels } from '../../../../../shared/constants/competencies/catbe-manoeuvres'
+import { manoeuvreTypeLabels } from '../../../../../shared/constants/competencies/catbe-manoeuvres';
 import { FaultSummary } from '../../../../../shared/models/fault-marking.model';
 import { FaultSummaryProvider } from '../../../../../providers/fault-summary/fault-summary';
 import { FaultCountProvider } from '../../../../../providers/fault-count/fault-count';

--- a/src/providers/fault-summary/__tests__/fault-summary.spec.ts
+++ b/src/providers/fault-summary/__tests__/fault-summary.spec.ts
@@ -115,6 +115,8 @@ describe('faultSummaryProvider', () => {
         };
         const result = faultSummaryProvider.getDrivingFaultsList(data, TestCategory.BE);
         expect(result.length).toEqual(2);
+        expect(result[0].competencyDisplayName).toEqual('Reverse - Control');
+        expect(result[1].competencyDisplayName).toEqual('Reverse - Observation');
       });
       it('should correctly return any uncouple recouple faults ', () => {
         const data: CatBEUniqueTypes.TestData = {

--- a/src/providers/fault-summary/fault-summary.ts
+++ b/src/providers/fault-summary/fault-summary.ts
@@ -6,7 +6,16 @@ import { CompetencyDisplayName } from '../../shared/models/competency-display-na
 import { CompetencyOutcome } from '../../shared/models/competency-outcome';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { ManoeuvreTypes } from '../../modules/tests/test-data/test-data.constants';
-import { manoeuvreCompetencyLabels, manoeuvreTypeLabels } from '../../shared/constants/competencies/catb-manoeuvres';
+import {
+  manoeuvreCompetencyLabels as manoeuvreCompetencyLabelsCatB,
+  manoeuvreTypeLabels as manoeuvreTypeLabelsCatB,
+}
+  from '../../shared/constants/competencies/catb-manoeuvres';
+import {
+  manoeuvreCompetencyLabels as manoeuvreCompetencyLabelsCatBe,
+  manoeuvreTypeLabels as manoeuvreTypeLabelsCatBe,
+}
+  from '../../shared/constants/competencies/catbe-manoeuvres';
 import { TestCategory } from '@dvsa/mes-test-schema/categories/common/test-category';
 import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
 import { FaultCountProvider } from '../fault-count/fault-count';
@@ -160,12 +169,23 @@ export class FaultSummaryProvider {
     return observationFaultComments || '';
   }
 
-  private createManoeuvreFault(key: string, type: ManoeuvreTypes, competencyComment: string): FaultSummary {
+  private createManoeuvreFaultCatB(key: string, type: ManoeuvreTypes, competencyComment: string): FaultSummary {
     const manoeuvreFaultSummary : FaultSummary = {
       comment: competencyComment || '',
-      competencyIdentifier: `${type}${manoeuvreCompetencyLabels[key]}` ,
-      competencyDisplayName:`${manoeuvreTypeLabels[type]} - ${manoeuvreCompetencyLabels[key]}`,
-      source: `${CommentSource.MANOEUVRES}-${type}-${manoeuvreCompetencyLabels[key]}`,
+      competencyIdentifier: `${type}${manoeuvreCompetencyLabelsCatB[key]}` ,
+      competencyDisplayName:`${manoeuvreTypeLabelsCatB[type]} - ${manoeuvreCompetencyLabelsCatB[key]}`,
+      source: `${CommentSource.MANOEUVRES}-${type}-${manoeuvreCompetencyLabelsCatB[key]}`,
+      faultCount: 1,
+    };
+    return manoeuvreFaultSummary;
+  }
+
+  private createManoeuvreFaultCatBe(key: string, type: ManoeuvreTypes, competencyComment: string): FaultSummary {
+    const manoeuvreFaultSummary : FaultSummary = {
+      comment: competencyComment || '',
+      competencyIdentifier: `${type}${manoeuvreCompetencyLabelsCatBe[key]}` ,
+      competencyDisplayName:`${manoeuvreTypeLabelsCatBe[type]} - ${manoeuvreCompetencyLabelsCatBe[key]}`,
+      source: `${CommentSource.MANOEUVRES}-${type}-${manoeuvreCompetencyLabelsCatB[key]}`,
       faultCount: 1,
     };
     return manoeuvreFaultSummary;
@@ -223,7 +243,7 @@ export class FaultSummaryProvider {
             manoeuvre.controlFaultComments,
             manoeuvre.observationFaultComments);
 
-          result.push(this.createManoeuvreFault(key, type, competencyComment));
+          result.push(this.createManoeuvreFaultCatB(key, type, competencyComment));
         }
       }, []);
       faultsEncountered.push(...faults);
@@ -246,7 +266,7 @@ export class FaultSummaryProvider {
             manoeuvre.controlFaultComments,
             manoeuvre.observationFaultComments);
 
-          result.push(this.createManoeuvreFault(key, type, competencyComment));
+          result.push(this.createManoeuvreFaultCatBe(key, type, competencyComment));
         }
       }, []);
       faultsEncountered.push(...faults);

--- a/src/providers/fault-summary/fault-summary.ts
+++ b/src/providers/fault-summary/fault-summary.ts
@@ -185,7 +185,7 @@ export class FaultSummaryProvider {
       comment: competencyComment || '',
       competencyIdentifier: `${type}${manoeuvreCompetencyLabelsCatBe[key]}` ,
       competencyDisplayName:`${manoeuvreTypeLabelsCatBe[type]} - ${manoeuvreCompetencyLabelsCatBe[key]}`,
-      source: `${CommentSource.MANOEUVRES}-${type}-${manoeuvreCompetencyLabelsCatB[key]}`,
+      source: `${CommentSource.MANOEUVRES}-${type}-${manoeuvreCompetencyLabelsCatBe[key]}`,
       faultCount: 1,
     };
     return manoeuvreFaultSummary;

--- a/src/shared/constants/competencies/catbe-manoeuvres.ts
+++ b/src/shared/constants/competencies/catbe-manoeuvres.ts
@@ -1,5 +1,5 @@
 export enum manoeuvreTypeLabels {
-    reverseLeft = 'Reverse left',
+    reverseLeft = 'Reverse',
   }
 
 interface ManoeuvreCompetencyLabel {


### PR DESCRIPTION
##  Description

* Changes Cat B+E manouevre label from 'Reverse Left' to 'Reverse'
    - Test Report
    - Debrief
    - Office
    - View Test Result (unable to test at present)
    
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

#### Test Report
![Screenshot 2019-12-09 at 15 51 52](https://user-images.githubusercontent.com/33055124/70450613-ee63ea80-1a9b-11ea-90f8-da096e2ed656.png)

#### Debrief
![Screenshot 2019-12-09 at 15 53 40](https://user-images.githubusercontent.com/33055124/70450706-181d1180-1a9c-11ea-8ec4-abb0e969df60.png)

#### Office
![Screenshot 2019-12-09 at 15 54 17](https://user-images.githubusercontent.com/33055124/70450763-32ef8600-1a9c-11ea-83bb-6bae8463df0d.png)


