### PR TITLE
mes-4254: Add test non-pass finalisation page

### DIFF
--- a/src/pages/non-pass-finalisation/cat-c/__tests__/non-pass-finalisation.cat-c.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-c/__tests__/non-pass-finalisation.cat-c.page.spec.ts
@@ -1,0 +1,153 @@
+import { ComponentFixture, async, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { IonicModule, NavController, Platform } from 'ionic-angular';
+import { NavControllerMock, PlatformMock } from 'ionic-mocks';
+import { AppModule } from '../../../../app/app.module';
+import { AuthenticationProvider } from '../../../../providers/authentication/authentication';
+import { AuthenticationProviderMock } from '../../../../providers/authentication/__mocks__/authentication.mock';
+import { Store } from '@ngrx/store';
+import { StoreModel } from '../../../../shared/models/store.model';
+import { MockComponent } from 'ng-mocks';
+import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
+import { NonPassFinalisationCatCPage } from '../non-pass-finalisation.cat-c.page';
+import {
+  NonPassFinalisationViewDidEnter,
+  NonPassFinalisationValidationError,
+} from '../../non-pass-finalisation.actions';
+import { ActivityCodeComponent } from '../../../office/components/activity-code/activity-code';
+import { SetTestStatusWriteUp } from '../../../../modules/tests/test-status/test-status.actions';
+import * as testActions from '../../../../modules/tests/tests.actions';
+import { TestCategory } from '@dvsa/mes-test-schema/categories/common/test-category';
+import { D255Component } from '../../../../components/test-finalisation/d255/d255';
+import { LanguagePreferencesComponent } from
+'../../../../components/test-finalisation/language-preference/language-preferences';
+import { DebriefWitnessedComponent } from
+'../../../../components/test-finalisation/debrief-witnessed/debrief-witnessed';
+import { FinalisationHeaderComponent } from
+'../../../../components/test-finalisation/finalisation-header/finalisation-header';
+import { D255Yes, D255No, DebriefWitnessed, DebriefUnwitnessed } from
+'../../../../modules/tests/test-summary/test-summary.actions';
+import { CandidateChoseToProceedWithTestInWelsh, CandidateChoseToProceedWithTestInEnglish } from
+'../../../../modules/tests/communication-preferences/communication-preferences.actions';
+import { GearboxCategoryChanged } from '../../../../modules/tests/vehicle-details/vehicle-details.actions';
+import { TransmissionComponent } from '../../../../components/common/transmission/transmission';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+
+describe('NonPassFinalisationCatCPage', () => {
+  let fixture: ComponentFixture<NonPassFinalisationCatCPage>;
+  let component: NonPassFinalisationCatCPage;
+  let store$: Store<StoreModel>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        NonPassFinalisationCatCPage,
+        MockComponent(PracticeModeBanner),
+        MockComponent(ActivityCodeComponent),
+        MockComponent(D255Component),
+        MockComponent(LanguagePreferencesComponent),
+        MockComponent(DebriefWitnessedComponent),
+        MockComponent(FinalisationHeaderComponent),
+        MockComponent(TransmissionComponent),
+      ],
+      imports: [
+        IonicModule,
+        AppModule,
+      ],
+      providers: [
+        { provide: NavController, useFactory: () => NavControllerMock.instance() },
+        { provide: Platform, useFactory: () => PlatformMock.instance() },
+        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(NonPassFinalisationCatCPage);
+        component = fixture.componentInstance;
+        store$ = TestBed.get(Store);
+        spyOn(store$, 'dispatch');
+      });
+  }));
+
+  describe('Class', () => {
+    describe('ionViewDidEnter', () => {
+      it('should dispatch a view did enter action', () => {
+        component.ionViewDidEnter();
+        expect(store$.dispatch).toHaveBeenCalledWith(new NonPassFinalisationViewDidEnter());
+      });
+    });
+    describe('d255Changed', () => {
+      it('should dispatch the correct action if the inputted value is true', () => {
+        component.d255Changed(true);
+        expect(store$.dispatch).toHaveBeenCalledWith(new D255Yes());
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+      it('should dispatch the correct action if the inputted value is false', () => {
+        component.d255Changed(false);
+        expect(store$.dispatch).toHaveBeenCalledWith(new D255No());
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('debriefWitnessedChanged', () => {
+      it('should dispatch the correct action if the inputted value is true', () => {
+        component.debriefWitnessedChanged(true);
+        expect(store$.dispatch).toHaveBeenCalledWith(new DebriefWitnessed());
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+      it('should dispatch the correct action if the inputted value is false', () => {
+        component.debriefWitnessedChanged(false);
+        expect(store$.dispatch).toHaveBeenCalledWith(new DebriefUnwitnessed());
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('isWelshChanged', () => {
+      it('should dispatch the correct action if the isWelsh flag is true', () => {
+        component.isWelshChanged(true);
+        expect(store$.dispatch).toHaveBeenCalledWith(new CandidateChoseToProceedWithTestInWelsh('Cymraeg'));
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+      it('should dispatch the correct action if the isWelsh flag is false', () => {
+        component.isWelshChanged(false);
+        expect(store$.dispatch).toHaveBeenCalledWith(new CandidateChoseToProceedWithTestInEnglish('English'));
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('transmissionChanged', () => {
+      it('should dispatch the correct action when called', () => {
+        component.transmissionChanged('Manual');
+        expect(store$.dispatch).toHaveBeenCalledWith(new GearboxCategoryChanged('Manual'));
+        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('OnContinue', () => {
+      it('should dispatch a change test state to WriteUp action', () => {
+        // Arrange
+        store$.dispatch(new testActions.StartTest(123, TestCategory.C));
+        component.slotId = '123';
+
+        // Act
+        component.continue();
+
+        // Assert
+        expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
+      });
+
+      it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
+        component.form = new FormGroup({
+          requiredControl1: new FormControl(null, [Validators.required]),
+          requiredControl2: new FormControl(null, [Validators.required]),
+          notRequiredControl: new FormControl(null),
+        });
+
+        component.continue();
+        tick();
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(new NonPassFinalisationValidationError('requiredControl1 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(new NonPassFinalisationValidationError('requiredControl2 is blank'));
+        expect(store$.dispatch)
+          .not
+          .toHaveBeenCalledWith(new NonPassFinalisationValidationError('notRequiredControl is blank'));
+      }));
+    });
+  });
+});

--- a/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.html
+++ b/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.html
@@ -1,0 +1,45 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>Finalise outcome BE - {{ pageState.candidateName$ | async }}</ion-title>
+  </ion-navbar>
+</ion-header>
+
+<ion-content>
+  <finalisation-header [candidateName]="pageState.candidateName$ | async"
+    [candidateDriverNumber]="pageState.candidateDriverNumber$ | async"
+    [outcomeText]="pageState.testOutcomeText$ | async"></finalisation-header>
+
+  <form [formGroup]="form">
+    <ion-grid class="grid">
+
+      <activity-code id="activity-code-card" [formGroup]="form" [activityCodeModel]="pageState.activityCode$ | async"
+        [activityCodeOptions]="activityCodeOptions" (activityCodeChange)="activityCodeChanged($event)"
+        [disabled]="false">
+      </activity-code>
+
+      <div no-padding [hidden]="!(pageState.isTestOutcomeSet$ | async)">
+
+        <transmission [formGroup]="form" (transmissionChange)="transmissionChanged($event)"></transmission> 
+
+        <d255 [display]="pageState.displayD255$ | async" [d255]="pageState.d255$ | async"
+          [outcome]="pageState.testOutcome$ | async" [formGroup]="form" (d255Change)="d255Changed($event)"></d255>
+
+        <language-preferences [formGroup]="form" [isWelsh]="pageState.isWelshTest$ | async"
+          (welshChanged)="isWelshChanged($event)"></language-preferences>
+
+        <debrief-witnessed [display]="pageState.displayDebriefWitnessed$ | async" [formGroup]="form"
+          [debriefWitnessed]="pageState.debriefWitnessed$ | async" [outcome]="pageState.testOutcome$ | async"
+          (debriefWitnessedChange)="debriefWitnessedChanged($event)"></debrief-witnessed>
+
+      </div>
+    </ion-grid>
+  </form>
+</ion-content>
+
+<ion-footer>
+  <div id="footer-background">
+    <button ion-button id="continue-button" class="mes-primary-button" (click)="continue()">
+      <h3>Submit</h3>
+    </button>
+  </div>
+</ion-footer>

--- a/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.module.ts
+++ b/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { ComponentsModule } from '../../../components/common/common-components.module';
+import { TestFinalisationComponentsModule } from
+  '../../../components/test-finalisation/test-finalisation-component.module';
+import { NonPassFinalisationCatCPage } from './non-pass-finalisation.cat-c.page';
+
+@NgModule({
+  declarations: [
+    NonPassFinalisationCatCPage,
+  ],
+  imports: [
+    IonicPageModule.forChild(NonPassFinalisationCatCPage),
+    ComponentsModule,
+    TestFinalisationComponentsModule,
+  ],
+})
+export class NonPassFinalisationCatCPageModule { }

--- a/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.ts
+++ b/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.ts
@@ -1,0 +1,232 @@
+import { Component, OnInit } from '@angular/core';
+import { IonicPage, NavController, Platform } from 'ionic-angular';
+import { AuthenticationProvider } from '../../../providers/authentication/authentication';
+import { Store, select } from '@ngrx/store';
+import { StoreModel } from '../../../shared/models/store.model';
+// TODO: MES-4287 Import Cat C page names
+import { CAT_BE } from '../../page-names.constants';
+import { Observable } from 'rxjs/Observable';
+import { getTests } from '../../../modules/tests/tests.reducer';
+import {
+  getCurrentTest,
+  getJournalData,
+  getActivityCode,
+  getTestOutcome,
+  isTestOutcomeSet,
+  getTestOutcomeText,
+} from '../../../modules/tests/tests.selector';
+import { getCandidate } from '../../../modules/tests/journal-data/candidate/candidate.reducer';
+import {
+  getUntitledCandidateName,
+  getCandidateDriverNumber,
+  formatDriverNumber,
+} from '../../../modules/tests/journal-data/candidate/candidate.selector';
+import {
+  NonPassFinalisationViewDidEnter,
+  NonPassFinalisationValidationError,
+} from '../non-pass-finalisation.actions';
+import { map, withLatestFrom, tap } from 'rxjs/operators';
+import { getTestSummary } from '../../../modules/tests/test-summary/test-summary.reducer';
+import { isDebriefWitnessed, getD255 } from '../../../modules/tests/test-summary/test-summary.selector';
+import {
+  getTestSlotAttributes,
+} from '../../../modules/tests/journal-data/test-slot-attributes/test-slot-attributes.reducer';
+import { isWelshTest } from '../../../modules/tests/journal-data/test-slot-attributes/test-slot-attributes.selector';
+import {
+  ActivityCodeModel,
+  activityCodeModelList,
+} from '../../office/components/activity-code/activity-code.constants';
+import { FormGroup } from '@angular/forms';
+import { PersistTests } from '../../../modules/tests/tests.actions';
+import { OutcomeBehaviourMapProvider } from '../../../providers/outcome-behaviour-map/outcome-behaviour-map';
+// TODO: MES-4287 Import Cat C behaviour map
+import { behaviourMap } from '../../office/office-behaviour-map.cat-be';
+import {
+  DebriefWitnessed,
+  DebriefUnwitnessed,
+  D255Yes,
+  D255No,
+} from '../../../modules/tests/test-summary/test-summary.actions';
+import {
+  CandidateChoseToProceedWithTestInWelsh,
+  CandidateChoseToProceedWithTestInEnglish,
+} from '../../../modules/tests/communication-preferences/communication-preferences.actions';
+import { SetTestStatusWriteUp } from '../../../modules/tests/test-status/test-status.actions';
+import { SetActivityCode } from '../../../modules/tests/activity-code/activity-code.actions';
+import { BasePageComponent } from '../../../shared/classes/base-page';
+import { getGearboxCategory, isAutomatic, isManual } from
+'../../../modules/tests/vehicle-details/vehicle-details.selector';
+import { getVehicleDetails } from '../../../modules/tests/vehicle-details/vehicle-details.reducer';
+import { GearboxCategory } from '@dvsa/mes-test-schema/categories/Common';
+import { GearboxCategoryChanged } from '../../../modules/tests/vehicle-details/vehicle-details.actions';
+
+interface NonPassFinalisationPageState {
+  candidateName$: Observable<string>;
+  candidateDriverNumber$: Observable<string>;
+  isTestOutcomeSet$: Observable<boolean>;
+  testOutcome$: Observable<string>;
+  testOutcomeText$: Observable<string>;
+  activityCode$: Observable<ActivityCodeModel>;
+  displayDebriefWitnessed$: Observable<boolean>;
+  debriefWitnessed$: Observable<boolean>;
+  displayD255$: Observable<boolean>;
+  d255$: Observable<boolean>;
+  isWelshTest$: Observable<boolean>;
+  transmission$: Observable<GearboxCategory>;
+  transmissionAutomaticRadioChecked$: Observable<boolean>;
+  transmissionManualRadioChecked$: Observable<boolean>;
+}
+
+@IonicPage()
+@Component({
+  selector: '.non-pass-finalisation-cat-c-page',
+  templateUrl: 'non-pass-finalisation.cat-c.page.html',
+})
+export class NonPassFinalisationCatCPage extends BasePageComponent implements OnInit {
+
+  pageState: NonPassFinalisationPageState;
+  form: FormGroup;
+  activityCodeOptions: ActivityCodeModel[];
+  slotId: string;
+
+  constructor(
+    public store$: Store<StoreModel>,
+    public navController: NavController,
+    public platform: Platform,
+    public authenticationProvider: AuthenticationProvider,
+    private outcomeBehaviourProvider: OutcomeBehaviourMapProvider,
+  ) {
+    super(platform, navController, authenticationProvider);
+    this.form = new FormGroup({});
+    this.activityCodeOptions = activityCodeModelList;
+    this.outcomeBehaviourProvider.setBehaviourMap(behaviourMap);
+  }
+
+  ngOnInit() {
+    this.store$.pipe(
+      select(getTests),
+      map(tests => tests.currentTest.slotId),
+    ).subscribe(slotId => this.slotId = slotId);
+
+    const currentTest$ = this.store$.pipe(
+      select(getTests),
+      select(getCurrentTest),
+    );
+    this.pageState = {
+      candidateName$: currentTest$.pipe(
+        select(getJournalData),
+        select(getCandidate),
+        select(getUntitledCandidateName),
+      ),
+      candidateDriverNumber$: currentTest$.pipe(
+        select(getJournalData),
+        select(getCandidate),
+        select(getCandidateDriverNumber),
+        map(formatDriverNumber),
+      ),
+      isTestOutcomeSet$: currentTest$.pipe(
+        select(isTestOutcomeSet),
+      ),
+      testOutcome$: currentTest$.pipe(
+        select(getTestOutcome),
+      ),
+      testOutcomeText$: currentTest$.pipe(
+        select(getTestOutcomeText),
+      ),
+      activityCode$: currentTest$.pipe(
+        select(getActivityCode),
+      ),
+      displayDebriefWitnessed$: currentTest$.pipe(
+        select(getTestOutcome),
+        withLatestFrom(currentTest$.pipe(
+          select(getTestSummary),
+          select(isDebriefWitnessed))),
+        map(([outcome, debrief]) =>
+          this.outcomeBehaviourProvider.isVisible(outcome, 'debriefWitnessed', debrief)),
+      ),
+      debriefWitnessed$: currentTest$.pipe(
+        select(getTestSummary),
+        select(isDebriefWitnessed),
+      ),
+      displayD255$: currentTest$.pipe(
+        select(getTestOutcome),
+        withLatestFrom(currentTest$.pipe(
+          select(getTestSummary),
+          select(getD255))),
+        map(([outcome, d255]) =>
+          this.outcomeBehaviourProvider.isVisible(outcome, 'd255', d255)),
+      ),
+      d255$: currentTest$.pipe(
+        select(getTestSummary),
+        select(getD255),
+      ),
+      isWelshTest$: currentTest$.pipe(
+        select(getJournalData),
+        select(getTestSlotAttributes),
+        select(isWelshTest),
+      ),
+      transmission$: currentTest$.pipe(
+        select(getVehicleDetails),
+        select(getGearboxCategory),
+      ),
+      transmissionAutomaticRadioChecked$: currentTest$.pipe(
+        select(getVehicleDetails),
+        map(isAutomatic),
+        tap((val) => {
+          if (val) this.form.controls['transmissionCtrl'].setValue('Automatic');
+        }),
+      ),
+      transmissionManualRadioChecked$: currentTest$.pipe(
+        select(getVehicleDetails),
+        map(isManual),
+        tap((val) => {
+          if (val) this.form.controls['transmissionCtrl'].setValue('Manual');
+        }),
+      ),
+    };
+  }
+
+  ionViewDidEnter(): void {
+    this.store$.dispatch(new NonPassFinalisationViewDidEnter());
+  }
+
+  continue() {
+    Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
+    if (this.form.valid) {
+      this.store$.dispatch(new SetTestStatusWriteUp(this.slotId));
+      this.store$.dispatch(new PersistTests());
+      // TODO: MES-4287 Redirect to CAT_C office page
+      this.navController.push(CAT_BE.BACK_TO_OFFICE_PAGE);
+      return;
+    }
+    Object.keys(this.form.controls).forEach((controlName) => {
+      if (this.form.controls[controlName].invalid) {
+        this.store$.dispatch(new NonPassFinalisationValidationError(`${controlName} is blank`));
+      }
+    });
+  }
+
+  activityCodeChanged(activityCodeModel: ActivityCodeModel) {
+    this.store$.dispatch(new SetActivityCode(activityCodeModel.activityCode));
+  }
+
+  debriefWitnessedChanged(debriefWitnessed: boolean) {
+    this.store$.dispatch(debriefWitnessed ? new DebriefWitnessed() : new DebriefUnwitnessed());
+  }
+
+  d255Changed(d255: boolean): void {
+    this.store$.dispatch(d255 ? new D255Yes() : new D255No());
+  }
+
+  transmissionChanged(transmission: GearboxCategory): void {
+    this.store$.dispatch(new GearboxCategoryChanged(transmission));
+  }
+
+  isWelshChanged(isWelsh: boolean) {
+    this.store$.dispatch(
+      isWelsh ?
+        new CandidateChoseToProceedWithTestInWelsh('Cymraeg')
+        : new CandidateChoseToProceedWithTestInEnglish('English'),
+    );
+  }
+}


### PR DESCRIPTION
## Description
Creates a placeholder page for the Category C Non Pass Finalisation page.
Please note:

- Test data still uses category BE. Sanitisation of the data will be addressed separately
- New Page name constants for category C will be created separately
- TODO comments have been added to help identify references to category BE which must be updated as part of the integration task: https://jira.dvsacloud.uk/browse/MES-4287

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
