### PR TITLE
fix bug that clears D255 and debriefWitnessed on autosave

### DIFF
--- a/src/providers/test-submission/test-submission.ts
+++ b/src/providers/test-submission/test-submission.ts
@@ -89,9 +89,12 @@ export class TestSubmissionProvider {
     return removeNullFields(data);
   }
 
+  // NOTE debrief witnessed and D255 should not be removed
   removeFieldsForPartialData = (data: TestResultSchemasUnion): Partial<TestResultSchemasUnion> => {
     Object.keys(data.testSummary).map((key: string) => {
-      data.testSummary[key] = null;
+      if (key !== 'debriefWitnessed' && key !== 'D255') {
+        data.testSummary[key] = null;
+      }
     });
 
     return data;


### PR DESCRIPTION
MES-4648

While checking autosave it was discovered that a recent change has resulted in autosaved tars submissions failing. (we were stripping out specific fields from testSummary for an autosave submission - this was changed to stripping out all fields (due to different category definitions for testSummary) however there are two fields that are in testSummary that were moved historically and we need to keep these (debriefWitnessed and D255).  D255 is used in the assessment of completeness for submitting to tars and because it was no longer there it throws an error.

Added filtering logic to ensure these two fields are kept.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
