### PR TITLE
MES-2716  - Rest of  Cat C Analytics

### DIFF
--- a/src/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
+++ b/src/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
@@ -8,10 +8,14 @@ import {
   AnalyticsScreenNames,
   AnalyticsEventCategories,
   AnalyticsErrorTypes,
+  AnalyticsEvents,
 } from '../../../providers/analytics/analytics.model';
-import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
+import { AnalyticRecorded, AnalyticNotRecorded } from '../../../providers/analytics/analytics.actions';
 import { StoreModel } from '../../../shared/models/store.model';
 import * as testsActions from '../../../modules/tests/tests.actions';
+import * as vehicleDetailsActions from '../../../modules/tests/vehicle-details/common/vehicle-details.actions';
+import * as testSummaryActions from '../../../modules/tests/test-summary/test-summary.actions';
+import * as commsActions from '../../../modules/tests/communication-preferences/communication-preferences.actions';
 import * as fakeJournalActions from '../../fake-journal/fake-journal.actions';
 import { testsReducer } from '../../../modules/tests/tests.reducer';
 import { PopulateCandidateDetails } from '../../../modules/tests/journal-data/common/candidate/candidate.actions';
@@ -21,16 +25,20 @@ import * as nonPassFinalisationActions from '../non-pass-finalisation.actions';
 import { candidateMock } from '../../../modules/tests/__mocks__/tests.mock';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { configureTestSuite } from 'ng-bullet';
+import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
+import { SetActivityCode } from '../../../modules/tests/activity-code/activity-code.actions';
+import { ActivityCodes } from '../../../shared/models/activity-codes';
+import { TransmissionType } from '../../../shared/models/transmission-type';
 
 describe('Non Pass Finalisation Analytics Effects', () => {
 
   let effects: NonPassFinalisationAnalyticsEffects;
-  let analyticsProviderMock;
+  let analyticsProviderMock: any;
   let actions$: any;
   let store$: Store<StoreModel>;
   const screenName = AnalyticsScreenNames.NON_PASS_FINALISATION;
-  // tslint:disable-next-line:max-line-length
-  const practiceScreenName = `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.NON_PASS_FINALISATION}`;
+  const practiceScreenName =
+    `${AnalyticsEventCategories.PRACTICE_MODE} - ${AnalyticsScreenNames.NON_PASS_FINALISATION}`;
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
@@ -116,6 +124,167 @@ describe('Non Pass Finalisation Analytics Effects', () => {
         expect(analyticsProviderMock.logError)
           .toHaveBeenCalledWith(`${AnalyticsErrorTypes.VALIDATION_ERROR} (${practiceScreenName})`,
             'error message');
+        done();
+      });
+    });
+  });
+  describe('transmissionChanged', () => {
+    it('should call logEvent with Manual if Gearbox Category is Manual', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      store$.dispatch(new SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new vehicleDetailsActions.GearboxCategoryChanged(TransmissionType.Manual));
+      // ASSERT
+      effects.transmissionChanged$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.POST_TEST,
+            AnalyticsEvents.GEARBOX_CATEGORY_CHANGED,
+            TransmissionType.Manual,
+          );
+        done();
+      });
+    });
+    it('should call logEvent with Automatic if Gearbox Category is Automatic', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      store$.dispatch(new SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new vehicleDetailsActions.GearboxCategoryChanged(TransmissionType.Automatic));
+      // ASSERT
+      effects.transmissionChanged$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.POST_TEST,
+            AnalyticsEvents.GEARBOX_CATEGORY_CHANGED,
+            TransmissionType.Automatic,
+          );
+        done();
+      });
+    });
+    it('should call not call logEvent if there is no activity code', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      // ACT
+      actions$.next(new vehicleDetailsActions.GearboxCategoryChanged(TransmissionType.Manual));
+      // ASSERT
+      effects.transmissionChanged$.subscribe((result) => {
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+  describe('d255Yes', () => {
+    it('should call logEvent', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      // ACT
+      actions$.next(new testSummaryActions.D255Yes());
+      // ASSERT
+      effects.d255Yes$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.POST_TEST,
+            AnalyticsEvents.D255,
+            'Yes',
+          );
+        done();
+      });
+    });
+  });
+  describe('d255No', () => {
+    it('should call logEvent', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      // ACT
+      actions$.next(new testSummaryActions.D255No());
+      // ASSERT
+      effects.d255No$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.POST_TEST,
+            AnalyticsEvents.D255,
+            'No',
+          );
+        done();
+      });
+    });
+  });
+  describe('candidateChoseToProceedWithTestInEnglish$', () => {
+    it('should call logEvent with the correct parameters', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      store$.dispatch(new SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new commsActions.CandidateChoseToProceedWithTestInEnglish(Language.ENGLISH));
+      // ASSERT
+      effects.candidateChoseToProccedWithTestInEnglish$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.POST_TEST,
+            AnalyticsEvents.LANGUAGE_CHANGED,
+            Language.ENGLISH,
+          );
+        done();
+      });
+    });
+    it('should call not call logEvent if there is no activity code', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      // ACT
+      actions$.next(new commsActions.CandidateChoseToProceedWithTestInEnglish(Language.ENGLISH));
+      // ASSERT
+      effects.candidateChoseToProccedWithTestInEnglish$.subscribe((result) => {
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+  describe('candidateChoseToProceedWithTestInWelsh$', () => {
+    it('should call logEvent with the correct parameters', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      store$.dispatch(new SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new commsActions.CandidateChoseToProceedWithTestInWelsh(Language.CYMRAEG));
+      // ASSERT
+      effects.candidateChoseToProccedWithTestInWelsh$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.POST_TEST,
+            AnalyticsEvents.LANGUAGE_CHANGED,
+            Language.CYMRAEG,
+          );
+        done();
+      });
+    });
+    it('should call not call logEvent if there is no activity code', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      // ACT
+      actions$.next(new commsActions.CandidateChoseToProceedWithTestInWelsh(Language.CYMRAEG));
+      // ASSERT
+      effects.candidateChoseToProccedWithTestInWelsh$.subscribe((result) => {
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
         done();
       });
     });

