### PR TITLE
mes-4254: Add back to office page

### DIFF
--- a/src/pages/back-to-office/cat-c/_tests_/back-to-office.cat-c.page.spec.ts
+++ b/src/pages/back-to-office/cat-c/_tests_/back-to-office.cat-c.page.spec.ts
@@ -1,0 +1,154 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { IonicModule, NavController, NavParams, Config, Platform } from 'ionic-angular';
+import { NavControllerMock, NavParamsMock, ConfigMock, PlatformMock } from 'ionic-mocks';
+
+import { AppModule } from '../../../../app/app.module';
+import { BackToOfficeCatCPage } from '../back-to-office.cat-c.page';
+import { AuthenticationProvider } from '../../../../providers/authentication/authentication';
+import { AuthenticationProviderMock } from '../../../../providers/authentication/__mocks__/authentication.mock';
+import { DateTimeProvider } from '../../../../providers/date-time/date-time';
+import { DateTimeProviderMock } from '../../../../providers/date-time/__mocks__/date-time.mock';
+import { StoreModule, Store } from '@ngrx/store';
+import { StoreModel } from '../../../../shared/models/store.model';
+import { ScreenOrientation } from '@ionic-native/screen-orientation';
+import { Insomnia } from '@ionic-native/insomnia';
+import { DeviceProvider } from '../../../../providers/device/device';
+import { DeviceProviderMock } from '../../../../providers/device/__mocks__/device.mock';
+import { InsomniaMock } from '../../../../shared/mocks/insomnia.mock';
+import { ScreenOrientationMock } from '../../../../shared/mocks/screen-orientation.mock';
+import { MockComponent } from 'ng-mocks';
+import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
+import { By } from '@angular/platform-browser';
+import { of } from 'rxjs/observable/of';
+
+describe('BackToOfficePage', () => {
+  let fixture: ComponentFixture<BackToOfficeCatCPage>;
+  let component: BackToOfficeCatCPage;
+  let navController: NavController;
+  let store$: Store<StoreModel>;
+  let screenOrientation: ScreenOrientation;
+  let insomnia: Insomnia;
+  let deviceProvider: DeviceProvider;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        BackToOfficeCatCPage,
+        MockComponent(PracticeModeBanner),
+      ],
+      imports: [
+        IonicModule,
+        AppModule,
+        StoreModule.forRoot({
+          tests: () => ({
+            currentTest: {
+              slotId: '123',
+            },
+            testStatus: {},
+            startedTests: {
+              123: {
+                vehicleDetails: {},
+                accompaniment: {},
+                testData: {
+                  dangerousFaults: {},
+                  drivingFaults: {},
+                  manoeuvres: {},
+                  seriousFaults: {},
+                  testRequirements: {},
+                  ETA: {},
+                  eco: {},
+                  vehicleChecks: {
+                    showMeQuestion: {
+                      code: 'S3',
+                      description: '',
+                      outcome: '',
+                    },
+                    tellMeQuestion: {
+                      code: '',
+                      description: '',
+                      outcome: '',
+                    },
+                  },
+                  eyesightTest: {},
+                },
+                activityCode: '28',
+                journalData: {
+                  candidate: {
+                    candidateName: 'Joe Bloggs',
+                    driverNumber: '123',
+                  },
+                },
+                rekey: false,
+              },
+            },
+          }),
+        }),
+      ],
+      providers: [
+        { provide: NavController, useFactory: () => NavControllerMock.instance() },
+        { provide: NavParams, useFactory: () => NavParamsMock.instance() },
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+        { provide: Platform, useFactory: () => PlatformMock.instance() },
+        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
+        { provide: DateTimeProvider, useClass: DateTimeProviderMock },
+        { provide: ScreenOrientation, useClass: ScreenOrientationMock },
+        { provide: Insomnia, useClass: InsomniaMock },
+        { provide: DeviceProvider, useClass: DeviceProviderMock },
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(BackToOfficeCatCPage);
+        component = fixture.componentInstance;
+        navController = TestBed.get(NavController);
+        screenOrientation = TestBed.get(ScreenOrientation);
+        insomnia = TestBed.get(Insomnia);
+        deviceProvider = TestBed.get(DeviceProvider);
+        store$ = TestBed.get(Store);
+        spyOn(store$, 'dispatch');
+      });
+  }));
+
+  describe('Class', () => {
+    describe('ionViewDidEnter', () => {
+      it('should disable test inhibitions when not in practice mode', () => {
+        component.ionViewDidEnter();
+        expect(deviceProvider.disableSingleAppMode).toHaveBeenCalled();
+        expect(screenOrientation.unlock).toHaveBeenCalled();
+        expect(insomnia.allowSleepAgain).toHaveBeenCalled();
+      });
+      it('should disable test inhibitions when in practice mode', () => {
+        component.isPracticeMode = true;
+        component.ionViewDidEnter();
+        expect(deviceProvider.disableSingleAppMode).not.toHaveBeenCalled();
+        expect(screenOrientation.unlock).toHaveBeenCalled();
+        expect(insomnia.allowSleepAgain).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('goToJournal', () => {
+    it('should call the popTo method in the navcontroller if not in practice mode', () => {
+      component.goToJournal();
+      expect(navController.popTo).toHaveBeenCalled();
+    });
+    it('should call the popTo method in the navcontroller if in practice mode', () => {
+      component.isPracticeMode = true;
+      component.goToJournal();
+      expect(navController.popTo).toHaveBeenCalled();
+    });
+  });
+
+  describe('DOM', () => {
+    it('should show the return to journal button when not a rekey', () => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('.bottom-button'))).toBeDefined();
+    });
+    it('should hide the return to journal button when this is a rekey', () => {
+      fixture.detectChanges();
+      component.pageState.isRekey$ = of(true);
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('.bottom-button'))).toBeNull();
+    });
+  });
+});

