### PR TITLE
MES-4037 -C1 , C1E, CE Vehicle Checks Fault Counters

### DIFF
--- a/src/pages/test-report/cat-be/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
+++ b/src/pages/test-report/cat-be/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
@@ -54,13 +54,13 @@ describe('VehicleChecksComponent', () => {
     };
 
     beforeEach(() => {
-      spyOn(component.faultCountProvider, 'getVehicleChecksFaultCountCatBE').and.returnValue(vehicleChecksScore);
+      spyOn(component.faultCountProvider, 'getVehicleChecksFaultCount').and.returnValue(vehicleChecksScore);
     });
 
     it('should set the vehicle checks driving fault count', (done: DoneFn) => {
       component.ngOnInit();
       component.componentState.vehicleChecksDrivingFaultCount$.subscribe((result) => {
-        expect(component.faultCountProvider.getVehicleChecksFaultCountCatBE).toHaveBeenCalled();
+        expect(component.faultCountProvider.getVehicleChecksFaultCount).toHaveBeenCalled();
         expect(result).toEqual(4);
         done();
       });
@@ -68,7 +68,7 @@ describe('VehicleChecksComponent', () => {
     it('should set the vehicle checks serious fault count', (done: DoneFn) => {
       component.ngOnInit();
       component.componentState.vehicleChecksSeriousFaultCount$.subscribe((result) => {
-        expect(component.faultCountProvider.getVehicleChecksFaultCountCatBE).toHaveBeenCalled();
+        expect(component.faultCountProvider.getVehicleChecksFaultCount).toHaveBeenCalled();
         expect(result).toEqual(1);
         done();
       });

--- a/src/pages/test-report/cat-be/components/vehicle-checks/vehicle-checks.ts
+++ b/src/pages/test-report/cat-be/components/vehicle-checks/vehicle-checks.ts
@@ -9,6 +9,7 @@ import { getVehicleChecksCatBE }
 from '../../../../../modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.selector';
 import { FaultCountProvider } from '../../../../../providers/fault-count/fault-count';
 import { Observable } from 'rxjs/Observable';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 interface ComponentState {
   vehicleChecksDrivingFaultCount$: Observable<number>;
@@ -37,14 +38,14 @@ export class VehicleChecksComponent implements OnInit {
         select(getTestData),
         select(getVehicleChecksCatBE),
         map((vehicleChecks) => {
-          return this.faultCountProvider.getVehicleChecksFaultCountCatBE(vehicleChecks).drivingFaults;
+          return this.faultCountProvider.getVehicleChecksFaultCount(TestCategory.BE , vehicleChecks).drivingFaults;
         }),
       ),
       vehicleChecksSeriousFaultCount$: currentTest$.pipe(
         select(getTestData),
         select(getVehicleChecksCatBE),
         map((vehicleChecks) => {
-          return this.faultCountProvider.getVehicleChecksFaultCountCatBE(vehicleChecks).seriousFaults;
+          return this.faultCountProvider.getVehicleChecksFaultCount(TestCategory.BE, vehicleChecks).seriousFaults;
         }),
       ),
     };

--- a/src/pages/test-report/cat-c/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
+++ b/src/pages/test-report/cat-c/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
@@ -56,13 +56,13 @@ describe('VehicleChecksComponent', () => {
 
     beforeEach(() => {
       // TODO: MES-4287 Use Category C
-      spyOn(component.faultCountProvider, 'getVehicleChecksFaultCountCatBE').and.returnValue(vehicleChecksScore);
+      spyOn(component.faultCountProvider, 'getVehicleChecksFaultCount').and.returnValue(vehicleChecksScore);
     });
 
     it('should set the vehicle checks driving fault count', (done: DoneFn) => {
       component.ngOnInit();
       component.componentState.vehicleChecksDrivingFaultCount$.subscribe((result) => {
-        expect(component.faultCountProvider.getVehicleChecksFaultCountCatBE).toHaveBeenCalled();
+        expect(component.faultCountProvider.getVehicleChecksFaultCount).toHaveBeenCalled();
         expect(result).toEqual(4);
         done();
       });
@@ -70,7 +70,7 @@ describe('VehicleChecksComponent', () => {
     it('should set the vehicle checks serious fault count', (done: DoneFn) => {
       component.ngOnInit();
       component.componentState.vehicleChecksSeriousFaultCount$.subscribe((result) => {
-        expect(component.faultCountProvider.getVehicleChecksFaultCountCatBE).toHaveBeenCalled();
+        expect(component.faultCountProvider.getVehicleChecksFaultCount).toHaveBeenCalled();
         expect(result).toEqual(1);
         done();
       });

--- a/src/pages/test-report/cat-c/components/vehicle-checks/vehicle-checks.ts
+++ b/src/pages/test-report/cat-c/components/vehicle-checks/vehicle-checks.ts
@@ -13,6 +13,7 @@ import { getVehicleChecksCatBE }
   from '../../../../../modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.selector';
 import { FaultCountProvider } from '../../../../../providers/fault-count/fault-count';
 import { Observable } from 'rxjs/Observable';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 interface ComponentState {
   vehicleChecksDrivingFaultCount$: Observable<number>;
@@ -45,7 +46,7 @@ export class VehicleChecksComponent implements OnInit {
         map((vehicleChecks) => {
 
           // TODO: MES-4287 use cat c function
-          return this.faultCountProvider.getVehicleChecksFaultCountCatBE(vehicleChecks).drivingFaults;
+          return this.faultCountProvider.getVehicleChecksFaultCount(TestCategory.BE , vehicleChecks).drivingFaults;
         }),
       ),
       vehicleChecksSeriousFaultCount$: currentTest$.pipe(
@@ -56,7 +57,7 @@ export class VehicleChecksComponent implements OnInit {
         map((vehicleChecks) => {
 
           // TODO: MES-4287 use cat c function
-          return this.faultCountProvider.getVehicleChecksFaultCountCatBE(vehicleChecks).seriousFaults;
+          return this.faultCountProvider.getVehicleChecksFaultCount(TestCategory.BE, vehicleChecks).seriousFaults;
         }),
       ),
     };

--- a/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks-modal/vehicle-checks-modal.cat-be.page.ts
+++ b/src/pages/waiting-room-to-car/cat-be/components/vehicle-checks-modal/vehicle-checks-modal.cat-be.page.ts
@@ -100,7 +100,7 @@ export class VehicleChecksCatBEModal {
         select(getTestData),
         select(getVehicleChecksCatBE),
         map((vehicleChecks) => {
-          return this.faultCountProvider.getVehicleChecksFaultCountCatBE(vehicleChecks);
+          return this.faultCountProvider.getVehicleChecksFaultCount(TestCategory.BE, vehicleChecks);
         }),
       ),
     };

--- a/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
+++ b/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
@@ -184,7 +184,7 @@ export class WaitingRoomToCarCatBEPage extends BasePageComponent {
         select(getTestData),
         select(getVehicleChecksCatBE),
         map((vehicleChecks) => {
-          return this.faultCountProvider.getVehicleChecksFaultCountCatBE(vehicleChecks);
+          return this.faultCountProvider.getVehicleChecksFaultCount(TestCategory.BE, vehicleChecks);
         }),
       ),
       vehicleChecks$: currentTest$.pipe(

--- a/src/pages/waiting-room-to-car/cat-c/components/vehicle-checks-modal/vehicle-checks-modal.cat-c.page.ts
+++ b/src/pages/waiting-room-to-car/cat-c/components/vehicle-checks-modal/vehicle-checks-modal.cat-c.page.ts
@@ -120,7 +120,7 @@ export class VehicleChecksCatCModal {
         map((vehicleChecks) => {
 
           // TODO: MES-4254 Use cat c Provider
-          return this.faultCountProvider.getVehicleChecksFaultCountCatBE(vehicleChecks);
+          return this.faultCountProvider.getVehicleChecksFaultCount(TestCategory.BE, vehicleChecks);
         }),
       ),
     };

--- a/src/pages/waiting-room-to-car/cat-c/waiting-room-to-car.cat-c.page.ts
+++ b/src/pages/waiting-room-to-car/cat-c/waiting-room-to-car.cat-c.page.ts
@@ -134,7 +134,7 @@ export class WaitingRoomToCarCatCPage extends BasePageComponent {
       vehicleChecksScore$: currentTest$.pipe(
         select(getTestData),
         select(getVehicleChecksCatC),
-        map(vehicleChecks => this.faultCountProvider.getVehicleChecksFaultCountCatC(vehicleChecks)),
+        map(vehicleChecks => this.faultCountProvider.getVehicleChecksFaultCount(TestCategory.C, vehicleChecks)),
       ),
       vehicleChecks$: currentTest$.pipe(
         select(getTestData),

--- a/src/providers/fault-count/fault-count.ts
+++ b/src/providers/fault-count/fault-count.ts
@@ -9,6 +9,9 @@ import { VehicleChecksScore } from '../../shared/models/vehicle-checks-score.mod
 import { getCompetencyFaults } from '../../shared/helpers/competency';
 import { QuestionResult } from '@dvsa/mes-test-schema/categories/common';
 import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
+import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
+import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
 
 @Injectable()
 export class FaultCountProvider {
@@ -43,6 +46,16 @@ export class FaultCountProvider {
     throw new Error(FaultCountProvider.getFaultSumCountErrMsg);
   }
 
+  public getVehicleChecksFaultCount = (category: TestCategory, data: Object): VehicleChecksScore => {
+    if (category === TestCategory.BE) return this.getVehicleChecksFaultCountCatBE(data);
+    if (category === TestCategory.C) return this.getVehicleChecksFaultCountCatC(data);
+    if (category === TestCategory.CE) return this.getVehicleChecksFaultCountCatCE(data);
+    if (category === TestCategory.C1) return this.getVehicleChecksFaultCountCatC1(data);
+    if (category === TestCategory.C1E) return this.getVehicleChecksFaultCountCatC1E(data);
+
+    throw new Error(FaultCountProvider.getFaultSumCountErrMsg);
+  }
+
   public getVehicleChecksFaultCountCatB = (vehicleChecks: CatBUniqueTypes.VehicleChecks): number => {
 
     if (!vehicleChecks) {
@@ -62,7 +75,7 @@ export class FaultCountProvider {
     return 0;
   }
 
-  public getVehicleChecksFaultCountCatBE = (vehicleChecks: CatBEUniqueTypes.VehicleChecks): VehicleChecksScore => {
+  private getVehicleChecksFaultCountCatBE = (vehicleChecks: CatBEUniqueTypes.VehicleChecks): VehicleChecksScore => {
 
     if (!vehicleChecks) {
       return { seriousFaults: 0, drivingFaults: 0 };
@@ -92,7 +105,7 @@ export class FaultCountProvider {
     };
   }
 
-  public getVehicleChecksFaultCountCatC = (vehicleChecks: CatCUniqueTypes.VehicleChecks): VehicleChecksScore => {
+  private getVehicleChecksFaultCountCatC = (vehicleChecks: CatCUniqueTypes.VehicleChecks): VehicleChecksScore => {
 
     if (!vehicleChecks) {
       return { seriousFaults: 0, drivingFaults: 0 };
@@ -113,6 +126,96 @@ export class FaultCountProvider {
     if (totalFaultCount === 5) {
       return {
         drivingFaults: 4,
+        seriousFaults: 1,
+      };
+    }
+    return {
+      drivingFaults: totalFaultCount,
+      seriousFaults: 0,
+    };
+  }
+
+  private getVehicleChecksFaultCountCatCE = (vehicleChecks: CatCEUniqueTypes.VehicleChecks): VehicleChecksScore => {
+
+    if (!vehicleChecks) {
+      return { seriousFaults: 0, drivingFaults: 0 };
+    }
+
+    const showMeQuestions: QuestionResult[] = get(vehicleChecks, 'showMeQuestions', []);
+    const tellMeQuestions: QuestionResult[] = get(vehicleChecks, 'tellMeQuestions', []);
+
+    const numberOfShowMeFaults: number = showMeQuestions.filter((showMeQuestion) => {
+      return showMeQuestion.outcome === CompetencyOutcome.DF;
+    }).length;
+    const numberOfTellMeFaults: number = tellMeQuestions.filter((tellMeQuestion) => {
+      return tellMeQuestion.outcome === CompetencyOutcome.DF;
+    }).length;
+
+    const totalFaultCount: number = numberOfShowMeFaults + numberOfTellMeFaults;
+
+    if (totalFaultCount === 2) {
+      return {
+        drivingFaults: 1,
+        seriousFaults: 1,
+      };
+    }
+    return {
+      drivingFaults: totalFaultCount,
+      seriousFaults: 0,
+    };
+  }
+
+  private getVehicleChecksFaultCountCatC1 = (vehicleChecks: CatC1UniqueTypes.VehicleChecks): VehicleChecksScore => {
+
+    if (!vehicleChecks) {
+      return { seriousFaults: 0, drivingFaults: 0 };
+    }
+
+    const showMeQuestions: QuestionResult[] = get(vehicleChecks, 'showMeQuestions', []);
+    const tellMeQuestions: QuestionResult[] = get(vehicleChecks, 'tellMeQuestions', []);
+
+    const numberOfShowMeFaults: number = showMeQuestions.filter((showMeQuestion) => {
+      return showMeQuestion.outcome === CompetencyOutcome.DF;
+    }).length;
+    const numberOfTellMeFaults: number = tellMeQuestions.filter((tellMeQuestion) => {
+      return tellMeQuestion.outcome === CompetencyOutcome.DF;
+    }).length;
+
+    const totalFaultCount: number = numberOfShowMeFaults + numberOfTellMeFaults;
+
+    if (totalFaultCount === 5) {
+      return {
+        drivingFaults: 4,
+        seriousFaults: 1,
+      };
+    }
+    return {
+      drivingFaults: totalFaultCount,
+      seriousFaults: 0,
+    };
+  }
+
+  private getVehicleChecksFaultCountCatC1E = (vehicleChecks: CatC1EUniqueTypes.VehicleChecks): VehicleChecksScore => {
+
+    if (!vehicleChecks) {
+      return { seriousFaults: 0, drivingFaults: 0 };
+    }
+
+    const showMeQuestions: QuestionResult[] = get(vehicleChecks, 'showMeQuestions', []);
+    const tellMeQuestions: QuestionResult[] = get(vehicleChecks, 'tellMeQuestions', []);
+
+    const numberOfShowMeFaults: number = showMeQuestions.filter((showMeQuestion) => {
+      return showMeQuestion.outcome === CompetencyOutcome.DF;
+    }).length;
+    const numberOfTellMeFaults: number = tellMeQuestions.filter((tellMeQuestion) => {
+      return tellMeQuestion.outcome === CompetencyOutcome.DF;
+    }).length;
+
+    const totalFaultCount: number = numberOfShowMeFaults + numberOfTellMeFaults;
+
+    if (totalFaultCount === 2) {
+      return {
+        drivingFaults: 1,
         seriousFaults: 1,
       };
     }

--- a/src/providers/fault-summary/fault-summary.ts
+++ b/src/providers/fault-summary/fault-summary.ts
@@ -313,7 +313,7 @@ export class FaultSummaryProvider {
       return result;
     }
 
-    const vehicleCheckFaults = this.faultCountProvider.getVehicleChecksFaultCountCatBE(vehicleChecks);
+    const vehicleCheckFaults = this.faultCountProvider.getVehicleChecksFaultCount(TestCategory.BE, vehicleChecks);
     if (vehicleCheckFaults.drivingFaults > 0) {
       const competency: FaultSummary = {
         comment: vehicleChecks.showMeTellMeComments || '',


### PR DESCRIPTION
## Description
- Created a new generic method which takes a category for all vehicle checks counters (apart from B) so it matches the other fault counters.
- Added new counters with the correct logic for CE, C1 and C1E

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
