### PR TITLE
Feature mes 4421 cat a mod 1 speed check competency

### DIFF
--- a/src/pages/test-report/cat-a-mod1/components/speed-check/__tests__/speed-check-header.page.spec.ts
+++ b/src/pages/test-report/cat-a-mod1/components/speed-check/__tests__/speed-check-header.page.spec.ts
@@ -1,0 +1,3 @@
+describe('SpeedCheckHeaderComponent', () => {
+  // todo: PREP-AMOD1 MES-4419 implement tests for component
+});

--- a/src/pages/test-report/cat-a-mod1/components/speed-check/__tests__/speed-check.page.spec.ts
+++ b/src/pages/test-report/cat-a-mod1/components/speed-check/__tests__/speed-check.page.spec.ts
@@ -1,0 +1,3 @@
+describe('SpeedCheckComponent', () => {
+  // todo: PREP-AMOD1 MES-4419 implement tests for component
+});

--- a/src/pages/test-report/cat-a-mod1/components/speed-check/spead-check-header.scss
+++ b/src/pages/test-report/cat-a-mod1/components/speed-check/spead-check-header.scss
@@ -1,0 +1,18 @@
+speed-check-header {
+  .input-header {
+    color: map-get($colors-gds, 'gds-black');
+
+    .text-zoom-regular &,
+    .text-zoom-large &,
+    .text-zoom-x-large & {
+      font-size: 17px;
+      font-weight: 500;
+      line-height: 25px;
+      margin-left: 50px;
+    }
+
+    .second {
+      margin-left: 50px;
+    }
+  }
+}

--- a/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check-header.html
+++ b/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check-header.html
@@ -1,0 +1,15 @@
+<ion-row>
+  <ion-col col-32></ion-col>
+  <ion-col col-32>
+    <span class='input-header'>First</span>
+    <span class='input-header second'>Second</span>
+  </ion-col>
+  <ion-col col-32>
+    <span class='section-header'>Speed requirement</span>
+  </ion-col>
+</ion-row>
+<ion-row>
+  <ion-col no-padding>
+    <div class="dark-divider"></div>
+  </ion-col>
+</ion-row>

--- a/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check-header.ts
+++ b/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check-header.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'speed-check-header',
+  templateUrl: 'speed-check-header.html',
+})
+export class SpeedCheckHeaderComponent {
+
+}

--- a/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check.html
+++ b/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check.html
@@ -1,0 +1,33 @@
+<ion-row>
+  <ion-col col-32>
+  <competency-button
+    [onTap]="onTap"
+    [onPress]="onPress"
+    [ngClass]=""
+  >
+    <span class='competency-label'>{{ getLabel() }}</span>
+    <div class="fault-wrapper">
+      <serious-fault-badge [showBadge]="showSerious()"></serious-fault-badge>
+      <dangerous-fault-badge [showBadge]="showDangerous()"></dangerous-fault-badge>
+    </div>
+  </competency-button>
+</ion-col>
+<ion-col col-32>
+  <input type="text" class="speed-input" maxlength="3">
+  <input type="text" class="speed-input second-input" maxlength="3">
+</ion-col>
+<ion-col col-20>
+  <competency-button
+    [onTap]="toggleNotMet()"
+    [ngClass]="{
+      'not-met': actionTaken
+    }">
+      <span class='competency-label'>Not met</span>
+  </competency-button>
+</ion-col>
+</ion-row>
+<ion-row>
+  <ion-col no-padding>
+    <div class="dark-divider"></div>
+  </ion-col>
+</ion-row>

--- a/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check.scss
+++ b/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check.scss
@@ -1,0 +1,35 @@
+speed-check {
+  .speed-input {
+    width: 60px;
+    margin-left: 50px;
+    font-size: 18px;
+    font-weight: 700;
+
+    .second-input {
+      margin-left: 25px;
+    }
+  }
+
+
+
+  competency-button {
+
+    &.not-met {
+      .competency-button {
+        background-color: #F2E8E7;
+        border: 2px solid map-get($colors-gds, "gds-red");
+
+        .competency-label {
+          // font-weight: bold;
+        }
+      }
+    }
+
+    .label {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+    }
+
+  }
+}

