### PR TITLE
MES-4413: adding fields for Waiting Roomm To Car

### DIFF
--- a/src/components/common/transmission/transmission.html
+++ b/src/components/common/transmission/transmission.html
@@ -2,7 +2,8 @@
     <div class="validation-bar" [class.ng-invalid]="isInvalid()">
     </div>
     <ion-col class="component-label" col-32 align-self-center>
-      <label>Transmission</label>
+      <label [hidden]="hideTransmissionLabel">Transmission</label>
+      <label [hidden]="hideConfirmTransmissionLabel">Confirm transmission</label>
     </ion-col>
     <ion-col align-self-center padding-left>
       <ion-row class="spacing-row"></ion-row>

--- a/src/components/common/transmission/transmission.ts
+++ b/src/components/common/transmission/transmission.ts
@@ -13,6 +13,11 @@ export class TransmissionComponent implements OnChanges {
   transmission: TransmissionType;
 
   @Input()
+  hideTransmissionLabel: boolean = false;
+  @Input()
+  hideConfirmTransmissionLabel: boolean = true;
+
+  @Input()
   formGroup: FormGroup;
 
   @Output()

--- a/src/modules/tests/vehicle-details/common/vehicle-details.actions.ts
+++ b/src/modules/tests/vehicle-details/common/vehicle-details.actions.ts
@@ -3,6 +3,7 @@ import { GearboxCategory } from '@dvsa/mes-test-schema/categories/common';
 
 export const VEHICLE_REGISTRATION_CHANGED = '[Vehicle Details] Registration changed';
 export const SCHOOL_CAR_TOGGLED = '[Vehicle Details] School car toggled';
+export const SCHOOL_BIKE_TOGGLED = '[Vehicle Details] School bike toggled';
 export const DUAL_CONTROLS_TOGGLED = '[Vehicle Details] Dual controls toggled';
 export const GEARBOX_CATEGORY_CHANGED = '[Vehicle Details] Gearbox category changed';
 export const CLEAR_GEARBOX_CATEGORY = '[Vehicle Details] Clear gearbox category';
@@ -15,6 +16,9 @@ export class VehicleRegistrationChanged implements Action {
 
 export class SchoolCarToggled implements Action {
   readonly type = SCHOOL_CAR_TOGGLED;
+}
+export class SchoolBikeToggled implements Action {
+  readonly type = SCHOOL_BIKE_TOGGLED;
 }
 
 export class DualControlsToggled implements Action {

--- a/src/pages/waiting-room-to-car/cat-a-mod1/__tests__/waiting-room-to-car.cat-a-mod1.page.spec.ts
+++ b/src/pages/waiting-room-to-car/cat-a-mod1/__tests__/waiting-room-to-car.cat-a-mod1.page.spec.ts
@@ -10,12 +10,10 @@ import { DateTimeProvider } from '../../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../../providers/date-time/__mocks__/date-time.mock';
 import { StoreModule, Store } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
-import { By } from '@angular/platform-browser';
 import { MockComponent } from 'ng-mocks';
 import {
   EyesightFailureConfirmationComponent,
 } from '../../components/eyesight-failure-confirmation/eyesight-failure-confirmation';
-import { of } from 'rxjs/observable/of';
 import { QuestionProvider } from '../../../../providers/question/question';
 import { QuestionProviderMock } from '../../../../providers/question/__mocks__/question.mock';
 import { EndTestLinkComponent } from '../../../../components/common/end-test-link/end-test-link';
@@ -26,11 +24,10 @@ import { VehicleDetailsComponent } from '../../components/vehicle-details/vehicl
 import { AccompanimentCardComponent } from '../../components/accompaniment-card/accompaniment-card';
 import { AccompanimentComponent } from '../../components/accompaniment/accompaniment';
 import { EyesightTestComponent } from '../../components/eyesight-test/eyesight-test';
-import { EyesightTestReset } from '../../../../modules/tests/test-data/common/eyesight-test/eyesight-test.actions';
 import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { WaitingRoomToCarValidationError } from '../../waiting-room-to-car.actions';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
-import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
+import { TransmissionComponent } from '../../../../components/common/transmission/transmission';
 
 describe('WaitingRoomToCarCatAMod1Page', () => {
   let fixture: ComponentFixture<WaitingRoomToCarCatAMod1Page>;
@@ -50,7 +47,7 @@ describe('WaitingRoomToCarCatAMod1Page', () => {
         MockComponent(AccompanimentCardComponent),
         MockComponent(AccompanimentComponent),
         MockComponent(PracticeModeBanner),
-        MockComponent(WarningBannerComponent),
+        MockComponent(TransmissionComponent),
       ],
       imports: [
         IonicModule,
@@ -98,43 +95,6 @@ describe('WaitingRoomToCarCatAMod1Page', () => {
     spyOn(store$, 'dispatch');
   }));
 
-  describe('DOM', () => {
-
-    describe('eyesight failure confirmation', () => {
-
-      // tslint:disable-next-line:max-line-length
-      it('should hide the rest of the form and show eyesight failure confirmation when page state indicates fail is selected', () => {
-        fixture.detectChanges();
-        component.pageState.eyesightTestComplete$ = of(true);
-        component.pageState.eyesightTestFailed$ = of(true);
-        fixture.detectChanges();
-        const eyesightFailureConfirmation = fixture.debugElement.query(By.css('eyesight-failure-confirmation'));
-        const formAfterEyesight = fixture.debugElement.query(By.css('#post-eyesight-form-content'));
-        expect(eyesightFailureConfirmation).not.toBeNull();
-        expect(formAfterEyesight.nativeElement.hidden).toEqual(true);
-      });
-      // tslint:disable-next-line:max-line-length
-      it('should show the rest of the form and not render eyesight failure confirmation when page state indicates pass is selected', () => {
-        fixture.detectChanges();
-        component.pageState.eyesightTestComplete$ = of(true);
-        fixture.detectChanges();
-        const eyesightFailureConfirmation = fixture.debugElement.query(By.css('eyesight-failure-confirmation'));
-        const formAfterEyesight = fixture.debugElement.query(By.css('#post-eyesight-form-content'));
-        expect(eyesightFailureConfirmation).toBeNull();
-        expect(formAfterEyesight.nativeElement.hidden).toEqual(false);
-      });
-      it('should dispatch an EyesightResultReset action when the when the method is called', () => {
-        component.eyesightFailCancelled();
-        expect(store$.dispatch).toHaveBeenCalledWith(new EyesightTestReset());
-      });
-      it('should show the is load secure warning banner', () => {
-        fixture.detectChanges();
-        const warningBanner = fixture.debugElement.query(By.css('warning-banner'));
-        expect(warningBanner).not.toBeNull();
-      });
-    });
-
-  });
   describe('ionViewWillLeave', () => {
     it('should dispatch the PersistTests action', () => {
       component.ionViewWillLeave();

--- a/src/pages/waiting-room-to-car/cat-a-mod1/waiting-room-to-car.cat-a-mod1.page.html
+++ b/src/pages/waiting-room-to-car/cat-a-mod1/waiting-room-to-car.cat-a-mod1.page.html
@@ -13,15 +13,14 @@
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <ion-grid>
 
-        <eyesight-test [formGroup]="form" [eyesightPassRadioChecked]="(pageState.eyesightTestComplete$ | async) && !(pageState.eyesightTestFailed$ | async)"
-          [eyesightFailRadioChecked]="pageState.eyesightTestFailed$ | async" (eyesightTestResultChange)="eyesightTestResultChanged($event)"></eyesight-test>
-
-        <ion-row *ngIf="pageState.eyesightTestFailed$ | async">
-          <eyesight-failure-confirmation [nextPageOnFail]="this.getDebriefPage()" [cancelFn]="eyesightFailCancelled"></eyesight-failure-confirmation>
-        </ion-row>
-
-        <ion-row no-padding [hidden]="pageState.eyesightTestFailed$ | async" id="post-eyesight-form-content">
+        <ion-row no-padding>
           <ion-col no-padding>
+            <transmission [formGroup]="form"
+              [hideTransmissionLabel]="true"
+              [hideConfirmTransmissionLabel]="false"
+              [transmission]="pageState.transmission$ | async"
+              (transmissionChange)="transmissionChanged($event)"></transmission>
+
             <vehicle-registration [formGroup]="form" [vehicleRegistration]="pageState.registrationNumber$ | async"
               (vehicleRegistrationChange)="vehicleRegistrationChanged($event)"></vehicle-registration>
 
@@ -32,13 +31,13 @@
               (interpreterAccompanimentChange)="interpreterAccompanimentToggled()">
             </accompaniment-card>
 
-            <!-- TODO - PREP-AMOD1: update to cat A -->
-            <!-- <vehicle-details-card [formGroup]="form" [schoolVehicleDetails]="pageState.schoolCar$ | async"
-              [dualVehicleDetails]="pageState.dualControls$ | async" (schoolVehicleDetailsChange)="schoolCarToggled()"
-              (dualVehicleDetailsChange)="dualControlsToggled()"></vehicle-details-card> -->
+            <vehicle-details-card [formGroup]="form"
+            [hideSchoolVehicleAndDualControlRow]="true"
+            [hideSchoolBikeRow]="false"
+            [schoolVehicleDetails]="pageState.schoolBike$ | async"
+            (schoolBikeVehicleDetailsChange)="schoolBikeToggled()"></vehicle-details-card>
           </ion-col>
         </ion-row>
-        <warning-banner warningText="Is the load secure?"></warning-banner>
       </ion-grid>
     </form>
   </div>

--- a/src/pages/waiting-room-to-car/cat-a-mod1/waiting-room-to-car.cat-a-mod1.page.ts
+++ b/src/pages/waiting-room-to-car/cat-a-mod1/waiting-room-to-car.cat-a-mod1.page.ts
@@ -8,9 +8,9 @@ import { Observable } from 'rxjs/Observable';
 import { GearboxCategory } from '@dvsa/mes-test-schema/categories/common';
 import { getCurrentTest, getJournalData } from '../../../modules/tests/tests.selector';
 import {
-  SchoolCarToggled,
   GearboxCategoryChanged,
   VehicleRegistrationChanged,
+  SchoolBikeToggled,
 } from '../../../modules/tests/vehicle-details/common/vehicle-details.actions';
 import { map } from 'rxjs/operators';
 import {
@@ -46,17 +46,6 @@ import { getUntitledCandidateName } from '../../../modules/tests/journal-data/co
 import { getTests } from '../../../modules/tests/tests.reducer';
 import { FormGroup } from '@angular/forms';
 import { QuestionProvider } from '../../../providers/question/question';
-import {
-  EyesightTestReset,
-  EyesightTestPassed,
-  EyesightTestFailed,
-} from '../../../modules/tests/test-data/common/eyesight-test/eyesight-test.actions';
-// TODO - PREP-AMOD1: update to cat A
-import {
-  hasEyesightTestGotSeriousFault, hasEyesightTestBeenCompleted,
-} from '../../../modules/tests/test-data/cat-be/test-data.cat-be.selector';
-// TODO - PREP-AMOD1: update to cat A
-import { getTestData } from '../../../modules/tests/test-data/cat-be/test-data.cat-be.reducer';
 import { PersistTests } from '../../../modules/tests/tests.actions';
 import { CAT_A_MOD1 } from '../../page-names.constants';
 import { BasePageComponent } from '../../../shared/classes/base-page';
@@ -71,8 +60,6 @@ interface WaitingRoomToCarPageState {
   supervisorAccompaniment$: Observable<boolean>;
   otherAccompaniment$: Observable<boolean>;
   interpreterAccompaniment$: Observable<boolean>;
-  eyesightTestComplete$: Observable<boolean>;
-  eyesightTestFailed$: Observable<boolean>;
   gearboxAutomaticRadioChecked$: Observable<boolean>;
   gearboxManualRadioChecked$: Observable<boolean>;
 }
@@ -85,8 +72,6 @@ interface WaitingRoomToCarPageState {
 export class WaitingRoomToCarCatAMod1Page extends BasePageComponent {
   pageState: WaitingRoomToCarPageState;
   form: FormGroup;
-
-  showEyesightFailureConfirmation: boolean = false;
 
   constructor(
     public store$: Store<StoreModel>,
@@ -142,14 +127,6 @@ export class WaitingRoomToCarCatAMod1Page extends BasePageComponent {
         select(getAccompaniment),
         select(getInterpreterAccompaniment),
       ),
-      eyesightTestComplete$: currentTest$.pipe(
-        select(getTestData),
-        select(hasEyesightTestBeenCompleted),
-      ),
-      eyesightTestFailed$: currentTest$.pipe(
-        select(getTestData),
-        select(hasEyesightTestGotSeriousFault),
-      ),
       gearboxAutomaticRadioChecked$: currentTest$.pipe(
         select(getVehicleDetails),
         map(isAutomatic),
@@ -169,8 +146,8 @@ export class WaitingRoomToCarCatAMod1Page extends BasePageComponent {
     this.store$.dispatch(new PersistTests());
   }
 
-  schoolCarToggled(): void {
-    this.store$.dispatch(new SchoolCarToggled());
+  schoolBikeToggled(): void {
+    this.store$.dispatch(new SchoolBikeToggled());
   }
 
   transmissionChanged(transmission: GearboxCategory): void {
@@ -225,20 +202,6 @@ export class WaitingRoomToCarCatAMod1Page extends BasePageComponent {
 
   isCtrlDirtyAndInvalid(controlName: string): boolean {
     return !this.form.value[controlName] && this.form.get(controlName).dirty;
-  }
-
-  setEyesightFailureVisibility(show: boolean) {
-    this.showEyesightFailureConfirmation = show;
-  }
-
-  eyesightFailCancelled = () => {
-    this.form.get('eyesightCtrl') && this.form.get('eyesightCtrl').reset();
-    this.store$.dispatch(new EyesightTestReset());
-  }
-
-  eyesightTestResultChanged(passed: boolean): void {
-    const action = passed ? new EyesightTestPassed() : new EyesightTestFailed();
-    this.store$.dispatch(action);
   }
 
   getDebriefPage() {

--- a/src/pages/waiting-room-to-car/components/vehicle-details-card/vehicle-details-card.html
+++ b/src/pages/waiting-room-to-car/components/vehicle-details-card/vehicle-details-card.html
@@ -4,18 +4,26 @@
       <label>Vehicle details (optional)</label>
     </ion-col>
     <ion-col align-self-center padding-left>
-      <ion-row>
+      <ion-row [hidden]="hideSchoolVehicleAndDualControlRow">
         <ion-col col-48>
-          <vehicle-details [formGroup]="formGroup" 
+          <vehicle-details [formGroup]="formGroup"
             [vehicleDetails]="schoolVehicleDetails"
             vehicleDetailsType="School car"
             (vehicleDetailsChange)="schoolVehicleDetailsChanged()"></vehicle-details>
         </ion-col>
-        <ion-col col-48> 
-          <vehicle-details [formGroup]="formGroup" 
+        <ion-col col-48>
+          <vehicle-details [formGroup]="formGroup"
             [vehicleDetails]="dualVehicleDetails"
             vehicleDetailsType="Dual control"
             (vehicleDetailsChange)="dualVehicleDetailsChanged()"></vehicle-details>
+        </ion-col>
+      </ion-row>
+      <ion-row [hidden]="hideSchoolBikeRow">
+        <ion-col col-48>
+          <vehicle-details [formGroup]="formGroup"
+          [vehicleDetails]="schoolBikeDetails"
+          vehicleDetailsType="School bike"
+          (vehicleDetailsChange)="schoolBikeVehicleDetailsChanged()"></vehicle-details>
         </ion-col>
       </ion-row>
     </ion-col>

--- a/src/pages/waiting-room-to-car/components/vehicle-details-card/vehicle-details-card.ts
+++ b/src/pages/waiting-room-to-car/components/vehicle-details-card/vehicle-details-card.ts
@@ -11,19 +11,31 @@ export class VehicleDetailsCardComponent {
   schoolVehicleDetails: boolean;
   @Input()
   dualVehicleDetails: boolean;
+  @Input()
+  schoolBikeVehicleDetails: boolean;
 
   @Input()
   formGroup: FormGroup;
+
+  @Input()
+  hideSchoolVehicleAndDualControlRow: boolean = false;
+  @Input()
+  hideSchoolBikeRow: boolean = true;
 
   @Output()
   schoolVehicleDetailsChange = new EventEmitter();
   @Output()
   dualVehicleDetailsChange = new EventEmitter();
+  @Output()
+  schoolBikeVehicleDetailsChange = new EventEmitter();
 
   schoolVehicleDetailsChanged(): void {
     this.schoolVehicleDetailsChange.emit();
   }
   dualVehicleDetailsChanged(): void {
     this.dualVehicleDetailsChange.emit();
+  }
+  schoolBikeVehicleDetailsChanged(): void {
+    this.schoolBikeVehicleDetailsChange.emit();
   }
 }


### PR DESCRIPTION
## Description
- Adding fields to Cat A Mod 1 WRTC (`transmission`, `school bike`)
- Removing `eyesight` and `warning banner`
- Screenshots attached show the difference between `Cat B` and `EUAM1` after changes were made to the shared components `vehicle-details-card` and `vehicle-details`
## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

<img width="549" alt="Screenshot 2020-01-22 at 09 10 51" src="https://user-images.githubusercontent.com/30832405/72882529-aff85700-3cfa-11ea-9667-dc849db8872c.png">
<img width="549" alt="Screenshot 2020-01-22 at 09 36 03" src="https://user-images.githubusercontent.com/30832405/72882542-b4bd0b00-3cfa-11ea-8046-085d6394c5d2.png">
