### PR TITLE
Bug fix manoeuvres for reverse left

### DIFF
--- a/src/modules/tests/test-data/cat-c/manoeuvres/manoeuvres.cat-c.selectors.ts
+++ b/src/modules/tests/test-data/cat-c/manoeuvres/manoeuvres.cat-c.selectors.ts
@@ -1,6 +1,16 @@
 import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
+import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
+import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
+
 import { get } from 'lodash';
 
-export const getReverseLeftSelected = (manoeuvres: CatCUniqueTypes.Manoeuvres) => {
+export type CatCManoeuvres =
+  | CatCUniqueTypes.Manoeuvres
+  | CatC1UniqueTypes.Manoeuvres
+  | CatCEUniqueTypes.Manoeuvres
+  | CatC1EUniqueTypes.Manoeuvres;
+
+export const getReverseLeftSelected = (manoeuvres: CatCManoeuvres) => {
   return get(manoeuvres, 'reverseLeft.selected', false);
 };

--- a/src/modules/tests/test-data/cat-c/test-data.cat-c.selector.ts
+++ b/src/modules/tests/test-data/cat-c/test-data.cat-c.selector.ts
@@ -2,45 +2,62 @@ import { Competencies, LegalRequirements } from '../test-data.constants';
 import { get } from 'lodash';
 import { CompetencyOutcome } from '../../../../shared/models/competency-outcome';
 import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
-import { QuestionProvider } from '../../../../providers/question/question';
-import { VehicleChecksQuestion } from '../../../../providers/question/vehicle-checks-question.model';
+import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
+import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
+import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
 import { NUMBER_OF_SHOW_ME_QUESTIONS }
   from '../../../../shared/constants/show-me-questions/show-me-questions.cat-be.constants';
 import { NUMBER_OF_TELL_ME_QUESTIONS }
   from '../../../../shared/constants/tell-me-questions/tell-me-questions.cat-be.constants';
-import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+
+export type CatCTestData =
+  | CatCUniqueTypes.TestData
+  | CatC1UniqueTypes.TestData
+  | CatCEUniqueTypes.TestData
+  | CatC1EUniqueTypes.TestData;
+
+export type CatCManoeuvres =
+  | CatCUniqueTypes.Manoeuvres
+  | CatC1UniqueTypes.Manoeuvres
+  | CatCEUniqueTypes.Manoeuvres
+  | CatC1EUniqueTypes.Manoeuvres;
+
+export type CatCTestRequirements =
+  | CatCUniqueTypes.TestRequirements
+  | CatC1UniqueTypes.TestRequirements
+  | CatCEUniqueTypes.TestRequirements
+  | CatC1EUniqueTypes.TestRequirements;
+
+export type CatCVehicleChecks =
+  | CatCUniqueTypes.VehicleChecks
+  | CatC1UniqueTypes.VehicleChecks
+  | CatCEUniqueTypes.VehicleChecks
+  | CatC1EUniqueTypes.VehicleChecks;
 
 export const getDrivingFaultCount = (
-  data: CatCUniqueTypes.TestData, competency: Competencies) => data.drivingFaults[competency];
+  data: CatCTestData, competency: Competencies) => data.drivingFaults[competency];
 
-export const getManoeuvres = (data: CatCUniqueTypes.TestData): CatCUniqueTypes.Manoeuvres => data.manoeuvres;
+export const getManoeuvres = (data: CatCTestData): CatCManoeuvres => data.manoeuvres;
 
 // TODO - We should pass a Manoeuvre object here instead of TestData
-export const hasManoeuvreBeenCompletedCatC = (data: CatCUniqueTypes.TestData) => {
+export const hasManoeuvreBeenCompletedCatC = (data: CatCTestData) => {
   return (
     get(data.manoeuvres, 'reverseLeft.selected')
   );
 };
 
 export const hasLegalRequirementBeenCompleted = (
-  data: CatCUniqueTypes.TestRequirements, legalRequirement: LegalRequirements) => {
+  data: CatCTestRequirements, legalRequirement: LegalRequirements) => {
   return data[legalRequirement];
 };
 
 export const getVehicleChecks = (
-  state: CatCUniqueTypes.TestData): CatCUniqueTypes.VehicleChecks => state.vehicleChecks;
-
-export const getTellMeQuestion = (state: CatCUniqueTypes.VehicleChecks): VehicleChecksQuestion => {
-  const questionProvider: QuestionProvider = new QuestionProvider();
-  return questionProvider
-    .getTellMeQuestions(TestCategory.C)
-    .find(question => question.code === get(state, 'tellMeQuestion.code'));
-};
+  state: CatCTestData): CatCVehicleChecks => state.vehicleChecks;
 
 export const areTellMeQuestionsSelected = (
-  state: CatCUniqueTypes.VehicleChecks) => typeof get(state, 'tellMeQuestions') !== 'undefined';
+  state: CatCVehicleChecks) => typeof get(state, 'tellMeQuestions') !== 'undefined';
 