--- a/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check.ts
+++ b/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check.ts
@@ -1,0 +1,45 @@
+import { Component, Input } from '@angular/core';
+import { Competencies } from '../../../../../modules/tests/test-data/test-data.constants';
+import { speedCheckLabels } from '../../../../../shared/constants/competencies/cata-mod1-competencies';
+
+@Component({
+  selector: 'speed-check',
+  templateUrl: 'speed-check.html',
+})
+export class SpeedCheckComponent {
+
+  @Input()
+  competency: Competencies;
+
+  // todo: PREP-AMOD1 to be implemented using state as part of MES - 4419
+  actionTaken: boolean;
+
+  constructor() { }
+
+  // todo: PREP-AMOD1 MES - 4419 implement
+  ngOnInit(): void { }
+
+  // todo: PREP-AMOD1 MES - 4419 implement
+  ngOnDestroy(): void { }
+
+  // todo: PREP-AMOD1 MES - 4419 implement
+  toggleNotMet():void { }
+
+  getLabel = (): string => speedCheckLabels[this.competency];
+
+  onTap = () => {
+    // todo: PREP-AMOD1 implement addOrRemoveFault();
+  }
+
+  onPress = () => {
+    // todo: PREP-AMOD1 implement addOrRemoveFault();
+  }
+
+  showSerious() {
+    // todo: PREP-AMOD1 implement showSerious() to return fault label
+  }
+
+  showDangerous() {
+    // todo: PREP-AMOD1 implement showDangerous() to return fault label
+  }
+}

--- a/src/pages/test-report/cat-a-mod1/components/test-report.cat-a-mod1.components.module.ts
+++ b/src/pages/test-report/cat-a-mod1/components/test-report.cat-a-mod1.components.module.ts
@@ -4,9 +4,13 @@ import { IonicModule } from 'ionic-angular';
 import { DirectivesModule } from '../../../../directives/directives.module';
 import { ComponentsModule } from '../../../../components/common/common-components.module';
 import { TestReportComponentsModule } from '../../components/test-report-components.module';
+import { SpeedCheckComponent } from './speed-check/speed-check';
+import { SpeedCheckHeaderComponent } from './speed-check/speed-check-header';
 
 @NgModule({
   declarations: [
+    SpeedCheckHeaderComponent,
+    SpeedCheckComponent,
   ],
   imports: [
     CommonModule,
@@ -16,6 +20,8 @@ import { TestReportComponentsModule } from '../../components/test-report-compone
     DirectivesModule,
   ],
   exports: [
+    SpeedCheckHeaderComponent,
+    SpeedCheckComponent,
   ],
 })
 export class TestReportCatAMod1ComponentsModule { }

--- a/src/pages/test-report/components/competency/competency.constants.ts
+++ b/src/pages/test-report/components/competency/competency.constants.ts
@@ -39,4 +39,6 @@ export enum competencyLabels  {
   pedestrianCrossings  = 'Pedestrian crossings',
   positionNormalStops  = 'Position/normal stop',
   awarenessPlanning  = 'Awareness planning',
+  speedCheckEmergency = 'Emergency stop',
+  speedCheckAvoidance = 'Avoidance Ex. Control Stop',
 }

--- a/src/shared/constants/competencies/cata-mod1-competencies.ts
+++ b/src/shared/constants/competencies/cata-mod1-competencies.ts
@@ -1,0 +1,4 @@
+export enum speedCheckLabels {
+  speedCheckEmergency = 'Emergency stop',
+  speedCheckAvoidance = 'Avoidance Ex. Control Stop',
+}


### PR DESCRIPTION
## Description
- Adding `speed-check-component` (containing `competency-button`, `input fields` and `action button`)
- Adding `speed-check-header-component` to allow the header to be displayed only once on the test report. (Header contains `First`, `Second` and `Speed requirement` labels)
- Note this ticket only adds UI properties. Implementation of logic will be added in `MES-4419`, I propose the unit tests will also be added in this as there is currently no functionality to test.
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

<img width="499" alt="Screenshot 2020-01-15 at 13 42 07" src="https://user-images.githubusercontent.com/30832405/72441675-fc93dd80-37a2-11ea-8f4c-a38321672f10.png">