--- a/src/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
+++ b/src/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
@@ -167,7 +167,7 @@ describe('Non Pass Finalisation Analytics Effects', () => {
         done();
       });
     });
-    it('should call not call logEvent if there is no activity code', (done) => {
+    it('should not call logEvent if there is no activity code', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
@@ -241,7 +241,7 @@ describe('Non Pass Finalisation Analytics Effects', () => {
         done();
       });
     });
-    it('should call not call logEvent if there is no activity code', (done) => {
+    it('should not call logEvent if there is no activity code', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
@@ -275,7 +275,7 @@ describe('Non Pass Finalisation Analytics Effects', () => {
         done();
       });
     });
-    it('should call not call logEvent if there is no activity code', (done) => {
+    it('should not call logEvent if there is no activity code', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));

--- a/src/pages/non-pass-finalisation/cat-a-mod1/non-pass-finalisation.cat-a-mod1.page.module.ts
+++ b/src/pages/non-pass-finalisation/cat-a-mod1/non-pass-finalisation.cat-a-mod1.page.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
+import { EffectsModule } from '@ngrx/effects';
 import { ComponentsModule } from '../../../components/common/common-components.module';
 import { TestFinalisationComponentsModule } from
   '../../../components/test-finalisation/test-finalisation-component.module';
 import { NonPassFinalisationCatAMod1Page } from './non-pass-finalisation.cat-a-mod1.page';
+import { NonPassFinalisationAnalyticsEffects } from '../non-pass-finalisation.analytics.effects';
 
 @NgModule({
   declarations: [
@@ -11,6 +13,7 @@ import { NonPassFinalisationCatAMod1Page } from './non-pass-finalisation.cat-a-m
   ],
   imports: [
     IonicPageModule.forChild(NonPassFinalisationCatAMod1Page),
+    EffectsModule.forFeature([NonPassFinalisationAnalyticsEffects]),
     ComponentsModule,
     TestFinalisationComponentsModule,
   ],

--- a/src/pages/non-pass-finalisation/cat-a-mod2/non-pass-finalisation.cat-a-mod2.page.module.ts
+++ b/src/pages/non-pass-finalisation/cat-a-mod2/non-pass-finalisation.cat-a-mod2.page.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
+import { EffectsModule } from '@ngrx/effects';
 import { ComponentsModule } from '../../../components/common/common-components.module';
 import { TestFinalisationComponentsModule } from
   '../../../components/test-finalisation/test-finalisation-component.module';
 import { NonPassFinalisationCatAMod2Page } from './non-pass-finalisation.cat-a-mod2.page';
+import { NonPassFinalisationAnalyticsEffects } from '../non-pass-finalisation.analytics.effects';
 
 @NgModule({
   declarations: [
@@ -11,6 +13,7 @@ import { NonPassFinalisationCatAMod2Page } from './non-pass-finalisation.cat-a-m
   ],
   imports: [
     IonicPageModule.forChild(NonPassFinalisationCatAMod2Page),
+    EffectsModule.forFeature([NonPassFinalisationAnalyticsEffects]),
     ComponentsModule,
     TestFinalisationComponentsModule,
   ],

--- a/src/pages/non-pass-finalisation/cat-b/non-pass-finalisation.cat-b.page.module.ts
+++ b/src/pages/non-pass-finalisation/cat-b/non-pass-finalisation.cat-b.page.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
+import { EffectsModule } from '@ngrx/effects';
 import { ComponentsModule } from '../../../components/common/common-components.module';
 import { TestFinalisationComponentsModule } from
 '../../../components/test-finalisation/test-finalisation-component.module';
 import { NonPassFinalisationCatBPage } from './non-pass-finalisation.cat-b.page';
+import { NonPassFinalisationAnalyticsEffects } from '../non-pass-finalisation.analytics.effects';
 
 @NgModule({
   declarations: [
@@ -11,6 +13,7 @@ import { NonPassFinalisationCatBPage } from './non-pass-finalisation.cat-b.page'
   ],
   imports: [
     IonicPageModule.forChild(NonPassFinalisationCatBPage),
+    EffectsModule.forFeature([NonPassFinalisationAnalyticsEffects]),
     ComponentsModule,
     TestFinalisationComponentsModule,
   ],

--- a/src/pages/non-pass-finalisation/cat-be/non-pass-finalisation.cat-be.page.module.ts
+++ b/src/pages/non-pass-finalisation/cat-be/non-pass-finalisation.cat-be.page.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
+import { EffectsModule } from '@ngrx/effects';
 import { ComponentsModule } from '../../../components/common/common-components.module';
 import { TestFinalisationComponentsModule } from
   '../../../components/test-finalisation/test-finalisation-component.module';
 import { NonPassFinalisationCatBEPage } from './non-pass-finalisation.cat-be.page';
+import { NonPassFinalisationAnalyticsEffects } from '../non-pass-finalisation.analytics.effects';
 
 @NgModule({
   declarations: [
@@ -11,6 +13,7 @@ import { NonPassFinalisationCatBEPage } from './non-pass-finalisation.cat-be.pag
   ],
   imports: [
     IonicPageModule.forChild(NonPassFinalisationCatBEPage),
+    EffectsModule.forFeature([NonPassFinalisationAnalyticsEffects]),
     ComponentsModule,
     TestFinalisationComponentsModule,
   ],

--- a/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.module.ts
+++ b/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
+import { EffectsModule } from '@ngrx/effects';
 import { ComponentsModule } from '../../../components/common/common-components.module';
 import { TestFinalisationComponentsModule } from
   '../../../components/test-finalisation/test-finalisation-component.module';
 import { NonPassFinalisationCatCPage } from './non-pass-finalisation.cat-c.page';
+import { NonPassFinalisationAnalyticsEffects } from '../non-pass-finalisation.analytics.effects';
 
 @NgModule({
   declarations: [
@@ -11,6 +13,7 @@ import { NonPassFinalisationCatCPage } from './non-pass-finalisation.cat-c.page'
   ],
   imports: [
     IonicPageModule.forChild(NonPassFinalisationCatCPage),
+    EffectsModule.forFeature([NonPassFinalisationAnalyticsEffects]),
     ComponentsModule,
     TestFinalisationComponentsModule,
   ],

--- a/src/pages/non-pass-finalisation/non-pass-finalisation.analytics.effects.ts
+++ b/src/pages/non-pass-finalisation/non-pass-finalisation.analytics.effects.ts
@@ -4,14 +4,26 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../shared/models/store.model';
 import * as nonPassFinalisationActions from './non-pass-finalisation.actions';
+import * as vehicleDetailsActions from '../../modules/tests/vehicle-details/common/vehicle-details.actions';
+import * as testSummaryActions from '../../modules/tests/test-summary/test-summary.actions';
+import * as commsActions from '../../modules/tests/communication-preferences/communication-preferences.actions';
 import { of } from 'rxjs/observable/of';
 import { withLatestFrom } from 'rxjs/operators/withLatestFrom';
 import { getTests } from '../../modules/tests/tests.reducer';
-import { AnalyticRecorded } from '../../providers/analytics/analytics.actions';
+import { AnalyticRecorded, AnalyticNotRecorded } from '../../providers/analytics/analytics.actions';
 import { TestsModel } from '../../modules/tests/tests.model';
 import { formatAnalyticsText } from '../../shared/helpers/format-analytics-text';
-import { AnalyticsScreenNames, AnalyticsErrorTypes } from '../../providers/analytics/analytics.model';
+import {
+  AnalyticsScreenNames,
+  AnalyticsErrorTypes,
+  AnalyticsEventCategories,
+  AnalyticsEvents,
+} from '../../providers/analytics/analytics.model';
 import { switchMap, concatMap } from 'rxjs/operators';
+import { ActivityCode } from '@dvsa/mes-test-schema/categories/common';
+import { getCurrentTest } from '../../modules/tests/tests.selector';
+import { getActivityCode } from '../../modules/tests/activity-code/activity-code.reducer';
+import { Language } from '../../modules/tests/communication-preferences/communication-preferences.model';
 
 @Injectable()
 export class NonPassFinalisationAnalyticsEffects {
@@ -56,6 +68,133 @@ export class NonPassFinalisationAnalyticsEffects {
         action.errorMessage,
       );
       return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  transmissionChanged$ = this.actions$.pipe(
+    ofType(vehicleDetailsActions.GEARBOX_CATEGORY_CHANGED),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getActivityCode),
+        ),
+      ),
+    )),
+    concatMap(([action, tests, activityCode]:
+        [vehicleDetailsActions.GearboxCategoryChanged, TestsModel, ActivityCode]) => {
+      if (activityCode != null) {
+        this.analytics.logEvent(
+          formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
+          formatAnalyticsText(AnalyticsEvents.GEARBOX_CATEGORY_CHANGED, tests),
+          action.gearboxCategory,
+        );
+        return of(new AnalyticRecorded());
+      }
+      return of(new AnalyticNotRecorded());
+    }),
+  );
+
+  @Effect()
+  d255Yes$ = this.actions$.pipe(
+    ofType(testSummaryActions.D255_YES),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    concatMap(([action, tests]: [testSummaryActions.D255Yes, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
+        formatAnalyticsText(AnalyticsEvents.D255, tests),
+        'Yes',
+      );
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  d255No$ = this.actions$.pipe(
+    ofType(testSummaryActions.D255_NO),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    concatMap(([action, tests]: [testSummaryActions.D255No, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
+        formatAnalyticsText(AnalyticsEvents.D255, tests),
+        'No',
+      );
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  candidateChoseToProccedWithTestInEnglish$ = this.actions$.pipe(
+    ofType(commsActions.CANDIDATE_CHOSE_TO_PROCEED_WITH_TEST_IN_ENGLISH),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getActivityCode),
+        ),
+      ),
+    )),
+    concatMap(([action, tests, activityCode]:
+      [commsActions.CandidateChoseToProceedWithTestInEnglish, TestsModel, ActivityCode]) => {
+      if (activityCode !== null) {
+        this.analytics.logEvent(
+          formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
+          formatAnalyticsText(AnalyticsEvents.LANGUAGE_CHANGED, tests),
+          Language.ENGLISH,
+        );
+        return of(new AnalyticRecorded());
+      }
+      return of(new AnalyticNotRecorded());
+    }),
+  );
+
+  @Effect()
+  candidateChoseToProccedWithTestInWelsh$ = this.actions$.pipe(
+    ofType(commsActions.CANDIDATE_CHOSE_TO_PROCEED_WITH_TEST_IN_WELSH),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getActivityCode),
+        ),
+      ),
+    )),
+    concatMap(([action, tests, activityCode]:
+      [commsActions.CandidateChoseToProceedWithTestInWelsh, TestsModel, ActivityCode]) => {
+      if (activityCode !== null) {
+        this.analytics.logEvent(
+          formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
+          formatAnalyticsText(AnalyticsEvents.LANGUAGE_CHANGED, tests),
+          Language.CYMRAEG,
+        );
+        return of(new AnalyticRecorded());
+      }
+      return of(new AnalyticNotRecorded());
     }),
   );
 

--- a/src/pages/pass-finalisation/__tests__/pass-finalisation.analytics.effects.spec.ts
+++ b/src/pages/pass-finalisation/__tests__/pass-finalisation.analytics.effects.spec.ts
@@ -9,6 +9,7 @@ import * as passCompletionActions from '../../../modules/tests/pass-completion/p
 import * as fakeJournalActions from '../../fake-journal/fake-journal.actions';
 import * as testSummaryActions from '../../../modules/tests/test-summary/test-summary.actions';
 import * as vehicleDetailsActions from '../../../modules/tests/vehicle-details/common/vehicle-details.actions';
+import * as commsActions from '../../../modules/tests/communication-preferences/communication-preferences.actions';
 import { AnalyticsProvider } from '../../../providers/analytics/analytics';
 import { AnalyticsProviderMock } from '../../../providers/analytics/__mocks__/analytics.mock';
 import {
@@ -28,6 +29,7 @@ import { configureTestSuite } from 'ng-bullet';
 import { SetActivityCode } from '../../../modules/tests/activity-code/activity-code.actions';
 import { ActivityCodes } from '../../../shared/models/activity-codes';
 import { TransmissionType } from '../../../shared/models/transmission-type';
+import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
 
 describe('Pass Finalisation Analytics Effects', () => {
 
@@ -246,7 +248,7 @@ describe('Pass Finalisation Analytics Effects', () => {
         done();
       });
     });
-    it('should call not call logEvent if there is no activty code', (done) => {
+    it('should call not call logEvent if there is no activity code', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
@@ -296,6 +298,74 @@ describe('Pass Finalisation Analytics Effects', () => {
             AnalyticsEvents.D255,
             'No',
           );
+        done();
+      });
+    });
+  });
+  describe('candidateChoseToProceedWithTestInEnglish$', () => {
+    it('should call logEvent with the correct parameters', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      store$.dispatch(new SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new commsActions.CandidateChoseToProceedWithTestInEnglish(Language.ENGLISH));
+      // ASSERT
+      effects.candidateChoseToProccedWithTestInEnglish$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.POST_TEST,
+            AnalyticsEvents.LANGUAGE_CHANGED,
+            Language.ENGLISH,
+          );
+        done();
+      });
+    });
+    it('should call not call logEvent if there is no activity code', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      // ACT
+      actions$.next(new commsActions.CandidateChoseToProceedWithTestInEnglish(Language.ENGLISH));
+      // ASSERT
+      effects.candidateChoseToProccedWithTestInEnglish$.subscribe((result) => {
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+  describe('candidateChoseToProceedWithTestInWelsh$', () => {
+    it('should call logEvent with the correct parameters', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      store$.dispatch(new SetActivityCode(ActivityCodes.PASS));
+      // ACT
+      actions$.next(new commsActions.CandidateChoseToProceedWithTestInWelsh(Language.CYMRAEG));
+      // ASSERT
+      effects.candidateChoseToProccedWithTestInWelsh$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent)
+          .toHaveBeenCalledWith(
+            AnalyticsEventCategories.POST_TEST,
+            AnalyticsEvents.LANGUAGE_CHANGED,
+            Language.CYMRAEG,
+          );
+        done();
+      });
+    });
+    it('should call not call logEvent if there is no activity code', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
+      store$.dispatch(new PopulateCandidateDetails(candidateMock));
+      // ACT
+      actions$.next(new commsActions.CandidateChoseToProceedWithTestInWelsh(Language.CYMRAEG));
+      // ASSERT
+      effects.candidateChoseToProccedWithTestInWelsh$.subscribe((result) => {
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
         done();
       });
     });

--- a/src/pages/pass-finalisation/__tests__/pass-finalisation.analytics.effects.spec.ts
+++ b/src/pages/pass-finalisation/__tests__/pass-finalisation.analytics.effects.spec.ts
@@ -248,7 +248,7 @@ describe('Pass Finalisation Analytics Effects', () => {
         done();
       });
     });
