### PR TITLE
MES-4515: Retry enabling ASAM

### DIFF
--- a/src/providers/device/device.ts
+++ b/src/providers/device/device.ts
@@ -7,8 +7,9 @@ import { LogType } from '../../shared/models/log.model';
 import { Store } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { LogHelper } from '../logs/logsHelper';
-import { from } from 'rxjs/observable/from';
-import { timeout, map, retry } from 'rxjs/operators';
+import { timeout, retry, map } from 'rxjs/operators';
+import { defer } from 'rxjs/observable/defer';
+import { Observable } from 'rxjs/Observable';
 
 declare let cordova: any;
 
@@ -47,32 +48,37 @@ export class DeviceProvider implements IDeviceProvider {
   /**
    * [enableSingleAppMode description]
    *
-   * @returns void
+   * @returns Promise<any>
    *
    * Runs setSingleAppMode(true) and retries a number
    * of times, eventually timing out after a specified
    * duration.
    *
-   * This method is designed to execute and
-   * complete in the background without blocking the
-   * user, hence the void return type. If with retries,
-   * ASAM still failed to enable, a unique log is sent.
-   */
-  enableSingleAppMode(): void {
-    from(this.setSingleAppMode(true)).pipe(
-      map((didSucceed: boolean): boolean | Error => {
-        if (!didSucceed) throw new Error();
-        return didSucceed;
-      }),
-      retry(this.enableASAMRetryLimit),
-      timeout(this.enableASAMTimeout),
-    ).toPromise()
-    .catch(() => {
-      this.store$.dispatch(new SaveLog(this.logHelper.createLog(
-        LogType.ERROR, null,
-        this.enableASAMRetryFailureMessage
-      )));
-    });
+   * This method is designed to execute and complete
+   * in the background without blocking the user.
+   * If after retrying, ASAM still failed to enable,
+   * a unique log is sent.
+  */
+  enableSingleAppMode = async(): Promise<any> => {
+    const enableAsamWithRetriesAndTimeout$: Observable<boolean> = defer(() => this.setSingleAppMode(true)).pipe(
+        map((didSucceed: boolean): boolean => {
+          if (!didSucceed) throw new Error('Call to enable ASAM failed');
+          return didSucceed;
+        }),
+        retry(this.enableASAMRetryLimit),
+        timeout(this.enableASAMTimeout),
+      );
+
+    const promisifiedEnableAsamWithRetriesAndTimeout = enableAsamWithRetriesAndTimeout$.toPromise()
+      .catch(() => {
+        this.store$.dispatch(new SaveLog(this.logHelper.createLog(
+          LogType.ERROR,
+          null,
+          this.enableASAMRetryFailureMessage,
+        )));
+      });
+
+    return await promisifiedEnableAsamWithRetriesAndTimeout;
   }
 
   disableSingleAppMode = async (): Promise<boolean> => {

--- a/src/providers/device/device.ts
+++ b/src/providers/device/device.ts
@@ -7,12 +7,17 @@ import { LogType } from '../../shared/models/log.model';
 import { Store } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import { LogHelper } from '../logs/logsHelper';
+import { from } from 'rxjs/observable/from';
+import { timeout, map, retry } from 'rxjs/operators';
 
 declare let cordova: any;
 
 @Injectable()
 export class DeviceProvider implements IDeviceProvider {
   private supportedDevices: string[] = [];
+  private enableASAMRetryLimit: number = 3;
+  private enableASAMTimeout: number = 10000;
+  private enableASAMRetryFailureMessage: string =  `All retries to enable ASAM failed`;
 
   constructor(
     public appConfig: AppConfigProvider,
@@ -39,8 +44,35 @@ export class DeviceProvider implements IDeviceProvider {
     return this.device.uuid;
   }
 
-  enableSingleAppMode = async (): Promise<boolean> => {
-    return await this.setSingleAppMode(true);
+  /**
+   * [enableSingleAppMode description]
+   *
+   * @returns void
+   *
+   * Runs setSingleAppMode(true) and retries a number
+   * of times, eventually timing out after a specified
+   * duration.
+   *
+   * This method is designed to execute and
+   * complete in the background without blocking the
+   * user, hence the void return type. If with retries,
+   * ASAM still failed to enable, a unique log is sent.
+   */
+  enableSingleAppMode(): void {
+    from(this.setSingleAppMode(true)).pipe(
+      map((didSucceed: boolean): boolean | Error => {
+        if (!didSucceed) throw new Error();
+        return didSucceed;
+      }),
+      retry(this.enableASAMRetryLimit),
+      timeout(this.enableASAMTimeout),
+    ).toPromise()
+    .catch(() => {
+      this.store$.dispatch(new SaveLog(this.logHelper.createLog(
+        LogType.ERROR, null,
+        this.enableASAMRetryFailureMessage
+      )));
+    });
   }
 
   disableSingleAppMode = async (): Promise<boolean> => {
@@ -52,7 +84,6 @@ export class DeviceProvider implements IDeviceProvider {
       if (cordova && cordova.plugins && cordova.plugins.ASAM) {
         cordova.plugins.ASAM.toggle(enabled, (didSucceed: boolean) => {
           const logMessage = `Call to ${enabled ? 'enable' : 'disable'} ASAM ${didSucceed ? 'succeeded' : 'failed'}`;
-          console.log(logMessage);
           if (!didSucceed) {
             const logError = `${enabled ? 'Enabling' : 'Disabling'} ASAM`;
             this.store$.dispatch(new SaveLog(this.logHelper.createLog(LogType.ERROR, logError, logMessage)));


### PR DESCRIPTION
## Description
See the [Jira ticket](https://jira.dvsacloud.uk/browse/MES-4515) for a description of the problem and the proposed solution -

- Refactors the `enableSingleAppMode()` method to include retries and a timeout.
- Uses rxjs operators to achieve this, using `from` and `toPromise` to dip in and back out of the observable interface.
- See [this GitHub thread](https://github.com/ReactiveX/rxjs/issues/1596#issuecomment-207529373) for an explanation of why we need `defer()`

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
