### PR TITLE
Bug fix vehicle checks for test report

### DIFF
--- a/src/modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.selector.ts
+++ b/src/modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.selector.ts
@@ -11,7 +11,7 @@ export type CatCVehicleChecks =
   | CatC1UniqueTypes.VehicleChecks
   | CatCEUniqueTypes.VehicleChecks
   | CatC1EUniqueTypes.VehicleChecks;
-  
+
 export const getSelectedShowMeQuestions = (
   vehicleChecks: CatCVehicleChecks,
 ): QuestionResult[] => {

--- a/src/modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.selector.ts
+++ b/src/modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.selector.ts
@@ -1,24 +1,33 @@
 import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
+import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
+import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
 import { QuestionResult } from '@dvsa/mes-test-schema/categories/common';
 import { createFeatureSelector } from '@ngrx/store';
 import { some } from 'lodash';
 
+export type CatCVehicleChecks =
+  | CatCUniqueTypes.VehicleChecks
+  | CatC1UniqueTypes.VehicleChecks
+  | CatCEUniqueTypes.VehicleChecks
+  | CatC1EUniqueTypes.VehicleChecks;
+  
 export const getSelectedShowMeQuestions = (
-  vehicleChecks: CatCUniqueTypes.VehicleChecks,
+  vehicleChecks: CatCVehicleChecks,
 ): QuestionResult[] => {
   return vehicleChecks.showMeQuestions;
 };
 
 export const getSelectedTellMeQuestions = (
-  vehicleChecksCatCReducer: CatCUniqueTypes.VehicleChecks,
+  vehicleChecksCatCReducer: CatCVehicleChecks,
 ): QuestionResult[] => {
   return vehicleChecksCatCReducer.tellMeQuestions;
 };
 
-export const vehicleChecksExist = (vehicleChecks: CatCUniqueTypes.VehicleChecks): boolean => {
+export const vehicleChecksExist = (vehicleChecks: CatCVehicleChecks): boolean => {
   const questions = [...vehicleChecks.showMeQuestions, ... vehicleChecks.tellMeQuestions];
   return some(questions, fault => fault.outcome != null);
 };
 
 export const getVehicleChecksCatC =
-  createFeatureSelector<CatCUniqueTypes.VehicleChecks>('vehicleChecks');
+  createFeatureSelector<CatCVehicleChecks>('vehicleChecks');

--- a/src/pages/test-report/cat-c/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
+++ b/src/pages/test-report/cat-c/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
@@ -12,6 +12,7 @@ import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/
 import { DrivingFaultsBadgeComponent }
 from '../../../../../../components/common/driving-faults-badge/driving-faults-badge';
 import { FaultCountProvider } from '../../../../../../providers/fault-count/fault-count';
+import { TestDataByCategoryProvider } from '../../../../../../providers/test-data-by-category/test-data-by-category';
 import { VehicleChecksScore } from '../../../../../../shared/models/vehicle-checks-score.model';
 import { By } from '@angular/platform-browser';
 import { of } from 'rxjs/observable/of';
@@ -37,6 +38,7 @@ describe('VehicleChecksComponent', () => {
       ],
       providers: [
         FaultCountProvider,
+        TestDataByCategoryProvider,
       ],
     });
   });
