### PR TITLE
[Cherry-Pick] MES-4501: Persisting test-data when cat be specific actions happen

### DIFF
--- a/src/pages/test-report/test-report.effects.ts
+++ b/src/pages/test-report/test-report.effects.ts
@@ -10,6 +10,9 @@ import * as testsActions from '../../modules/tests/tests.actions';
 import * as testRequirementsActions
   from '../../modules/tests/test-data/cat-b/test-requirements/test-requirements.actions';
 import * as manoeuvresActions from '../../modules/tests/test-data/common/manoeuvres/manoeuvres.actions';
+import * as manoeuvresCatBEActions from '../../modules/tests/test-data/cat-be/manoeuvres/manoeuvres.cat-be.actions';
+import * as uncoupleRecoupleActions
+  from '../../modules/tests/test-data/cat-be/uncouple-recouple/uncouple-recouple.actions';
 import * as vehicleChecksActions from '../../modules/tests/test-data/cat-b/vehicle-checks/vehicle-checks.actions';
 import * as ecoActions from '../../modules/tests/test-data/common/eco/eco.actions';
 import * as etaActions from '../../modules/tests/test-data/common/eta/eta.actions';
@@ -63,6 +66,7 @@ export class TestReportEffects {
     }),
   );
 
+  // TODO: This is not really scalable if we introduce other categories
   @Effect()
   persistTestReport$ = this.actions$.pipe(
     ofType(
@@ -77,6 +81,12 @@ export class TestReportEffects {
       manoeuvresActions.ADD_MANOEUVRE_SERIOUS_FAULT,
       manoeuvresActions.ADD_MANOEUVRE_DANGEROUS_FAULT,
       manoeuvresActions.REMOVE_MANOEUVRE_FAULT,
+      manoeuvresCatBEActions.DESELECT_REVERSE_LEFT_MANOEUVRE,
+      uncoupleRecoupleActions.TOGGLE_UNCOUPLE_RECOUPLE,
+      uncoupleRecoupleActions.UNCOUPLE_RECOUPLE_ADD_DRIVING_FAULT,
+      uncoupleRecoupleActions.UNCOUPLE_RECOUPLE_ADD_SERIOUS_FAULT,
+      uncoupleRecoupleActions.UNCOUPLE_RECOUPLE_ADD_DANGEROUS_FAULT,
+      uncoupleRecoupleActions.UNCOUPLE_RECOUPLE_REMOVE_FAULT,
       controlledStopActions.TOGGLE_CONTROLLED_STOP,
       controlledStopActions.CONTROLLED_STOP_ADD_DRIVING_FAULT,
       controlledStopActions.CONTROLLED_STOP_ADD_SERIOUS_FAULT,


### PR DESCRIPTION
## Description

Cherry-pick 7f0489c1594e011516477ab0d323a055d3de07e2

Persisting every action which happens on test report category BE

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