-    it('should call not call logEvent if there is no activity code', (done) => {
+    it('should not call logEvent if there is no activity code', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
@@ -322,7 +322,7 @@ describe('Pass Finalisation Analytics Effects', () => {
         done();
       });
     });
-    it('should call not call logEvent if there is no activity code', (done) => {
+    it('should not call logEvent if there is no activity code', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));
@@ -356,7 +356,7 @@ describe('Pass Finalisation Analytics Effects', () => {
         done();
       });
     });
-    it('should call not call logEvent if there is no activity code', (done) => {
+    it('should not call logEvent if there is no activity code', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123, TestCategory.C));
       store$.dispatch(new PopulateCandidateDetails(candidateMock));

--- a/src/pages/pass-finalisation/pass-finalisation.analytics.effects.ts
+++ b/src/pages/pass-finalisation/pass-finalisation.analytics.effects.ts
@@ -27,6 +27,8 @@ import * as vehicleDetailsActions from '../../modules/tests/vehicle-details/comm
 import { getActivityCode } from '../../modules/tests/activity-code/activity-code.reducer';
 import { getCurrentTest } from '../../modules/tests/tests.selector';
 import { ActivityCode } from '@dvsa/mes-test-schema/categories/common';
+import * as commsActions from '../../modules/tests/communication-preferences/communication-preferences.actions';
+import { Language } from '../../modules/tests/communication-preferences/communication-preferences.model';
 
 @Injectable()
 export class PassFinalisationAnalyticsEffects {
@@ -221,6 +223,64 @@ export class PassFinalisationAnalyticsEffects {
         'No',
       );
       return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  candidateChoseToProccedWithTestInEnglish$ = this.actions$.pipe(
+    ofType(commsActions.CANDIDATE_CHOSE_TO_PROCEED_WITH_TEST_IN_ENGLISH),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getActivityCode),
+        ),
+      ),
+    )),
+    concatMap(([action, tests, activityCode]:
+      [commsActions.CandidateChoseToProceedWithTestInEnglish, TestsModel, ActivityCode]) => {
+      if (activityCode !== null) {
+        this.analytics.logEvent(
+          formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
+          formatAnalyticsText(AnalyticsEvents.LANGUAGE_CHANGED, tests),
+          Language.ENGLISH,
+        );
+        return of(new AnalyticRecorded());
+      }
+      return of(new AnalyticNotRecorded());
+    }),
+  );
+
+  @Effect()
+  candidateChoseToProccedWithTestInWelsh$ = this.actions$.pipe(
+    ofType(commsActions.CANDIDATE_CHOSE_TO_PROCEED_WITH_TEST_IN_WELSH),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+        this.store$.pipe(
+          select(getTests),
+          select(getCurrentTest),
+          select(getActivityCode),
+        ),
+      ),
+    )),
+    concatMap(([action, tests, activityCode]:
+      [commsActions.CandidateChoseToProceedWithTestInWelsh, TestsModel, ActivityCode]) => {
+      if (activityCode !== null) {
+        this.analytics.logEvent(
+          formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
+          formatAnalyticsText(AnalyticsEvents.LANGUAGE_CHANGED, tests),
+          Language.CYMRAEG,
+        );
+        return of(new AnalyticRecorded());
+      }
+      return of(new AnalyticNotRecorded());
     }),
   );
 

