### PR TITLE
mes-4254: Add test pass finalisation page

### DIFF
--- a/src/pages/pass-finalisation/cat-c/_tests_/pass-finalisation.cat-be.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-c/_tests_/pass-finalisation.cat-be.page.spec.ts
@@ -1,0 +1,180 @@
+import { ComponentFixture, async, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { IonicModule, NavController, NavParams, Config, Platform } from 'ionic-angular';
+import { NavControllerMock, NavParamsMock, ConfigMock, PlatformMock } from 'ionic-mocks';
+import { AppModule } from '../../../../app/app.module';
+import { AuthenticationProvider } from '../../../../providers/authentication/authentication';
+import { AuthenticationProviderMock } from '../../../../providers/authentication/__mocks__/authentication.mock';
+import { DateTimeProvider } from '../../../../providers/date-time/date-time';
+import { DateTimeProviderMock } from '../../../../providers/date-time/__mocks__/date-time.mock';
+import { Store } from '@ngrx/store';
+import { StoreModel } from '../../../../shared/models/store.model';
+import { PersistTests } from '../../../../modules/tests/tests.actions';
+import { MockComponent } from 'ng-mocks';
+import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
+import { PassCertificateNumberComponent } from '../../components/pass-certificate-number/pass-certificate-number';
+import { LicenseProvidedComponent } from '../../components/license-provided/license-provided';
+import { D255Component } from '../../../../components/test-finalisation/d255/d255';
+import { DebriefWitnessedComponent } from
+  '../../../../components/test-finalisation/debrief-witnessed/debrief-witnessed';
+import { LanguagePreferencesComponent } from
+  '../../../../components/test-finalisation/language-preference/language-preferences';
+import { FinalisationHeaderComponent } from
+  '../../../../components/test-finalisation/finalisation-header/finalisation-header';
+import { ProvisionalLicenseReceived, ProvisionalLicenseNotReceived, PassCertificateNumberChanged } from
+  '../../../../modules/tests/pass-completion/pass-completion.actions';
+import {
+  PassFinalisationViewDidEnter,
+  PassFinalisationValidationError,
+} from '../../pass-finalisation.actions';
+import { GearboxCategoryChanged } from '../../../../modules/tests/vehicle-details/vehicle-details.actions';
+import { D255Yes, D255No, DebriefWitnessed, DebriefUnwitnessed } from
+  '../../../../modules/tests/test-summary/test-summary.actions';
+import { CandidateChoseToProceedWithTestInWelsh, CandidateChoseToProceedWithTestInEnglish } from
+  '../../../../modules/tests/communication-preferences/communication-preferences.actions';
+import { PassFinalisationCatCPage } from '../pass-finalisation.cat-c.page';
+import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
+import { TransmissionComponent } from '../../../../components/common/transmission/transmission';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { PASS_CERTIFICATE_NUMBER_CTRL }
+  from '../../components/pass-certificate-number/pass-certificate-number.constants';
+
+describe('PassFinalisationCatCPage', () => {
+  let fixture: ComponentFixture<PassFinalisationCatCPage>;
+  let component: PassFinalisationCatCPage;
+  let store$: Store<StoreModel>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        PassFinalisationCatCPage,
+        MockComponent(PracticeModeBanner),
+        MockComponent(PassCertificateNumberComponent),
+        MockComponent(LicenseProvidedComponent),
+        MockComponent(TransmissionComponent),
+        MockComponent(D255Component),
+        MockComponent(DebriefWitnessedComponent),
+        MockComponent(FinalisationHeaderComponent),
+        MockComponent(LanguagePreferencesComponent),
+        MockComponent(WarningBannerComponent),
+      ],
+      imports: [IonicModule, AppModule],
+      providers: [
+        { provide: NavController, useFactory: () => NavControllerMock.instance() },
+        { provide: NavParams, useFactory: () => NavParamsMock.instance() },
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+        { provide: Platform, useFactory: () => PlatformMock.instance() },
+        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
+        { provide: DateTimeProvider, useClass: DateTimeProviderMock },
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(PassFinalisationCatCPage);
+        component = fixture.componentInstance;
+        store$ = TestBed.get(Store);
+        spyOn(store$, 'dispatch');
+      });
+  }));
+
+  describe('Class', () => {
+    describe('ionViewDidEnter', () => {
+      it('should dispatch the VIEW_DID_ENTER action when the function is run', () => {
+        component.ionViewDidEnter();
+        expect(store$.dispatch).toHaveBeenCalledWith(new PassFinalisationViewDidEnter());
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('provisionalLicenseReceived', () => {
+      it('should dispatch the correct action when called', () => {
+        component.provisionalLicenseReceived();
+        expect(store$.dispatch).toHaveBeenCalledWith(new ProvisionalLicenseReceived());
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('provisionalLicenseNotReceived', () => {
+      it('should dispatch the correct action when called', () => {
+        component.provisionalLicenseNotReceived();
+        expect(store$.dispatch).toHaveBeenCalledWith(new ProvisionalLicenseNotReceived());
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('transmissionChanged', () => {
+      it('should dispatch the correct action when called', () => {
+        component.transmissionChanged('Manual');
+        expect(store$.dispatch).toHaveBeenCalledWith(new GearboxCategoryChanged('Manual'));
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('passCertificateNumberChanged', () => {
+      it('should dispatch the correct action when called', () => {
+        component.passCertificateNumberChanged('1e3f5y64');
+        expect(store$.dispatch).toHaveBeenCalledWith(new PassCertificateNumberChanged('1e3f5y64'));
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('d255Changed', () => {
+      it('should dispatch the correct action if the inputted value is true', () => {
+        component.d255Changed(true);
+        expect(store$.dispatch).toHaveBeenCalledWith(new D255Yes());
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+      it('should dispatch the correct action if the inputted value is false', () => {
+        component.d255Changed(false);
+        expect(store$.dispatch).toHaveBeenCalledWith(new D255No());
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('debriefWitnessedChanged', () => {
+      it('should dispatch the correct action if the inputted value is true', () => {
+        component.debriefWitnessedChanged(true);
+        expect(store$.dispatch).toHaveBeenCalledWith(new DebriefWitnessed());
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+      it('should dispatch the correct action if the inputted value is false', () => {
+        component.debriefWitnessedChanged(false);
+        expect(store$.dispatch).toHaveBeenCalledWith(new DebriefUnwitnessed());
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('isWelshChanged', () => {
+      it('should dispatch the correct action if the isWelsh flag is true', () => {
+        component.isWelshChanged(true);
+        expect(store$.dispatch).toHaveBeenCalledWith(new CandidateChoseToProceedWithTestInWelsh('Cymraeg'));
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+      it('should dispatch the correct action if the isWelsh flag is false', () => {
+        component.isWelshChanged(false);
+        expect(store$.dispatch).toHaveBeenCalledWith(new CandidateChoseToProceedWithTestInEnglish('English'));
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('onSubmit', () => {
+      // Unit tests for the components TypeScript class
+      it('should dispatch the PersistTests action', () => {
+        component.onSubmit();
+        expect(store$.dispatch).toHaveBeenCalledWith(new PersistTests());
+      });
+
+      it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
+        component.form = new FormGroup({
+          requiredControl1: new FormControl(null, [Validators.required]),
+          requiredControl2: new FormControl(null, [Validators.required]),
+          [PASS_CERTIFICATE_NUMBER_CTRL]: new FormControl(null, [Validators.required]),
+          notRequiredControl: new FormControl(null),
+        });
+
+        component.onSubmit();
+        tick();
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(new PassFinalisationValidationError('requiredControl1 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(new PassFinalisationValidationError('requiredControl2 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(new PassFinalisationValidationError(`${PASS_CERTIFICATE_NUMBER_CTRL} is invalid`));
+        expect(store$.dispatch)
+          .not
+          .toHaveBeenCalledWith(new PassFinalisationValidationError('notRequiredControl is blank'));
+      }));
+    });
+  });
+});

--- a/src/pages/pass-finalisation/cat-c/components/code-78/__tests__/code-78.spec.ts
+++ b/src/pages/pass-finalisation/cat-c/components/code-78/__tests__/code-78.spec.ts
@@ -1,0 +1,116 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { IonicModule } from 'ionic-angular';
+import { FormGroup } from '@angular/forms';
+import { Code78Component } from '../code-78';
+import { MockComponent } from 'ng-mocks';
+import { WarningBannerComponent } from '../../../../../../components/common/warning-banner/warning-banner';
+import { TestCategory } from '@dvsa/mes-test-schema/categories/common/test-category';
+import { TransmissionType } from '../../../../../../shared/models/transmission-type';
+
+describe('code78Component', () => {
+  let fixture: ComponentFixture<Code78Component>;
+  let component: Code78Component;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        Code78Component,
+        MockComponent(WarningBannerComponent),
+      ],
+      imports: [
+        IonicModule,
+      ],
+      providers: [
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(Code78Component);
+        component = fixture.componentInstance;
+        component.form = new FormGroup({});
+      });
+  }));
+
+  describe('Class', () => {
+    describe('Code78Present', () => {
+      it('should emit code 78 present if code 78 is present is selected', () => {
+        spyOn(component.code78Present, 'emit');
+        component.code78IsPresent();
+        expect(component.code78Present.emit).toHaveBeenCalled();
+      });
+    });
+
+    describe('Code78NotPresent', () => {
+      it('should emit code 78 not present if code 78 is not present is selected', () => {
+        spyOn(component.code78NotPresent, 'emit');
+        component.code78IsNotPresent();
+        expect(component.code78NotPresent.emit).toHaveBeenCalled();
+      });
+    });
+
+    describe('isInvalid', () => {
+      it('should validate the field when it is valid', () => {
+        component.ngOnChanges();
+        component.form.get(Code78Component.fieldName).setValue('yes');
+        fixture.detectChanges();
+        const result: boolean = component.isInvalid();
+        expect(result).toEqual(false);
+      });
+
+      it('should not validate the field when it is dirty', () => {
+        component.ngOnChanges();
+        component.formControl.markAsDirty();
+        fixture.detectChanges();
+        const result: boolean = component.isInvalid();
+        expect(result).toEqual(true);
+      });
+    });
+
+    describe('showAutomaticBanner', () => {
+      it('should show the automatic banner when it is valid', () => {
+        component.ngOnChanges();
+        // TODO: MES-4287 Use category C
+        component.category = TestCategory.BE;
+        component.transmission = TransmissionType.Automatic;
+        component.form.get(Code78Component.fieldName).setValue('yes');
+        fixture.detectChanges();
+        expect(component.shouldShowAutomaticBanner()).toEqual(true);
+      });
+    });
+
+    describe('should show manual banner', () => {
+      it('should show the manual banner when it is valid', () => {
+        component.ngOnChanges();
+        // TODO: MES-4287 Use category C
+        component.category = TestCategory.BE;
+        component.transmission = TransmissionType.Manual;
+        component.form.get(Code78Component.fieldName).setValue('yes');
+        fixture.detectChanges();
+        expect(component.shouldShowManualBanner()).toEqual(true);
+      });
+    });
+
+    describe('shouldHideBanner', () => {
+      it('should hide banner when only transmission is selected', () => {
+        component.ngOnChanges();
+        component.transmission = TransmissionType.Manual;
+        fixture.detectChanges();
+        expect(component.shouldHideBanner()).toEqual(true);
+      });
+
+      it('should hide banner when only code78 is selected', () => {
+        component.ngOnChanges();
+        component.form.get(Code78Component.fieldName).setValue('yes');
+        fixture.detectChanges();
+        expect(component.shouldHideBanner()).toEqual(true);
+      });
+
+      it('should hide banner nothing is selected', () => {
+        component.ngOnChanges();
+        component.formControl.markAsDirty();
+        fixture.detectChanges();
+        expect(component.shouldHideBanner()).toEqual(true);
+      });
+    });
+  });
+});

--- a/src/pages/pass-finalisation/cat-c/components/code-78/__tests__/code-78.spec.ts
+++ b/src/pages/pass-finalisation/cat-c/components/code-78/__tests__/code-78.spec.ts
@@ -69,8 +69,7 @@ describe('code78Component', () => {
     describe('showAutomaticBanner', () => {
       it('should show the automatic banner when it is valid', () => {
         component.ngOnChanges();
-        // TODO: MES-4287 Use category C
-        component.category = TestCategory.BE;
+        component.category = TestCategory.C;
         component.transmission = TransmissionType.Automatic;
         component.form.get(Code78Component.fieldName).setValue('yes');
         fixture.detectChanges();
@@ -81,8 +80,7 @@ describe('code78Component', () => {
     describe('should show manual banner', () => {
       it('should show the manual banner when it is valid', () => {
         component.ngOnChanges();
-        // TODO: MES-4287 Use category C
-        component.category = TestCategory.BE;
+        component.category = TestCategory.C;
         component.transmission = TransmissionType.Manual;
         component.form.get(Code78Component.fieldName).setValue('yes');
         fixture.detectChanges();

--- a/src/pages/pass-finalisation/cat-c/components/code-78/code-78.html
+++ b/src/pages/pass-finalisation/cat-c/components/code-78/code-78.html
@@ -1,0 +1,31 @@
+<ion-row class="mes-validated-row mes-row-separator" id="code-78-card">
+  <div class="validation-bar" [class.ng-invalid]="isInvalid()">
+  </div>
+  <ion-col class="component-label" col-32 align-self-center>
+    <label>Code 78 received</label>
+  </ion-col>
+  <ion-col align-self-center padding-left>
+    <ion-row class="spacing-row"></ion-row>
+    <ion-row [formGroup]="form">
+      <ion-col col-48>
+        <input formControlName="code78Ctrl" type="radio" id="code-78-received" value="yes" class="gds-radio-button"
+          [checked]="code78PresentRadioChecked" (click)="code78IsPresent()">
+        <label for="code-78-received" class="radio-label">Yes</label>
+      </ion-col>
+      <ion-col>
+        <input formControlName="code78Ctrl" type="radio" id="code-78-not-received" value="no" class="gds-radio-button"
+          [checked]="code78NotPresentRadioChecked" (click)="code78IsNotPresent()">
+        <label for="code-78-not-received" class="radio-label">No</label>
+      </ion-col>
+    </ion-row>
+    <ion-row class="validation-message-row" align-items-center>
+      <div class="validation-text" id="code-78-received-validation-text" [class.ng-invalid]="isInvalid()">
+        Select a response
+      </div>
+    </ion-row>
+  </ion-col>
+</ion-row>
+<warning-banner *ngIf="shouldShowManualBanner()" [warningText]="manualMessage">
+</warning-banner>
+<warning-banner *ngIf="shouldShowAutomaticBanner()" [warningText]="automaticMessage">
+</warning-banner>

--- a/src/pages/pass-finalisation/cat-c/components/code-78/code-78.ts
+++ b/src/pages/pass-finalisation/cat-c/components/code-78/code-78.ts
@@ -50,8 +50,7 @@ export class Code78Component implements OnChanges {
   shouldShowManualBanner(): boolean {
     if (!this.shouldHideBanner()) {
       switch (this.category as TestCategory) {
-        // TODO: MES-4287 Use category C
-        case TestCategory.BE:
+        case TestCategory.C:
           return this.transmission === TransmissionType.Manual;
       }
     }
@@ -61,8 +60,7 @@ export class Code78Component implements OnChanges {
   shouldShowAutomaticBanner(): boolean {
     if (!this.shouldHideBanner()) {
       switch (this.category as TestCategory) {
-        // TODO: MES-4287 Use category C
-        case TestCategory.BE:
+        case TestCategory.C:
           return this.transmission === TransmissionType.Automatic;
       }
     }

--- a/src/pages/pass-finalisation/cat-c/components/code-78/code-78.ts
+++ b/src/pages/pass-finalisation/cat-c/components/code-78/code-78.ts
@@ -1,0 +1,79 @@
+import { Component, Input, OnChanges, Output, EventEmitter } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { TestCategory } from '@dvsa/mes-test-schema/categories/common/test-category';
+import { Code78Present, Code78NotPresent } from '../../../../../modules/tests/pass-completion/pass-completion.actions';
+import { TransmissionType } from '../../../../../shared/models/transmission-type';
+
+@Component({
+  selector: 'code-78',
+  templateUrl: 'code-78.html',
+})
+
+export class Code78Component implements OnChanges {
+  @Input()
+  form: FormGroup;
+
+  @Input()
+  category: TestCategory;
+
+  @Input()
+  transmission: TransmissionType;
+
+  @Output()
+  code78Present = new EventEmitter<Code78Present>();
+
+  @Output()
+  code78NotPresent = new EventEmitter<Code78NotPresent>();
+
+  formControl: FormControl;
+  static readonly fieldName: string = 'code78Ctrl';
+  manualMessage: string = 'A <b><em>manual</em></b> licence will be issued';
+  automaticMessage: string = 'An <b><em>automatic</em></b> licence will be issued';
+
+  ngOnChanges(): void {
+    if (!this.formControl) {
+      this.formControl = new FormControl('', [Validators.required]);
+      this.form.addControl(Code78Component.fieldName, this.formControl);
+    }
+  }
+
+  shouldHideBanner(): boolean {
+    return (
+      !this.formControl.valid || !this.transmission
+    );
+  }
+
+  isInvalid(): boolean {
+    return !this.formControl.valid && this.formControl.dirty;
+  }
+
+  shouldShowManualBanner(): boolean {
+    if (!this.shouldHideBanner()) {
+      switch (this.category as TestCategory) {
+        // TODO: MES-4287 Use category C
+        case TestCategory.BE:
+          return this.transmission === TransmissionType.Manual;
+      }
+    }
+    return false;
+  }
+
+  shouldShowAutomaticBanner(): boolean {
+    if (!this.shouldHideBanner()) {
+      switch (this.category as TestCategory) {
+        // TODO: MES-4287 Use category C
+        case TestCategory.BE:
+          return this.transmission === TransmissionType.Automatic;
+      }
+    }
+    return false;
+  }
+
+  code78IsPresent(): void {
+    this.code78Present.emit();
+  }
+
+  code78IsNotPresent(): void {
+    this.code78NotPresent.emit();
+  }
+}

--- a/src/pages/pass-finalisation/cat-c/components/pass-finalisation.cat-c.components.module.ts
+++ b/src/pages/pass-finalisation/cat-c/components/pass-finalisation.cat-c.components.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from 'ionic-angular';
+import { Code78Component } from './code-78/code-78';
+import { ComponentsModule } from '../../../../components/common/common-components.module';
+
+@NgModule({
+  declarations: [
+    Code78Component,
+  ],
+  imports: [
+    IonicModule,
+    CommonModule,
+    ComponentsModule,
+  ],
+  exports:[
+    Code78Component,
+  ],
+})
+export class PassFinalisationCatCComponentsModule {}

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.html
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.html
@@ -1,0 +1,55 @@
+<ion-header>
+  <ion-navbar hideBackButton>
+    <ion-title>Test debrief - {{pageState.candidateUntitledName$ | async}}</ion-title>
+  </ion-navbar>
+</ion-header>
+
+<ion-content>
+  <div>
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <ion-grid>
+
+        <finalisation-header [candidateName]="pageState.candidateName$ | async"
+          [candidateDriverNumber]="pageState.candidateDriverNumber$ | async"
+          [outcomeText]="pageState.testOutcomeText$ | async"></finalisation-header>
+
+        <ion-row class="mes-component-row mes-row-separator" id="application-reference-card" align-items-center>
+          <ion-col class="component-label" col-32>
+            <label>Application reference</label>
+          </ion-col>
+          <ion-col padding-left>
+            <span class="mes-data">{{pageState.applicationNumber$ | async }}</span>
+          </ion-col>
+        </ion-row>
+
+        <license-provided [form]="form" (licenseReceived)="provisionalLicenseReceived()"
+          (licenseNotReceived)="provisionalLicenseNotReceived()"> </license-provided>
+
+        <transmission [formGroup]="form" (transmissionChange)="transmissionChanged($event)"></transmission>
+        <warning-banner *ngIf="pageState.transmissionAutomaticRadioChecked$ | async"
+          warningText="An automatic licence will be issued."></warning-banner>
+
+        <pass-certificate-number [form]="form" (passCertificateNumberChange)="passCertificateNumberChanged($event)"></pass-certificate-number>
+
+        <d255 [display]=true [d255]="pageState.d255$ | async" [outcome]="testOutcome" [formGroup]="form"
+          (d255Change)="d255Changed($event)"></d255>
+        <warning-banner *ngIf="pageState.d255$ | async" warningText="By selecting Yes you are confirming a D255 is required."></warning-banner>
+
+        <language-preferences [formGroup]="form" [isWelsh]="(pageState.conductedLanguage$ | async) === 'Cymraeg'"
+          (welshChanged)="isWelshChanged($event)"></language-preferences>
+
+        <debrief-witnessed [display]=true [formGroup]="form" [debriefWitnessed]="pageState.debriefWitnessed$ | async"
+          [outcome]="testOutcome" (debriefWitnessedChange)="debriefWitnessedChanged($event)">
+        </debrief-witnessed>
+
+      </ion-grid>
+    </form>
+  </div>
+</ion-content>
+<ion-footer>
+  <ion-row class="mes-full-width-card box-shadow">
+    <button type="submit" class="mes-primary-button" ion-button (click)="onSubmit()">
+      <h3>Continue</h3>
+    </button>
+  </ion-row>
+</ion-footer>

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.module.ts
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { PassFinalisationCatCPage } from './pass-finalisation.cat-c.page';
+import { EffectsModule } from '@ngrx/effects';
+import { PassFinalisationAnalyticsEffects } from '../pass-finalisation.analytics.effects';
+import { ComponentsModule } from '../../../components/common/common-components.module';
+import { TestFinalisationComponentsModule } from
+'../../../components/test-finalisation/test-finalisation-component.module';
+import { PassFinalisationComponentsModule } from '../components/pass-finalisation-components.module';
+import { PassFinalisationCatCComponentsModule } from './components/pass-finalisation.cat-c.components.module';
+
+@NgModule({
+  declarations: [
+    PassFinalisationCatCPage,
+  ],
+  imports: [
+    IonicPageModule.forChild(PassFinalisationCatCPage),
+    EffectsModule.forFeature([PassFinalisationAnalyticsEffects]),
+    ComponentsModule,
+    TestFinalisationComponentsModule,
+    PassFinalisationComponentsModule,
+    PassFinalisationCatCComponentsModule,
+  ],
+})
+export class PassFinalisationCatCPageModule {}

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
@@ -1,0 +1,266 @@
+import { Component, ViewChild, ElementRef } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { IonicPage, NavController, NavParams, Platform } from 'ionic-angular';
+import { Store, select } from '@ngrx/store';
+import { StoreModel } from '../../../shared/models/store.model';
+import {
+  PassFinalisationViewDidEnter,
+  PassFinalisationValidationError,
+} from './../pass-finalisation.actions';
+import {
+  ProvisionalLicenseReceived,
+  ProvisionalLicenseNotReceived,
+  PopulatePassCompletion,
+  PassCertificateNumberChanged,
+} from '../../../modules/tests/pass-completion/pass-completion.actions';
+import { getPassCompletion } from '../../../modules/tests/pass-completion/pass-completion.reducer';
+import {
+  getPassCertificateNumber,
+  isProvisionalLicenseProvided,
+  isProvisionalLicenseNotProvided,
+} from '../../../modules/tests/pass-completion/pass-completion.selector';
+import { Observable } from 'rxjs/Observable';
+import { getCandidate } from '../../../modules/tests/journal-data/candidate/candidate.reducer';
+import {
+  getCandidateName, getCandidateDriverNumber, formatDriverNumber, getUntitledCandidateName,
+} from '../../../modules/tests/journal-data/candidate/candidate.selector';
+import {
+  getApplicationReference,
+} from '../../../modules/tests/journal-data/application-reference/application-reference.reducer';
+import {
+  getApplicationNumber,
+} from '../../../modules/tests/journal-data/application-reference/application-reference.selector';
+import { getCurrentTest, getJournalData, getTestOutcomeText } from '../../../modules/tests/tests.selector';
+import { map, tap } from 'rxjs/operators';
+import { Subscription } from 'rxjs/Subscription';
+import { getTests } from '../../../modules/tests/tests.reducer';
+import { PersistTests } from '../../../modules/tests/tests.actions';
+// TODO: MES-4287 use Cat C reducer
+import { getVehicleDetails } from '../../../modules/tests/vehicle-details/vehicle-details.cat-be.reducer';
+import {
+  getGearboxCategory,
+  isAutomatic,
+  isManual,
+} from '../../../modules/tests/vehicle-details/vehicle-details.selector';
+import { GearboxCategoryChanged } from '../../../modules/tests/vehicle-details/vehicle-details.actions';
+// TODO: MES-4287 Import Cat C page names
+import { CAT_BE } from '../../page-names.constants';
+import { getTestSummary } from '../../../modules/tests/test-summary/test-summary.reducer';
+import { isDebriefWitnessed, getD255 } from '../../../modules/tests/test-summary/test-summary.selector';
+import {
+  D255Yes,
+  D255No,
+  DebriefWitnessed,
+  DebriefUnwitnessed,
+} from '../../../modules/tests/test-summary/test-summary.actions';
+import { OutcomeBehaviourMapProvider } from '../../../providers/outcome-behaviour-map/outcome-behaviour-map';
+// TODO: MES-4287 Import Cat C behaviour map
+import { behaviourMap } from '../../office/office-behaviour-map.cat-be';
+import { ActivityCodes } from '../../../shared/models/activity-codes';
+import {
+  CandidateChoseToProceedWithTestInWelsh,
+  CandidateChoseToProceedWithTestInEnglish,
+} from '../../../modules/tests/communication-preferences/communication-preferences.actions';
+import {
+  getCommunicationPreference,
+} from '../../../modules/tests/communication-preferences/communication-preferences.reducer';
+import {
+  getConductedLanguage,
+} from '../../../modules/tests/communication-preferences/communication-preferences.selector';
+import { AuthenticationProvider } from '../../../providers/authentication/authentication';
+import { BasePageComponent } from '../../../shared/classes/base-page';
+import { GearboxCategory } from '@dvsa/mes-test-schema/categories/Common';
+import { TestCategory } from '@dvsa/mes-test-schema/categories/common/test-category';
+import { PASS_CERTIFICATE_NUMBER_CTRL } from '../components/pass-certificate-number/pass-certificate-number.constants';
+
+interface PassFinalisationPageState {
+  candidateName$: Observable<string>;
+  candidateUntitledName$: Observable<string>;
+  candidateDriverNumber$: Observable<string>;
+  testOutcomeText$: Observable<string>;
+  applicationNumber$: Observable<string>;
+  provisionalLicenseProvidedRadioChecked$: Observable<boolean>;
+  provisionalLicenseNotProvidedRadioChecked$: Observable<boolean>;
+  passCertificateNumber$: Observable<string>;
+  transmission$: Observable<GearboxCategory>;
+  transmissionAutomaticRadioChecked$: Observable<boolean>;
+  transmissionManualRadioChecked$: Observable<boolean>;
+  d255$: Observable<boolean>;
+  debriefWitnessed$: Observable<boolean>;
+  conductedLanguage$: Observable<string>;
+}
+
+@IonicPage()
+@Component({
+  selector: '.pass-finalisation-cat-c-page',
+  templateUrl: 'pass-finalisation.cat-c.page.html',
+})
+export class PassFinalisationCatCPage extends BasePageComponent {
+  pageState: PassFinalisationPageState;
+  passCertificateCtrl: string = PASS_CERTIFICATE_NUMBER_CTRL;
+  @ViewChild('passCertificateNumberInput')
+  passCertificateNumberInput: ElementRef;
+  inputSubscriptions: Subscription[] = [];
+  testOutcome: string = ActivityCodes.PASS;
+  form: FormGroup;
+  // TODO: MES-4287 Use test category C
+  category: TestCategory = TestCategory.BE;
+
+  constructor(
+    public store$: Store<StoreModel>,
+    public navController: NavController,
+    public navParams: NavParams,
+    public platform: Platform,
+    public authenticationProvider: AuthenticationProvider,
+    private outcomeBehaviourProvider: OutcomeBehaviourMapProvider,
+  ) {
+    super(platform, navController, authenticationProvider);
+    this.form = new FormGroup({});
+    this.outcomeBehaviourProvider.setBehaviourMap(behaviourMap);
+  }
+
+  ngOnInit(): void {
+
+    const currentTest$ = this.store$.pipe(
+      select(getTests),
+      select(getCurrentTest),
+    );
+
+    this.pageState = {
+      candidateName$: currentTest$.pipe(
+        select(getJournalData),
+        select(getCandidate),
+        select(getCandidateName),
+      ),
+      candidateUntitledName$: currentTest$.pipe(
+        select(getJournalData),
+        select(getCandidate),
+        select(getUntitledCandidateName),
+      ),
+      candidateDriverNumber$: currentTest$.pipe(
+        select(getJournalData),
+        select(getCandidate),
+        select(getCandidateDriverNumber),
+        map(formatDriverNumber),
+      ),
+      testOutcomeText$: currentTest$.pipe(
+        select(getTestOutcomeText),
+      ),
+      applicationNumber$: currentTest$.pipe(
+        select(getJournalData),
+        select(getApplicationReference),
+        select(getApplicationNumber),
+      ),
+      provisionalLicenseProvidedRadioChecked$: currentTest$.pipe(
+        select(getPassCompletion),
+        map(isProvisionalLicenseProvided),
+        tap((val) => {
+          if (val) this.form.controls['provisionalLicenseProvidedCtrl'].setValue('yes');
+        }),
+      ),
+      provisionalLicenseNotProvidedRadioChecked$: currentTest$.pipe(
+        select(getPassCompletion),
+        map(isProvisionalLicenseNotProvided),
+        tap((val) => {
+          if (val) this.form.controls['provisionalLicenseProvidedCtrl'].setValue('no');
+        }),
+      ),
+      passCertificateNumber$: currentTest$.pipe(
+        select(getPassCompletion),
+        select(getPassCertificateNumber),
+        tap(val => this.form.controls[this.passCertificateCtrl].setValue(val)),
+      ),
+      transmission$: currentTest$.pipe(
+        select(getVehicleDetails),
+        select(getGearboxCategory),
+      ),
+      transmissionAutomaticRadioChecked$: currentTest$.pipe(
+        select(getVehicleDetails),
+        map(isAutomatic),
+        tap((val) => {
+          if (val) this.form.controls['transmissionCtrl'].setValue('Automatic');
+        }),
+      ),
+      transmissionManualRadioChecked$: currentTest$.pipe(
+        select(getVehicleDetails),
+        map(isManual),
+        tap((val) => {
+          if (val) this.form.controls['transmissionCtrl'].setValue('Manual');
+        }),
+      ),
+      debriefWitnessed$: currentTest$.pipe(
+        select(getTestSummary),
+        select(isDebriefWitnessed),
+      ),
+      d255$: currentTest$.pipe(
+        select(getTestSummary),
+        select(getD255),
+      ),
+      conductedLanguage$: currentTest$.pipe(
+        select(getCommunicationPreference),
+        select(getConductedLanguage),
+      ),
+    };
+    this.store$.dispatch(new PopulatePassCompletion());
+  }
+
+  ionViewDidLeave(): void {
+    if (this.inputSubscriptions) {
+      this.inputSubscriptions.forEach(sub => sub.unsubscribe());
+    }
+  }
+
+  ionViewDidEnter(): void {
+    this.store$.dispatch(new PassFinalisationViewDidEnter());
+  }
+
+  provisionalLicenseReceived(): void {
+    this.store$.dispatch(new ProvisionalLicenseReceived());
+  }
+
+  provisionalLicenseNotReceived(): void {
+    this.store$.dispatch(new ProvisionalLicenseNotReceived());
+  }
+
+  transmissionChanged(transmission: GearboxCategory): void {
+    this.store$.dispatch(new GearboxCategoryChanged(transmission));
+  }
+
+  onSubmit() {
+    Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
+    if (this.form.valid) {
+      this.store$.dispatch(new PersistTests());
+      // TODO: MES-4287 Redirect to CAT_C health declaration page
+      this.navController.push(CAT_BE.HEALTH_DECLARATION_PAGE);
+      return;
+    }
+    Object.keys(this.form.controls).forEach((controlName) => {
+      if (this.form.controls[controlName].invalid) {
+        if (controlName === PASS_CERTIFICATE_NUMBER_CTRL) {
+          this.store$.dispatch(new PassFinalisationValidationError(`${controlName} is invalid`));
+        }
+        this.store$.dispatch(new PassFinalisationValidationError(`${controlName} is blank`));
+      }
+    });
+  }
+
+  passCertificateNumberChanged(passCertificateNumber: string): void {
+    this.store$.dispatch(new PassCertificateNumberChanged(passCertificateNumber));
+  }
+
+  d255Changed(d255: boolean): void {
+    this.store$.dispatch(d255 ? new D255Yes() : new D255No());
+  }
+
+  debriefWitnessedChanged(debriefWitnessed: boolean) {
+    this.store$.dispatch(debriefWitnessed ? new DebriefWitnessed() : new DebriefUnwitnessed());
+  }
+
+  isWelshChanged(isWelsh: boolean) {
+    this.store$.dispatch(
+      isWelsh ?
+        new CandidateChoseToProceedWithTestInWelsh('Cymraeg')
+        : new CandidateChoseToProceedWithTestInEnglish('English'),
+    );
+  }
+}

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
@@ -103,8 +103,7 @@ export class PassFinalisationCatCPage extends BasePageComponent {
   inputSubscriptions: Subscription[] = [];
   testOutcome: string = ActivityCodes.PASS;
   form: FormGroup;
-  // TODO: MES-4287 Use test category C
-  category: TestCategory = TestCategory.BE;
+  category: TestCategory = TestCategory.C;
 
   constructor(
     public store$: Store<StoreModel>,


### PR DESCRIPTION
## Description
Creates a placeholder page for the Category C Pass Finalisation page.
Please note:

- Test data still uses category BE. Sanitisation of the data will be addressed separately
- New Page name constants for category C will be created separately
- TODO comments have been added to help identify references to category BE which must be updated as part of the integration task: https://jira.dvsacloud.uk/browse/MES-4287

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
