### PR TITLE
mes-4336: ensure single app mode works for CAT B+E

### DIFF
--- a/src/pages/waiting-room/cat-be/__tests__/waiting-room.cat-be.page.spec.ts
+++ b/src/pages/waiting-room/cat-be/__tests__/waiting-room.cat-be.page.spec.ts
@@ -172,16 +172,9 @@ describe('WaitingRoomCatBEPage', () => {
     });
 
     describe('ionViewDidEnter', () => {
-      it('should enable single app mode if on ios and not in practice mode', () => {
-        component.isPracticeMode = false;
+      it('should enable single app mode if on ios', () => {
         component.ionViewDidEnter();
         expect(deviceProvider.enableSingleAppMode).toHaveBeenCalled();
-      });
-
-      it('should note enable single app mode if on ios and in practice mode', () => {
-        component.isPracticeMode = true;
-        component.ionViewDidEnter();
-        expect(deviceProvider.enableSingleAppMode).not.toHaveBeenCalled();
       });
 
       it('should lock the screen orientation to Portrait Primary', () => {

--- a/src/pages/waiting-room/cat-be/__tests__/waiting-room.cat-be.page.spec.ts
+++ b/src/pages/waiting-room/cat-be/__tests__/waiting-room.cat-be.page.spec.ts
@@ -28,6 +28,8 @@ import { Subscription } from 'rxjs/Subscription';
 import * as communicationPreferenceActions
   from '../../../../modules/tests/communication-preferences/communication-preferences.actions';
 import { Language } from '../../../../modules/tests/communication-preferences/communication-preferences.model';
+import { DeviceProvider } from '../../../../providers/device/device';
+import { DeviceProviderMock } from '../../../../providers/device/__mocks__/device.mock';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { ScreenOrientationMock } from '../../../../shared/mocks/screen-orientation.mock';
 import { Insomnia } from '@ionic-native/insomnia';
@@ -51,6 +53,7 @@ describe('WaitingRoomCatBEPage', () => {
   let fixture: ComponentFixture<WaitingRoomCatBEPage>;
   let component: WaitingRoomCatBEPage;
   let store$: Store<StoreModel>;
+  let deviceProvider: DeviceProvider;
   let deviceAuthenticationProvider: DeviceAuthenticationProvider;
   let screenOrientation: ScreenOrientation;
   let insomnia: Insomnia;
@@ -110,6 +113,7 @@ describe('WaitingRoomCatBEPage', () => {
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
         { provide: DeviceAuthenticationProvider, useClass: DeviceAuthenticationProviderMock },
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
+        { provide: DeviceProvider, useClass: DeviceProviderMock },
         { provide: ScreenOrientation, useClass: ScreenOrientationMock },
         { provide: Insomnia, useClass: InsomniaMock },
         { provide: App, useClass: MockAppComponent },
@@ -119,6 +123,7 @@ describe('WaitingRoomCatBEPage', () => {
       .then(() => {
         fixture = TestBed.createComponent(WaitingRoomCatBEPage);
         component = fixture.componentInstance;
+        deviceProvider = TestBed.get(DeviceProvider);
         screenOrientation = TestBed.get(ScreenOrientation);
         insomnia = TestBed.get(Insomnia);
         deviceAuthenticationProvider = TestBed.get(DeviceAuthenticationProvider);
@@ -167,6 +172,18 @@ describe('WaitingRoomCatBEPage', () => {
     });
 
     describe('ionViewDidEnter', () => {
+      it('should enable single app mode if on ios and not in practice mode', () => {
+        component.isPracticeMode = false;
+        component.ionViewDidEnter();
+        expect(deviceProvider.enableSingleAppMode).toHaveBeenCalled();
+      });
+
+      it('should note enable single app mode if on ios and in practice mode', () => {
+        component.isPracticeMode = true;
+        component.ionViewDidEnter();
+        expect(deviceProvider.enableSingleAppMode).not.toHaveBeenCalled();
+      });
+
       it('should lock the screen orientation to Portrait Primary', () => {
         component.ionViewDidEnter();
         expect(screenOrientation.lock)

--- a/src/pages/waiting-room/cat-be/waiting-room.cat-be.page.ts
+++ b/src/pages/waiting-room/cat-be/waiting-room.cat-be.page.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { IonicPage, NavController, NavParams, Platform, Navbar, ModalController } from 'ionic-angular';
+import { PracticeableBasePageComponent } from '../../../shared/classes/practiceable-base-page';
 import { AuthenticationProvider } from '../../../providers/authentication/authentication';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../../shared/models/store.model';
@@ -43,8 +44,8 @@ import {
 import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
 import { Insomnia } from '@ionic-native/insomnia';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
+import { DeviceProvider } from '../../../providers/device/device';
 import { configureI18N } from '../../../shared/helpers/translation.helpers';
-import { BasePageComponent } from '../../../shared/classes/base-page';
 import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE/index';
 import { isEmpty } from 'lodash';
 import { ErrorTypes } from '../../../shared/models/error-message';
@@ -66,7 +67,7 @@ interface WaitingRoomPageState {
   selector: '.waiting-room-cat-be-page',
   templateUrl: 'waiting-room.cat-be.page.html',
 })
-export class WaitingRoomCatBEPage extends BasePageComponent implements OnInit {
+export class WaitingRoomCatBEPage extends PracticeableBasePageComponent implements OnInit {
 
   @ViewChild(Navbar) navBar: Navbar;
 
@@ -85,13 +86,14 @@ export class WaitingRoomCatBEPage extends BasePageComponent implements OnInit {
     public platform: Platform,
     public authenticationProvider: AuthenticationProvider,
     private deviceAuthenticationProvider: DeviceAuthenticationProvider,
+    private deviceProvider: DeviceProvider,
     private screenOrientation: ScreenOrientation,
     private insomnia: Insomnia,
     private translate: TranslateService,
     private modalController: ModalController,
     private app: App,
   ) {
-    super(platform, navController, authenticationProvider);
+    super(platform, navController, authenticationProvider, store$);
     this.formGroup = new FormGroup({});
   }
 
@@ -101,6 +103,10 @@ export class WaitingRoomCatBEPage extends BasePageComponent implements OnInit {
     if (super.isIos()) {
       this.screenOrientation.lock(this.screenOrientation.ORIENTATIONS.PORTRAIT_PRIMARY);
       this.insomnia.keepAwake();
+
+      if (!this.isPracticeMode) {
+        this.deviceProvider.enableSingleAppMode();
+      }
     }
 
     this.navBar.backButtonClick = (e: UIEvent) => {

--- a/src/pages/waiting-room/cat-be/waiting-room.cat-be.page.ts
+++ b/src/pages/waiting-room/cat-be/waiting-room.cat-be.page.ts
@@ -1,7 +1,6 @@
 import { Component, ViewChild, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { IonicPage, NavController, NavParams, Platform, Navbar, ModalController } from 'ionic-angular';
-import { PracticeableBasePageComponent } from '../../../shared/classes/practiceable-base-page';
 import { AuthenticationProvider } from '../../../providers/authentication/authentication';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../../shared/models/store.model';
@@ -46,6 +45,7 @@ import { Insomnia } from '@ionic-native/insomnia';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { DeviceProvider } from '../../../providers/device/device';
 import { configureI18N } from '../../../shared/helpers/translation.helpers';
+import { BasePageComponent } from '../../../shared/classes/base-page';
 import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE/index';
 import { isEmpty } from 'lodash';
 import { ErrorTypes } from '../../../shared/models/error-message';
@@ -67,7 +67,7 @@ interface WaitingRoomPageState {
   selector: '.waiting-room-cat-be-page',
   templateUrl: 'waiting-room.cat-be.page.html',
 })
-export class WaitingRoomCatBEPage extends PracticeableBasePageComponent implements OnInit {
+export class WaitingRoomCatBEPage extends BasePageComponent implements OnInit {
 
   @ViewChild(Navbar) navBar: Navbar;
 
@@ -93,7 +93,7 @@ export class WaitingRoomCatBEPage extends PracticeableBasePageComponent implemen
     private modalController: ModalController,
     private app: App,
   ) {
-    super(platform, navController, authenticationProvider, store$);
+    super(platform, navController, authenticationProvider);
     this.formGroup = new FormGroup({});
   }
 
@@ -103,10 +103,7 @@ export class WaitingRoomCatBEPage extends PracticeableBasePageComponent implemen
     if (super.isIos()) {
       this.screenOrientation.lock(this.screenOrientation.ORIENTATIONS.PORTRAIT_PRIMARY);
       this.insomnia.keepAwake();
-
-      if (!this.isPracticeMode) {
-        this.deviceProvider.enableSingleAppMode();
-      }
+      this.deviceProvider.enableSingleAppMode();
     }
 
     this.navBar.backButtonClick = (e: UIEvent) => {


### PR DESCRIPTION
## Description
Fixes a bug which ensures the app runs in single app mode when a CAT B+E test is started.
Jira: https://jira.dvsacloud.uk/browse/MES-4336

- Adds same functionality as implemented for CAT B including unit tests
- Fix will also need to be added to CAT C waiting room page

## Notes
The fix has not been verified on a physical device because due to availability of an enrolled device.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
