### PR TITLE
mes-4254: add cat c debrief page

### DIFF
--- a/src/pages/debrief/cat-c/__tests__/debrief.cat-c.page.spec.ts
+++ b/src/pages/debrief/cat-c/__tests__/debrief.cat-c.page.spec.ts
@@ -1,0 +1,294 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { IonicModule, NavController, NavParams, Config, Platform } from 'ionic-angular';
+import { NavControllerMock, NavParamsMock, ConfigMock, PlatformMock } from 'ionic-mocks';
+
+import { AppModule } from '../../../../app/app.module';
+import { DebriefCatCPage } from '../debrief.cat-c.page';
+import { AuthenticationProvider } from '../../../../providers/authentication/authentication';
+import { AuthenticationProviderMock } from '../../../../providers/authentication/__mocks__/authentication.mock';
+import { DateTimeProvider } from '../../../../providers/date-time/date-time';
+import { DateTimeProviderMock } from '../../../../providers/date-time/__mocks__/date-time.mock';
+import { By } from '@angular/platform-browser';
+import { ComponentsModule } from '../../../../components/common/common-components.module';
+import { StoreModel } from '../../../../shared/models/store.model';
+import { StoreModule, Store } from '@ngrx/store';
+import {
+  AddDangerousFault,
+} from '../../../../modules/tests/test-data/common/dangerous-faults/dangerous-faults.actions';
+import { AddSeriousFault } from '../../../../modules/tests/test-data/common/serious-faults/serious-faults.actions';
+import { AddDrivingFault } from '../../../../modules/tests/test-data/common/driving-faults/driving-faults.actions';
+import {
+  EyesightTestFailed,
+  EyesightTestPassed,
+} from '../../../../modules/tests/test-data/common/eyesight-test/eyesight-test.actions';
+import { Competencies } from '../../../../modules/tests/test-data/test-data.constants';
+import { DebriefComponentsModule } from '../../components/debrief-components.module';
+import { ScreenOrientation } from '@ionic-native/screen-orientation';
+import { Insomnia } from '@ionic-native/insomnia';
+import { InsomniaMock } from '../../../../shared/mocks/insomnia.mock';
+import { ScreenOrientationMock } from '../../../../shared/mocks/screen-orientation.mock';
+import { TranslateModule, TranslateService } from 'ng2-translate';
+import { fullCompetencyLabels } from '../../../../shared/constants/competencies/catb-competencies';
+import { TestSlotAttributes } from '@dvsa/mes-test-schema/categories/Common';
+import { PopulateTestSlotAttributes }
+  from '../../../../modules/tests/journal-data/test-slot-attributes/test-slot-attributes.actions';
+import { EndDebrief } from '../../debrief.actions';
+import * as welshTranslations from '../../../../assets/i18n/cy.json';
+// TODO: MES-4287 Import Cat C page names
+import { CAT_BE } from '../../../page-names.constants';
+import { Language } from '../../../../modules/tests/communication-preferences/communication-preferences.model';
+import { configureI18N } from '../../../../shared/helpers/translation.helpers';
+import { TestCategory } from '@dvsa/mes-test-schema/categories/common/test-category';
+// TODO: MES-4287 Use Cat C types
+import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
+import { FaultSummaryProvider } from '../../../../providers/fault-summary/fault-summary';
+import { of } from 'rxjs/observable/of';
+
+describe('DebriefCatCPage', () => {
+  let fixture: ComponentFixture<DebriefCatCPage>;
+  let component: DebriefCatCPage;
+  let navController: NavController;
+  let store$: Store<StoreModel>;
+  let translate: TranslateService;
+
+  const testSlotAttributes: TestSlotAttributes = {
+    welshTest: false,
+    extendedTest: false,
+    slotId: 123,
+    specialNeeds: false,
+    start: '',
+    vehicleTypeCode: '',
+  };
+
+  beforeEach(async(() => {
+    // TODO: MES-4287 Use Cat C types
+    const exampleTestData: CatBEUniqueTypes.TestData  = {
+      dangerousFaults: {},
+      drivingFaults: {},
+      manoeuvres: {},
+      seriousFaults: {},
+      testRequirements: {},
+      ETA: {},
+      eco: {},
+      vehicleChecks: {
+        tellMeQuestions: [{}],
+        showMeQuestions: [{}],
+      },
+      uncoupleRecouple: {},
+    };
+
+    TestBed.configureTestingModule({
+      declarations: [DebriefCatCPage],
+      imports: [
+        IonicModule,
+        AppModule,
+        ComponentsModule,
+        DebriefComponentsModule,
+        StoreModule.forRoot({
+          tests: () => ({
+            currentTest: {
+              slotId: '123',
+            },
+            testStatus: {},
+            startedTests: {
+              123: {
+                testSlotAttributes,
+                // TODO: MES-4287 Use Cat C test category
+                category: TestCategory.BE,
+                vehicleDetails: {},
+                accompaniment: {},
+                testData: exampleTestData,
+                journalData: {
+                  candidate: {
+                    candidateName: 'Joe Bloggs',
+                  },
+                },
+              },
+            },
+          }),
+          testReport: () => ({
+            seriousMode: false,
+            dangerousMode: false,
+            removeFaultMode: false,
+            isValid: false,
+          }),
+        }),
+        TranslateModule,
+      ],
+      providers: [
+        { provide: NavController, useFactory: () => NavControllerMock.instance() },
+        { provide: NavParams, useFactory: () => NavParamsMock.instance() },
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+        { provide: Platform, useFactory: () => PlatformMock.instance() },
+        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
+        { provide: DateTimeProvider, useClass: DateTimeProviderMock },
+        { provide: ScreenOrientation, useClass: ScreenOrientationMock },
+        { provide: Insomnia, useClass: InsomniaMock },
+        { provide: FaultSummaryProvider, useClass: FaultSummaryProvider },
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(DebriefCatCPage);
+        component = fixture.componentInstance;
+        navController = TestBed.get(NavController);
+        store$ = TestBed.get(Store);
+        spyOn(store$, 'dispatch').and.callThrough();
+        translate = TestBed.get(TranslateService);
+        translate.setDefaultLang('en');
+      });
+  }));
+
+  describe('DOM', () => {
+    it('should display passed container if outcome is `passed`', () => {
+      fixture.detectChanges();
+      component.outcome = 'Pass';
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.passed'))).not.toBeNull();
+      expect(fixture.debugElement.query(By.css('.failed'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('.terminated'))).toBeNull();
+    });
+    it('should display failed container if outcome is `fail`', () => {
+      fixture.detectChanges();
+      component.outcome = 'Fail';
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.failed'))).not.toBeNull();
+      expect(fixture.debugElement.query(By.css('.passed'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('.terminated'))).toBeNull();
+    });
+    it('should display terminated container if outcome is `terminated`', () => {
+      fixture.detectChanges();
+      component.outcome = 'Terminated';
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.terminated'))).not.toBeNull();
+      expect(fixture.debugElement.query(By.css('.passed'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('.failed'))).toBeNull();
+    });
+
+    it('should display the candidate name in the title', () => {
+      fixture.detectChanges();
+      component.pageState.candidateName$ = of('John Doe');
+      fixture.detectChanges();
+      const title = fixture.debugElement.query(By.css('ion-title'));
+      expect(title.nativeElement.textContent).toEqual('Debrief - John Doe');
+    });
+
+  });
+
+  it('should not display dangerous faults container if there are no dangerous faults', () => {
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#dangerous-fault'))).toBeNull();
+  });
+
+  it('should not display serious faults container if there are no serious faults', () => {
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#serious-fault'))).toBeNull();
+  });
+
+  it('should not display driving faults container if there are no driving faults', () => {
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#driving-fault'))).toBeNull();
+  });
+
+  it('should display dangerous faults container if there are dangerous faults', () => {
+    store$.dispatch(new AddDangerousFault(Competencies.controlsClutch));
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#dangerous-fault'))).not.toBeNull();
+  });
+
+  it('should display serious faults container if there are serious faults', () => {
+    store$.dispatch(new AddSeriousFault(Competencies.controlsClutch));
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#serious-fault'))).not.toBeNull();
+  });
+
+  it('should display driving faults container if there are driving faults', () => {
+    store$.dispatch(new AddDrivingFault({ competency: Competencies.controlsClutch, newFaultCount: 1 }));
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#driving-fault'))).not.toBeNull();
+  });
+
+  describe('endDebrief', () => {
+    it('should dispatch the PersistTests action', () => {
+      component.endDebrief();
+      expect(store$.dispatch).toHaveBeenCalledWith(new EndDebrief);
+    });
+    it('should navigate to PassFinalisationPage when outcome = pass', () => {
+      component.outcome = 'Pass';
+      component.endDebrief();
+      // TODO: MES-4287 Use Cat C page names
+      expect(navController.push).toHaveBeenCalledWith(CAT_BE.PASS_FINALISATION_PAGE);
+    });
+    it('should navigate to BackToOfficePage when outcome = fail', () => {
+      component.outcome = 'Fail';
+      component.endDebrief();
+      // TODO: MES-4287 Use Cat C page names
+      expect(navController.push).toHaveBeenCalledWith(CAT_BE.POST_DEBRIEF_HOLDING_PAGE);
+    });
+    it('should navigate to the BackToOfficePage when outcomes = terminated', () => {
+      component.outcome = 'Terminated';
+      component.endDebrief();
+      // TODO: MES-4287 Use Cat C page names
+      expect(navController.push).toHaveBeenCalledWith(CAT_BE.POST_DEBRIEF_HOLDING_PAGE);
+    });
+  });
+
+  describe('translation of fault competencies', () => {
+    it('should display fault competencies in English by default', () => {
+      store$.dispatch(new AddDrivingFault({ competency: Competencies.moveOffSafety, newFaultCount: 1 }));
+      store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsSignalling));
+      store$.dispatch(new AddDangerousFault(Competencies.useOfMirrorsChangeDirection));
+      fixture.detectChanges();
+      const drivingFaultLabel = fixture.debugElement.query(By.css('#driving-fault .counter-label')).nativeElement;
+      const seriousLabel = fixture.debugElement.query(By.css('#serious-fault .counter-label')).nativeElement;
+      const dangerousLabel = fixture.debugElement.query(By.css('#dangerous-fault .counter-label')).nativeElement;
+
+      expect(drivingFaultLabel.innerHTML).toBe(fullCompetencyLabels.moveOffSafety);
+      expect(seriousLabel.innerHTML).toBe(fullCompetencyLabels.useOfMirrorsSignalling);
+      expect(dangerousLabel.innerHTML).toBe(fullCompetencyLabels.useOfMirrorsChangeDirection);
+    });
+    it('should display fault competencies in Welsh for a Welsh test', (done) => {
+      store$.dispatch(new AddDrivingFault({ competency: Competencies.moveOffSafety, newFaultCount: 1 }));
+      store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsSignalling));
+      store$.dispatch(new AddDangerousFault(Competencies.useOfMirrorsChangeDirection));
+      fixture.detectChanges();
+      configureI18N(Language.CYMRAEG, translate);
+      translate.onLangChange.subscribe(() => {
+        fixture.detectChanges();
+        const drivingFaultLabel = fixture.debugElement.query(By.css('#driving-fault .counter-label')).nativeElement;
+        const seriousLabel = fixture.debugElement.query(By.css('#serious-fault .counter-label')).nativeElement;
+        const dangerousLabel = fixture.debugElement.query(By.css('#dangerous-fault .counter-label')).nativeElement;
+
+        const expectedDrivingFaultTranslation = (<any>welshTranslations).debrief.competencies.moveOffSafety;
+        const expectedSeriousFaultTranslation = (<any>welshTranslations).debrief.competencies.useOfMirrorsSignalling;
+        const expectedDangerousFaultTranslation =
+            (<any>welshTranslations).debrief.competencies.useOfMirrorsChangeDirection;
+
+        expect(drivingFaultLabel.innerHTML).toBe(expectedDrivingFaultTranslation);
+        expect(seriousLabel.innerHTML).toBe(expectedSeriousFaultTranslation);
+        expect(dangerousLabel.innerHTML).toBe(expectedDangerousFaultTranslation);
+        done();
+      });
+      store$.dispatch(new PopulateTestSlotAttributes({ ...testSlotAttributes, welshTest: true }));
+    });
+  });
+
+  describe('Eyesight Test', () => {
+    it('should display the eyesight test serious fault', () => {
+      store$.dispatch(new EyesightTestFailed());
+      fixture.detectChanges();
+      const seriousLabel = fixture.debugElement.query(By.css('#serious-fault .counter-label')).nativeElement;
+      expect(seriousLabel.innerHTML).toBe(fullCompetencyLabels.eyesightTest);
+    });
+
+    it('should not display a eyesight test serious fault if the test is passed', () => {
+      store$.dispatch(new EyesightTestPassed());
+      fixture.detectChanges();
+      const label = fixture.debugElement.query(By.css('#serious-fault .counter-label'));
+      expect(label).toBeNull();
+    });
+  });
+});

