### PR TITLE
Re-enables fork-ts-checker-webpack-plugin for faster unit testing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "precommit": "run-s lint:fix lint compile-no-emit",
     "test": "npm run update-mock-data && npm run schema-version && npm run test:jasmine",
     "test:jasmine": "karma start ./test-config/karma.conf.js",
+    "test:jasmine-reload": "karma start ./test-config/karma.conf.js --no-single-run",
     "test:jasmine-ci": "karma start ./test-config/karma.conf.js --single-run",
     "test:jasmine-coverage": "karma start ./test-config/karma.conf.js --coverage",
     "test:e2e-simulator-bdd": "protractor e2e-simulator-bdd.conf.js",

--- a/test-config/webpack.test.js
+++ b/test-config/webpack.test.js
@@ -1,5 +1,6 @@
 var webpack = require('webpack');
 var path = require('path');
+var ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 module.exports = {
   devtool: 'inline-source-map',
@@ -15,7 +16,7 @@ module.exports = {
         loader: 'ts-loader',
         options: {
           // disable type checker - we will use it in fork plugin
-          transpileOnly: false
+          transpileOnly: true
         }
       }, 'angular2-template-loader']
     },
@@ -46,6 +47,7 @@ module.exports = {
       root('./src'), // location of your src
       {} // a map of your routes
     ),
+    new ForkTsCheckerWebpackPlugin()
   ]
 };
 


### PR DESCRIPTION
## Description
- Re-enables fork-ts-checker-webpack-plugin (previously disabled due to now remedied module import error related to mes-test-schema).
- Adds `test:jasmine-reload` script to `package.json` which can be used to run unit tests with hot reloading (tests will re-run automatically on changes). This can be useful when (e.g) working on a single unit test, focussed with `fdescibe()` etc.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