--- a/src/pages/test-report/cat-be/components/reverse-diagram-modal/reverse-diagram-modal.html
+++ b/src/pages/test-report/cat-be/components/reverse-diagram-modal/reverse-diagram-modal.html
@@ -30,7 +30,7 @@
                   <ion-col col-42>
                     <input type="number" step="0.01" id="vehicleLength" class="vehicle-length-input"
                     [value]="vehicleLength"
-                    (keyup)="calculateDistanceLength($event.target.value)">
+                    (keyup)="onLengthKeyup($event.target.value)">
                   </ion-col>
                 </ion-row>
               </ion-col>
@@ -42,7 +42,7 @@
                   <ion-col col-42>
                     <input type="number" step="0.01" id="vehicleWidth" class="vehicle-width-input"
                     [value]="vehicleWidth"
-                    (keyup)="calculateDistanceWidth($event.target.value)">
+                    (keyup)="onWidthKeyup($event.target.value)">
                   </ion-col>
                 </ion-row>
               </ion-col>

--- a/src/pages/test-report/cat-be/components/reverse-diagram-modal/reverse-diagram-modal.module.ts
+++ b/src/pages/test-report/cat-be/components/reverse-diagram-modal/reverse-diagram-modal.module.ts
@@ -1,7 +1,11 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
+import { EffectsModule } from '@ngrx/effects';
 import { ReverseDiagramCatBEPage } from './reverse-diagram-modal';
 import { ReversingDistancesProvider } from '../../../../../providers/reversing-distances/reversing-distances';
