### PR TITLE
Mes 4290 use cat c page names

### DIFF
--- a/src/pages/back-to-office/cat-c/back-to-office.cat-c.page.ts
+++ b/src/pages/back-to-office/cat-c/back-to-office.cat-c.page.ts
@@ -14,8 +14,7 @@ import { getTests } from '../../../modules/tests/tests.reducer';
 import { getCurrentTest } from '../../../modules/tests/tests.selector';
 import { getRekeyIndicator } from '../../../modules/tests/rekey/rekey.reducer';
 import { isRekey } from '../../../modules/tests/rekey/rekey.selector';
-// TODO: MES-4287 Import Cat C page names
-import { CAT_BE } from '../../../pages/page-names.constants';
+import { CAT_C } from '../../../pages/page-names.constants';
 
 interface BackToOfficePageState {
   isRekey$: Observable<boolean>;
@@ -79,7 +78,6 @@ export class BackToOfficeCatCPage extends PracticeableBasePageComponent {
   }
 
   goToOfficePage() {
-     // TODO: MES-4287 Redirect to CAT_C office page
-    this.navController.push(CAT_BE.OFFICE_PAGE);
+    this.navController.push(CAT_C.OFFICE_PAGE);
   }
 }

--- a/src/pages/debrief/cat-c/__tests__/debrief.cat-c.page.spec.ts
+++ b/src/pages/debrief/cat-c/__tests__/debrief.cat-c.page.spec.ts
@@ -34,8 +34,7 @@ import { PopulateTestSlotAttributes }
   from '../../../../modules/tests/journal-data/test-slot-attributes/test-slot-attributes.actions';
 import { EndDebrief } from '../../debrief.actions';
 import * as welshTranslations from '../../../../assets/i18n/cy.json';
-// TODO: MES-4287 Import Cat C page names
-import { CAT_BE } from '../../../page-names.constants';
+import { CAT_C } from '../../../page-names.constants';
 import { Language } from '../../../../modules/tests/communication-preferences/communication-preferences.model';
 import { configureI18N } from '../../../../shared/helpers/translation.helpers';
 import { TestCategory } from '@dvsa/mes-test-schema/categories/common/test-category';
@@ -219,20 +218,17 @@ describe('DebriefCatCPage', () => {
     it('should navigate to PassFinalisationPage when outcome = pass', () => {
       component.outcome = 'Pass';
       component.endDebrief();
-      // TODO: MES-4287 Use Cat C page names
-      expect(navController.push).toHaveBeenCalledWith(CAT_BE.PASS_FINALISATION_PAGE);
+      expect(navController.push).toHaveBeenCalledWith(CAT_C.PASS_FINALISATION_PAGE);
     });
     it('should navigate to BackToOfficePage when outcome = fail', () => {
       component.outcome = 'Fail';
       component.endDebrief();
-      // TODO: MES-4287 Use Cat C page names
-      expect(navController.push).toHaveBeenCalledWith(CAT_BE.POST_DEBRIEF_HOLDING_PAGE);
+      expect(navController.push).toHaveBeenCalledWith(CAT_C.POST_DEBRIEF_HOLDING_PAGE);
     });
     it('should navigate to the BackToOfficePage when outcomes = terminated', () => {
       component.outcome = 'Terminated';
       component.endDebrief();
-      // TODO: MES-4287 Use Cat C page names
-      expect(navController.push).toHaveBeenCalledWith(CAT_BE.POST_DEBRIEF_HOLDING_PAGE);
+      expect(navController.push).toHaveBeenCalledWith(CAT_C.POST_DEBRIEF_HOLDING_PAGE);
     });
   });
 

--- a/src/pages/debrief/cat-c/debrief.cat-c.page.ts
+++ b/src/pages/debrief/cat-c/debrief.cat-c.page.ts
@@ -24,8 +24,7 @@ import {
 } from '../../../modules/tests/communication-preferences/communication-preferences.reducer';
 import { getConductedLanguage } from
   '../../../modules/tests/communication-preferences/communication-preferences.selector';
-// TODO: MES-4287 Import Cat C page names
-import { CAT_BE } from '../../page-names.constants';
+import { CAT_C } from '../../page-names.constants';
 import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
 import { configureI18N } from '../../../shared/helpers/translation.helpers';
 import { BasePageComponent } from '../../../shared/classes/base-page';