--- a/src/pages/debrief/cat-c/debrief.cat-c.page.html
+++ b/src/pages/debrief/cat-c/debrief.cat-c.page.html
@@ -1,0 +1,25 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>{{ 'debrief.title' | translate }} - {{pageState.candidateName$ | async}}</ion-title>
+    <ion-buttons end *ngIf="authenticationProvider.logoutEnabled()">
+      <button ion-button (click)="logout()">Sign Out</button>
+    </ion-buttons>
+  </ion-navbar>
+  <test-outcome-debrief-card [outcome]="outcome"></test-outcome-debrief-card>
+</ion-header>
+
+<ion-content>
+  <eta-debrief-card [hasPhysicalEta]="hasPhysicalEta" [hasVerbalEta]="hasVerbalEta"></eta-debrief-card>
+  <dangerous-faults-debrief-card [dangerousFaults]="pageState.dangerousFaults$ | async"></dangerous-faults-debrief-card>
+  <serious-faults-debrief-card [seriousFaults]="pageState.seriousFaults$ | async"></serious-faults-debrief-card>
+  <driving-faults-debrief-card [drivingFaults]="pageState.drivingFaults$ | async" [drivingFaultCount]="pageState.drivingFaultCount$ | async"></driving-faults-debrief-card>
+  <eco-debrief-card [adviceGivenControl]="adviceGivenControl" [adviceGivenPlanning]="adviceGivenPlanning"></eco-debrief-card>
+  <vehicle-checks-card></vehicle-checks-card>
+</ion-content>
+<ion-footer>
+  <div id="end-debrief-background">
+    <button ion-button id="end-debrief-button" class="mes-primary-button" (click)="endDebrief()">
+      <h3>{{ 'debrief.end' | translate }}</h3>
+    </button>
+  </div>
+</ion-footer>