+import {
+  ReverseDiagramModalAnalyticsEffects,
+} from '../../../components/reverse-diagram-modal/reverse-diagram-modal.analytics.effects';
 
 @NgModule({
   declarations: [
@@ -9,6 +13,7 @@ import { ReversingDistancesProvider } from '../../../../../providers/reversing-d
   ],
   imports: [
     IonicPageModule.forChild(ReverseDiagramCatBEPage),
+    EffectsModule.forFeature([ReverseDiagramModalAnalyticsEffects]),
   ],
   providers: [
     ReversingDistancesProvider,

--- a/src/pages/test-report/cat-be/components/reverse-diagram-modal/reverse-diagram-modal.ts
+++ b/src/pages/test-report/cat-be/components/reverse-diagram-modal/reverse-diagram-modal.ts
@@ -15,6 +15,10 @@ import {
 import { getCurrentTest } from '../../../../../modules/tests/tests.selector';
 import { ReversingDistancesProvider } from '../../../../../providers/reversing-distances/reversing-distances';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import {
+  ReverseDiagramLengthChanged,
+  ReverseDiagramWidthChanged,
+} from '../../../components/reverse-diagram-modal/reverse-diagram-modal.actions';
 
 interface ReverseDiagramPageState {
   vehicleLength$: Observable<number>;
@@ -115,5 +119,15 @@ export class ReverseDiagramCatBEPage implements OnInit {
 
   closeModal(): void {
     this.onClose();
+  }
+
+  onLengthKeyup(vehicleLength: number) : void {
+    this.calculateDistanceLength(vehicleLength);
+    this.store$.dispatch(new ReverseDiagramLengthChanged());
+  }
+
+  onWidthKeyup(vehicleWidth: number) : void {
+    this.calculateDistanceWidth(vehicleWidth);
+    this.store$.dispatch(new ReverseDiagramWidthChanged());
   }
 }

--- a/src/pages/test-report/cat-be/components/reverse-diagram-modal/reverse-diagram-modal.ts
+++ b/src/pages/test-report/cat-be/components/reverse-diagram-modal/reverse-diagram-modal.ts
@@ -91,6 +91,7 @@ export class ReverseDiagramCatBEPage implements OnInit {
     const reversingLenghts = this.reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.BE);
     this.distanceFromMiddle = reversingLenghts.middleDistance;
     this.distanceFromStart = reversingLenghts.startDistance;
+    this.vehicleLength = length;
   }
 
   calculateDistanceWidth(width: number): void {
@@ -99,6 +100,7 @@ export class ReverseDiagramCatBEPage implements OnInit {
       vehicleWidth: width,
     };
     this.distanceOfBayWidth = this.reversingDistancesProvider.getDistanceWidth(vehicleDetails, TestCategory.BE);
+    this.vehicleWidth = width;
   }
 
   ionViewWillEnter(): boolean {
@@ -122,12 +124,12 @@ export class ReverseDiagramCatBEPage implements OnInit {
   }
 
   onLengthKeyup(vehicleLength: number) : void {
+    this.store$.dispatch(new ReverseDiagramLengthChanged(this.vehicleLength, vehicleLength));
     this.calculateDistanceLength(vehicleLength);
-    this.store$.dispatch(new ReverseDiagramLengthChanged());
   }
 
   onWidthKeyup(vehicleWidth: number) : void {
+    this.store$.dispatch(new ReverseDiagramWidthChanged(this.vehicleWidth, vehicleWidth));
     this.calculateDistanceWidth(vehicleWidth);
-    this.store$.dispatch(new ReverseDiagramWidthChanged());
   }
 }

--- a/src/pages/test-report/cat-c/components/reverse-diagram-modal/reverse-diagram-modal.cat-c.html
+++ b/src/pages/test-report/cat-c/components/reverse-diagram-modal/reverse-diagram-modal.cat-c.html
@@ -30,7 +30,7 @@
                   <ion-col col-42>
                     <input type="number" step="0.01" id="vehicleLength" class="vehicle-length-input"
                     [value]="vehicleLength"
-                    (keyup)="calculateReversingLengths($event.target.value)">
+                    (keyup)="onLengthKeyup($event.target.value)">
                   </ion-col>
                 </ion-row>
               </ion-col>
@@ -42,7 +42,7 @@
                   <ion-col col-42>
                     <input type="number" step="0.01" id="vehicleWidth" class="vehicle-width-input"
                     [value]="vehicleWidth"
-                    (keyup)="calculateReversingWidth($event.target.value)">
+                    (keyup)="onWidthKeyup($event.target.value)">
                   </ion-col>
                 </ion-row>
               </ion-col>

--- a/src/pages/test-report/cat-c/components/reverse-diagram-modal/reverse-diagram-modal.cat-c.module.ts
+++ b/src/pages/test-report/cat-c/components/reverse-diagram-modal/reverse-diagram-modal.cat-c.module.ts
@@ -1,7 +1,11 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
+import { EffectsModule } from '@ngrx/effects';
 import { ReverseDiagramCatCPage } from './reverse-diagram-modal.cat-c';
 import { ReversingDistancesProvider } from '../../../../../providers/reversing-distances/reversing-distances';
+import {
+  ReverseDiagramModalAnalyticsEffects,
+} from '../../../components/reverse-diagram-modal/reverse-diagram-modal.analytics.effects';
 
 @NgModule({
   declarations: [
@@ -9,6 +13,7 @@ import { ReversingDistancesProvider } from '../../../../../providers/reversing-d
   ],
   imports: [
     IonicPageModule.forChild(ReverseDiagramCatCPage),
+    EffectsModule.forFeature([ReverseDiagramModalAnalyticsEffects]),
   ],
   providers: [
     ReversingDistancesProvider,

--- a/src/pages/test-report/cat-c/components/reverse-diagram-modal/reverse-diagram-modal.cat-c.ts
+++ b/src/pages/test-report/cat-c/components/reverse-diagram-modal/reverse-diagram-modal.cat-c.ts
@@ -100,6 +100,7 @@ export class ReverseDiagramCatCPage implements OnInit {
     const reversingLengths = this.reversingDistancesProvider.getDistanceLength(vehicleDetails, this.category);
     this.reversingLengthStart = reversingLengths.startDistance;
     this.reversingLengthMiddle = reversingLengths.middleDistance;
+    this.vehicleLength = vehicleLength;
   }
 
   calculateReversingWidth(vehicleWidth: number): void {
@@ -109,6 +110,7 @@ export class ReverseDiagramCatCPage implements OnInit {
     };
 
     this.reversingWidth = this.reversingDistancesProvider.getDistanceWidth(vehicleDetails, this.category);
+    this.vehicleWidth = vehicleWidth;
   }
 
   ionViewWillEnter(): boolean {
@@ -132,12 +134,12 @@ export class ReverseDiagramCatCPage implements OnInit {
   }
 
   onLengthKeyup(vehicleLength: number) : void {
+    this.store$.dispatch(new ReverseDiagramLengthChanged(this.vehicleLength , vehicleLength));
     this.calculateReversingLengths(vehicleLength);
-    this.store$.dispatch(new ReverseDiagramLengthChanged());
   }
 
   onWidthKeyup(vehicleWidth: number) : void {
+    this.store$.dispatch(new ReverseDiagramWidthChanged(this.vehicleWidth, vehicleWidth));
     this.calculateReversingWidth(vehicleWidth);
-    this.store$.dispatch(new ReverseDiagramWidthChanged());
   }
 }

--- a/src/pages/test-report/cat-c/components/reverse-diagram-modal/reverse-diagram-modal.cat-c.ts
+++ b/src/pages/test-report/cat-c/components/reverse-diagram-modal/reverse-diagram-modal.cat-c.ts
@@ -17,6 +17,10 @@ import {
 import { getCurrentTest } from '../../../../../modules/tests/tests.selector';
 import { getTestCategory } from '../../../../../modules/tests/category/category.reducer';
 import { CategoryCode } from '@dvsa/mes-test-schema/categories/common';
+import {
+  ReverseDiagramLengthChanged,
+  ReverseDiagramWidthChanged,
+} from '../../../components/reverse-diagram-modal/reverse-diagram-modal.actions';
 
 interface ReverseDiagramPageState {
   vehicleLength$: Observable<number>;
@@ -125,5 +129,15 @@ export class ReverseDiagramCatCPage implements OnInit {
 
   closeModal(): void {
     this.onClose();
+  }
+
+  onLengthKeyup(vehicleLength: number) : void {
+    this.calculateReversingLengths(vehicleLength);
+    this.store$.dispatch(new ReverseDiagramLengthChanged());
+  }
+
+  onWidthKeyup(vehicleWidth: number) : void {
+    this.calculateReversingWidth(vehicleWidth);
+    this.store$.dispatch(new ReverseDiagramWidthChanged());
   }
 }

--- a/src/pages/test-report/components/reverse-diagram-modal/__tests__/reverse-diagram-modal.analytics.effects.spec.ts
+++ b/src/pages/test-report/components/reverse-diagram-modal/__tests__/reverse-diagram-modal.analytics.effects.spec.ts
@@ -155,4 +155,42 @@ describe('Reverse Diagram Modal Analytics Effects', () => {
       });
     });
   });
+
+  describe('reverseDiagramLengthChanged', () => {
+    it('should call logEvent with the correct parameters', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions$.next(new reverseDiagramModalActions.ReverseDiagramLengthChanged());
+      // ASSERT
+      effects.reverseDiagramLengthChanged$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REVERSE_DIAGRAM_LENGTH_CHANGED}`,
+        );
+        done();
+      });
+    });
+  });
+
+  describe('reverseDiagramWidthChanged', () => {
+    it('should call logEvent with the correct parameters', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
+      // ACT
+      actions$.next(new reverseDiagramModalActions.ReverseDiagramWidthChanged());
+      // ASSERT
+      effects.reverseDiagramWidthChanged$.subscribe((result) => {
+        expect(result instanceof AnalyticRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REVERSE_DIAGRAM_WIDTH_CHANGED}`,
+        );
+        done();
+      });
+    });
+  });
 });

