### PR TITLE
Enable Redux Remote Devtools for iOS Simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ fastlane/report.xml
 test/e2e/test.config.ts
 mock/local-journal.json
 mock/local-journal-non-test-activities.json
+remotedev-server/
 
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ DVSA Mobile Examiner Services (GDS Beta phase)
 #### Serve with local data
 - `npm run serve:local` (This will take the files in `/mock/` and serve them. You can edit them in `src/assets/mock` after running the command, this will live reload the UI with the new updated mock data. To point the app to different mock data, edit the `environment/environment.local.ts` file)
 
+### Serve to iOS Emulator with livereload and Redux Remote Devtools
+
+Run the following in separate terminals:
+
+- `npm run remote-devtools-server`
+- `npm run serve:emulator` (Note: you must have simulator / iOS version specified in the `package.json` file installed via Xcode)
+
+To open Redux Remote Devtools:
+
+- install the [Chrome Redux Devtools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en) extension if not already installed
+- right click the icon in your browser toolbar and select 'Open Remote Devtools'
+- on first launch, you will need to update the settings as follows
+    - select use custom (local) 
+    - set the host name to `localhost`
+    - set the port to `8000`
+
 ### Mac users
 
 To run the app in the simulator with live code reload, run the following:

--- a/bin/remote-devtools-server.sh
+++ b/bin/remote-devtools-server.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ ! -d "remotedev-server" ] ; then
+    git clone https://github.com/somq/remotedev-server.git
+    cd remotedev-server && npm i && node bin/remotedev.js --hostname=localhost --port=8000 --wsEngine=ws --logLevel=3
+else
+    cd remotedev-server && node bin/remotedev.js --hostname=localhost --port=8000 --wsEngine=ws --logLevel=3
+fi

--- a/ngrx-devtool-proxy/remote-devtools-connection-proxy.ts
+++ b/ngrx-devtool-proxy/remote-devtools-connection-proxy.ts
@@ -1,0 +1,30 @@
+import { ReduxDevtoolsExtensionConnection } from '@ngrx/store-devtools/src/extension';
+
+export class RemoteDevToolsConnectionProxy implements ReduxDevtoolsExtensionConnection {
+  constructor(public remotedev: any, public instanceId: string) {}
+  init() {}
+  error() {}
+
+  subscribe(listener: (change: any) => void): any {
+    const listenerWrapper = (change: any) => {
+      console.log(`change: `, change);
+      listener(change);
+    };
+
+    this.remotedev.subscribe(listenerWrapper);
+    // Hack fix for commit/time-travelling etc. if the devtools are already open
+    setTimeout(() => listenerWrapper({ type: 'START' }));
+  }
+
+  unsubscribe(): any {
+    // HACK fix bug in @ngrx/store-devtools that calls this instead of returning
+    // a lambda that calls it when their Observable wrapper is unsubscribed.
+    return () => this.remotedev.unsubscribe(this.instanceId);
+  }
+
+  send(action: any, state: any): any {
+    // Was commented has 'Not Called' but it's appear
+    // we finally need this to send back responses to Redux DevTools
+    this.remotedev.send(action, state);
+  }
+}

--- a/ngrx-devtool-proxy/remote-devtools-proxy.ts
+++ b/ngrx-devtool-proxy/remote-devtools-proxy.ts
@@ -1,10 +1,10 @@
 import {
   ReduxDevtoolsExtension,
   ReduxDevtoolsExtensionConnection,
-  ReduxDevtoolsExtensionConfig
+  ReduxDevtoolsExtensionConfig,
 } from '@ngrx/store-devtools/src/extension';