@@ -175,18 +174,15 @@ export class DebriefCatCPage extends BasePageComponent {
   endDebrief(): void {
     this.store$.dispatch(new EndDebrief());
     if (this.outcome === 'Pass') {
-      // TODO: MES-4287 Redirect to CAT_C pass finalisation page
-      this.navController.push(CAT_BE.PASS_FINALISATION_PAGE);
+      this.navController.push(CAT_C.PASS_FINALISATION_PAGE);
       return;
     }
-    this.navController.push(CAT_BE.POST_DEBRIEF_HOLDING_PAGE).then(() => {
-      // TODO: MES-4287 Get view for CAT_C test report page
-      const testReportPage = this.navController.getViews().find(view => view.id === CAT_BE.TEST_REPORT_PAGE);
+    this.navController.push(CAT_C.POST_DEBRIEF_HOLDING_PAGE).then(() => {
+      const testReportPage = this.navController.getViews().find(view => view.id === CAT_C.TEST_REPORT_PAGE);
       if (testReportPage) {
         this.navController.removeView(testReportPage);
       }
-      // TODO: MES-4287 Get view for CAT_C debrief page
-      const debriefPage = this.navController.getViews().find(view => view.id === CAT_BE.DEBRIEF_PAGE);
+      const debriefPage = this.navController.getViews().find(view => view.id === CAT_C.DEBRIEF_PAGE);
       if (debriefPage) {
         this.navController.removeView(debriefPage);
       }

--- a/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.html
+++ b/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.html
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-navbar>
-    <ion-title>Finalise outcome BE - {{ pageState.candidateName$ | async }}</ion-title>
+    <ion-title>Finalise outcome C - {{ pageState.candidateName$ | async }}</ion-title>
   </ion-navbar>
 </ion-header>
 

--- a/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.ts
+++ b/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.ts
@@ -3,8 +3,7 @@ import { IonicPage, NavController, Platform } from 'ionic-angular';
 import { AuthenticationProvider } from '../../../providers/authentication/authentication';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../../shared/models/store.model';
-// TODO: MES-4287 Import Cat C page names
-import { CAT_BE } from '../../page-names.constants';
+import { CAT_C } from '../../page-names.constants';
 import { Observable } from 'rxjs/Observable';
 import { getTests } from '../../../modules/tests/tests.reducer';
 import {
@@ -195,8 +194,7 @@ export class NonPassFinalisationCatCPage extends BasePageComponent implements On
     if (this.form.valid) {
       this.store$.dispatch(new SetTestStatusWriteUp(this.slotId));
       this.store$.dispatch(new PersistTests());
-      // TODO: MES-4287 Redirect to CAT_C office page
-      this.navController.push(CAT_BE.BACK_TO_OFFICE_PAGE);
+      this.navController.push(CAT_C.BACK_TO_OFFICE_PAGE);
       return;
     }
     Object.keys(this.form.controls).forEach((controlName) => {

--- a/src/pages/office/cat-c/office.cat-c.page.ts
+++ b/src/pages/office/cat-c/office.cat-c.page.ts
@@ -93,8 +93,7 @@ import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 import { startsWith } from 'lodash';
 import { getRekeyIndicator } from '../../../modules/tests/rekey/rekey.reducer';
 import { isRekey } from '../../../modules/tests/rekey/rekey.selector';
-// TODO: MES-4287 Import Cat C page names
-import { CAT_BE, JOURNAL_PAGE } from '../../page-names.constants';
+import { CAT_C, JOURNAL_PAGE } from '../../page-names.constants';
 import { SetActivityCode } from '../../../modules/tests/activity-code/activity-code.actions';
 import { TestCategory } from '@dvsa/mes-test-schema/categories/common/test-category';
 import {
@@ -559,8 +558,7 @@ export class OfficeCatCPage extends BasePageComponent {
 
   goToReasonForRekey() {
     if (this.isFormValid()) {
-      // TODO: MES-4287 Redirect to CAT_C rekey reason page
-      this.navController.push(CAT_BE.REKEY_REASON_PAGE);
+      this.navController.push(CAT_C.REKEY_REASON_PAGE);
     }
   }
 

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
@@ -43,8 +43,7 @@ import {
   isManual,
 } from '../../../modules/tests/vehicle-details/vehicle-details.selector';
 import { GearboxCategoryChanged } from '../../../modules/tests/vehicle-details/vehicle-details.actions';
-// TODO: MES-4287 Import Cat C page names
-import { CAT_BE } from '../../page-names.constants';
+import { CAT_C } from '../../page-names.constants';
 import { getTestSummary } from '../../../modules/tests/test-summary/test-summary.reducer';
 import { isDebriefWitnessed, getD255 } from '../../../modules/tests/test-summary/test-summary.selector';
 import {
@@ -229,8 +228,7 @@ export class PassFinalisationCatCPage extends BasePageComponent {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
       this.store$.dispatch(new PersistTests());
-      // TODO: MES-4287 Redirect to CAT_C health declaration page
-      this.navController.push(CAT_BE.HEALTH_DECLARATION_PAGE);
+      this.navController.push(CAT_C.HEALTH_DECLARATION_PAGE);
       return;
     }
     Object.keys(this.form.controls).forEach((controlName) => {


### PR DESCRIPTION
## Description
Switch the use of page name constants from CAT_BE to CAT_C on the post test pages.

Please note:

- Test data still uses category BE. Sanitisation of the data will be addressed separately

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