--- a/src/pages/test-report/components/reverse-diagram-modal/__tests__/reverse-diagram-modal.analytics.effects.spec.ts
+++ b/src/pages/test-report/components/reverse-diagram-modal/__tests__/reverse-diagram-modal.analytics.effects.spec.ts
@@ -161,7 +161,7 @@ describe('Reverse Diagram Modal Analytics Effects', () => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions$.next(new reverseDiagramModalActions.ReverseDiagramLengthChanged());
+      actions$.next(new reverseDiagramModalActions.ReverseDiagramLengthChanged(100 , 10));
       // ASSERT
       effects.reverseDiagramLengthChanged$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
@@ -169,6 +169,7 @@ describe('Reverse Diagram Modal Analytics Effects', () => {
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
           `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REVERSE_DIAGRAM_LENGTH_CHANGED}`,
+          'from 100 to 10',
         );
         done();
       });
@@ -180,7 +181,7 @@ describe('Reverse Diagram Modal Analytics Effects', () => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions$.next(new reverseDiagramModalActions.ReverseDiagramWidthChanged());
+      actions$.next(new reverseDiagramModalActions.ReverseDiagramWidthChanged(100, 10));
       // ASSERT
       effects.reverseDiagramWidthChanged$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
@@ -188,6 +189,7 @@ describe('Reverse Diagram Modal Analytics Effects', () => {
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
           `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REVERSE_DIAGRAM_WIDTH_CHANGED}`,
+          'from 100 to 10',
         );
         done();
       });