@@ -45,8 +47,7 @@ describe('VehicleChecksComponent', () => {
     fixture = TestBed.createComponent(VehicleChecksComponent);
     component = fixture.componentInstance;
     store$ = TestBed.get(Store);
-    // TODO: MES-4287 Use Category C
-    store$.dispatch(new StartTest(105, TestCategory.BE));
+    store$.dispatch(new StartTest(105, TestCategory.C));
   }));
 
   describe('Class', () => {
@@ -56,7 +57,6 @@ describe('VehicleChecksComponent', () => {
     };
 
     beforeEach(() => {
-      // TODO: MES-4287 Use Category C
       spyOn(component.faultCountProvider, 'getVehicleChecksFaultCount').and.returnValue(vehicleChecksScore);
     });
 

--- a/src/pages/test-report/cat-c/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
+++ b/src/pages/test-report/cat-c/components/vehicle-checks/__tests__/vehicle-checks.spec.ts
@@ -61,6 +61,7 @@ describe('VehicleChecksComponent', () => {
     });
 
     it('should set the vehicle checks driving fault count', (done: DoneFn) => {
+      component.testCategory = TestCategory.C;
       component.ngOnInit();
       component.componentState.vehicleChecksDrivingFaultCount$.subscribe((result) => {
         expect(component.faultCountProvider.getVehicleChecksFaultCount).toHaveBeenCalled();
@@ -69,6 +70,7 @@ describe('VehicleChecksComponent', () => {
       });
     });
     it('should set the vehicle checks serious fault count', (done: DoneFn) => {
+      component.testCategory = TestCategory.C;
       component.ngOnInit();
       component.componentState.vehicleChecksSeriousFaultCount$.subscribe((result) => {
         expect(component.faultCountProvider.getVehicleChecksFaultCount).toHaveBeenCalled();
@@ -81,6 +83,7 @@ describe('VehicleChecksComponent', () => {
   describe('DOM', () => {
 
     it('should pass the number of VC driving faults to the driving faults component', () => {
+      component.testCategory = TestCategory.C;
       fixture.detectChanges();
       const drivingFaultsBadge = fixture.debugElement.query(By.css('.driving-faults'))
         .componentInstance as DrivingFaultsBadgeComponent;
@@ -90,6 +93,7 @@ describe('VehicleChecksComponent', () => {
     });
 
     it('should pass true to the serious faults badge if there are serious VC faults', () => {
+      component.testCategory = TestCategory.C;
       fixture.detectChanges();
       const seriousFaultsBadge = fixture.debugElement.query(By.css('serious-fault-badge'))
         .componentInstance as SeriousFaultBadgeComponent;

--- a/src/pages/test-report/cat-c/components/vehicle-checks/vehicle-checks.ts
+++ b/src/pages/test-report/cat-c/components/vehicle-checks/vehicle-checks.ts
@@ -55,7 +55,5 @@ export class VehicleChecksComponent implements OnInit {
         }),
       ),
     };
-
-    console.log('TEST CATEGORY', this.testCategory);
   }
 }

--- a/src/pages/test-report/cat-c/components/vehicle-checks/vehicle-checks.ts
+++ b/src/pages/test-report/cat-c/components/vehicle-checks/vehicle-checks.ts
@@ -1,19 +1,15 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import { getTests } from '../../../../../modules/tests/tests.reducer';
 import { getCurrentTest } from '../../../../../modules/tests/tests.selector';
 import { StoreModel } from '../../../../../shared/models/store.model';
-
-// TODO: MES-4287 Import cat c reducer
-import { getTestData } from '../../../../../modules/tests/test-data/cat-be/test-data.cat-be.reducer';
 import { map } from 'rxjs/operators';
-
-// TODO: MES-4287 Import cat c selectors
-import { getVehicleChecksCatBE }
-  from '../../../../../modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.selector';
+import { getVehicleChecksCatC }
+  from '../../../../../modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.selector';
 import { FaultCountProvider } from '../../../../../providers/fault-count/fault-count';
 import { Observable } from 'rxjs/Observable';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { TestDataByCategoryProvider } from '../../../../../providers/test-data-by-category/test-data-by-category';
 
 interface ComponentState {
   vehicleChecksDrivingFaultCount$: Observable<number>;
@@ -25,11 +21,17 @@ interface ComponentState {
   templateUrl: 'vehicle-checks.html',
 })
 export class VehicleChecksComponent implements OnInit {
+
+  @Input()
+  testCategory: TestCategory;
+
   componentState: ComponentState;
 
   constructor(
     private store$: Store<StoreModel>,
-    public faultCountProvider: FaultCountProvider) {}
+    public faultCountProvider: FaultCountProvider,
+    private testDataByCategory: TestDataByCategoryProvider,
+  ) {}
 
   ngOnInit(): void {
     const currentTest$ = this.store$.pipe(
@@ -39,29 +41,21 @@ export class VehicleChecksComponent implements OnInit {
 
     this.componentState = {
       vehicleChecksDrivingFaultCount$: currentTest$.pipe(
-        select(getTestData),
-
-        // TODO: MES-4287 use cat C function
-        select(getVehicleChecksCatBE),
+        select(this.testDataByCategory.getTestDataByCategoryCode(this.testCategory)),
+        select(getVehicleChecksCatC),
         map((vehicleChecks) => {
-
-          // TODO: MES-4287 use cat c function
-          return this.faultCountProvider.getVehicleChecksFaultCount(TestCategory.BE , vehicleChecks).drivingFaults;
+          return this.faultCountProvider.getVehicleChecksFaultCount(this.testCategory, vehicleChecks).drivingFaults;
         }),
       ),
       vehicleChecksSeriousFaultCount$: currentTest$.pipe(
-        select(getTestData),
-
-        // TODO: MES-4287 Use cat c function
-        select(getVehicleChecksCatBE),
+        select(this.testDataByCategory.getTestDataByCategoryCode(this.testCategory)),
+        select(getVehicleChecksCatC),
         map((vehicleChecks) => {
-
-          // TODO: MES-4287 use cat c function
-          return this.faultCountProvider.getVehicleChecksFaultCount(TestCategory.BE, vehicleChecks).seriousFaults;
+          return this.faultCountProvider.getVehicleChecksFaultCount(this.testCategory, vehicleChecks).seriousFaults;
         }),
       ),
     };
 
+    console.log('TEST CATEGORY', this.testCategory);
   }
-
 }

--- a/src/pages/test-report/cat-c/test-report.cat-c.page.html
+++ b/src/pages/test-report/cat-c/test-report.cat-c.page.html
@@ -98,7 +98,7 @@
         </ion-row>
         <ion-row>
           <ion-col>
-            <vehicle-checks></vehicle-checks>
+            <vehicle-checks [testCategory]="pageState.testCategory$ | async"></vehicle-checks>
           </ion-col>
         </ion-row>
         <ion-row>


### PR DESCRIPTION
## Description
The vehicle checks component for CAT C was referencing CAT BE methods for selectors/reducers etc
Also, functionality to call the correct category specific methods was absent.

- Uses provider implemented in PR https://github.com/dvsa/mes-mobile-app/pull/1185 to pull test data via category code (Can be used for CAT D and sub cats also)
- Passes test category into the vehicle checks component
- Union Types used on vehicle checks selector to save duplicating whole selector files
- Vehicle checks component uses the test category to call correct state management methods

## Checklist

- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![Simulator Screen Shot - iPad Pro (10 5-inch) - 2020-01-31 at 09 57 46](https://user-images.githubusercontent.com/54100299/73530383-4cfc7380-4410-11ea-8d2f-2a370b276420.png)
![Simulator Screen Shot - iPad Pro (10 5-inch) - 2020-01-31 at 09 58 06](https://user-images.githubusercontent.com/54100299/73530384-4cfc7380-4410-11ea-8a9b-be1331bfd8db.png)
![Simulator Screen Shot - iPad Pro (10 5-inch) - 2020-01-31 at 09 58 12](https://user-images.githubusercontent.com/54100299/73530385-4cfc7380-4410-11ea-96f2-4d02aaf8e6f2.png)
