### PR TITLE
Mes 2735 collect end test data

### DIFF
--- a/src/pages/office/cat-c/__tests__/office.cat-c.page.spec.ts
+++ b/src/pages/office/cat-c/__tests__/office.cat-c.page.spec.ts
@@ -30,7 +30,6 @@ import {
   AddDangerousFault,
 } from '../../../../modules/tests/test-data/common/dangerous-faults/dangerous-faults.actions';
 import { AddSeriousFault } from '../../../../modules/tests/test-data/common/serious-faults/serious-faults.actions';
-import { EyesightTestFailed } from '../../../../modules/tests/test-data/common/eyesight-test/eyesight-test.actions';
 import { ExaminerActions, Competencies } from '../../../../modules/tests/test-data/test-data.constants';
 import { By } from '@angular/platform-browser';
 import { PersistTests } from '../../../../modules/tests/tests.actions';
@@ -99,8 +98,7 @@ describe('OfficePage', () => {
             testStatus: {},
             startedTests: {
               123: {
-                // TODO: MES-4287 Use category C
-                category: TestCategory.BE,
+                category: TestCategory.C,
                 vehicleDetails: {},
                 accompaniment: {},
                 testData: {
@@ -239,12 +237,6 @@ describe('OfficePage', () => {
     });
     it('should display serious fault comment textbox if there are any', () => {
       store$.dispatch(new AddSeriousFault(Competencies.judgementOvertaking));
-      fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('#seriousFaultComment'))).toBeDefined();
-    });
-
-    it('should display the serious fault comment textbox if the eyesight test is failed', () => {
-      store$.dispatch(new EyesightTestFailed());
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css('#seriousFaultComment'))).toBeDefined();
     });

--- a/src/pages/office/cat-c/office.cat-c.page.ts
+++ b/src/pages/office/cat-c/office.cat-c.page.ts
@@ -74,6 +74,7 @@ import {
   Identification,
   IndependentDriving,
   QuestionResult,
+  CategoryCode,
 } from '@dvsa/mes-test-schema/categories/common';
 import {
   AddDangerousFaultComment,
@@ -106,6 +107,7 @@ import {
   vehicleChecksExist,
 } from '../../../modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.selector';
 import { getVehicleChecks } from '../../../modules/tests/test-data/cat-c/test-data.cat-c.selector';
+import { getTestCategory } from '../../../modules/tests/category/category.reducer';
 
 interface OfficePageState {
   activityCode$: Observable<ActivityCodeModel>;
@@ -143,6 +145,7 @@ interface OfficePageState {
   seriousFaults$: Observable<FaultSummary[]>;
   isRekey$: Observable<boolean>;
   vehicleChecks$: Observable<QuestionResult[]>;
+  testCategory$: Observable<CategoryCode>;
 }
 
 @IonicPage()
@@ -160,6 +163,7 @@ export class OfficeCatCPage extends BasePageComponent {
 
   weatherConditions: WeatherConditionSelection[];
   activityCodeOptions: ActivityCodeModel[];
+  testCategory: CategoryCode;
 
   constructor(
     private store$: Store<StoreModel>,
@@ -192,7 +196,12 @@ export class OfficeCatCPage extends BasePageComponent {
       select(getTests),
       select(getCurrentTest),
     );
+
     this.pageState = {
+      testCategory$: currentTest$.pipe(
+        select(getTestCategory),
+        map(result => this.testCategory = result),
+      ),
       activityCode$: currentTest$.pipe(
         select(getActivityCode),
       ),
@@ -304,7 +313,7 @@ export class OfficeCatCPage extends BasePageComponent {
           this.outcomeBehaviourProvider.isVisible(
             outcome,
             'faultComment',
-            this.faultSummaryProvider.getDrivingFaultsList(data, TestCategory.C),
+            this.faultSummaryProvider.getDrivingFaultsList(data, this.testCategory as TestCategory),
           )),
       ),
       displaySeriousFault$: currentTest$.pipe(
@@ -328,7 +337,7 @@ export class OfficeCatCPage extends BasePageComponent {
           this.outcomeBehaviourProvider.isVisible(
             outcome,
             'faultComment',
-            this.faultSummaryProvider.getDrivingFaultsList(data, TestCategory.C),
+            this.faultSummaryProvider.getDrivingFaultsList(data, this.testCategory as TestCategory),
           )),
       ),
       displayVehicleChecks$: currentTest$.pipe(
@@ -368,19 +377,19 @@ export class OfficeCatCPage extends BasePageComponent {
       ),
       dangerousFaults$: currentTest$.pipe(
         select(getTestData),
-        map(data => this.faultSummaryProvider.getDangerousFaultsList(data, TestCategory.C)),
+        map(data => this.faultSummaryProvider.getDangerousFaultsList(data, this.testCategory as TestCategory)),
       ),
       seriousFaults$: currentTest$.pipe(
         select(getTestData),
-        map(data => this.faultSummaryProvider.getSeriousFaultsList(data, TestCategory.C)),
+        map(data => this.faultSummaryProvider.getSeriousFaultsList(data, this.testCategory as TestCategory)),
       ),
       drivingFaults$: currentTest$.pipe(
         select(getTestData),
-        map(data => this.faultSummaryProvider.getDrivingFaultsList(data, TestCategory.C)),
+        map(data => this.faultSummaryProvider.getDrivingFaultsList(data, this.testCategory as TestCategory)),
       ),
       drivingFaultCount$: currentTest$.pipe(
         select(getTestData),
-        map(data => this.faultCountProvider.getDrivingFaultSumCount(TestCategory.C, data)),
+        map(data => this.faultCountProvider.getDrivingFaultSumCount(this.testCategory as TestCategory, data)),
       ),
       displayDrivingFaultComments$: currentTest$.pipe(
         select(getTestData),
@@ -588,5 +597,4 @@ export class OfficeCatCPage extends BasePageComponent {
 
     return dangerousFaultCount === 0 && seriousFaultCount === 0 && drivingFaultCount > 15;
   }
-
 }


### PR DESCRIPTION
## Description
Ensures all end test data is captured on the Office Page:

- Works correctly for CAT C and its sub categories
- Form state is preserved when returning the form after using the 'Save for later' option
- Driving fault comment fields are displayed in 16DF or more scenarios
- Submission of the test data is part of https://jira.dvsacloud.uk/browse/MES-2701

JIRA: https://jira.dvsacloud.uk/browse/MES-2735


## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![Simulator Screen Shot - iPad Pro (10 5-inch) - 2020-01-27 at 15 58 14](https://user-images.githubusercontent.com/54100299/73190452-ecbeb680-411d-11ea-9954-cfc56de8b639.png)
![Simulator Screen Shot - iPad Pro (10 5-inch) - 2020-01-27 at 16 00 00](https://user-images.githubusercontent.com/54100299/73190636-2d1e3480-411e-11ea-86cd-858ece94e4c5.png)
![Simulator Screen Shot - iPad Pro (10 5-inch) - 2020-01-27 at 16 00 09](https://user-images.githubusercontent.com/54100299/73190637-2d1e3480-411e-11ea-99bf-d7e9597b43c2.png)
![Simulator Screen Shot - iPad Pro (10 5-inch) - 2020-01-27 at 16 00 16](https://user-images.githubusercontent.com/54100299/73190638-2d1e3480-411e-11ea-84b3-d72ad81ad2d8.png)
![Simulator Screen Shot - iPad Pro (10 5-inch) - 2020-01-28 at 11 03 13](https://user-images.githubusercontent.com/54100299/73258597-f566c980-41bd-11ea-86c7-480b5d073a88.png)
![Simulator Screen Shot - iPad Pro (10 5-inch) - 2020-01-28 at 11 03 20](https://user-images.githubusercontent.com/54100299/73258599-f566c980-41bd-11ea-9e01-0d9f5b089310.png)