--- a/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.actions.ts
+++ b/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.actions.ts
@@ -19,9 +19,11 @@ export class ReverseDiagramClosed implements Action {
 }
 export class ReverseDiagramLengthChanged implements Action {
   readonly type = REVERSE_DIAGRAM_LENGTH_CHANGED;
+  constructor(public previousLength: number , public newLength: number) {}
 }
 export class ReverseDiagramWidthChanged implements Action {
   readonly type = REVERSE_DIAGRAM_WIDTH_CHANGED;
+  constructor(public previousWidth: number , public newWidth: number) {}
 }
 
 export type Types =

--- a/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.actions.ts
+++ b/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.actions.ts
@@ -3,6 +3,8 @@ import { Action } from '@ngrx/store';
 export const REVERSE_DIAGRAM_VIEW_DID_ENTER = '[ReverseDiagramPage] Reverse Diagram Did Enter';
 export const REVERSE_DIAGRAM_OPENED = '[ReverseDiagramPage] Reverse Diagram Opened';
 export const REVERSE_DIAGRAM_CLOSED = '[ReverseDiagramPage] Reverse Diagram Closed';
+export const REVERSE_DIAGRAM_LENGTH_CHANGED = '[ReverseDiagramPage] Change Vehicle Length';
+export const REVERSE_DIAGRAM_WIDTH_CHANGED = '[ReverseDiagramPage] Change Vehicle Width';
 
 export class ReverseDiagramViewDidEnter implements Action {
   readonly type = REVERSE_DIAGRAM_VIEW_DID_ENTER;
@@ -15,7 +17,16 @@ export class ReverseDiagramOpened implements Action {
 export class ReverseDiagramClosed implements Action {
   readonly type = REVERSE_DIAGRAM_CLOSED;
 }
+export class ReverseDiagramLengthChanged implements Action {
+  readonly type = REVERSE_DIAGRAM_LENGTH_CHANGED;
+}
+export class ReverseDiagramWidthChanged implements Action {
+  readonly type = REVERSE_DIAGRAM_WIDTH_CHANGED;
+}
+
 export type Types =
   | ReverseDiagramViewDidEnter
   | ReverseDiagramOpened
-  | ReverseDiagramClosed;
+  | ReverseDiagramClosed
+  | ReverseDiagramLengthChanged
+  | ReverseDiagramWidthChanged;

--- a/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.analytics.effects.ts
+++ b/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.analytics.effects.ts
@@ -133,6 +133,7 @@ export class ReverseDiagramModalAnalyticsEffects {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
         formatAnalyticsText(AnalyticsEvents.REVERSE_DIAGRAM_LENGTH_CHANGED, tests),
+        `from ${action.previousLength} to ${action.newLength}`,
       );
       return of(new AnalyticRecorded());
     }),
@@ -152,6 +153,7 @@ export class ReverseDiagramModalAnalyticsEffects {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
         formatAnalyticsText(AnalyticsEvents.REVERSE_DIAGRAM_WIDTH_CHANGED, tests),
+        `from ${action.previousWidth} to ${action.newWidth}`,
       );
       return of(new AnalyticRecorded());
     }),

--- a/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.analytics.effects.ts
+++ b/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.analytics.effects.ts
@@ -9,14 +9,7 @@ import {
   AnalyticsEventCategories,
   AnalyticsEvents,
 } from '../../../../providers/analytics/analytics.model';
-import {
-  REVERSE_DIAGRAM_VIEW_DID_ENTER,
-  ReverseDiagramViewDidEnter,
-  REVERSE_DIAGRAM_OPENED,
-  ReverseDiagramOpened,
-  REVERSE_DIAGRAM_CLOSED,
-  ReverseDiagramClosed,
-} from './reverse-diagram-modal.actions';
+import * as reverseDiagramActions from './reverse-diagram-modal.actions';
 import { StoreModel } from '../../../../shared/models/store.model';
 import { Store, select } from '@ngrx/store';
 import { getTests } from '../../../../modules/tests/tests.reducer';
