### PR TITLE
Correctly showing banner when code78 exists and doesn't for cat Cs

### DIFF
--- a/src/pages/pass-finalisation/cat-c/_tests_/pass-finalisation.cat-c.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-c/_tests_/pass-finalisation.cat-c.page.spec.ts
@@ -191,6 +191,7 @@ describe('PassFinalisationCatCPage', () => {
       it('should show the automatic banner when it is valid', () => {
         component.transmission = TransmissionType.Automatic;
         component.code78Present = true;
+        component.testCategory = TestCategory.C;
         expect(component.shouldShowAutomaticBanner()).toEqual(true);
       });
     });
@@ -199,6 +200,7 @@ describe('PassFinalisationCatCPage', () => {
       it('should show the manual banner when it is valid', () => {
         component.transmission = TransmissionType.Manual;
         component.code78Present = true;
+        component.testCategory = TestCategory.C;
         expect(component.shouldShowManualBanner()).toEqual(true);
       });
     });

--- a/src/pages/pass-finalisation/cat-c/_tests_/pass-finalisation.cat-c.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-c/_tests_/pass-finalisation.cat-c.page.spec.ts
@@ -53,6 +53,136 @@ describe('PassFinalisationCatCPage', () => {
     { category: TestCategory.CE, showCode78: true },
   ];
 
+  const automaticManualBannerConditions = [
+    { category: TestCategory.C,
+      code78: true,
+      transmission: TransmissionType.Automatic,
+      automaticBanner: true,
+      manualBanner: false,
+      desc: 'Automatic banner shown when automatic transmission and code78 present',
+    },
+    {
+      category: TestCategory.C,
+      code78: false,
+      transmission: TransmissionType.Automatic,
+      automaticBanner: false,
+      manualBanner: true,
+      desc: 'Manual banner shown when automatic transmission and no code78 present',
+    },
+    {
+      category: TestCategory.C,
+      code78: false,
+      transmission: TransmissionType.Manual,
+      automaticBanner: false,
+      manualBanner: true,
+      desc: 'Manual banner shown when manual transmission and no code78 present',
+    },
+    {
+      category: TestCategory.C,
+      code78: true,
+      transmission: TransmissionType.Manual,
+      automaticBanner: false,
+      manualBanner: true,
+      desc: 'Manual banner shown when manual transmission and code78 present',
+    },
+    {
+      category: TestCategory.CE,
+      code78: true,
+      transmission: TransmissionType.Automatic,
+      automaticBanner: true,
+      manualBanner: false,
+      desc: 'Automatic banner shown when automatic transmission and code78 present',
+    },
+    {
+      category: TestCategory.CE,
+      code78: false,
+      transmission: TransmissionType.Automatic,
+      automaticBanner: false,
+      manualBanner: true,
+      desc: 'Manual banner shown when automatic transmission and no code78 present',
+    },
+    {
+      category: TestCategory.CE,
+      code78: false,
+      transmission: TransmissionType.Manual,
+      automaticBanner: false,
+      manualBanner: true,
+      desc: 'Manual banner shown when manual transmission and no code78 present',
+    },
+    {
+      category: TestCategory.CE,
+      code78: true,
+      transmission: TransmissionType.Manual,
+      automaticBanner: false,
+      manualBanner: true,
+      desc: 'Manual banner shown when manual transmission and code78 present',
+    },
+    {
+      category: TestCategory.C1,
+      code78: true,
+      transmission: TransmissionType.Automatic,
+      automaticBanner: false,
+      manualBanner: false,
+      desc: 'No banner shown when automatic transmission and code78 present',
+    },
+    {
+      category: TestCategory.C1,
+      code78: false,
+      transmission: TransmissionType.Automatic,
+      automaticBanner: false,
+      manualBanner: false,
+      desc: 'No banner shown when automatic transmission and no code78 present',
+    },
+    {
+      category: TestCategory.C1,
+      code78: false,
+      transmission: TransmissionType.Manual,
+      automaticBanner: false,
+      manualBanner: false,
+      desc: 'No banner shown when manual transmission and no code78 present',
+    },
+    {
+      category: TestCategory.C1,
+      code78: true,
+      transmission: TransmissionType.Manual,
+      automaticBanner: false,
+      manualBanner: false,
+      desc: 'No banner shown when manual transmission and code78 present',
+    },
+    {
+      category: TestCategory.C1E,
+      code78: true,
+      transmission: TransmissionType.Automatic,
+      automaticBanner: false,
+      manualBanner: false,
+      desc: 'No banner shown when automatic transmission and code78 present',
+    },
+    {
+      category: TestCategory.C1E,
+      code78: false,
+      transmission: TransmissionType.Automatic,
+      automaticBanner: false,
+      manualBanner: false,
+      desc: 'No banner shown when automatic transmission and no code78 present',
+    },
+    {
+      category: TestCategory.C1E,
+      code78: false,
+      transmission: TransmissionType.Manual,
+      automaticBanner: false,
+      manualBanner: false,
+      desc: 'No banner shown when manual transmission and no code78 present',
+    },
+    {
+      category: TestCategory.C1E,
+      code78: true,
+      transmission: TransmissionType.Manual,
+      automaticBanner: false,
+      manualBanner: false,
+      desc: 'No banner shown when manual transmission and code78 present',
+    },
+  ];
+
   configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [
@@ -187,21 +317,14 @@ describe('PassFinalisationCatCPage', () => {
       }));
     });
 
-    describe('showAutomaticBanner', () => {
-      it('should show the automatic banner when it is valid', () => {
-        component.transmission = TransmissionType.Automatic;
-        component.code78Present = true;
-        component.testCategory = TestCategory.C;
-        expect(component.shouldShowAutomaticBanner()).toEqual(true);
-      });
-    });
+    automaticManualBannerConditions.forEach((cat) => {
+      it(`${cat.desc} (${cat.category})`, () => {
+        component.transmission = cat.transmission;
+        component.code78Present = cat.code78;
+        component.testCategory = cat.category;
+        expect(component.shouldShowAutomaticBanner()).toEqual(cat.automaticBanner);
+        expect(component.shouldShowManualBanner()).toEqual(cat.manualBanner);
 
-    describe('should show manual banner', () => {
-      it('should show the manual banner when it is valid', () => {
-        component.transmission = TransmissionType.Manual;
-        component.code78Present = true;
-        component.testCategory = TestCategory.C;
-        expect(component.shouldShowManualBanner()).toEqual(true);
       });
     });
 

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.ts
@@ -278,7 +278,7 @@ export class PassFinalisationCatCPage extends BasePageComponent {
   }
 
   shouldShowCode78Banner(): boolean {
-    return this.code78Present !== null && this.transmission !== null;
+    return this.code78Present !== null && this.transmission !== null && this.shouldShowCode78();
   }
 
   shouldShowManualBanner(): boolean {
@@ -295,7 +295,7 @@ export class PassFinalisationCatCPage extends BasePageComponent {
   shouldShowAutomaticBanner(): boolean {
     if (this.shouldShowCode78Banner()) {
       return (
-        this.transmission === TransmissionType.Automatic && this.code78Present
+        this.code78Present && this.transmission === TransmissionType.Automatic
       );
     }
     return false;


### PR DESCRIPTION
## Description

Show and hide automatic/manual banner and code78 banner based on category and if code78 exists.

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
