### PR TITLE
MES-4060 - Fixed Pass Finalisation Rehydration

### DIFF
--- a/src/components/common/transmission/transmission.html
+++ b/src/components/common/transmission/transmission.html
@@ -9,14 +9,12 @@
       <ion-row [formGroup]="formGroup">
         <ion-col col-48>
           <input type="radio" id="transmission-manual" formControlName="transmissionCtrl" name="transmissionCtrl"
-            class="gds-radio-button" [class.ng-invalid]="isInvalid()" (change)="transmissionChanged($event.target.value)" value='Manual'
-            [checked]="transmissionManualRadioChecked">
+            class="gds-radio-button" [class.ng-invalid]="isInvalid()" (change)="transmissionChanged($event.target.value)" value='Manual'>
           <label for="transmission-manual" class="radio-label">Manual</label>
         </ion-col>
         <ion-col>
           <input type="radio" id="transmission-automatic" formControlName="transmissionCtrl" name="transmissionCtrl"
-            class="gds-radio-button" [class.ng-invalid]="isInvalid()" (change)="transmissionChanged($event.target.value)" value='Automatic'
-            [checked]="transmissionAutomaticRadioChecked">
+            class="gds-radio-button" [class.ng-invalid]="isInvalid()" (change)="transmissionChanged($event.target.value)" value='Automatic'>
           <label for="transmission-automatic" class="radio-label">Automatic</label>
         </ion-col>
       </ion-row>