--- a/src/pages/debrief/cat-c/debrief.cat-c.page.module.ts
+++ b/src/pages/debrief/cat-c/debrief.cat-c.page.module.ts
@@ -1,0 +1,30 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { DebriefCatCPage } from './debrief.cat-c.page';
+import { EffectsModule } from '@ngrx/effects';
+import { DebriefAnalyticsEffects } from '../debrief.analytics.effects';
+import { ComponentsModule } from '../../../components/common/common-components.module';
+import { DebriefComponentsModule } from '../components/debrief-components.module';
+import { TranslateModule } from 'ng2-translate';
+import { DebriefEffects } from '../debrief.effects';
+import { FaultSummaryProvider } from '../../../providers/fault-summary/fault-summary';
+
+@NgModule({
+  declarations: [
+    DebriefCatCPage,
+  ],
+  imports: [
+    DebriefComponentsModule,
+    IonicPageModule.forChild(DebriefCatCPage),
+    EffectsModule.forFeature([
+      DebriefEffects,
+      DebriefAnalyticsEffects,
+    ]),
+    ComponentsModule,
+    TranslateModule,
+  ],
+  providers: [
+    FaultSummaryProvider,
+  ],
+})
+export class DebriefCatCPageModule { }

--- a/src/pages/debrief/cat-c/debrief.cat-c.page.ts
+++ b/src/pages/debrief/cat-c/debrief.cat-c.page.ts
@@ -1,0 +1,196 @@
+import { NavController, NavParams, Platform, IonicPage } from 'ionic-angular';
+import { Store, select } from '@ngrx/store';
+import { StoreModel } from '../../../shared/models/store.model';
+import { AuthenticationProvider } from '../../../providers/authentication/authentication';
+import { getCurrentTest, getJournalData } from '../../../modules/tests/tests.selector';
+import { DebriefViewDidEnter, EndDebrief } from '../debrief.actions';
+import { Observable } from 'rxjs/Observable';
+import { getTests } from '../../../modules/tests/tests.reducer';
+// TODO: MES-4287 use Cat C reducer
+import { getTestData } from '../../../modules/tests/test-data/cat-be/test-data.cat-be.reducer';
+import { getETA, getEco } from '../../../modules/tests/test-data/common/test-data.selector';
+import { map, tap, withLatestFrom } from 'rxjs/operators';
+import { Component } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
+import { merge } from 'rxjs/observable/merge';
+import { getTestOutcome } from '../debrief.selector';
+import { FaultSummary } from '../../../shared/models/fault-marking.model';
+import { ScreenOrientation } from '@ionic-native/screen-orientation';
+import { Insomnia } from '@ionic-native/insomnia';
+import { TranslateService } from 'ng2-translate';
+import { ETA, Eco } from '@dvsa/mes-test-schema/categories/Common';
+import {
+  getCommunicationPreference,
+} from '../../../modules/tests/communication-preferences/communication-preferences.reducer';
+import { getConductedLanguage } from
+  '../../../modules/tests/communication-preferences/communication-preferences.selector';
+// TODO: MES-4287 Import Cat C page names
+import { CAT_BE } from '../../page-names.constants';
+import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
+import { configureI18N } from '../../../shared/helpers/translation.helpers';
+import { BasePageComponent } from '../../../shared/classes/base-page';
+import { FaultCountProvider } from '../../../providers/fault-count/fault-count';
+import { getTestCategory } from '../../../modules/tests/category/category.reducer';
+import { TestCategory } from '@dvsa/mes-test-schema/categories/common/test-category';
+import { FaultSummaryProvider } from '../../../providers/fault-summary/fault-summary';
+import { getCandidate } from '../../../modules/tests/journal-data/candidate/candidate.reducer';
+import { getUntitledCandidateName } from '../../../modules/tests/journal-data/candidate/candidate.selector';
+
+interface DebriefPageState {
+  seriousFaults$: Observable<string[]>;
+  dangerousFaults$: Observable<string[]>;
+  drivingFaults$: Observable<FaultSummary[]>;
+  drivingFaultCount$: Observable<number>;
+  etaFaults$: Observable<ETA>;
+  ecoFaults$: Observable<Eco>;
+  testResult$: Observable<string>;
+  conductedLanguage$: Observable<string>;
+  candidateName$: Observable<string>;
+}
+
+@IonicPage()
+@Component({
+  selector: '.debrief-cat-c-page',
+  templateUrl: 'debrief.cat-c.page.html',
+})
+
+export class DebriefCatCPage extends BasePageComponent {
+
+  pageState: DebriefPageState;
+  subscription: Subscription;
+  isPassed: boolean;
+
+  // Used for now to test displaying pass/fail/terminated messages
+  public outcome: string;
+
+  public hasPhysicalEta: boolean = false;
+  public hasVerbalEta: boolean = false;
+
+  public adviceGivenControl: boolean = false;
+  public adviceGivenPlanning: boolean = false;
+
+  constructor(
+    public store$: Store<StoreModel>,
+    public navController: NavController,
+    public navParams: NavParams,
+    public platform: Platform,
+    public authenticationProvider: AuthenticationProvider,
+    public screenOrientation: ScreenOrientation,
+    public insomnia: Insomnia,
+    private translate: TranslateService,
+    private faultCountProvider: FaultCountProvider,
+    private faultSummaryProvider: FaultSummaryProvider,
+  ) {
+    super(platform, navController, authenticationProvider);
+  }
+
+  ngOnInit(): void {
+    const currentTest$ = this.store$.pipe(
+      select(getTests),
+      select(getCurrentTest),
+    );
+    const category$ = currentTest$.pipe(
+      select(getTestCategory),
+    );
+    this.pageState = {
+      seriousFaults$: currentTest$.pipe(
+        select(getTestData),
+        map(data =>
+          // TODO: MES-4287 Use category C
+          this.faultSummaryProvider.getSeriousFaultsList(data, TestCategory.BE)
+          .map(fault => fault.competencyIdentifier)),
+      ),
+      dangerousFaults$: currentTest$.pipe(
+        select(getTestData),
+        map(data =>
+          // TODO: MES-4287 Use category C
+          this.faultSummaryProvider.getDangerousFaultsList(data, TestCategory.BE)
+          .map(fault => fault.competencyIdentifier)),
+      ),
+      drivingFaults$: currentTest$.pipe(
+        select(getTestData),
+        // TODO: MES-4287 Use category C
+        map(data => this.faultSummaryProvider.getDrivingFaultsList(data, TestCategory.BE)),
+      ),
+      drivingFaultCount$: currentTest$.pipe(
+        select(getTestData),
+        withLatestFrom(category$),
+        map(([testData, category]) => {
+          return this.faultCountProvider.getDrivingFaultSumCount(category as TestCategory, testData);
+        }),
+      ),
+      etaFaults$: currentTest$.pipe(
+        select(getTestData),
+        select(getETA),
+      ),
+      ecoFaults$: currentTest$.pipe(
+        select(getTestData),
+        select(getEco),
+      ),
+      testResult$: currentTest$.pipe(
+        select(getTestOutcome),
+      ),
+      conductedLanguage$: currentTest$.pipe(
+        select(getCommunicationPreference),
+        select(getConductedLanguage),
+      ),
+      candidateName$: currentTest$.pipe(
+        select(getJournalData),
+        select(getCandidate),
+        select(getUntitledCandidateName),
+      ),
+    };
+
+    const { testResult$, etaFaults$, ecoFaults$, conductedLanguage$ } = this.pageState;
+
+    this.subscription = merge(
+      testResult$.pipe(map(result => this.outcome = result)),
+      etaFaults$.pipe(
+        map((eta) => {
+          this.hasPhysicalEta = eta.physical;
+          this.hasVerbalEta = eta.verbal;
+        }),
+      ),
+      ecoFaults$.pipe(
+        map((eco) => {
+          this.adviceGivenControl = eco.adviceGivenControl;
+          this.adviceGivenPlanning = eco.adviceGivenPlanning;
+        }),
+      ),
+      conductedLanguage$.pipe(tap(value => configureI18N(value as Language, this.translate))),
+    ).subscribe();
+  }
+
+  ionViewDidEnter(): void {
+    this.store$.dispatch(new DebriefViewDidEnter());
+  }
+
+  ionViewDidLeave(): void {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+
+    }
+  }
+
+  endDebrief(): void {
+    this.store$.dispatch(new EndDebrief());
+    if (this.outcome === 'Pass') {
+      // TODO: MES-4287 Redirect to CAT_C pass finalisation page
+      this.navController.push(CAT_BE.PASS_FINALISATION_PAGE);
+      return;
+    }
+    this.navController.push(CAT_BE.POST_DEBRIEF_HOLDING_PAGE).then(() => {
+      // TODO: MES-4287 Get view for CAT_C test report page
+      const testReportPage = this.navController.getViews().find(view => view.id === CAT_BE.TEST_REPORT_PAGE);
+      if (testReportPage) {
+        this.navController.removeView(testReportPage);
+      }
+      // TODO: MES-4287 Get view for CAT_C debrief page
+      const debriefPage = this.navController.getViews().find(view => view.id === CAT_BE.DEBRIEF_PAGE);
+      if (debriefPage) {
+        this.navController.removeView(debriefPage);
+      }
+    });
+  }
+
+}


### PR DESCRIPTION
## Description
Creates a placeholder page for the Category C Debrief page.
Please note:

- Test data still uses category BE. Sanitisation of the data will be addressed separately
- New Page name constants for category C will be created separately
- TODO comments have been added to help identify references to category BE which must be updated as part of the integration task: https://jira.dvsacloud.uk/browse/MES-4287

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