-import {RemoteDevToolsConnectionProxy} from './remote-devtools-connection-proxy';
-import {connect} from 'remotedev/lib/devTools';
+import { RemoteDevToolsConnectionProxy } from './remote-devtools-connection-proxy';
+import { connect } from 'remotedev/lib/devTools';
 
 export class RemoteDevToolsProxy implements ReduxDevtoolsExtension {
   remotedev: any = null;

--- a/ngrx-devtool-proxy/remote-devtools-proxy.ts
+++ b/ngrx-devtool-proxy/remote-devtools-proxy.ts
@@ -1,0 +1,51 @@
+import {
+  ReduxDevtoolsExtension,
+  ReduxDevtoolsExtensionConnection,
+  ReduxDevtoolsExtensionConfig
+} from '@ngrx/store-devtools/src/extension';
+import {RemoteDevToolsConnectionProxy} from './remote-devtools-connection-proxy';
+import {connect} from 'remotedev/lib/devTools';
+
+export class RemoteDevToolsProxy implements ReduxDevtoolsExtension {
+  remotedev: any = null;
+  defaultOptions = {
+    realtime: true,
+    // Needs to match what you run `remotedev` command with and
+    // what you setup in remote devtools local connection settings
+    hostname: 'localhost',
+    port: 8000,
+    autoReconnect: true,
+    connectTimeout: 20000,
+    ackTimeout: 10000,
+    secure: true,
+  };
+
+  constructor(defaultOptions: Object) {
+    this.defaultOptions = Object.assign(this.defaultOptions, defaultOptions);
+  }
+
+  connect(options: {
+    shouldStringify?: boolean;
+    instanceId: string;
+  }): ReduxDevtoolsExtensionConnection {
+    const connectOptions = Object.assign(this.defaultOptions, options);
+
+    this.remotedev = connect(connectOptions);
+
+    const connectionProxy = new RemoteDevToolsConnectionProxy(
+      this.remotedev,
+      connectOptions.instanceId,
+    );
+    return connectionProxy;
+  }
+
+  send(
+    action: any,
+    state: any,
+    options: ReduxDevtoolsExtensionConfig,
+    // shouldStringify?: boolean,
+    instanceId?: string,
+  ): any {
+    this.remotedev.send(action, state);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8298,6 +8298,12 @@
         }
       }
     },
+    "base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs=",
+      "dev": true
+    },
     "base64-arraybuffer": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
@@ -15721,6 +15727,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsan": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/jsan/-/jsan-3.1.13.tgz",
+      "integrity": "sha512-9kGpCsGHifmw6oJet+y8HaCl14y7qgAsxVdV3pCHDySNR3BfDC30zgkssd7x5LRVAT22dnpbe9JdzzmXZnq9/g==",
+      "dev": true
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -16675,6 +16687,12 @@
       "requires": {
         "immediate": "~3.0.5"
       }
+    },
+    "linked-list": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/linked-list/-/linked-list-0.1.0.tgz",
+      "integrity": "sha1-eYsP+X0bkqT9CEgPVa6k6dSdN78=",
+      "dev": true
     },
     "livereload-js": {
       "version": "2.4.0",
@@ -22216,6 +22234,18 @@
         "xtend": "^4.0.1"
       }
     },