--- a/src/modules/tests/pass-completion/__tests__/pass-completion.reducer.spec.ts
+++ b/src/modules/tests/pass-completion/__tests__/pass-completion.reducer.spec.ts
@@ -3,14 +3,9 @@ import {
   PassCertificateNumberChanged,
   ProvisionalLicenseReceived,
   ProvisionalLicenseNotReceived,
-  PopulatePassCompletion,
 } from '../pass-completion.actions';
 
 describe('pass completion reducer', () => {
-  it('should populate the unanswered defaults when receiving POPULATE_PASS_COMPLETION', () => {
-    const result = passCompletionReducer(initialState, new PopulatePassCompletion());
-    expect(result).toEqual({ passCertificateNumber: null, provisionalLicenceProvided: null });
-  });
   it('should put the pass certificate number into the state on pass certificate number changed action', () => {
     const result = passCompletionReducer(initialState, new PassCertificateNumberChanged('ABC123'));
     expect(result.passCertificateNumber).toBe('ABC123');

--- a/src/modules/tests/pass-completion/cat-c/__tests__/pass-completion.reducer.cat-c.spec.ts
+++ b/src/modules/tests/pass-completion/cat-c/__tests__/pass-completion.reducer.cat-c.spec.ts
@@ -1,6 +1,5 @@
 import { passCompletionCatCReducer, initialState } from '../pass-completion.cat-c.reducer';
 import {
-  PopulatePassCompletion,
   PassCertificateNumberChanged,
   ProvisionalLicenseReceived,
   ProvisionalLicenseNotReceived,
@@ -8,10 +7,6 @@ import {
 import { Code78Present, Code78NotPresent } from '../pass-completion.cat-c.actions';
 
 describe('pass completion reducer', () => {
-  it('should populate the unanswered defaults when receiving POPULATE_PASS_COMPLETION', () => {
-    const result = passCompletionCatCReducer(initialState, new PopulatePassCompletion());
-    expect(result).toEqual({ passCertificateNumber: null, provisionalLicenceProvided: null });
-  });
   it('should put the pass certificate number into the state on pass certificate number changed action', () => {
     const result = passCompletionCatCReducer(initialState, new PassCertificateNumberChanged('ABC123'));
     expect(result.passCertificateNumber).toBe('ABC123');

--- a/src/modules/tests/pass-completion/cat-c/pass-completion.cat-c.reducer.ts
+++ b/src/modules/tests/pass-completion/cat-c/pass-completion.cat-c.reducer.ts
@@ -3,7 +3,11 @@ import * as passCompletionActions from '../pass-completion.actions';
 import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C/index';
 import { createFeatureSelector } from '@ngrx/store';
 
-export const initialState: CatCUniqueTypes.PassCompletion = null;
+export const initialState: CatCUniqueTypes.PassCompletion = {
+  passCertificateNumber: null,
+  provisionalLicenceProvided: null,
+  code78Present: null,
+};
 
 export const passCompletionCatCReducer = (
   state = initialState,
@@ -19,11 +23,6 @@ export const passCompletionCatCReducer = (
       return {
         ...state,
         code78Present: false,
-      };
-    case passCompletionActions.POPULATE_PASS_COMPLETION:
-      return {
-        passCertificateNumber: null,
-        provisionalLicenceProvided: null,
       };
     case passCompletionActions.PASS_CERTIFICATE_NUMBER_CHANGED:
       return {

--- a/src/modules/tests/pass-completion/pass-completion.actions.ts
+++ b/src/modules/tests/pass-completion/pass-completion.actions.ts
@@ -1,15 +1,10 @@
 import { Action } from '@ngrx/store';
 
-export const POPULATE_PASS_COMPLETION = '[Pass Completion] Populate with default answers';
 export const PASS_CERTIFICATE_NUMBER_CHANGED = '[Pass Completion] Pass certificate number changed';
 export const PROVISIONAL_LICENSE_RECEIVED = '[Pass Completion] Provisional license received';
 export const PROVISIONAL_LICENSE_NOT_RECEIVED = '[Pass Completion] Provisional license not received';
 export const CODE_78_PRESENT = '[Pass Completion] Code 78 present';
 export const CODE_78_NOT_PRESENT = '[Pass Completion] Code 78 not present';
-
-export class PopulatePassCompletion implements Action {
-  readonly type = POPULATE_PASS_COMPLETION;
-}
 
 export class PassCertificateNumberChanged implements Action {
   readonly type = PASS_CERTIFICATE_NUMBER_CHANGED;
@@ -33,7 +28,6 @@ export class Code78NotPresent implements Action {
 }
 
 export type Types =
-  | PopulatePassCompletion
   | PassCertificateNumberChanged
   | ProvisionalLicenseReceived
   | ProvisionalLicenseNotReceived

--- a/src/modules/tests/pass-completion/pass-completion.reducer.ts
+++ b/src/modules/tests/pass-completion/pass-completion.reducer.ts
@@ -2,15 +2,13 @@ import * as passCompletionActions from './pass-completion.actions';
 import { PassCompletion } from '@dvsa/mes-test-schema/categories/common';
 import { createFeatureSelector } from '@ngrx/store';
 
-export const initialState: PassCompletion = null;
+export const initialState: PassCompletion = {
+  passCertificateNumber: null,
+  provisionalLicenceProvided: null,
+};
 
 export const passCompletionReducer = (state = initialState, action: passCompletionActions.Types) => {
   switch (action.type) {
-    case passCompletionActions.POPULATE_PASS_COMPLETION:
-      return {
-        passCertificateNumber: null,
-        provisionalLicenceProvided: null,
-      };
     case passCompletionActions.PASS_CERTIFICATE_NUMBER_CHANGED:
       return {
         ...state,

--- a/src/pages/health-declaration/cat-a-mod1/__tests__/health-declaration.cat-a-mod1.page.spec.ts
+++ b/src/pages/health-declaration/cat-a-mod1/__tests__/health-declaration.cat-a-mod1.page.spec.ts
@@ -110,7 +110,6 @@ describe('HealthDeclarationCatAMod1Page', () => {
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
         component.subscription = new Subscription();
-        store$.dispatch(new passCompletionActions.PopulatePassCompletion()); // Will have been dispatched by prior page
       });
 
   }));

--- a/src/pages/health-declaration/cat-a-mod2/__tests__/health-declaration.cat-a-mod2.page.spec.ts
+++ b/src/pages/health-declaration/cat-a-mod2/__tests__/health-declaration.cat-a-mod2.page.spec.ts
@@ -110,7 +110,6 @@ describe('HealthDeclarationCatAMod2Page', () => {
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
         component.subscription = new Subscription();
-        store$.dispatch(new passCompletionActions.PopulatePassCompletion()); // Will have been dispatched by prior page
       });
 
   }));

--- a/src/pages/health-declaration/cat-b/__tests__/health-declaration.cat-b.page.spec.ts
+++ b/src/pages/health-declaration/cat-b/__tests__/health-declaration.cat-b.page.spec.ts
@@ -110,7 +110,6 @@ describe('HealthDeclarationCatBPage', () => {
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
         component.subscription = new Subscription();
-        store$.dispatch(new passCompletionActions.PopulatePassCompletion()); // Will have been dispatched by prior page
       });
 
   }));

--- a/src/pages/health-declaration/cat-be/__tests__/health-declaration.cat-be.page.spec.ts
+++ b/src/pages/health-declaration/cat-be/__tests__/health-declaration.cat-be.page.spec.ts
@@ -110,7 +110,6 @@ describe('HealthDeclarationCatBEPage', () => {
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
         component.subscription = new Subscription();
-        store$.dispatch(new passCompletionActions.PopulatePassCompletion()); // Will have been dispatched by prior page
       });
 
   }));

--- a/src/pages/health-declaration/cat-c/__tests__/health-declaration.cat-c.page.spec.ts
+++ b/src/pages/health-declaration/cat-c/__tests__/health-declaration.cat-c.page.spec.ts
@@ -110,7 +110,6 @@ describe('HealthDeclarationCatCPage', () => {
         translate = TestBed.get(TranslateService);
         translate.setDefaultLang('en');
         component.subscription = new Subscription();
-        store$.dispatch(new passCompletionActions.PopulatePassCompletion()); // Will have been dispatched by prior page
       });
 
   }));

--- a/src/pages/pass-finalisation/cat-a-mod1/pass-finalisation.cat-a-mod1.page.html
+++ b/src/pages/pass-finalisation/cat-a-mod1/pass-finalisation.cat-a-mod1.page.html
@@ -22,14 +22,27 @@
           </ion-col>
         </ion-row>
 
-        <license-provided [form]="form" (licenseReceived)="provisionalLicenseReceived()"
-          (licenseNotReceived)="provisionalLicenseNotReceived()"> </license-provided>
+        <license-provided
+          [form]="form"
+          [license]="pageState.provisionalLicense$ | async"
+          (licenseReceived)="provisionalLicenseReceived()"
+          (licenseNotReceived)="provisionalLicenseNotReceived()">
+        </license-provided>
 
-        <transmission [formGroup]="form" (transmissionChange)="transmissionChanged($event)"></transmission>
+        <transmission
+          [formGroup]="form"
+          [transmission]="pageState.transmission$ | async"
+          (transmissionChange)="transmissionChanged($event)">
+        </transmission>
+
         <warning-banner *ngIf="displayTransmissionBanner()" warningText="An automatic licence will be issued.">
-          </warning-banner>
+        </warning-banner>
 
-        <pass-certificate-number [form]="form" (passCertificateNumberChange)="passCertificateNumberChanged($event)"></pass-certificate-number>
+        <pass-certificate-number
+          [form]="form"
+          [passCertificateNumberInput]="pageState.passCertificateNumber$ | async"
+          (passCertificateNumberChange)="passCertificateNumberChanged($event)">
+        </pass-certificate-number>
 
         <d255 [display]=true [d255]="pageState.d255$ | async" [outcome]="testOutcome" [formGroup]="form"
           (d255Change)="d255Changed($event)"></d255>

--- a/src/pages/pass-finalisation/cat-a-mod1/pass-finalisation.cat-a-mod1.page.ts
+++ b/src/pages/pass-finalisation/cat-a-mod1/pass-finalisation.cat-a-mod1.page.ts
@@ -16,7 +16,6 @@ import { getPassCompletion } from '../../../modules/tests/pass-completion/pass-c
 import {
   getPassCertificateNumber,
   isProvisionalLicenseProvided,
-  isProvisionalLicenseNotProvided,
 } from '../../../modules/tests/pass-completion/pass-completion.selector';
 import { Observable } from 'rxjs/Observable';
 
@@ -32,18 +31,14 @@ import {
   getApplicationNumber,
 } from '../../../modules/tests/journal-data/common/application-reference/application-reference.selector';
 import { getCurrentTest, getJournalData, getTestOutcomeText } from '../../../modules/tests/tests.selector';
-import { map, tap } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { Subscription } from 'rxjs/Subscription';
 import { getTests } from '../../../modules/tests/tests.reducer';
 import { PersistTests } from '../../../modules/tests/tests.actions';
 
 // TODO - PREP-AMOD1 - implement category specific reducer
 import { getVehicleDetails } from '../../../modules/tests/vehicle-details/cat-be/vehicle-details.cat-be.reducer';
-import {
-  getGearboxCategory,
-  isAutomatic,
-  isManual,
-} from '../../../modules/tests/vehicle-details/common/vehicle-details.selector';
+import { getGearboxCategory } from '../../../modules/tests/vehicle-details/common/vehicle-details.selector';
 import { GearboxCategoryChanged } from '../../../modules/tests/vehicle-details/common/vehicle-details.actions';
 import { CAT_A_MOD1 } from '../../page-names.constants';
 import { getTestSummary } from '../../../modules/tests/test-summary/test-summary.reducer';
@@ -83,12 +78,9 @@ interface PassFinalisationPageState {
   candidateDriverNumber$: Observable<string>;
   testOutcomeText$: Observable<string>;
   applicationNumber$: Observable<string>;
-  provisionalLicenseProvidedRadioChecked$: Observable<boolean>;
-  provisionalLicenseNotProvidedRadioChecked$: Observable<boolean>;
+  provisionalLicense$: Observable<boolean>;
   passCertificateNumber$: Observable<string>;
   transmission$: Observable<GearboxCategory>;
-  transmissionAutomaticRadioChecked$: Observable<boolean>;
-  transmissionManualRadioChecked$: Observable<boolean>;
   d255$: Observable<boolean>;
   debriefWitnessed$: Observable<boolean>;
   conductedLanguage$: Observable<string>;
@@ -156,42 +148,17 @@ export class PassFinalisationCatAMod1Page extends BasePageComponent {
         select(getApplicationReference),
         select(getApplicationNumber),
       ),
-      provisionalLicenseProvidedRadioChecked$: currentTest$.pipe(
+      provisionalLicense$: currentTest$.pipe(
         select(getPassCompletion),
         map(isProvisionalLicenseProvided),
-        tap((val) => {
-          if (val) this.form.controls['provisionalLicenseProvidedCtrl'].setValue('yes');
-        }),
-      ),
-      provisionalLicenseNotProvidedRadioChecked$: currentTest$.pipe(
-        select(getPassCompletion),
-        map(isProvisionalLicenseNotProvided),
-        tap((val) => {
-          if (val) this.form.controls['provisionalLicenseProvidedCtrl'].setValue('no');
-        }),
       ),
       passCertificateNumber$: currentTest$.pipe(
         select(getPassCompletion),
         select(getPassCertificateNumber),
-        tap(val => this.form.controls[this.passCertificateCtrl].setValue(val)),
       ),
       transmission$: currentTest$.pipe(
         select(getVehicleDetails),
         select(getGearboxCategory),
-      ),
-      transmissionAutomaticRadioChecked$: currentTest$.pipe(
-        select(getVehicleDetails),
-        map(isAutomatic),
-        tap((val) => {
-          if (val) this.form.controls['transmissionCtrl'].setValue('Automatic');
-        }),
-      ),
-      transmissionManualRadioChecked$: currentTest$.pipe(
-        select(getVehicleDetails),
-        map(isManual),
-        tap((val) => {
-          if (val) this.form.controls['transmissionCtrl'].setValue('Manual');
-        }),
       ),
       debriefWitnessed$: currentTest$.pipe(
         select(getTestSummary),

--- a/src/pages/pass-finalisation/cat-a-mod1/pass-finalisation.cat-a-mod1.page.ts
+++ b/src/pages/pass-finalisation/cat-a-mod1/pass-finalisation.cat-a-mod1.page.ts
@@ -10,7 +10,6 @@ import {
 import {
   ProvisionalLicenseReceived,
   ProvisionalLicenseNotReceived,
-  PopulatePassCompletion,
   PassCertificateNumberChanged,
 } from '../../../modules/tests/pass-completion/pass-completion.actions';
 import { getPassCompletion } from '../../../modules/tests/pass-completion/pass-completion.reducer';
@@ -213,7 +212,6 @@ export class PassFinalisationCatAMod1Page extends BasePageComponent {
       transmission$.pipe(map(value => this.transmission = value)),
     );
     this.subscription = this.merged$.subscribe();
-    this.store$.dispatch(new PopulatePassCompletion());
   }
 
   ionViewDidLeave(): void {

--- a/src/pages/pass-finalisation/cat-a-mod2/pass-finalisation.cat-a-mod2.page.html
+++ b/src/pages/pass-finalisation/cat-a-mod2/pass-finalisation.cat-a-mod2.page.html
@@ -22,14 +22,27 @@
           </ion-col>
         </ion-row>
 
-        <license-provided [form]="form" (licenseReceived)="provisionalLicenseReceived()"
-          (licenseNotReceived)="provisionalLicenseNotReceived()"> </license-provided>
+        <license-provided
+          [form]="form"
+          [license]="pageState.provisionalLicense$ | async"
+          (licenseReceived)="provisionalLicenseReceived()"
+          (licenseNotReceived)="provisionalLicenseNotReceived()">
+        </license-provided>
 
-        <transmission [formGroup]="form" (transmissionChange)="transmissionChanged($event)"></transmission>
+        <transmission
+          [formGroup]="form"
+          [transmission]="pageState.transmission$ | async"
+          (transmissionChange)="transmissionChanged($event)">
+        </transmission>
+
         <warning-banner *ngIf="displayTransmissionBanner()" warningText="An automatic licence will be issued.">
-          </warning-banner>
+        </warning-banner>
 
-        <pass-certificate-number [form]="form" (passCertificateNumberChange)="passCertificateNumberChanged($event)"></pass-certificate-number>
+        <pass-certificate-number
+          [form]="form"
+          [passCertificateNumberInput]="pageState.passCertificateNumber$ | async"
+          (passCertificateNumberChange)="passCertificateNumberChanged($event)">
+        </pass-certificate-number>
 
         <d255 [display]=true [d255]="pageState.d255$ | async" [outcome]="testOutcome" [formGroup]="form"
           (d255Change)="d255Changed($event)"></d255>

--- a/src/pages/pass-finalisation/cat-a-mod2/pass-finalisation.cat-a-mod2.page.ts
+++ b/src/pages/pass-finalisation/cat-a-mod2/pass-finalisation.cat-a-mod2.page.ts
@@ -10,7 +10,6 @@ import {
 import {
   ProvisionalLicenseReceived,
   ProvisionalLicenseNotReceived,
-  PopulatePassCompletion,
   PassCertificateNumberChanged,
 } from '../../../modules/tests/pass-completion/pass-completion.actions';
 import { getPassCompletion } from '../../../modules/tests/pass-completion/pass-completion.reducer';
@@ -211,7 +210,6 @@ export class PassFinalisationCatAMod2Page extends BasePageComponent {
       transmission$.pipe(map(value => this.transmission = value)),
     );
     this.subscription = this.merged$.subscribe();
-    this.store$.dispatch(new PopulatePassCompletion());
   }
 
   ionViewDidLeave(): void {

--- a/src/pages/pass-finalisation/cat-a-mod2/pass-finalisation.cat-a-mod2.page.ts
+++ b/src/pages/pass-finalisation/cat-a-mod2/pass-finalisation.cat-a-mod2.page.ts
@@ -16,7 +16,6 @@ import { getPassCompletion } from '../../../modules/tests/pass-completion/pass-c
 import {
   getPassCertificateNumber,
   isProvisionalLicenseProvided,
-  isProvisionalLicenseNotProvided,
 } from '../../../modules/tests/pass-completion/pass-completion.selector';
 import { Observable } from 'rxjs/Observable';
 
@@ -32,18 +31,14 @@ import {
   getApplicationNumber,
 } from '../../../modules/tests/journal-data/common/application-reference/application-reference.selector';
 import { getCurrentTest, getJournalData, getTestOutcomeText } from '../../../modules/tests/tests.selector';
-import { map, tap } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { Subscription } from 'rxjs/Subscription';
 import { getTests } from '../../../modules/tests/tests.reducer';
 import { PersistTests } from '../../../modules/tests/tests.actions';
 
 // TODO - PREP-AMOD2 - Implement category specific reducer
 import { getVehicleDetails } from '../../../modules/tests/vehicle-details/cat-be/vehicle-details.cat-be.reducer';
-import {
-  getGearboxCategory,
-  isAutomatic,
-  isManual,
-} from '../../../modules/tests/vehicle-details/common/vehicle-details.selector';
+import { getGearboxCategory } from '../../../modules/tests/vehicle-details/common/vehicle-details.selector';
 import { GearboxCategoryChanged } from '../../../modules/tests/vehicle-details/common/vehicle-details.actions';
 import { CAT_A_MOD2 } from '../../page-names.constants';
 import { getTestSummary } from '../../../modules/tests/test-summary/test-summary.reducer';
@@ -82,12 +77,9 @@ interface PassFinalisationPageState {
   candidateDriverNumber$: Observable<string>;
   testOutcomeText$: Observable<string>;
   applicationNumber$: Observable<string>;
-  provisionalLicenseProvidedRadioChecked$: Observable<boolean>;
-  provisionalLicenseNotProvidedRadioChecked$: Observable<boolean>;
+  provisionalLicense$: Observable<boolean>;
   passCertificateNumber$: Observable<string>;
   transmission$: Observable<GearboxCategory>;
-  transmissionAutomaticRadioChecked$: Observable<boolean>;
-  transmissionManualRadioChecked$: Observable<boolean>;
   d255$: Observable<boolean>;
   debriefWitnessed$: Observable<boolean>;
   conductedLanguage$: Observable<string>;
@@ -154,42 +146,17 @@ export class PassFinalisationCatAMod2Page extends BasePageComponent {
         select(getApplicationReference),
         select(getApplicationNumber),
       ),
-      provisionalLicenseProvidedRadioChecked$: currentTest$.pipe(
+      provisionalLicense$: currentTest$.pipe(
         select(getPassCompletion),
         map(isProvisionalLicenseProvided),
-        tap((val) => {
-          if (val) this.form.controls['provisionalLicenseProvidedCtrl'].setValue('yes');
-        }),
-      ),
-      provisionalLicenseNotProvidedRadioChecked$: currentTest$.pipe(
-        select(getPassCompletion),
-        map(isProvisionalLicenseNotProvided),
-        tap((val) => {
-          if (val) this.form.controls['provisionalLicenseProvidedCtrl'].setValue('no');
-        }),
       ),
       passCertificateNumber$: currentTest$.pipe(
         select(getPassCompletion),
         select(getPassCertificateNumber),
-        tap(val => this.form.controls[this.passCertificateCtrl].setValue(val)),
       ),
       transmission$: currentTest$.pipe(
         select(getVehicleDetails),
         select(getGearboxCategory),
-      ),
-      transmissionAutomaticRadioChecked$: currentTest$.pipe(
-        select(getVehicleDetails),
-        map(isAutomatic),
-        tap((val) => {
-          if (val) this.form.controls['transmissionCtrl'].setValue('Automatic');
-        }),
-      ),
-      transmissionManualRadioChecked$: currentTest$.pipe(
-        select(getVehicleDetails),
-        map(isManual),
-        tap((val) => {
-          if (val) this.form.controls['transmissionCtrl'].setValue('Manual');
-        }),
       ),
       debriefWitnessed$: currentTest$.pipe(
         select(getTestSummary),

--- a/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.html
+++ b/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.html
@@ -23,14 +23,23 @@
           </ion-col>
         </ion-row>
 
-        <license-provided [form]="form" (licenseReceived)="provisionalLicenseReceived()"
-          (licenseNotReceived)="provisionalLicenseNotReceived()"> </license-provided>
+        <license-provided
+          [form]="form"
+          [license]="pageState.provisionalLicense$ | async"
+          (licenseReceived)="provisionalLicenseReceived()"
+          (licenseNotReceived)="provisionalLicenseNotReceived()">
+        </license-provided>
 
         <transmission [formGroup]="form" (transmissionChange)="transmissionChanged($event)"></transmission>
+
         <warning-banner *ngIf="displayTransmissionBanner()" warningText="An automatic licence will be issued.">
         </warning-banner>
 
-        <pass-certificate-number [form]="form" (passCertificateNumberChange)="passCertificateNumberChanged($event)"></pass-certificate-number>
+        <pass-certificate-number
+          [form]="form"
+          [passCertificateNumberInput]="pageState.passCertificateNumber$ | async"
+          (passCertificateNumberChange)="passCertificateNumberChanged($event)">
+        </pass-certificate-number>
 
         <d255 [display]=true [d255]="pageState.d255$ | async" [outcome]="testOutcome" [formGroup]="form"
           (d255Change)="d255Changed($event)"></d255>

--- a/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.ts
+++ b/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.ts
@@ -10,7 +10,6 @@ import {
 import {
   ProvisionalLicenseReceived,
   ProvisionalLicenseNotReceived,
-  PopulatePassCompletion,
   PassCertificateNumberChanged,
 } from '../../../modules/tests/pass-completion/pass-completion.actions';
 import { getPassCompletion } from '../../../modules/tests/pass-completion/pass-completion.reducer';
@@ -205,7 +204,6 @@ export class PassFinalisationCatBPage extends PracticeableBasePageComponent {
       transmission$.pipe(map(value => this.transmission = value)),
     );
     this.subscription = this.merged$.subscribe();
-    this.store$.dispatch(new PopulatePassCompletion());
   }
 
   ionViewDidLeave(): void {

--- a/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.ts
+++ b/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.ts
@@ -16,7 +16,6 @@ import { getPassCompletion } from '../../../modules/tests/pass-completion/pass-c
 import {
   getPassCertificateNumber,
   isProvisionalLicenseProvided,
-  isProvisionalLicenseNotProvided,
 } from '../../../modules/tests/pass-completion/pass-completion.selector';
 import { Observable } from 'rxjs/Observable';
 import { getCandidate } from '../../../modules/tests/journal-data/cat-b/candidate/candidate.reducer';
@@ -76,8 +75,7 @@ interface PassFinalisationPageState {
   candidateDriverNumber$: Observable<string>;
   testOutcomeText$: Observable<string>;
   applicationNumber$: Observable<string>;
-  provisionalLicenseProvidedRadioChecked$: Observable<boolean>;
-  provisionalLicenseNotProvidedRadioChecked$: Observable<boolean>;
+  provisionalLicense$: Observable<boolean>;
   passCertificateNumber$: Observable<string>;
   transmission$: Observable<GearboxCategory>;
   transmissionAutomaticRadioChecked$: Observable<boolean>;
@@ -148,24 +146,13 @@ export class PassFinalisationCatBPage extends PracticeableBasePageComponent {
         select(getApplicationReference),
         select(getApplicationNumber),
       ),
-      provisionalLicenseProvidedRadioChecked$: currentTest$.pipe(
+      provisionalLicense$: currentTest$.pipe(
         select(getPassCompletion),
         map(isProvisionalLicenseProvided),
-        tap((val) => {
-          if (val) this.form.controls['provisionalLicenseProvidedCtrl'].setValue('yes');
-        }),
-      ),
-      provisionalLicenseNotProvidedRadioChecked$: currentTest$.pipe(
-        select(getPassCompletion),
-        map(isProvisionalLicenseNotProvided),
-        tap((val) => {
-          if (val) this.form.controls['provisionalLicenseProvidedCtrl'].setValue('no');
-        }),
       ),
       passCertificateNumber$: currentTest$.pipe(
         select(getPassCompletion),
         select(getPassCertificateNumber),
-        tap(val => this.form.controls[this.passCertificateCtrl].setValue(val)),
       ),
       transmission$: currentTest$.pipe(
         select(getVehicleDetails),

--- a/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.html
+++ b/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.html
@@ -22,14 +22,27 @@
           </ion-col>
         </ion-row>
 
-        <license-provided [form]="form" (licenseReceived)="provisionalLicenseReceived()"
-          (licenseNotReceived)="provisionalLicenseNotReceived()"> </license-provided>
+        <license-provided
+          [form]="form"
+          [license]="pageState.provisionalLicense$ | async"
+          (licenseReceived)="provisionalLicenseReceived()"
+          (licenseNotReceived)="provisionalLicenseNotReceived()">
+        </license-provided>
 
-        <transmission [formGroup]="form" (transmissionChange)="transmissionChanged($event)"></transmission>
+        <transmission
+          [formGroup]="form"
+          [transmission]="pageState.transmission$ | async"
+          (transmissionChange)="transmissionChanged($event)">
+        </transmission>
+
         <warning-banner *ngIf="displayTransmissionBanner()" warningText="An automatic licence will be issued.">
-          </warning-banner>
+        </warning-banner>
 
-        <pass-certificate-number [form]="form" (passCertificateNumberChange)="passCertificateNumberChanged($event)"></pass-certificate-number>
+        <pass-certificate-number
+          [form]="form"
+          [passCertificateNumberInput]="pageState.passCertificateNumber$ | async"
+          (passCertificateNumberChange)="passCertificateNumberChanged($event)">
+        </pass-certificate-number>
 
         <d255 [display]=true [d255]="pageState.d255$ | async" [outcome]="testOutcome" [formGroup]="form"
           (d255Change)="d255Changed($event)"></d255>

--- a/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.ts
+++ b/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.ts
@@ -16,7 +16,6 @@ import { getPassCompletion } from '../../../modules/tests/pass-completion/pass-c
 import {
   getPassCertificateNumber,
   isProvisionalLicenseProvided,
-  isProvisionalLicenseNotProvided,
 } from '../../../modules/tests/pass-completion/pass-completion.selector';
 import { Observable } from 'rxjs/Observable';
 import { getCandidate } from '../../../modules/tests/journal-data/cat-be/candidate/candidate.cat-be.reducer';
@@ -30,16 +29,12 @@ import {
   getApplicationNumber,
 } from '../../../modules/tests/journal-data/common/application-reference/application-reference.selector';
 import { getCurrentTest, getJournalData, getTestOutcomeText } from '../../../modules/tests/tests.selector';
-import { map, tap } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { Subscription } from 'rxjs/Subscription';
 import { getTests } from '../../../modules/tests/tests.reducer';
 import { PersistTests } from '../../../modules/tests/tests.actions';
 import { getVehicleDetails } from '../../../modules/tests/vehicle-details/cat-be/vehicle-details.cat-be.reducer';
-import {
-  getGearboxCategory,
-  isAutomatic,
-  isManual,
-} from '../../../modules/tests/vehicle-details/common/vehicle-details.selector';
+import { getGearboxCategory } from '../../../modules/tests/vehicle-details/common/vehicle-details.selector';
 import { GearboxCategoryChanged } from '../../../modules/tests/vehicle-details/common/vehicle-details.actions';
 import { CAT_BE } from '../../page-names.constants';
 import { getTestSummary } from '../../../modules/tests/test-summary/test-summary.reducer';
@@ -76,12 +71,9 @@ interface PassFinalisationPageState {
   candidateDriverNumber$: Observable<string>;
   testOutcomeText$: Observable<string>;
   applicationNumber$: Observable<string>;
-  provisionalLicenseProvidedRadioChecked$: Observable<boolean>;
-  provisionalLicenseNotProvidedRadioChecked$: Observable<boolean>;
+  provisionalLicense$: Observable<boolean>;
   passCertificateNumber$: Observable<string>;
   transmission$: Observable<GearboxCategory>;
-  transmissionAutomaticRadioChecked$: Observable<boolean>;
-  transmissionManualRadioChecked$: Observable<boolean>;
   d255$: Observable<boolean>;
   debriefWitnessed$: Observable<boolean>;
   conductedLanguage$: Observable<string>;
@@ -148,42 +140,17 @@ export class PassFinalisationCatBEPage extends BasePageComponent {
         select(getApplicationReference),
         select(getApplicationNumber),
       ),
-      provisionalLicenseProvidedRadioChecked$: currentTest$.pipe(
+      provisionalLicense$: currentTest$.pipe(
         select(getPassCompletion),
         map(isProvisionalLicenseProvided),
-        tap((val) => {
-          if (val) this.form.controls['provisionalLicenseProvidedCtrl'].setValue('yes');
-        }),
-      ),
-      provisionalLicenseNotProvidedRadioChecked$: currentTest$.pipe(
-        select(getPassCompletion),
-        map(isProvisionalLicenseNotProvided),
-        tap((val) => {
-          if (val) this.form.controls['provisionalLicenseProvidedCtrl'].setValue('no');
-        }),
       ),
       passCertificateNumber$: currentTest$.pipe(
         select(getPassCompletion),
         select(getPassCertificateNumber),
-        tap(val => this.form.controls[this.passCertificateCtrl].setValue(val)),
       ),
       transmission$: currentTest$.pipe(
         select(getVehicleDetails),
         select(getGearboxCategory),
-      ),
-      transmissionAutomaticRadioChecked$: currentTest$.pipe(
-        select(getVehicleDetails),
-        map(isAutomatic),
-        tap((val) => {
-          if (val) this.form.controls['transmissionCtrl'].setValue('Automatic');
-        }),
-      ),
-      transmissionManualRadioChecked$: currentTest$.pipe(
-        select(getVehicleDetails),
-        map(isManual),
-        tap((val) => {
-          if (val) this.form.controls['transmissionCtrl'].setValue('Manual');
-        }),
       ),
       debriefWitnessed$: currentTest$.pipe(
         select(getTestSummary),

--- a/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.ts
+++ b/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.ts
@@ -10,7 +10,6 @@ import {
 import {
   ProvisionalLicenseReceived,
   ProvisionalLicenseNotReceived,
-  PopulatePassCompletion,
   PassCertificateNumberChanged,
 } from '../../../modules/tests/pass-completion/pass-completion.actions';
 import { getPassCompletion } from '../../../modules/tests/pass-completion/pass-completion.reducer';
@@ -205,7 +204,6 @@ export class PassFinalisationCatBEPage extends BasePageComponent {
       transmission$.pipe(map(value => this.transmission = value)),
     );
     this.subscription = this.merged$.subscribe();
-    this.store$.dispatch(new PopulatePassCompletion());
   }
 
   ionViewDidLeave(): void {

--- a/src/pages/pass-finalisation/cat-c/components/code-78/__tests__/code-78.spec.ts
+++ b/src/pages/pass-finalisation/cat-c/components/code-78/__tests__/code-78.spec.ts
@@ -48,14 +48,15 @@ describe('code78Component', () => {
 
     describe('isInvalid', () => {
       it('should validate the field when it is valid', () => {
+        component.code78 = true;
         component.ngOnChanges();
-        component.form.get(Code78Component.fieldName).setValue('yes');
         fixture.detectChanges();
         const result: boolean = component.isInvalid();
         expect(result).toEqual(false);
       });
 
       it('should not validate the field when it is dirty', () => {
+        component.code78 = null;
         component.ngOnChanges();
         component.formControl.markAsDirty();
         fixture.detectChanges();

--- a/src/pages/pass-finalisation/cat-c/components/code-78/code-78.html
+++ b/src/pages/pass-finalisation/cat-c/components/code-78/code-78.html
@@ -9,12 +9,12 @@
     <ion-row [formGroup]="form">
       <ion-col col-48>
         <input formControlName="code78Ctrl" type="radio" id="code-78-received" value="yes" class="gds-radio-button"
-          [checked]="code78PresentRadioChecked" (click)="code78IsPresent()">
+          (click)="code78IsPresent()">
         <label for="code-78-received" class="radio-label">Yes</label>
       </ion-col>
       <ion-col>
         <input formControlName="code78Ctrl" type="radio" id="code-78-not-received" value="no" class="gds-radio-button"
-          [checked]="code78NotPresentRadioChecked" (click)="code78IsNotPresent()">
+          (click)="code78IsNotPresent()">
         <label for="code-78-not-received" class="radio-label">No</label>
       </ion-col>
     </ion-row>

--- a/src/pages/pass-finalisation/cat-c/components/code-78/code-78.ts
+++ b/src/pages/pass-finalisation/cat-c/components/code-78/code-78.ts
@@ -1,6 +1,10 @@
 import { Component, Input, OnChanges, Output, EventEmitter } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
-import { TransmissionType } from '../../../../../shared/models/transmission-type';
+
+enum ValidCode78Values {
+  YES = 'yes',
+  NO = 'no',
+}
 
 @Component({
   selector: 'code-78',
@@ -12,7 +16,7 @@ export class Code78Component implements OnChanges {
   form: FormGroup;
 
   @Input()
-  transmission: TransmissionType;
+  code78: boolean;
 
   @Output()
   code78Present = new EventEmitter<boolean>();
@@ -24,6 +28,12 @@ export class Code78Component implements OnChanges {
     if (!this.formControl) {
       this.formControl = new FormControl('', [Validators.required]);
       this.form.addControl(Code78Component.fieldName, this.formControl);
+    }
+
+    if (this.code78 !== null) {
+      this.formControl.patchValue(this.code78 ? ValidCode78Values.YES : ValidCode78Values.NO);
+    } else {
+      this.formControl.patchValue(null);
     }
   }
 

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.html
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.html
@@ -37,9 +37,6 @@
           (transmissionChange)="transmissionChanged($event)">
         </transmission>
 
-        <warning-banner *ngIf="displayTransmissionBanner()" warningText="An automatic licence will be issued.">
-        </warning-banner>
-
         <code-78 [form]="form" [code78]="pageState.code78$ | async"
           (code78Present)="onCode78Present($event)"></code-78>
 

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.html
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.html
@@ -21,22 +21,36 @@
           </ion-col>
         </ion-row>
 
-        <license-provided [form]="form" (licenseReceived)="provisionalLicenseReceived()" (licenseNotReceived)="provisionalLicenseNotReceived()">
+        <license-provided
+          [form]="form"
+          [license]="pageState.provisionalLicense$ | async"
+          (licenseReceived)="provisionalLicenseReceived()"
+          (licenseNotReceived)="provisionalLicenseNotReceived()">
         </license-provided>
 
         <warning-banner *ngIf="shouldShowCandidateDoesntNeedLicenseBanner()" warningText="{{askCandidateLicenseMessage}}">
         </warning-banner>
 
-        <transmission [formGroup]="form" (transmissionChange)="transmissionChanged($event)"></transmission>
-        <warning-banner *ngIf="displayTransmissionBanner()" warningText="An automatic licence will be issued."></warning-banner>
+        <transmission
+          [formGroup]="form"
+          [transmission]="pageState.transmission$ | async"
+          (transmissionChange)="transmissionChanged($event)">
+        </transmission>
 
-        <code-78 [form]="form" [transmission]="pageState.transmission$ | async"
+        <warning-banner *ngIf="displayTransmissionBanner()" warningText="An automatic licence will be issued.">
+        </warning-banner>
+
+        <code-78 [form]="form" [code78]="pageState.code78$ | async"
           (code78Present)="onCode78Present($event)"></code-78>
 
         <warning-banner *ngIf="shouldShowManualBanner()" warningText="{{manualMessage}}"></warning-banner>
         <warning-banner *ngIf="shouldShowAutomaticBanner()" warningText="{{automaticMessage}}"></warning-banner>
 
-        <pass-certificate-number [form]="form" (passCertificateNumberChange)="passCertificateNumberChanged($event)"></pass-certificate-number>
+        <pass-certificate-number
+          [form]="form"
+          [passCertificateNumberInput]="pageState.passCertificateNumber$ | async"
+          (passCertificateNumberChange)="passCertificateNumberChanged($event)">
+        </pass-certificate-number>
 
         <d255 [display]=true [d255]="pageState.d255$ | async" [outcome]="testOutcome" [formGroup]="form" (d255Change)="d255Changed($event)"></d255>
         <warning-banner *ngIf="pageState.d255$ | async" warningText="By selecting Yes you are confirming a D255 is required."></warning-banner>

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
@@ -17,7 +17,6 @@ import {
 import {
   getPassCertificateNumber,
   isProvisionalLicenseProvided,
-  isProvisionalLicenseNotProvided,
 } from '../../../modules/tests/pass-completion/pass-completion.selector';
 import { Observable } from 'rxjs/Observable';
 import { getCandidate } from '../../../modules/tests/journal-data/cat-c/candidate/candidate.cat-c.reducer';
@@ -31,17 +30,13 @@ import {
   getApplicationNumber,
 } from '../../../modules/tests/journal-data/common/application-reference/application-reference.selector';
 import { getCurrentTest, getJournalData, getTestOutcomeText } from '../../../modules/tests/tests.selector';
-import { map, tap } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { Subscription } from 'rxjs/Subscription';
 import { getTests } from '../../../modules/tests/tests.reducer';
 import { PersistTests } from '../../../modules/tests/tests.actions';
 // TODO: MES-4287 use Cat C reducer
 import { getVehicleDetails } from '../../../modules/tests/vehicle-details/cat-be/vehicle-details.cat-be.reducer';
-import {
-  getGearboxCategory,
-  isAutomatic,
-  isManual,
-} from '../../../modules/tests/vehicle-details/common/vehicle-details.selector';
+import { getGearboxCategory } from '../../../modules/tests/vehicle-details/common/vehicle-details.selector';
 import { GearboxCategoryChanged } from '../../../modules/tests/vehicle-details/common/vehicle-details.actions';
 import { CAT_C } from '../../page-names.constants';
 import { getTestSummary } from '../../../modules/tests/test-summary/test-summary.reducer';
@@ -73,6 +68,7 @@ import { PASS_CERTIFICATE_NUMBER_CTRL } from '../components/pass-certificate-num
 import { TransmissionType } from '../../../shared/models/transmission-type';
 import { merge } from 'rxjs/observable/merge';
 import { getPassCompletion } from '../../../modules/tests/pass-completion/cat-c/pass-completion.cat-c.reducer';
+import { getCode78 } from '../../../modules/tests/pass-completion/cat-c/pass-completion.cat-c.selector';
 
 interface PassFinalisationPageState {
   candidateName$: Observable<string>;
@@ -80,15 +76,13 @@ interface PassFinalisationPageState {
   candidateDriverNumber$: Observable<string>;
   testOutcomeText$: Observable<string>;
   applicationNumber$: Observable<string>;
-  provisionalLicenseProvidedRadioChecked$: Observable<boolean>;
-  provisionalLicenseNotProvidedRadioChecked$: Observable<boolean>;
+  provisionalLicense$: Observable<boolean>;
   passCertificateNumber$: Observable<string>;
   transmission$: Observable<GearboxCategory>;
-  transmissionAutomaticRadioChecked$: Observable<boolean>;
-  transmissionManualRadioChecked$: Observable<boolean>;
   d255$: Observable<boolean>;
   debriefWitnessed$: Observable<boolean>;
   conductedLanguage$: Observable<string>;
+  code78$: Observable<boolean>;
 }
 
 @IonicPage()
@@ -104,7 +98,7 @@ export class PassFinalisationCatCPage extends BasePageComponent {
   inputSubscriptions: Subscription[] = [];
   testOutcome: string = ActivityCodes.PASS;
   form: FormGroup;
-  merged$: Observable<string>;
+  merged$: Observable<string | boolean>;
   transmission: GearboxCategory;
   subscription: Subscription;
   code78Present: boolean = null;
@@ -157,48 +151,17 @@ export class PassFinalisationCatCPage extends BasePageComponent {
         select(getApplicationReference),
         select(getApplicationNumber),
       ),
-      provisionalLicenseProvidedRadioChecked$: currentTest$.pipe(
+      provisionalLicense$: currentTest$.pipe(
         select(getPassCompletion),
-        map(isProvisionalLicenseProvided),
-        tap((val) => {
-          if (val) {
-            this.form.controls['provisionalLicenseProvidedCtrl'].setValue(
-              'yes',
-            );
-          }
-        }),
-      ),
-      provisionalLicenseNotProvidedRadioChecked$: currentTest$.pipe(
-        select(getPassCompletion),
-        map(isProvisionalLicenseNotProvided),
-        tap((val) => {
-          if (val) {
-            this.form.controls['provisionalLicenseProvidedCtrl'].setValue('no');
-          }
-        }),
+        select(isProvisionalLicenseProvided),
       ),
       passCertificateNumber$: currentTest$.pipe(
         select(getPassCompletion),
         select(getPassCertificateNumber),
-        tap(val => this.form.controls[this.passCertificateCtrl].setValue(val)),
       ),
       transmission$: currentTest$.pipe(
         select(getVehicleDetails),
         select(getGearboxCategory),
-      ),
-      transmissionAutomaticRadioChecked$: currentTest$.pipe(
-        select(getVehicleDetails),
-        map(isAutomatic),
-        tap((val) => {
-          if (val) this.form.controls['transmissionCtrl'].setValue('Automatic');
-        }),
-      ),
-      transmissionManualRadioChecked$: currentTest$.pipe(
-        select(getVehicleDetails),
-        map(isManual),
-        tap((val) => {
-          if (val) this.form.controls['transmissionCtrl'].setValue('Manual');
-        }),
       ),
       debriefWitnessed$: currentTest$.pipe(
         select(getTestSummary),
@@ -212,12 +175,18 @@ export class PassFinalisationCatCPage extends BasePageComponent {
         select(getCommunicationPreference),
         select(getConductedLanguage),
       ),
+      code78$: currentTest$.pipe(
+        select(getPassCompletion),
+        select(getCode78),
+      ),
     };
 
-    const { transmission$ } = this.pageState;
+    const { transmission$, code78$, provisionalLicense$ } = this.pageState;
 
     this.merged$ = merge(
-      transmission$.pipe(map(value => (this.transmission = value))),
+      transmission$.pipe(map(value => this.transmission = value)),
+      code78$.pipe(map(value => this.code78Present = value)),
+      provisionalLicense$.pipe(map(value => this.provisionalLicenseIsReceived = value)),
     );
     this.subscription = this.merged$.subscribe();
   }
@@ -233,12 +202,10 @@ export class PassFinalisationCatCPage extends BasePageComponent {
   }
 
   provisionalLicenseReceived(): void {
-    this.provisionalLicenseIsReceived = true;
     this.store$.dispatch(new ProvisionalLicenseReceived());
   }
 
   provisionalLicenseNotReceived(): void {
-    this.provisionalLicenseIsReceived = false;
     this.store$.dispatch(new ProvisionalLicenseNotReceived());
   }
 
@@ -247,7 +214,6 @@ export class PassFinalisationCatCPage extends BasePageComponent {
   }
 
   onCode78Present(present: boolean) {
-    this.code78Present = present;
     if (present) {
       this.store$.dispatch(new Code78Present());
     } else {

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
@@ -10,7 +10,6 @@ import {
 import {
   ProvisionalLicenseReceived,
   ProvisionalLicenseNotReceived,
-  PopulatePassCompletion,
   PassCertificateNumberChanged,
   Code78NotPresent,
   Code78Present,
@@ -221,8 +220,6 @@ export class PassFinalisationCatCPage extends BasePageComponent {
       transmission$.pipe(map(value => (this.transmission = value))),
     );
     this.subscription = this.merged$.subscribe();
-
-    this.store$.dispatch(new PopulatePassCompletion());
   }
 
   ionViewDidLeave(): void {

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
@@ -268,14 +268,6 @@ export class PassFinalisationCatCPage extends BasePageComponent {
     );
   }
 
-  displayTransmissionBanner(): boolean {
-    return (
-      !this.form.controls['transmissionCtrl'].pristine &&
-      this.transmission === TransmissionType.Automatic &&
-      !this.shouldShowCode78Banner()
-    );
-  }
-
   shouldShowCode78Banner(): boolean {
     return this.code78Present !== null && this.transmission !== null;
   }

--- a/src/pages/pass-finalisation/components/license-provided/__tests__/license-provided.spec.ts
+++ b/src/pages/pass-finalisation/components/license-provided/__tests__/license-provided.spec.ts
@@ -45,14 +45,15 @@ describe('licenseProvidedComponent', () => {
 
     describe('isInvalid', () => {
       it('should validate the field when it is valid', () => {
+        component.license = true;
         component.ngOnChanges();
-        component.form.get(LicenseProvidedComponent.fieldName).setValue('yes');
         fixture.detectChanges();
         const result: boolean = component.isInvalid();
         expect(result).toEqual(false);
       });
 
       it('should not validate the field when it is dirty', () => {
+        component.license = null;
         component.ngOnChanges();
         component.formControl.markAsDirty();
         fixture.detectChanges();

--- a/src/pages/pass-finalisation/components/license-provided/license-provided.html
+++ b/src/pages/pass-finalisation/components/license-provided/license-provided.html
@@ -9,12 +9,12 @@
     <ion-row [formGroup]="form">
       <ion-col col-48>
         <input formControlName="provisionalLicenseProvidedCtrl" type="radio" id="license-received" value="yes"
-          [checked]="provisionalLicenseProvidedRadioChecked" class="gds-radio-button" (click)="provisionalLicenseReceived()">
+          class="gds-radio-button" (click)="provisionalLicenseReceived()">
         <label for="license-received" class="radio-label">Yes</label>
       </ion-col>
       <ion-col>
         <input formControlName="provisionalLicenseProvidedCtrl" type="radio" id="license-not-received" value="no"
-          [checked]="provisionalLicenseNotProvidedRadioChecked" class="gds-radio-button" (click)="provisionalLicenseNotReceived()">
+          class="gds-radio-button" (click)="provisionalLicenseNotReceived()">
         <label for="license-not-received" class="radio-label">No</label>
       </ion-col>
     </ion-row>

--- a/src/pages/pass-finalisation/components/license-provided/license-provided.ts
+++ b/src/pages/pass-finalisation/components/license-provided/license-provided.ts
@@ -16,12 +16,20 @@ import {
 } from
   '../../../../modules/tests/pass-completion/pass-completion.actions';
 
+enum ValidLicenceProvidedValues {
+    YES = 'yes',
+    NO = 'no',
+  }
+
 @Component({
   selector: 'license-provided',
   templateUrl: 'license-provided.html',
 })
 
 export class LicenseProvidedComponent implements OnChanges {
+
+  @Input()
+  license: boolean;
 
   @Output()
   licenseReceived = new EventEmitter<ProvisionalLicenseReceived>();
@@ -39,6 +47,12 @@ export class LicenseProvidedComponent implements OnChanges {
     if (!this.formControl) {
       this.formControl = new FormControl('', [Validators.required]);
       this.form.addControl(LicenseProvidedComponent.fieldName, this.formControl);
+    }
+
+    if (this.license !== null) {
+      this.formControl.patchValue(this.license ? ValidLicenceProvidedValues.YES : ValidLicenceProvidedValues.NO);
+    } else {
+      this.formControl.patchValue(null);
     }
   }
 

--- a/src/providers/test-submission/__tests__/test-submission.spec.ts
+++ b/src/providers/test-submission/__tests__/test-submission.spec.ts
@@ -13,6 +13,7 @@ import { Device } from '@ionic-native/device';
 import { AppConfigProvider } from '../../app-config/app-config';
 import { AppConfigProviderMock } from '../../app-config/__mocks__/app-config.mock';
 import { TestStatus } from '../../../modules/tests/test-status/test-status.model';
+import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
 
 describe('TestSubmissionProvider', () => {
 
@@ -279,6 +280,55 @@ describe('TestSubmissionProvider', () => {
 
       // ASSERT
       expect(result).toEqual('https://www.example.com/api/v1/test-result');
+    });
+  });
+
+  describe('removePassCompletionWhenTestIsNotPass', () => {
+    it('should not remove the pass completion key if the activity code is a Pass', () => {
+      const result: Partial<TestResultSchemasUnion> = testSubmissionProvider.removePassCompletionWhenTestIsNotPass({
+        activityCode: '1',
+        category: 'B',
+        accompaniment: {
+          ADI: true,
+        },
+        passCompletion: {
+          passCertificateNumber: 'A123456X',
+          provisionalLicenceProvided: true,
+        },
+      });
+
+      expect(result).toEqual({
+        activityCode: '1',
+        category: 'B',
+        accompaniment: {
+          ADI: true,
+        },
+        passCompletion: {
+          passCertificateNumber: 'A123456X',
+          provisionalLicenceProvided: true,
+        },
+      });
+    });
+    it('should remove the pass completion key if the activity code is not a pass', () => {
+      const result: Partial<TestResultSchemasUnion> = testSubmissionProvider.removePassCompletionWhenTestIsNotPass({
+        activityCode: '3',
+        category: 'B',
+        accompaniment: {
+          ADI: true,
+        },
+        passCompletion: {
+          passCertificateNumber: 'A123456X',
+          provisionalLicenceProvided: true,
+        },
+      });
+
+      expect(result).toEqual({
+        activityCode: '3',
+        category: 'B',
+        accompaniment: {
+          ADI: true,
+        },
+      });
     });
   });
 

--- a/src/providers/test-submission/test-submission.ts
+++ b/src/providers/test-submission/test-submission.ts
@@ -15,6 +15,7 @@ import { LogHelper } from '../logs/logsHelper';
 import { AppConfigProvider } from '../app-config/app-config';
 import { TestStatus } from '../../modules/tests/test-status/test-status.model';
 import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories/index';
+import { ActivityCodes } from '../../shared/models/activity-codes';
 
 export interface TestToSubmit {
   index: number;
@@ -42,10 +43,12 @@ export class TestSubmissionProvider {
   submitTest = (testToSubmit: TestToSubmit): Observable<HttpResponse<any> | HttpErrorResponse> => {
     // Using cloneDeep() to prevent the initialState of the reducers from being modified
     const deepClonedData = cloneDeep(testToSubmit.payload);
-    const cleanData = this.removeNullFieldsDeep(
-      this.isPartialSubmission(testToSubmit)
-        ? this.removeFieldsForPartialData(deepClonedData)
-        : deepClonedData);
+    const cleanData =
+      this.removeNullFieldsDeep(
+        this.removePassCompletionWhenTestIsNotPass(
+          this.isPartialSubmission(testToSubmit)
+            ? this.removeFieldsForPartialData(deepClonedData)
+            : deepClonedData));
 
     return this.httpClient.post(
       this.buildUrl(testToSubmit),
@@ -85,6 +88,7 @@ export class TestSubmissionProvider {
     };
     return removeNullFields(data);
   }
+
   removeFieldsForPartialData = (data: TestResultSchemasUnion): Partial<TestResultSchemasUnion> => {
     data.testSummary.additionalInformation = null;
     data.testSummary.candidateDescription = null;
@@ -93,6 +97,13 @@ export class TestSubmissionProvider {
     data.testSummary.routeNumber = null;
     data.testSummary.weatherConditions = null;
 
+    return data;
+  }
+
+  removePassCompletionWhenTestIsNotPass = (data: Partial<TestResultSchemasUnion>): Partial<TestResultSchemasUnion> => {
+    if (data.activityCode !== ActivityCodes.PASS) {
+      unset(data, 'passCompletion');
+    }
     return data;
   }
 }


### PR DESCRIPTION
## Description

- Refactored the Populate Pass Completion action.

The idea behind the initial implementation was if the test was not a Pass then the store would just have a null for the Pass Completion object, and on submission, the passSubmission key would be removed from the data we submit as we remove null keys. 

If the Pass Finalisation Page was loaded then action would be dispatched to create the pass finalisation object using null as its default values. This caused any data to be lost if it had been previously entered and the app had crashed, meaning rehydration wouldn't work. 

My proposed solution is to remove the action and initialise the pass completion object as we normally would for anything else. In the submission provider if the activity code is not a 1 then we remove the key.

- Fixed Rehydration for Pass Certificate Number
- Fixed Rehydration for Licence Received
- Fixed Rehydration for Code 78
- Fixed Rehydration for Transmission on all except Cat B
- Fixed way banners were implemented on Cat C page as we had 2 versions of state (from the store and a local one for code78 and provisional licence) 
- Removed extra transmission banner which wasn't needed

**All changes have been tested on Cat B , B+E and C only**

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