@@ -47,7 +40,7 @@ export class ReverseDiagramModalAnalyticsEffects {
 
   @Effect()
   reverseDiagramViewDidEnter$ = this.actions$.pipe(
-    ofType(REVERSE_DIAGRAM_VIEW_DID_ENTER),
+    ofType(reverseDiagramActions.REVERSE_DIAGRAM_VIEW_DID_ENTER),
     concatMap(action => of(action).pipe(
       withLatestFrom(
         this.store$.pipe(
@@ -76,7 +69,7 @@ export class ReverseDiagramModalAnalyticsEffects {
     )),
     switchMap((
       [action, tests, applicationReference, candidateId, category]:
-      [ReverseDiagramViewDidEnter, TestsModel, string, number, CategoryCode],
+      [reverseDiagramActions.ReverseDiagramViewDidEnter, TestsModel, string, number, CategoryCode],
     ) => {
       this.analytics.addCustomDimension(AnalyticsDimensionIndices.TEST_CATEGORY, category);
       this.analytics.addCustomDimension(AnalyticsDimensionIndices.CANDIDATE_ID, `${candidateId}`);
@@ -90,7 +83,7 @@ export class ReverseDiagramModalAnalyticsEffects {
 
   @Effect()
   reverseDiagramOpened$ = this.actions$.pipe(
-    ofType(REVERSE_DIAGRAM_OPENED),
+    ofType(reverseDiagramActions.REVERSE_DIAGRAM_OPENED),
     concatMap(action => of(action).pipe(
       withLatestFrom(
         this.store$.pipe(
@@ -98,7 +91,7 @@ export class ReverseDiagramModalAnalyticsEffects {
         ),
       ),
     )),
-    concatMap(([action, tests]: [ReverseDiagramOpened, TestsModel]) => {
+    concatMap(([action, tests]: [reverseDiagramActions.ReverseDiagramOpened, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
         formatAnalyticsText(AnalyticsEvents.REVERSE_DIAGRAM_OPENED, tests),
@@ -109,7 +102,7 @@ export class ReverseDiagramModalAnalyticsEffects {
 
   @Effect()
   reverseDiagramClosed$ = this.actions$.pipe(
-    ofType(REVERSE_DIAGRAM_CLOSED),
+    ofType(reverseDiagramActions.REVERSE_DIAGRAM_CLOSED),
     concatMap(action => of(action).pipe(
       withLatestFrom(
         this.store$.pipe(
@@ -117,10 +110,48 @@ export class ReverseDiagramModalAnalyticsEffects {
         ),
       ),
     )),
-    concatMap(([action, tests]: [ReverseDiagramClosed, TestsModel]) => {
+    concatMap(([action, tests]: [reverseDiagramActions.ReverseDiagramClosed, TestsModel]) => {
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
         formatAnalyticsText(AnalyticsEvents.REVERSE_DIAGRAM_CLOSED, tests),
+      );
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  reverseDiagramLengthChanged$ = this.actions$.pipe(
+    ofType(reverseDiagramActions.REVERSE_DIAGRAM_LENGTH_CHANGED),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    concatMap(([action, tests]: [reverseDiagramActions.ReverseDiagramLengthChanged, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.REVERSE_DIAGRAM_LENGTH_CHANGED, tests),
+      );
+      return of(new AnalyticRecorded());
+    }),
+  );
+
+  @Effect()
+  reverseDiagramWidthChanged$ = this.actions$.pipe(
+    ofType(reverseDiagramActions.REVERSE_DIAGRAM_WIDTH_CHANGED),
+    concatMap(action => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    concatMap(([action, tests]: [reverseDiagramActions.ReverseDiagramWidthChanged, TestsModel]) => {
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
+        formatAnalyticsText(AnalyticsEvents.REVERSE_DIAGRAM_WIDTH_CHANGED, tests),
       );
       return of(new AnalyticRecorded());
     }),

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -104,6 +104,8 @@ export enum AnalyticsEvents {
   REVERSE_LEFT_POPOVER_CLOSED = 'close reversing manoevure',
   REVERSE_DIAGRAM_OPENED = 'open reversing diagram',
   REVERSE_DIAGRAM_CLOSED = 'close reversing diagram',
+  REVERSE_DIAGRAM_LENGTH_CHANGED = 'change vehicle length on reversing diagram',
+  REVERSE_DIAGRAM_WIDTH_CHANGED = 'change vehicle width on reversing diagram',
   TOGGLE_CODE_78 = 'toggle code 78',
   TOGGLE_LICENSE_RECEIVED = 'toggle license recieved',
   D255 = 'set D255',

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -110,6 +110,7 @@ export enum AnalyticsEvents {
   TOGGLE_LICENSE_RECEIVED = 'toggle license recieved',
   D255 = 'set D255',
   GEARBOX_CATEGORY_CHANGED = 'set transmission',
+  LANGUAGE_CHANGED = 'language changed',
 }
 
 export enum AnalyticsLabels {

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -107,7 +107,7 @@ export enum AnalyticsEvents {
   REVERSE_DIAGRAM_LENGTH_CHANGED = 'change vehicle length on reversing diagram',
   REVERSE_DIAGRAM_WIDTH_CHANGED = 'change vehicle width on reversing diagram',
   TOGGLE_CODE_78 = 'toggle code 78',
-  TOGGLE_LICENSE_RECEIVED = 'toggle license recieved',
+  TOGGLE_LICENSE_RECEIVED = 'toggle licence received',
   D255 = 'set D255',
   GEARBOX_CATEGORY_CHANGED = 'set transmission',
   LANGUAGE_CHANGED = 'language changed',


### PR DESCRIPTION
## Description
- Fixed issue with Reversing Diagram Modal Analytics not firing
- Fixed issue with Non-Pass Completion Page Analytics not firing
- Added Length Changed Analytics Event on the Reversing Diagram Modal for B+E & C
- Added Width Changed Analytics Event on the Reversing Diagram Modal for B+E & C
- Added Conducted Language Analytics Event on Pass Completion 2 Page for all categories.

## Checklist

- [x] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
