### PR TITLE
Fix-3878: reinstate transmission validation

### DIFF
--- a/src/pages/pass-finalisation/cat-b/_tests_/pass-finalisation.cat-b.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-b/_tests_/pass-finalisation.cat-b.page.spec.ts
@@ -37,6 +37,7 @@ import { TransmissionComponent } from '../../../../components/common/transmissio
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { PASS_CERTIFICATE_NUMBER_CTRL }
   from '../../components/pass-certificate-number/pass-certificate-number.constants';
+import { Subscription } from 'rxjs/Subscription';
 
 describe('PassFinalisationCatBPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatBPage>;
@@ -71,6 +72,7 @@ describe('PassFinalisationCatBPage', () => {
       .then(() => {
         fixture = TestBed.createComponent(PassFinalisationCatBPage);
         component = fixture.componentInstance;
+        component.subscription = new Subscription();
         store$ = TestBed.get(Store);
         spyOn(store$, 'dispatch');
       });

--- a/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.html
+++ b/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.html
@@ -27,7 +27,8 @@
           (licenseNotReceived)="provisionalLicenseNotReceived()"> </license-provided>
 
         <transmission [formGroup]="form" (transmissionChange)="transmissionChanged($event)"></transmission>
-        <warning-banner *ngIf="pageState.transmissionAutomaticRadioChecked$ | async" warningText="An automatic licence will be issued."></warning-banner>
+        <warning-banner *ngIf="displayTransmissionBanner()" warningText="An automatic licence will be issued.">
+        </warning-banner>
 
         <pass-certificate-number [form]="form" (passCertificateNumberChange)="passCertificateNumberChanged($event)"></pass-certificate-number>
 

--- a/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.ts
+++ b/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.ts
@@ -216,10 +216,10 @@ export class PassFinalisationCatBPage extends PracticeableBasePageComponent {
   }
 
   ionViewDidEnter(): void {
+    this.store$.dispatch(new PassFinalisationViewDidEnter());
     if (this.subscription.closed && this.merged$) {
       this.subscription = this.merged$.subscribe();
     }
-    this.store$.dispatch(new PassFinalisationViewDidEnter());
   }
 
   provisionalLicenseReceived(): void {

--- a/src/pages/pass-finalisation/cat-be/_tests_/pass-finalisation.cat-be.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-be/_tests_/pass-finalisation.cat-be.page.spec.ts
@@ -37,6 +37,7 @@ import { TransmissionComponent } from '../../../../components/common/transmissio
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { PASS_CERTIFICATE_NUMBER_CTRL }
   from '../../components/pass-certificate-number/pass-certificate-number.constants';
+import { Subscription } from 'rxjs/Subscription';
 
 describe('PassFinalisationCatBEPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatBEPage>;
@@ -71,6 +72,7 @@ describe('PassFinalisationCatBEPage', () => {
       .then(() => {
         fixture = TestBed.createComponent(PassFinalisationCatBEPage);
         component = fixture.componentInstance;
+        component.subscription = new Subscription();
         store$ = TestBed.get(Store);
         spyOn(store$, 'dispatch');
       });

--- a/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.html
+++ b/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.html
@@ -26,8 +26,8 @@
           (licenseNotReceived)="provisionalLicenseNotReceived()"> </license-provided>
 
         <transmission [formGroup]="form" (transmissionChange)="transmissionChanged($event)"></transmission>
-        <warning-banner *ngIf="pageState.transmissionAutomaticRadioChecked$ | async"
-          warningText="An automatic licence will be issued."></warning-banner>
+        <warning-banner *ngIf="displayTransmissionBanner()" warningText="An automatic licence will be issued.">
+          </warning-banner>
 
         <pass-certificate-number [form]="form" (passCertificateNumberChange)="passCertificateNumberChanged($event)"></pass-certificate-number>
 

--- a/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.ts
+++ b/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.ts
@@ -217,10 +217,10 @@ export class PassFinalisationCatBEPage extends BasePageComponent {
   }
 
   ionViewDidEnter(): void {
+    this.store$.dispatch(new PassFinalisationViewDidEnter());
     if (this.subscription.closed && this.merged$) {
       this.subscription = this.merged$.subscribe();
     }
-    this.store$.dispatch(new PassFinalisationViewDidEnter());
   }
 
   provisionalLicenseReceived(): void {


### PR DESCRIPTION
## Description
- Reinstate validation for `transmission` component on `pass-finalisation.cat-b` and `pass-finalisation.cat-be`.
- Display `warning-banner-component` based on result of boolean function `displayTransmissionBanner()`
## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="496" alt="Screenshot 2019-12-16 at 16 32 02" src="https://user-images.githubusercontent.com/30832405/70945259-b2f18f00-204c-11ea-8b09-d94157b2945b.png">

<img width="496" alt="Screenshot 2019-12-16 at 16 32 11" src="https://user-images.githubusercontent.com/30832405/70945268-b71dac80-204c-11ea-9a63-8b1edb3e1935.png">

<img width="496" alt="Screenshot 2019-12-16 at 16 32 17" src="https://user-images.githubusercontent.com/30832405/70945277-bbe26080-204c-11ea-8893-c9e0fdb43778.png">
