### PR TITLE
MES-4056 hide code 78 field on C1 and C1+E tests on debrief page

### DIFF
--- a/src/pages/pass-finalisation/cat-c/_tests_/pass-finalisation.cat-c.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-c/_tests_/pass-finalisation.cat-c.page.spec.ts
@@ -38,6 +38,7 @@ import { PASS_CERTIFICATE_NUMBER_CTRL }
   from '../../components/pass-certificate-number/pass-certificate-number.constants';
 import { Code78Component } from '../components/code-78/code-78';
 import { TransmissionType } from '../../../../shared/models/transmission-type';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 describe('PassFinalisationCatCPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatCPage>;
@@ -200,6 +201,28 @@ describe('PassFinalisationCatCPage', () => {
         expect(component.shouldShowCode78Banner()).toEqual(false);
       });
 
+    });
+
+    describe('showCode78', () => {
+      it('should return true when the test is a category C', () => {
+        component.testCategory = TestCategory.C;
+        expect(component.showCode78()).toBeTruthy();
+      });
+
+      it('should return true when the test is a category C+E', () => {
+        component.testCategory = TestCategory.CE;
+        expect(component.showCode78()).toBeTruthy();
+      });
+
+      it('should return false when the test is a category C1E', () => {
+        component.testCategory = TestCategory.C1E;
+        expect(component.showCode78()).toBeFalsy();
+      });
+
+      it('should return false when the test is a category C1', () => {
+        component.testCategory = TestCategory.C1;
+        expect(component.showCode78()).toBeFalsy();
+      });
     });
   });
 });

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.html
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.html
@@ -30,8 +30,10 @@
         <transmission [formGroup]="form" (transmissionChange)="transmissionChanged($event)"></transmission>
         <warning-banner *ngIf="displayTransmissionBanner()" warningText="An automatic licence will be issued."></warning-banner>
 
-        <code-78 [form]="form" [transmission]="pageState.transmission$ | async"
+        <div *ngIf="showCode78()">
+          <code-78 [form]="form" [transmission]="pageState.transmission$ | async"
           (code78Present)="onCode78Present($event)"></code-78>
+        </div>
 
         <warning-banner *ngIf="shouldShowManualBanner()" warningText="{{manualMessage}}"></warning-banner>
         <warning-banner *ngIf="shouldShowAutomaticBanner()" warningText="{{automaticMessage}}"></warning-banner>

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
@@ -69,11 +69,13 @@ import {
 } from '../../../modules/tests/communication-preferences/communication-preferences.selector';
 import { AuthenticationProvider } from '../../../providers/authentication/authentication';
 import { BasePageComponent } from '../../../shared/classes/base-page';
-import { GearboxCategory } from '@dvsa/mes-test-schema/categories/common';
+import { CategoryCode, GearboxCategory } from '@dvsa/mes-test-schema/categories/common';
 import { PASS_CERTIFICATE_NUMBER_CTRL } from '../components/pass-certificate-number/pass-certificate-number.constants';
 import { TransmissionType } from '../../../shared/models/transmission-type';
 import { merge } from 'rxjs/observable/merge';
 import { getPassCompletion } from '../../../modules/tests/pass-completion/cat-c/pass-completion.cat-c.reducer';
+import { getTestCategory } from '../../../modules/tests/category/category.reducer';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 interface PassFinalisationPageState {
   candidateName$: Observable<string>;
@@ -90,6 +92,7 @@ interface PassFinalisationPageState {
   d255$: Observable<boolean>;
   debriefWitnessed$: Observable<boolean>;
   conductedLanguage$: Observable<string>;
+  testCategory$: Observable<CategoryCode>;
 }
 
 @IonicPage()
@@ -110,6 +113,7 @@ export class PassFinalisationCatCPage extends BasePageComponent {
   subscription: Subscription;
   code78Present: boolean = null;
   provisionalLicenseIsReceived: boolean;
+  testCategory: CategoryCode;
 
   manualMessage: string = 'A <b><em>manual</em></b> licence will be issued';
   automaticMessage: string =
@@ -213,12 +217,16 @@ export class PassFinalisationCatCPage extends BasePageComponent {
         select(getCommunicationPreference),
         select(getConductedLanguage),
       ),
+      testCategory$: currentTest$.pipe(
+        select(getTestCategory),
+      ),
     };
 
-    const { transmission$ } = this.pageState;
+    const { transmission$, testCategory$ } = this.pageState;
 
     this.merged$ = merge(
       transmission$.pipe(map(value => (this.transmission = value))),
+      testCategory$.pipe(map(value => (this.testCategory = value))),
     );
     this.subscription = this.merged$.subscribe();
 
@@ -344,4 +352,6 @@ export class PassFinalisationCatCPage extends BasePageComponent {
   shouldShowCandidateDoesntNeedLicenseBanner(): boolean {
     return this.provisionalLicenseIsReceived;
   }
+
+  showCode78 = (): boolean => this.testCategory === TestCategory.C || this.testCategory === TestCategory.CE;
 }


### PR DESCRIPTION
## Description
Hide the Code78 field for Cat C1 and C1+E on the debrief page

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