-export const areTellMeQuestionsCorrect = (state: CatCUniqueTypes.VehicleChecks) => {
+export const areTellMeQuestionsCorrect = (state: CatCVehicleChecks) => {
   const tellMeQuestions = get(state, 'tellMeQuestions');
   let correct = true;
 
@@ -59,7 +76,7 @@ export const areTellMeQuestionsCorrect = (state: CatCUniqueTypes.VehicleChecks) 
 
 // TODO - We should really pass a Vehicle Checks object here and not Test Data
 // TODO - Also this has to go into a provider
-export const hasVehicleChecksBeenCompletedCatC = (data: CatCUniqueTypes.TestData): boolean => {
+export const hasVehicleChecksBeenCompletedCatC = (data: CatCTestData): boolean => {
   let showMeQuestionComplete = true;
   let tellMeQuestionComplete = true;
 

--- a/src/modules/tests/tests.module.ts
+++ b/src/modules/tests/tests.module.ts
@@ -12,6 +12,7 @@ import { ExaminerBookedEffects } from './examiner-booked/examiner-booked.effects
 import { ExaminerConductedEffects } from './examiner-conducted/examiner-conducted.effects';
 import { FaultCountProvider } from '../../providers/fault-count/fault-count';
 import { TestStatusAnalyticsEffects } from './test-status/test-status.analytics.effects';
+import { TestDataByCategoryProvider } from '../../providers/test-data-by-category/test-data-by-category';
 
 @NgModule({
   imports: [
@@ -30,6 +31,7 @@ import { TestStatusAnalyticsEffects } from './test-status/test-status.analytics.
     FaultCountProvider,
     NavigationProvider,
     NavigationStateProvider,
+    TestDataByCategoryProvider,
   ],
 })
 export class TestsModule {}

--- a/src/pages/test-report/cat-c/components/reverse-left/__tests__/reverse-left.spec.ts
+++ b/src/pages/test-report/cat-c/components/reverse-left/__tests__/reverse-left.spec.ts
@@ -52,7 +52,6 @@ describe('reverseLeftComponent', () => {
     fixture = TestBed.createComponent(ReverseLeftComponent);
     component = fixture.componentInstance;
     store$ = TestBed.get(Store);
-    // TODO: MES-4287 use category C
     store$.dispatch(new StartTest(105, TestCategory.C));
   }));
 

--- a/src/pages/test-report/cat-c/test-report.cat-c.page.html
+++ b/src/pages/test-report/cat-c/test-report.cat-c.page.html
@@ -71,7 +71,7 @@
         <ion-row>
           <ion-col>
             <reverse-left [completed]="manoeuvresCompleted" [controlLabel]="'Reverse Left'"
-              [clickCallback]="getCallback()">
+              [clickCallback]="getCallback()" [testCategory]="pageState.testCategory$ | async">
               <reverse-left-popover></reverse-left-popover>
             </reverse-left>
           </ion-col>

--- a/src/providers/test-data-by-category/__tests__/test-data-by-category.spec.ts
+++ b/src/providers/test-data-by-category/__tests__/test-data-by-category.spec.ts
@@ -1,0 +1,18 @@
+import { TestDataByCategoryProvider } from '../test-data-by-category';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+
+describe('TestDataByCategoryProvider', () => {
+
+  let provider: TestDataByCategoryProvider;
+
+  beforeEach(() => {
+    provider = new TestDataByCategoryProvider();
+  });
+
+  describe('getTestDataByCategoryCode()', () => {
+    it('should return CAT C test data for a C Catgeory Code', () => {
+      const testData = provider.getTestDataByCategoryCode(TestCategory.C);
+      expect(testData).toEqual(jasmine.any(Function));
+    });
+  });
+});

--- a/src/providers/test-data-by-category/__tests__/test-data-by-category.spec.ts
+++ b/src/providers/test-data-by-category/__tests__/test-data-by-category.spec.ts
@@ -18,13 +18,13 @@ describe('TestDataByCategoryProvider', () => {
 
     it('should throw an error when there is no matching test category', () => {
       expect(() => {
-        provider.getTestDataByCategoryCode('z' as TestCategory)
+        provider.getTestDataByCategoryCode('z' as TestCategory);
       }).toThrowError('Error getting test category');
     });
 
     it('should throw an error when test category is undefined', () => {
       expect(() => {
-        provider.getTestDataByCategoryCode(undefined)
+        provider.getTestDataByCategoryCode(undefined);
       }).toThrowError('Error getting test category');
     });
   });

--- a/src/providers/test-data-by-category/__tests__/test-data-by-category.spec.ts
+++ b/src/providers/test-data-by-category/__tests__/test-data-by-category.spec.ts
@@ -13,6 +13,19 @@ describe('TestDataByCategoryProvider', () => {
     it('should return CAT C test data for a C Catgeory Code', () => {
       const testData = provider.getTestDataByCategoryCode(TestCategory.C);
       expect(testData).toEqual(jasmine.any(Function));
+      expect(testData).not.toThrow();
+    });
+
+    it('should throw an error when there is no matching test category', () => {
+      expect(() => {
+        provider.getTestDataByCategoryCode('z' as TestCategory)
+      }).toThrowError('Error getting test category');
+    });
+
+    it('should throw an error when test category is undefined', () => {
+      expect(() => {
+        provider.getTestDataByCategoryCode(undefined)
+      }).toThrowError('Error getting test category');
     });
   });
 });

--- a/src/providers/test-data-by-category/test-data-by-category.ts
+++ b/src/providers/test-data-by-category/test-data-by-category.ts
@@ -8,13 +8,16 @@ import { getTestData as getTestDataC1E } from '../../modules/tests/test-data/cat
 
 @Injectable()
 export class TestDataByCategoryProvider {
+
+  static getTestDataByCategoryCodeErrMsg: string = 'Error getting test category';
+
   public getTestDataByCategoryCode(category: CategoryCode) {
     switch (category) {
       case TestCategory.C: return getTestDataC;
       case TestCategory.C1: return getTestDataC1;
       case TestCategory.CE: return getTestDataCE;
       case TestCategory.C1E: return getTestDataC1E;
-      default: return getTestDataC;
+      default: throw new Error(TestDataByCategoryProvider.getTestDataByCategoryCodeErrMsg);
     }
   }
 }

--- a/src/providers/test-data-by-category/test-data-by-category.ts
+++ b/src/providers/test-data-by-category/test-data-by-category.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { CategoryCode } from '@dvsa/mes-test-schema/categories/common';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { getTestData as getTestDataC } from '../../modules/tests/test-data/cat-c/test-data.cat-c.reducer';
+import { getTestData as getTestDataC1 } from '../../modules/tests/test-data/cat-c/test-data.cat-c1.reducer';
+import { getTestData as getTestDataCE } from '../../modules/tests/test-data/cat-c/test-data.cat-ce.reducer';
+import { getTestData as getTestDataC1E } from '../../modules/tests/test-data/cat-c/test-data.cat-c1e.reducer';
+
+@Injectable()
+export class TestDataByCategoryProvider {
+  public getTestDataByCategoryCode(category: CategoryCode) {
+    switch (category) {
+      case TestCategory.C: return getTestDataC;
+      case TestCategory.C1: return getTestDataC1;
+      case TestCategory.CE: return getTestDataCE;
+      case TestCategory.C1E: return getTestDataC1E;
+      default: return getTestDataC;
+    }
+  }
+}


### PR DESCRIPTION
## Description
The reverse Left component for CAT C was referencing CAT BE methods for selectors/reducers etc
Also, functionality to call the correct category specific methods was absent.

- Adds basic provider to pull test data via category code (Can be used for CAT D and sub cats also)
- Passes test category into the reverse left component
- Type unions used on test data selector to save duplicating whole selector files
- Reverse left component uses the test category to call correct state management methods

## Checklist

- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

![Simulator Screen Shot - iPad Pro (10 5-inch) - 2020-01-29 at 17 55 44](https://user-images.githubusercontent.com/54100299/73383350-0ea46e80-42c1-11ea-8521-ea8a69457937.png)
![Simulator Screen Shot - iPad Pro (10 5-inch) - 2020-01-29 at 17 55 56](https://user-images.githubusercontent.com/54100299/73383351-0ea46e80-42c1-11ea-9f6b-b7b37a032a6d.png)