--- a/src/pages/back-to-office/cat-c/back-to-office.cat-c.page.html
+++ b/src/pages/back-to-office/cat-c/back-to-office.cat-c.page.html
@@ -1,0 +1,19 @@
+
+<ion-header>
+    <practice-mode-banner *ngIf="isPracticeMode"></practice-mode-banner>
+</ion-header>
+<ion-content no-bounce id="back-to-office-page">
+    <div class="container">
+        <img id='dvsa-logo' src='../../../assets/imgs/back-to-office/logo.png' />
+    </div>
+    <div class="container">
+        <button ion-button class="mes-neutral-button office-button top-button" (click)="goToOfficePage()" id="continue-to-write-up">
+            Continue to write up
+        </button>
+    </div>
+    <div class="container" *ngIf="!(pageState.isRekey$ | async)">
+        <button ion-button class="mes-neutral-button office-button bottom-button" (click)="goToJournal()">
+            Return to journal
+        </button>
+    </div>
+</ion-content>

--- a/src/pages/back-to-office/cat-c/back-to-office.cat-c.page.module.ts
+++ b/src/pages/back-to-office/cat-c/back-to-office.cat-c.page.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { ComponentsModule } from '../../../components/common/common-components.module';
+import { BackToOfficeCatCPage } from './back-to-office.cat-c.page';
+import { TranslateModule } from 'ng2-translate';
+import { EffectsModule } from '@ngrx/effects';
+import { BackToOfficeAnalyticsEffects } from '../back-to-office.analytics.effects';
+
+@NgModule({
+  declarations: [
+    BackToOfficeCatCPage,
+  ],
+  imports: [
+    IonicPageModule.forChild(BackToOfficeCatCPage),
+    EffectsModule.forFeature([
+      BackToOfficeAnalyticsEffects,
+    ]),
+    ComponentsModule,
+    TranslateModule,
+  ],
+})
+export class BackToOfficeCatCPageModule { }

