### PR TITLE
fix vehicle checks css

### DIFF
--- a/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks/vehicle-checks.scss
+++ b/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks/vehicle-checks.scss
@@ -8,7 +8,8 @@ vehicle-checks-cat-be {
     .vehicle-checks-result {
       font-weight: 600;
       font-size: 23px;
-    } 
+      align-items: center;
+    }
 
     .serious-fault-row {
       margin-bottom: 8px;
@@ -30,12 +31,10 @@ vehicle-checks-cat-be {
   }
 
   ion-icon {
-    padding-left: 6px;
-    padding-right: 10px;
     font-size: 14px;
     font-weight: bold;
   }
-  
+
   .see-answer-link-container {
     text-align: right;
     padding-right: 24px;
@@ -44,5 +43,5 @@ vehicle-checks-cat-be {
   .small-top-margin {
     margin-top: 24px;
   }
-  
+
 }


### PR DESCRIPTION
## Description
Small CSS fix for alignment of items within Vehicle Checks within B+E WRTC page

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (iOS)

Before
![Screenshot 2019-12-17 at 10 59 15](https://user-images.githubusercontent.com/33055124/70990941-778fa880-20be-11ea-85e5-ba21aa9386dd.png)

After
![Screenshot 2019-12-17 at 11 04 12](https://user-images.githubusercontent.com/33055124/70990959-7eb6b680-20be-11ea-84a9-7b4de9c99493.png)