+    "remotedev": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/remotedev/-/remotedev-0.2.9.tgz",
+      "integrity": "sha512-W8dHOv9BcFnetFEd08yNb5O9Hd+zkTFFnf9FRjNCkb4u+JgQ/U152Aw4q83AmY3m34d6KZwhK5ip/Qc331+4vA==",
+      "dev": true,
+      "requires": {
+        "jsan": "^3.1.3",
+        "querystring": "^0.2.0",
+        "rn-host-detect": "^1.0.1",
+        "socketcluster-client": "^13.0.0"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -22445,6 +22475,12 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "rn-host-detect": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.1.5.tgz",
+      "integrity": "sha512-ufk2dFT3QeP9HyZ/xTuMtW27KnFy815CYitJMqQm+pgG3ZAtHBsrU8nXizNKkqXGy3bQmhEoloVbrfbvMJMqkg==",
+      "dev": true
     },
     "rollup": {
       "version": "0.50.0",
@@ -22898,6 +22934,27 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "sc-channel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.2.0.tgz",
+      "integrity": "sha512-M3gdq8PlKg0zWJSisWqAsMmTVxYRTpVRqw4CWAdKBgAfVKumFcTjoCV0hYu7lgUXccCtCD8Wk9VkkE+IXCxmZA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1"
+      }
+    },
+    "sc-errors": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.4.1.tgz",
+      "integrity": "sha512-dBn92iIonpChTxYLgKkIT/PCApvmYT6EPIbRvbQKTgY6tbEbIy8XVUv4pGyKwEK4nCmvX4TKXcN0iXC6tNW6rQ==",
+      "dev": true
+    },
+    "sc-formatter": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sc-formatter/-/sc-formatter-3.0.2.tgz",
+      "integrity": "sha512-9PbqYBpCq+OoEeRQ3QfFIGE6qwjjBcd2j7UjgDlhnZbtSnuGgHdcRklPKYGuYFH82V/dwd+AIpu8XvA1zqTd+A==",
       "dev": true
     },
     "schema-utils": {
@@ -23443,6 +23500,47 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
+        }
+      }
+    },
+    "socketcluster-client": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-13.0.1.tgz",
+      "integrity": "sha512-hxiE2xz6mgaBlhXbtBa4POgWVEvIcjCoHzf5LTUVhI9IL8V2ltV3Ze8pQsi9egqTjSz4RHPfyrJ7BiETe5Kthw==",
+      "dev": true,
+      "requires": {
+        "base-64": "0.1.0",
+        "clone": "2.1.1",
+        "component-emitter": "1.2.1",
+        "linked-list": "0.1.0",
+        "querystring": "0.2.0",
+        "sc-channel": "^1.2.0",
+        "sc-errors": "^1.4.0",
+        "sc-formatter": "^3.0.1",
+        "uuid": "3.2.1",
+        "ws": "5.1.1"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+          "dev": true
+        },
+        "ws": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
+          "integrity": "sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://github.com/dvsa/mes-mobile-app",
   "private": true,
   "scripts": {
+    "remote-devtools-server": "./bin/remote-devtools-server.sh",
     "clean": "ionic-app-scripts clean",
     "bootstrap": "json2ts schema/schemaExaminerSchedule.json > src/shared/models/DJournal.ts",
     "schema-version": "buildScripts/generate-test-schema-version.js",
@@ -17,6 +18,7 @@
     "ionic:build": "ionic-app-scripts build",
     "ionic:serve": "ionic-app-scripts serve",
     "serve:local": "run-s update-mock-data copy-mock-data schema-version config:local ionic:serve",
+    "serve:emulator": "npm run config:dev-tools && ionic cordova emulate ios --address=localhost --l --c -- --buildFlag='-UseModernBuildSystem=0' -lc --target='iPad-Pro--10-5-inch-,com.apple.CoreSimulator.SimRuntime.iOS-12-4'",
     "ionic:deploy": "git push ionic master",
     "format:all": "npx prettier --write \"src/**/*{.ts,.js,.json,.css,.scss}\"",
     "prepush": "run-s lint test gitSecrets scanRepo",
@@ -32,6 +34,7 @@
     "gitSecrets": "git secrets --scan",
     "scanRepo": "git log -p -n 15 | scanrepo",
     "stylelint": "stylelint 'src/**/*.scss' fix --config stylelint.json",
+    "config:dev-tools": "cp src/environment/environment.dev.dev-tools.ts src/environment/environment.ts",
     "config:dev": "cp src/environment/environment.dev.ts src/environment/environment.ts",
     "config:perf": "cp src/environment/environment.perf.ts src/environment/environment.ts",
     "config:uat": "cp src/environment/environment.uat.ts src/environment/environment.ts",
@@ -41,8 +44,7 @@
     "copy-mock-data": "cp -r mock/ src/assets/mock/",
     "update-mock-data": "npm run update-mock-data:journal && npm run update-mock-data:nta",
     "update-mock-data:journal": "ts-node -P tsconfig.scripts.json mock/generate-local-journal.ts",
-    "update-mock-data:nta": "ts-node -P tsconfig.scripts.json mock/generate-local-journal-non-test-activities.ts",
-    "livereload": "ionic cordova emulate ios --address=localhost --l --c -- --buildFlag='-UseModernBuildSystem=0' -lc --target='iPad-Pro--10-5-inch-,com.apple.CoreSimulator.SimRuntime.iOS-12-4'"
+    "update-mock-data:nta": "ts-node -P tsconfig.scripts.json mock/generate-local-journal-non-test-activities.ts"
   },
   "dependencies": {
     "@angular/animations": "5.2.11",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "copy-mock-data": "cp -r mock/ src/assets/mock/",
     "update-mock-data": "npm run update-mock-data:journal && npm run update-mock-data:nta",
     "update-mock-data:journal": "ts-node -P tsconfig.scripts.json mock/generate-local-journal.ts",
-    "update-mock-data:nta": "ts-node -P tsconfig.scripts.json mock/generate-local-journal-non-test-activities.ts"
+    "update-mock-data:nta": "ts-node -P tsconfig.scripts.json mock/generate-local-journal-non-test-activities.ts",
+    "livereload": "ionic cordova emulate ios --address=localhost --l --c -- --buildFlag='-UseModernBuildSystem=0' -lc --target='iPad-Pro--10-5-inch-,com.apple.CoreSimulator.SimRuntime.iOS-12-4'"
   },
   "dependencies": {
     "@angular/animations": "5.2.11",
@@ -161,6 +162,7 @@
     "null-loader": "^0.1.1",
     "protractor": "^5.4.1",
     "protractor-cucumber-framework": "^6.1.1",
+    "remotedev": "^0.2.9",
     "request": "^2.88.0",
     "rxjs-tslint-rules": "^4.14.3",
     "semver": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "serve:emulator": "npm run config:dev-tools && ionic cordova emulate ios --address=localhost --l --c -- --buildFlag='-UseModernBuildSystem=0' -lc --target='iPad-Pro--10-5-inch-,com.apple.CoreSimulator.SimRuntime.iOS-12-4'",
     "ionic:deploy": "git push ionic master",
     "format:all": "npx prettier --write \"src/**/*{.ts,.js,.json,.css,.scss}\"",
-    "prepush": "run-s lint test gitSecrets scanRepo",
+    "prepush": "run-s lint config:dev test gitSecrets scanRepo",
     "precommit": "run-s lint:fix lint compile-no-emit",
     "test": "npm run update-mock-data && npm run schema-version && npm run test:jasmine",
     "test:jasmine": "karma start ./test-config/karma.conf.js",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -47,12 +47,27 @@ import { SchemaValidatorProvider } from '../providers/schema-validator/schema-va
 import {
   PassCertificateValidationProvider,
 } from '../providers/pass-certificate-validation/pass-certificate-validation';
+import { RemoteDevToolsProxy } from '../../ngrx-devtool-proxy/remote-devtools-proxy';
 
 export function createTranslateLoader(http: Http) {
   return new TranslateStaticLoader(http, 'assets/i18n', '.json');
 }
 
 const enableDevTools = environment && environment.enableDevTools;
+
+// Register our remote devtools if we're on-device and not in a browser and dev tools enabled
+if (!window['devToolsExtension'] && !window['__REDUX_DEVTOOLS_EXTENSION__'] && enableDevTools) {
+  const remoteDevToolsProxy = new RemoteDevToolsProxy({
+    connectTimeout: 300000, // extend for pauses during debugging
+    ackTimeout: 120000, // extend for pauses during debugging
+    secure: false, // dev only
+  });
+
+  // support both the legacy and new keys, for now
+  window['devToolsExtension'] = remoteDevToolsProxy;
+  window['__REDUX_DEVTOOLS_EXTENSION__'] = remoteDevToolsProxy;
+  console.log(`window: `, window);
+}
 
 @NgModule({
   declarations: [App],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -66,7 +66,6 @@ if (!window['devToolsExtension'] && !window['__REDUX_DEVTOOLS_EXTENSION__'] && e
   // support both the legacy and new keys, for now
   window['devToolsExtension'] = remoteDevToolsProxy;
   window['__REDUX_DEVTOOLS_EXTENSION__'] = remoteDevToolsProxy;
-  console.log(`window: `, window);
 }
 
 @NgModule({

--- a/src/environment/environment.dev.dev-tools.ts
+++ b/src/environment/environment.dev.dev-tools.ts
@@ -1,0 +1,20 @@
+import { MdmConfig } from '@dvsa/mes-config-schema/mdm-config';
+
+export const environment: MdmConfig = {
+  isRemote: true,
+  configUrl: 'https://dev.mes.dev-dvsacloud.uk/v1/configuration/dev',
+  daysToCacheLogs: 7,
+  enableDevTools: true,
+  logoutClearsTestPersistence: true,
+  logsPostApiKey: '',
+  logsApiUrl: 'https://dev.mes.dev-dvsacloud.uk/v1/logs',
+  logsAutoSendInterval: 6000,
+  authentication: {
+    context: 'https://login.windows.net/common',
+    resourceUrl: '09fdd68c-4f2f-45c2-be55-dd98104d4f74',
+    clientId: '09fdd68c-4f2f-45c2-be55-dd98104d4f74',
+    redirectUrl: 'x-msauth-uk-gov-dvsa-mobile-examiner-app://uk.gov.dvsa.mobile-examiner-app',
+    logoutUrl: 'https://login.windows.net/6c448d90-4ca1-4caf-ab59-0a2aa67d7801/oauth2/logout',
+    employeeIdKey: 'extn.employeeId',
+  },
+};

--- a/src/environment/environment.dev.ts
+++ b/src/environment/environment.dev.ts
@@ -4,7 +4,7 @@ export const environment: MdmConfig = {
   isRemote: true,
   configUrl: 'https://dev.mes.dev-dvsacloud.uk/v1/configuration/dev',
   daysToCacheLogs: 7,
-  enableDevTools: true,
+  enableDevTools: false,
   logoutClearsTestPersistence: true,
   logsPostApiKey: '',
   logsApiUrl: 'https://dev.mes.dev-dvsacloud.uk/v1/logs',

--- a/src/environment/environment.dev.ts
+++ b/src/environment/environment.dev.ts
@@ -4,7 +4,7 @@ export const environment: MdmConfig = {
   isRemote: true,
   configUrl: 'https://dev.mes.dev-dvsacloud.uk/v1/configuration/dev',
   daysToCacheLogs: 7,
-  enableDevTools: false,
+  enableDevTools: true,
   logoutClearsTestPersistence: true,
   logsPostApiKey: '',
   logsApiUrl: 'https://dev.mes.dev-dvsacloud.uk/v1/logs',


### PR DESCRIPTION
## Description
- Enables remote dev tools for inspection of NGRX store from iOS Simulator (credit to [this](https://github.com/somq/ionic4-remote-devtool) repo)
- Adds script for running app in iOS Simulator in livereload mode

### Usage
1. Start the dev tools server
`npm run remote-devtools-server`
2. Run the app (in another terminal)
`npm run serve:emulator`
3. Open remote dev tools and change settings as below:
![Screenshot 2019-12-17 at 15 11 19](https://user-images.githubusercontent.com/33055124/71007873-9c484800-20df-11ea-993e-aad44e8fa5cc.png)

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots
![Screenshot 2019-12-17 at 15 22 02](https://user-images.githubusercontent.com/33055124/71008781-1927f180-20e1-11ea-8f11-e1b9f6a55bad.png)