--- a/src/pages/back-to-office/cat-c/back-to-office.cat-c.page.ts
+++ b/src/pages/back-to-office/cat-c/back-to-office.cat-c.page.ts
@@ -1,0 +1,85 @@
+import { Component } from '@angular/core';
+import { IonicPage, NavController, NavParams, Platform } from 'ionic-angular';
+import { PracticeableBasePageComponent } from '../../../shared/classes/practiceable-base-page';
+import { AuthenticationProvider } from '../../../providers/authentication/authentication';
+import { Store, select } from '@ngrx/store';
+import { StoreModel } from '../../../shared/models/store.model';
+import { BackToOfficeViewDidEnter, DeferWriteUp } from '../back-to-office.actions';
+import { DeviceProvider } from '../../../providers/device/device';
+import { ScreenOrientation } from '@ionic-native/screen-orientation';
+import { Insomnia } from '@ionic-native/insomnia';
+import { JOURNAL_PAGE } from '../../page-names.constants';
+import { Observable } from 'rxjs/Observable';
+import { getTests } from '../../../modules/tests/tests.reducer';
+import { getCurrentTest } from '../../../modules/tests/tests.selector';
+import { getRekeyIndicator } from '../../../modules/tests/rekey/rekey.reducer';
+import { isRekey } from '../../../modules/tests/rekey/rekey.selector';
+// TODO: MES-4287 Import Cat C page names
+import { CAT_BE } from '../../../pages/page-names.constants';
+
+interface BackToOfficePageState {
+  isRekey$: Observable<boolean>;
+}
+
+@IonicPage()
+@Component({
+  selector: '.back-to-office-cat-c-page',
+  templateUrl: 'back-to-office.cat-c.page.html',
+})
+export class BackToOfficeCatCPage extends PracticeableBasePageComponent {
+  pageState: BackToOfficePageState;
+
+  constructor(
+    store$: Store<StoreModel>,
+    private deviceProvider: DeviceProvider,
+    public navController: NavController,
+    public navParams: NavParams,
+    public platform: Platform,
+    public authenticationProvider: AuthenticationProvider,
+    public screenOrientation: ScreenOrientation,
+    public insomnia: Insomnia,
+  ) {
+    super(platform, navController, authenticationProvider, store$);
+  }
+
+  ngOnInit(): void {
+    super.ngOnInit();
+
+    this.pageState = {
+      isRekey$: this.store$.pipe(
+        select(getTests),
+        select(getCurrentTest),
+        select(getRekeyIndicator),
+        select(isRekey),
+      ),
+    };
+  }
+
+  ionViewDidEnter(): void {
+    if (super.isIos()) {
+      this.screenOrientation.unlock();
+      this.insomnia.allowSleepAgain();
+
+      if (!this.isPracticeMode) {
+        this.deviceProvider.disableSingleAppMode();
+      }
+    }
+
+    this.store$.dispatch(new BackToOfficeViewDidEnter());
+  }
+
+  goToJournal() {
+    if (this.isPracticeMode) {
+      this.exitPracticeMode();
+      return;
+    }
+    this.store$.dispatch(new DeferWriteUp());
+    const journalPage = this.navController.getViews().find(view => view.id === JOURNAL_PAGE);
+    this.navController.popTo(journalPage);
+  }
+
+  goToOfficePage() {
+     // TODO: MES-4287 Redirect to CAT_C office page
+    this.navController.push(CAT_BE.OFFICE_PAGE);
+  }
+}


### PR DESCRIPTION
## Description
Creates a placeholder page for the Category C Back to Office page.
Please note:

- Any test data still uses category BE. Sanitisation of the data will be addressed separately
- New Page name constants for category C will be created separately
- TODO comments have been added to help identify references to category BE which must be updated as part of the integration task: https://jira.dvsacloud.uk/browse/MES-4287

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
