### PR TITLE
Mes 4743 fault count summary provider

### DIFF
--- a/src/providers/fault-count/__mocks__/cat-C1-test-data-state-object.ts
+++ b/src/providers/fault-count/__mocks__/cat-C1-test-data-state-object.ts
@@ -1,4 +1,4 @@
-import { QuestionResult } from '@dvsa/mes-test-schema/categories/BE/partial';
+import { QuestionResult } from '@dvsa/mes-test-schema/categories/C1/partial';
 import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
 
 export const catC1TestDataStateObject: CatC1UniqueTypes.TestData = {

--- a/src/providers/fault-count/__mocks__/cat-C1E-test-data-state-object.ts
+++ b/src/providers/fault-count/__mocks__/cat-C1E-test-data-state-object.ts
@@ -1,4 +1,4 @@
-import { QuestionResult } from '@dvsa/mes-test-schema/categories/BE/partial';
+import { QuestionResult } from '@dvsa/mes-test-schema/categories/C1E/partial';
 import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
 
 export const catC1ETestDataStateObject: CatC1EUniqueTypes.TestData = {

--- a/src/providers/fault-count/__mocks__/cat-CE-test-data-state-object.ts
+++ b/src/providers/fault-count/__mocks__/cat-CE-test-data-state-object.ts
@@ -1,4 +1,4 @@
-import { QuestionResult } from '@dvsa/mes-test-schema/categories/BE/partial';
+import { QuestionResult } from '@dvsa/mes-test-schema/categories/CE/partial';
 import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
 
 export const catCETestDataStateObject: CatCEUniqueTypes.TestData = {

--- a/src/providers/fault-count/__mocks__/cat-D-test-data-state-object.ts
+++ b/src/providers/fault-count/__mocks__/cat-D-test-data-state-object.ts
@@ -1,7 +1,7 @@
-import { QuestionResult } from '@dvsa/mes-test-schema/categories/C/partial';
-import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { QuestionResult } from '@dvsa/mes-test-schema/categories/D/partial';
+import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
 
-export const catCTestDataStateObject: CatCUniqueTypes.TestData = {
+export const catDTestDataStateObject: CatDUniqueTypes.TestData = {
   drivingFaults: {
     controlsGears: 1,
     pedestrianCrossings: 2,
@@ -46,4 +46,22 @@ export const catCTestDataStateObject: CatCUniqueTypes.TestData = {
       outcome: 'P',
     }] as QuestionResult[],
   },
+  pcvDoorExercise: {
+    drivingFault: true,
+    seriousFault: false,
+  },
+  safetyQuestions: [
+    {
+      description: 'string',
+      outcome: 'P',
+    },
+    {
+      description: 'string',
+      outcome: 'P',
+    },
+    {
+      description: 'string',
+      outcome: 'P',
+    },
+  ],
 };

--- a/src/providers/fault-count/__mocks__/cat-D1-test-data-state-object.ts
+++ b/src/providers/fault-count/__mocks__/cat-D1-test-data-state-object.ts
@@ -1,7 +1,7 @@
-import { QuestionResult } from '@dvsa/mes-test-schema/categories/C/partial';
-import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { QuestionResult } from '@dvsa/mes-test-schema/categories/D1/partial';
+import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
 
-export const catCTestDataStateObject: CatCUniqueTypes.TestData = {
+export const catD1TestDataStateObject: CatD1UniqueTypes.TestData = {
   drivingFaults: {
     controlsGears: 1,
     pedestrianCrossings: 2,
@@ -46,4 +46,22 @@ export const catCTestDataStateObject: CatCUniqueTypes.TestData = {
       outcome: 'P',
     }] as QuestionResult[],
   },
+  pcvDoorExercise: {
+    drivingFault: true,
+    seriousFault: false,
+  },
+  safetyQuestions: [
+    {
+      description: 'string',
+      outcome: 'P',
+    },
+    {
+      description: 'string',
+      outcome: 'P',
+    },
+    {
+      description: 'string',
+      outcome: 'P',
+    },
+  ],
 };

--- a/src/providers/fault-count/__mocks__/cat-D1E-test-data-state-object.ts
+++ b/src/providers/fault-count/__mocks__/cat-D1E-test-data-state-object.ts
@@ -1,7 +1,7 @@
-import { QuestionResult } from '@dvsa/mes-test-schema/categories/C/partial';
-import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { QuestionResult } from '@dvsa/mes-test-schema/categories/D1E/partial';
+import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
 
-export const catCTestDataStateObject: CatCUniqueTypes.TestData = {
+export const catD1ETestDataStateObject: CatD1EUniqueTypes.TestData = {
   drivingFaults: {
     controlsGears: 1,
     pedestrianCrossings: 2,
@@ -46,4 +46,22 @@ export const catCTestDataStateObject: CatCUniqueTypes.TestData = {
       outcome: 'P',
     }] as QuestionResult[],
   },
+  pcvDoorExercise: {
+    drivingFault: true,
+    seriousFault: false,
+  },
+  safetyQuestions: [
+    {
+      description: 'string',
+      outcome: 'P',
+    },
+    {
+      description: 'string',
+      outcome: 'P',
+    },
+    {
+      description: 'string',
+      outcome: 'P',
+    },
+  ],
 };

--- a/src/providers/fault-count/__mocks__/cat-DE-test-data-state-object.ts
+++ b/src/providers/fault-count/__mocks__/cat-DE-test-data-state-object.ts
@@ -1,7 +1,7 @@
-import { QuestionResult } from '@dvsa/mes-test-schema/categories/C/partial';
-import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { QuestionResult } from '@dvsa/mes-test-schema/categories/DE/partial';
+import { CatDEUniqueTypes } from '@dvsa/mes-test-schema/categories/DE';
 
-export const catCTestDataStateObject: CatCUniqueTypes.TestData = {
+export const catDETestDataStateObject: CatDEUniqueTypes.TestData = {
   drivingFaults: {
     controlsGears: 1,
     pedestrianCrossings: 2,
@@ -46,4 +46,22 @@ export const catCTestDataStateObject: CatCUniqueTypes.TestData = {
       outcome: 'P',
     }] as QuestionResult[],
   },
+  pcvDoorExercise: {
+    drivingFault: true,
+    seriousFault: false,
+  },
+  safetyQuestions: [
+    {
+      description: 'string',
+      outcome: 'P',
+    },
+    {
+      description: 'string',
+      outcome: 'P',
+    },
+    {
+      description: 'string',
+      outcome: 'P',
+    },
+  ],
 };

--- a/src/providers/fault-count/__tests__/fault-count.spec.ts
+++ b/src/providers/fault-count/__tests__/fault-count.spec.ts
@@ -1,20 +1,29 @@
-import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 import { FaultCountProvider } from '../fault-count';
 import { TestBed } from '@angular/core/testing';
+
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
+import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
+
 import { catAM1TestDataStateObject } from '../__mocks__/cat-AM1-test-data-state-object';
 import { catBTestDataStateObject } from '../__mocks__/cat-B-test-data-state-object';
 import { catBETestDataStateObject } from '../__mocks__/cat-BE-test-data-state-object';
-import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { catCTestDataStateObject } from '../__mocks__/cat-C-test-data-state-object';
-import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
 import { catCETestDataStateObject } from '../__mocks__/cat-CE-test-data-state-object';
 import { catC1ETestDataStateObject } from '../__mocks__/cat-C1E-test-data-state-object';
 import { catC1TestDataStateObject } from '../__mocks__/cat-C1-test-data-state-object';
+import { catDTestDataStateObject } from '../__mocks__/cat-D-test-data-state-object';
+import { catDETestDataStateObject } from '../__mocks__/cat-DE-test-data-state-object';
+import { catD1ETestDataStateObject } from '../__mocks__/cat-D1E-test-data-state-object';
+import { catD1TestDataStateObject } from '../__mocks__/cat-D1-test-data-state-object';
+
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 import { FaultCountBHelper } from '../cat-b/fault-count.cat-b';
 import { FaultCountBEHelper } from '../cat-be/fault-count.cat-be';
 import { FaultCountCHelper } from '../cat-c/fault-count.cat-c';
+import { FaultCountDHelper } from '../cat-d/fault-count.cat-d';
+
 import { configureTestSuite } from 'ng-bullet';
 import { FaultCountAM1Helper } from '../cat-a-mod1/fault-count.cat-a-mod1';
 
@@ -61,32 +70,73 @@ describe('FaultCountProvider', () => {
     spyOn(FaultCountAM1Helper, 'getDangerousFaultSumCountCatAM1').and.callThrough();
     spyOn(FaultCountAM1Helper, 'getSeriousFaultSumCountCatAM1').and.callThrough();
     spyOn(FaultCountAM1Helper, 'getRidingFaultSumCountCatAM1').and.callThrough();
+    
+    spyOn(FaultCountDHelper, 'getDrivingFaultSumCountCatD').and.callThrough();
+    spyOn(FaultCountDHelper, 'getSeriousFaultSumCountCatD').and.callThrough();
+    spyOn(FaultCountDHelper, 'getDangerousFaultSumCountCatD').and.callThrough();
+
+    spyOn(FaultCountDHelper, 'getDrivingFaultSumCountCatD1').and.callThrough();
+    spyOn(FaultCountDHelper, 'getSeriousFaultSumCountCatD1').and.callThrough();
+    spyOn(FaultCountDHelper, 'getDangerousFaultSumCountCatD1').and.callThrough();
+
+    spyOn(FaultCountDHelper, 'getDrivingFaultSumCountCatDE').and.callThrough();
+    spyOn(FaultCountDHelper, 'getSeriousFaultSumCountCatDE').and.callThrough();
+    spyOn(FaultCountDHelper, 'getDangerousFaultSumCountCatDE').and.callThrough();
+
+    spyOn(FaultCountDHelper, 'getDrivingFaultSumCountCatD1E').and.callThrough();
+    spyOn(FaultCountDHelper, 'getSeriousFaultSumCountCatD1E').and.callThrough();
+    spyOn(FaultCountDHelper, 'getDangerousFaultSumCountCatD1E').and.callThrough();
+
   });
 
   describe('getDrivingFaultSumCount', () => {
-    it('should call the category B specific method for getting the driving fault sum count', () => {
-      faultCountProvider.getDrivingFaultSumCount(TestCategory.B, catBTestDataStateObject);
-      expect((FaultCountBHelper as any).getDrivingFaultSumCountCatB).toHaveBeenCalled();
+    describe('CAT B', () => {
+      it('should call the category B specific method for getting the driving fault sum count', () => {
+        faultCountProvider.getDrivingFaultSumCount(TestCategory.B, catBTestDataStateObject);
+        expect((FaultCountBHelper as any).getDrivingFaultSumCountCatB).toHaveBeenCalled();
+      });
+      it('should call the category BE specific method for getting the driving fault sum count', () => {
+        faultCountProvider.getDrivingFaultSumCount(TestCategory.BE, catBETestDataStateObject);
+        expect((FaultCountBEHelper as any).getDrivingFaultSumCountCatBE).toHaveBeenCalled();
+      });
     });
-    it('should call the category BE specific method for getting the driving fault sum count', () => {
-      faultCountProvider.getDrivingFaultSumCount(TestCategory.BE, catBETestDataStateObject);
-      expect((FaultCountBEHelper as any).getDrivingFaultSumCountCatBE).toHaveBeenCalled();
+
+    describe('CAT C', () => {
+      it('should call the category C specific method for getting the driving fault sum count', () => {
+        faultCountProvider.getDrivingFaultSumCount(TestCategory.C, catCTestDataStateObject);
+        expect((FaultCountCHelper as any).getDrivingFaultSumCountCatC).toHaveBeenCalled();
+      });
+      it('should call the category CE specific method for getting the driving fault sum count', () => {
+        faultCountProvider.getDrivingFaultSumCount(TestCategory.CE, catCETestDataStateObject);
+        expect((FaultCountCHelper as any).getDrivingFaultSumCountCatCE).toHaveBeenCalled();
+      });
+      it('should call the category C1E specific method for getting the driving fault sum count', () => {
+        faultCountProvider.getDrivingFaultSumCount(TestCategory.C1E, catC1ETestDataStateObject);
+        expect((FaultCountCHelper as any).getDrivingFaultSumCountCatC1E).toHaveBeenCalled();
+      });
+      it('should call the category C1 specific method for getting the driving fault sum count', () => {
+        faultCountProvider.getDrivingFaultSumCount(TestCategory.C1, catC1TestDataStateObject);
+        expect((FaultCountCHelper as any).getDrivingFaultSumCountCatC1).toHaveBeenCalled();
+      });
     });
-    it('should call the category C specific method for getting the driving fault sum count', () => {
-      faultCountProvider.getDrivingFaultSumCount(TestCategory.C, catCTestDataStateObject);
-      expect((FaultCountCHelper as any).getDrivingFaultSumCountCatC).toHaveBeenCalled();
-    });
-    it('should call the category CE specific method for getting the driving fault sum count', () => {
-      faultCountProvider.getDrivingFaultSumCount(TestCategory.CE, catCETestDataStateObject);
-      expect((FaultCountCHelper as any).getDrivingFaultSumCountCatCE).toHaveBeenCalled();
-    });
-    it('should call the category C1E specific method for getting the driving fault sum count', () => {
-      faultCountProvider.getDrivingFaultSumCount(TestCategory.C1E, catC1ETestDataStateObject);
-      expect((FaultCountCHelper as any).getDrivingFaultSumCountCatC1E).toHaveBeenCalled();
-    });
-    it('should call the category C1 specific method for getting the driving fault sum count', () => {
-      faultCountProvider.getDrivingFaultSumCount(TestCategory.C1, catC1TestDataStateObject);
-      expect((FaultCountCHelper as any).getDrivingFaultSumCountCatC1).toHaveBeenCalled();
+
+    describe('CAT D', () => {
+      it('should call the category D specific method for getting the driving fault sum count', () => {
+        faultCountProvider.getDrivingFaultSumCount(TestCategory.D, catDTestDataStateObject);
+        expect((FaultCountDHelper as any).getDrivingFaultSumCountCatD).toHaveBeenCalled();
+      });
+      it('should call the category DE specific method for getting the driving fault sum count', () => {
+        faultCountProvider.getDrivingFaultSumCount(TestCategory.DE, catDETestDataStateObject);
+        expect((FaultCountDHelper as any).getDrivingFaultSumCountCatDE).toHaveBeenCalled();
+      });
+      it('should call the category D1E specific method for getting the driving fault sum count', () => {
+        faultCountProvider.getDrivingFaultSumCount(TestCategory.D1E, catD1ETestDataStateObject);
+        expect((FaultCountDHelper as any).getDrivingFaultSumCountCatD1E).toHaveBeenCalled();
+      });
+      it('should call the category D1 specific method for getting the driving fault sum count', () => {
+        faultCountProvider.getDrivingFaultSumCount(TestCategory.D1, catD1TestDataStateObject);
+        expect((FaultCountDHelper as any).getDrivingFaultSumCountCatD1).toHaveBeenCalled();
+      });
     });
     it('shoud call the category AM1 specific method for getting the riding fault sum count', () => {
       faultCountProvider.getDrivingFaultSumCount(TestCategory.EUAM1, catAM1TestDataStateObject);
@@ -95,29 +145,53 @@ describe('FaultCountProvider', () => {
   });
 
   describe('getSeriousFaultSumCount', () => {
-    it('should call the category B specific method for getting the serious fault sum count', () => {
-      faultCountProvider.getSeriousFaultSumCount(TestCategory.B, catBTestDataStateObject);
-      expect((FaultCountBHelper as any).getSeriousFaultSumCountCatB).toHaveBeenCalled();
+    describe('CAT B', () => {
+      it('should call the category B specific method for getting the serious fault sum count', () => {
+        faultCountProvider.getSeriousFaultSumCount(TestCategory.B, catBTestDataStateObject);
+        expect((FaultCountBHelper as any).getSeriousFaultSumCountCatB).toHaveBeenCalled();
+      });
+      it('should call the category BE specific method for getting the serious fault sum count', () => {
+        faultCountProvider.getSeriousFaultSumCount(TestCategory.BE, catBETestDataStateObject);
+        expect((FaultCountBEHelper as any).getSeriousFaultSumCountCatBE).toHaveBeenCalled();
+      });
+    })
+
+    describe('CAT C', () => {
+      it('should call the category C specific method for getting the serious fault sum count', () => {
+        faultCountProvider.getSeriousFaultSumCount(TestCategory.C, catCTestDataStateObject);
+        expect((FaultCountCHelper as any).getSeriousFaultSumCountCatC).toHaveBeenCalled();
+      });
+      it('should call the category CE specific method for getting the serious fault sum count', () => {
+        faultCountProvider.getSeriousFaultSumCount(TestCategory.CE, catCETestDataStateObject);
+        expect((FaultCountCHelper as any).getSeriousFaultSumCountCatCE).toHaveBeenCalled();
+      });
+      it('should call the category C1 specific method for getting the serious fault sum count', () => {
+        faultCountProvider.getSeriousFaultSumCount(TestCategory.C1, catC1TestDataStateObject);
+        expect((FaultCountCHelper as any).getSeriousFaultSumCountCatC1).toHaveBeenCalled();
+      });
+      it('should call the category C1E specific method for getting the serious fault sum count', () => {
+        faultCountProvider.getSeriousFaultSumCount(TestCategory.C1E, catC1ETestDataStateObject);
+        expect((FaultCountCHelper as any).getSeriousFaultSumCountCatC1E).toHaveBeenCalled();
+      });
     });
-    it('should call the category BE specific method for getting the serious fault sum count', () => {
-      faultCountProvider.getSeriousFaultSumCount(TestCategory.BE, catBETestDataStateObject);
-      expect((FaultCountBEHelper as any).getSeriousFaultSumCountCatBE).toHaveBeenCalled();
-    });
-    it('should call the category C specific method for getting the serious fault sum count', () => {
-      faultCountProvider.getSeriousFaultSumCount(TestCategory.C, catCTestDataStateObject);
-      expect((FaultCountCHelper as any).getSeriousFaultSumCountCatC).toHaveBeenCalled();
-    });
-    it('should call the category CE specific method for getting the serious fault sum count', () => {
-      faultCountProvider.getSeriousFaultSumCount(TestCategory.CE, catCETestDataStateObject);
-      expect((FaultCountCHelper as any).getSeriousFaultSumCountCatCE).toHaveBeenCalled();
-    });
-    it('should call the category C1 specific method for getting the serious fault sum count', () => {
-      faultCountProvider.getSeriousFaultSumCount(TestCategory.C1, catC1TestDataStateObject);
-      expect((FaultCountCHelper as any).getSeriousFaultSumCountCatC1).toHaveBeenCalled();
-    });
-    it('should call the category C1E specific method for getting the serious fault sum count', () => {
-      faultCountProvider.getSeriousFaultSumCount(TestCategory.C1E, catC1ETestDataStateObject);
-      expect((FaultCountCHelper as any).getSeriousFaultSumCountCatC1E).toHaveBeenCalled();
+
+    describe('CAT D', () => {
+      it('should call the category D specific method for getting the serious fault sum count', () => {
+        faultCountProvider.getSeriousFaultSumCount(TestCategory.D, catDTestDataStateObject);
+        expect((FaultCountDHelper as any).getSeriousFaultSumCountCatD).toHaveBeenCalled();
+      });
+      it('should call the category DE specific method for getting the serious fault sum count', () => {
+        faultCountProvider.getSeriousFaultSumCount(TestCategory.DE, catDETestDataStateObject);
+        expect((FaultCountDHelper as any).getSeriousFaultSumCountCatDE).toHaveBeenCalled();
+      });
+      it('should call the category D1 specific method for getting the serious fault sum count', () => {
+        faultCountProvider.getSeriousFaultSumCount(TestCategory.D1, catD1TestDataStateObject);
+        expect((FaultCountDHelper as any).getSeriousFaultSumCountCatD1).toHaveBeenCalled();
+      });
+      it('should call the category D1E specific method for getting the serious fault sum count', () => {
+        faultCountProvider.getSeriousFaultSumCount(TestCategory.D1E, catD1ETestDataStateObject);
+        expect((FaultCountDHelper as any).getSeriousFaultSumCountCatD1E).toHaveBeenCalled();
+      });
     });
     it('should call the category AM1 specific method for getting the serious fault sum count', () => {
       faultCountProvider.getSeriousFaultSumCount(TestCategory.EUAM1, catAM1TestDataStateObject);
@@ -126,35 +200,60 @@ describe('FaultCountProvider', () => {
   });
 
   describe('getDangerousFaultSumCount', () => {
-    it('should call the category B specific method for getting the dangerous fault sum count', () => {
-      faultCountProvider.getDangerousFaultSumCount(TestCategory.B, catBTestDataStateObject);
-      expect((FaultCountBHelper as any).getDangerousFaultSumCountCatB).toHaveBeenCalled();
+    describe('CAT B', () => {
+      it('should call the category B specific method for getting the dangerous fault sum count', () => {
+        faultCountProvider.getDangerousFaultSumCount(TestCategory.B, catBTestDataStateObject);
+        expect((FaultCountBHelper as any).getDangerousFaultSumCountCatB).toHaveBeenCalled();
+      });
+      it('should call the category BE specific method for getting the dangerous fault sum count', () => {
+        faultCountProvider.getDangerousFaultSumCount(TestCategory.BE, catBETestDataStateObject);
+        expect((FaultCountBEHelper as any).getDangerousFaultSumCountCatBE).toHaveBeenCalled();
+      });
     });
-    it('should call the category BE specific method for getting the dangerous fault sum count', () => {
-      faultCountProvider.getDangerousFaultSumCount(TestCategory.BE, catBETestDataStateObject);
-      expect((FaultCountBEHelper as any).getDangerousFaultSumCountCatBE).toHaveBeenCalled();
+    
+    describe('CAT C', () => {
+      it('should call the category C specific method for getting the dangerous fault sum count', () => {
+        faultCountProvider.getDangerousFaultSumCount(TestCategory.C, catCTestDataStateObject);
+        expect((FaultCountCHelper as any).getDangerousFaultSumCountCatC).toHaveBeenCalled();
+      });
+      it('should call the category C1 specific method for getting the dangerous fault sum count', () => {
+        faultCountProvider.getDangerousFaultSumCount(TestCategory.C1, catC1TestDataStateObject);
+        expect((FaultCountCHelper as any).getDangerousFaultSumCountCatC1).toHaveBeenCalled();
+      });
+      it('should call the category CE specific method for getting the dangerous fault sum count', () => {
+        faultCountProvider.getDangerousFaultSumCount(TestCategory.CE, catCETestDataStateObject);
+        expect((FaultCountCHelper as any).getDangerousFaultSumCountCatCE).toHaveBeenCalled();
+      });
+      it('should call the category C1E specific method for getting the dangerous fault sum count', () => {
+        faultCountProvider.getDangerousFaultSumCount(TestCategory.C1E, catC1ETestDataStateObject);
+        expect((FaultCountCHelper as any).getDangerousFaultSumCountCatC1E).toHaveBeenCalled();
+      });
     });
-    it('should call the category C specific method for getting the dangerous fault sum count', () => {
-      faultCountProvider.getDangerousFaultSumCount(TestCategory.C, catCTestDataStateObject);
-      expect((FaultCountCHelper as any).getDangerousFaultSumCountCatC).toHaveBeenCalled();
-    });
-    it('should call the category C1 specific method for getting the dangerous fault sum count', () => {
-      faultCountProvider.getDangerousFaultSumCount(TestCategory.C1, catC1TestDataStateObject);
-      expect((FaultCountCHelper as any).getDangerousFaultSumCountCatC1).toHaveBeenCalled();
-    });
-    it('should call the category CE specific method for getting the dangerous fault sum count', () => {
-      faultCountProvider.getDangerousFaultSumCount(TestCategory.CE, catCETestDataStateObject);
-      expect((FaultCountCHelper as any).getDangerousFaultSumCountCatCE).toHaveBeenCalled();
-    });
-    it('should call the category C1E specific method for getting the dangerous fault sum count', () => {
-      faultCountProvider.getDangerousFaultSumCount(TestCategory.C1E, catC1ETestDataStateObject);
-      expect((FaultCountCHelper as any).getDangerousFaultSumCountCatC1E).toHaveBeenCalled();
+
+    describe('CAT D', () => {
+      it('should call the category D specific method for getting the dangerous fault sum count', () => {
+        faultCountProvider.getDangerousFaultSumCount(TestCategory.D, catDTestDataStateObject);
+        expect((FaultCountDHelper as any).getDangerousFaultSumCountCatD).toHaveBeenCalled();
+      });
+      it('should call the category D1 specific method for getting the dangerous fault sum count', () => {
+        faultCountProvider.getDangerousFaultSumCount(TestCategory.D1, catD1TestDataStateObject);
+        expect((FaultCountDHelper as any).getDangerousFaultSumCountCatD1).toHaveBeenCalled();
+      });
+      it('should call the category DE specific method for getting the dangerous fault sum count', () => {
+        faultCountProvider.getDangerousFaultSumCount(TestCategory.DE, catDETestDataStateObject);
+        expect((FaultCountDHelper as any).getDangerousFaultSumCountCatDE).toHaveBeenCalled();
+      });
+      it('should call the category D1E specific method for getting the dangerous fault sum count', () => {
+        faultCountProvider.getDangerousFaultSumCount(TestCategory.D1E, catD1ETestDataStateObject);
+        expect((FaultCountDHelper as any).getDangerousFaultSumCountCatD1E).toHaveBeenCalled();
+      });
     });
     it('should call the category AM1 specific method for getting the dangerous fault sum count', () => {
       faultCountProvider.getDangerousFaultSumCount(TestCategory.EUAM1, catAM1TestDataStateObject);
       expect((FaultCountAM1Helper as any).getDangerousFaultSumCountCatAM1).toHaveBeenCalled();
     });
   });
+
 
   describe('getDrivingFaultSumCountCatB', () => {
     it('should return the driving fault for cat B count correctly', () => {
@@ -182,7 +281,7 @@ describe('FaultCountProvider', () => {
 
   describe('getDrivingFaultSumCountCatCE', () => {
     it('should return the driving fault for cat CE count correctly', () => {
-      expect((FaultCountCHelper as any).getDrivingFaultSumCountCatC(catCETestDataStateObject)).toBe(5);
+      expect((FaultCountCHelper as any).getDrivingFaultSumCountCatCE(catCETestDataStateObject)).toBe(5);
     });
   });
 
@@ -195,6 +294,30 @@ describe('FaultCountProvider', () => {
   describe('getRidingFaultSumCountCatAM1', () => {
     it('should return the driving fault for cat AM1 count correctly', () => {
       expect((FaultCountAM1Helper as any).getRidingFaultSumCountCatAM1(catAM1TestDataStateObject)).toBe(5);
+    });
+  });
+  
+  describe('getDrivingFaultSumCountCatD', () => {
+    it('should return the driving fault for cat D count correctly', () => {
+      expect((FaultCountDHelper as any).getDrivingFaultSumCountCatD(catDTestDataStateObject)).toBe(5);
+    });
+  });
+
+  describe('getDrivingFaultSumCountCatD1', () => {
+    it('should return the driving fault for cat D1 count correctly', () => {
+      expect((FaultCountDHelper as any).getDrivingFaultSumCountCatD1(catD1TestDataStateObject)).toBe(5);
+    });
+  });
+
+  describe('getDrivingFaultSumCountCatDE', () => {
+    it('should return the driving fault for cat DE count correctly', () => {
+      expect((FaultCountDHelper as any).getDrivingFaultSumCountCatDE(catDETestDataStateObject)).toBe(5);
+    });
+  });
+
+  describe('getDrivingFaultSumCountCatD1E', () => {
+    it('should return the driving fault for cat D1E count correctly', () => {
+      expect((FaultCountDHelper as any).getDrivingFaultSumCountCatD1E(catD1ETestDataStateObject)).toBe(5);
     });
   });
 

--- a/src/providers/fault-count/__tests__/fault-count.spec.ts
+++ b/src/providers/fault-count/__tests__/fault-count.spec.ts
@@ -154,7 +154,7 @@ describe('FaultCountProvider', () => {
         faultCountProvider.getSeriousFaultSumCount(TestCategory.BE, catBETestDataStateObject);
         expect((FaultCountBEHelper as any).getSeriousFaultSumCountCatBE).toHaveBeenCalled();
       });
-    })
+    });
 
     describe('CAT C', () => {
       it('should call the category C specific method for getting the serious fault sum count', () => {
@@ -210,7 +210,7 @@ describe('FaultCountProvider', () => {
         expect((FaultCountBEHelper as any).getDangerousFaultSumCountCatBE).toHaveBeenCalled();
       });
     });
-    
+
     describe('CAT C', () => {
       it('should call the category C specific method for getting the dangerous fault sum count', () => {
         faultCountProvider.getDangerousFaultSumCount(TestCategory.C, catCTestDataStateObject);
@@ -253,7 +253,6 @@ describe('FaultCountProvider', () => {
       expect((FaultCountAM1Helper as any).getDangerousFaultSumCountCatAM1).toHaveBeenCalled();
     });
   });
-
 
   describe('getDrivingFaultSumCountCatB', () => {
     it('should return the driving fault for cat B count correctly', () => {

--- a/src/providers/fault-count/cat-d/fault-count.cat-d.ts
+++ b/src/providers/fault-count/cat-d/fault-count.cat-d.ts
@@ -1,0 +1,271 @@
+import { pickBy, get } from 'lodash';
+import { QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
+import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
+import { CatDEUniqueTypes } from '@dvsa/mes-test-schema/categories/DE';
+import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
+import { sumManoeuvreFaults } from '../../../shared/helpers/faults';
+import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
+import { VehicleChecksScore } from '../../../shared/models/vehicle-checks-score.model';
+import { getCompetencyFaults } from '../../../shared/helpers/competency';
+
+export class FaultCountDHelper {
+
+  public static getDangerousFaultSumCountCatD = (data: CatDUniqueTypes.TestData): number => {
+    return FaultCountDHelper.getDangerousFaultSumCountNonTrailer(data);
+  }
+
+  public static getDangerousFaultSumCountCatDE = (data: CatDEUniqueTypes.TestData): number => {
+    return FaultCountDHelper.getDangerousFaultSumCountTrailer(data);
+  }
+
+  public static getDangerousFaultSumCountCatD1E = (data: CatD1EUniqueTypes.TestData): number => {
+    return FaultCountDHelper.getDangerousFaultSumCountTrailer(data);
+  }
+
+  public static getDangerousFaultSumCountCatD1 = (data: CatD1UniqueTypes.TestData): number => {
+    return FaultCountDHelper.getDangerousFaultSumCountNonTrailer(data);
+  }
+
+  public static getVehicleChecksFaultCountCatD = (
+    vehicleChecks: CatDUniqueTypes.VehicleChecks,
+  ): VehicleChecksScore => {
+    return FaultCountDHelper.getVehicleChecksFaultCountNonTrailer(vehicleChecks);
+  }
+
+  public static getVehicleChecksFaultCountCatDE = (
+    vehicleChecks: CatDEUniqueTypes.VehicleChecks,
+  ): VehicleChecksScore => {
+    return FaultCountDHelper.getVehicleChecksFaultCountTrailer(vehicleChecks);
+  }
+
+  public static getVehicleChecksFaultCountCatD1 = (
+    vehicleChecks: CatD1UniqueTypes.VehicleChecks,
+  ): VehicleChecksScore => {
+    return FaultCountDHelper.getVehicleChecksFaultCountNonTrailer(vehicleChecks);
+  }
+
+  public static getVehicleChecksFaultCountCatD1E = (
+    vehicleChecks: CatD1EUniqueTypes.VehicleChecks,
+  ): VehicleChecksScore => {
+    return FaultCountDHelper.getVehicleChecksFaultCountTrailer(vehicleChecks);
+  }
+
+  public static getSeriousFaultSumCountCatD = (data: CatDUniqueTypes.TestData): number => {
+    return FaultCountDHelper.getSeriousFaultSumCountNonTrailer(data);
+  }
+
+  public static getSeriousFaultSumCountCatD1 = (data: CatD1UniqueTypes.TestData): number => {
+    return FaultCountDHelper.getSeriousFaultSumCountNonTrailer(data);
+  }
+
+  public static getSeriousFaultSumCountCatDE = (data: CatDEUniqueTypes.TestData): number => {
+    return FaultCountDHelper.getSeriousFaultSumCountTrailer(data);
+  }
+
+  public static getSeriousFaultSumCountCatD1E = (data: CatD1EUniqueTypes.TestData): number => {
+    return FaultCountDHelper.getSeriousFaultSumCountTrailer(data);
+  }
+
+  public static getDrivingFaultSumCountCatD = (data: CatDUniqueTypes.TestData): number => {
+    return FaultCountDHelper.getDrivingFaultSumCountNonTrailer(data);
+  }
+
+  public static getDrivingFaultSumCountCatD1 = (data: CatD1UniqueTypes.TestData): number => {
+    return FaultCountDHelper.getDrivingFaultSumCountNonTrailer(data);
+  }
+
+  public static getDrivingFaultSumCountCatDE = (data: CatDEUniqueTypes.TestData): number => {
+    return FaultCountDHelper.getDrivingFaultSumCountTrailer(data);
+  }
+
+  public static getDrivingFaultSumCountCatD1E = (data: CatD1EUniqueTypes.TestData): number => {
+    return FaultCountDHelper.getDrivingFaultSumCountTrailer(data);
+  }
+
+  private static getVehicleChecksFaultCountNonTrailer = (
+    vehicleChecks: CatDUniqueTypes.VehicleChecks | CatD1EUniqueTypes.VehicleChecks,
+    ): VehicleChecksScore => {
+
+    if (!vehicleChecks) {
+      return { seriousFaults: 0, drivingFaults: 0 };
+    }
+
+    const showMeQuestions: QuestionResult[] = get(vehicleChecks, 'showMeQuestions', []);
+    const tellMeQuestions: QuestionResult[] = get(vehicleChecks, 'tellMeQuestions', []);
+
+    const numberOfShowMeFaults: number = showMeQuestions.filter((showMeQuestion) => {
+      return showMeQuestion.outcome === CompetencyOutcome.DF;
+    }).length;
+    const numberOfTellMeFaults: number = tellMeQuestions.filter((tellMeQuestion) => {
+      return tellMeQuestion.outcome === CompetencyOutcome.DF;
+    }).length;
+
+    const totalFaultCount: number = numberOfShowMeFaults + numberOfTellMeFaults;
+
+    if (totalFaultCount === 5) {
+      return {
+        drivingFaults: 4,
+        seriousFaults: 1,
+      };
+    }
+    return {
+      drivingFaults: totalFaultCount,
+      seriousFaults: 0,
+    };
+  }
+
+  private static getVehicleChecksFaultCountTrailer = (
+    vehicleChecks: CatDEUniqueTypes.VehicleChecks | CatD1EUniqueTypes.VehicleChecks,
+  ): VehicleChecksScore => {
+
+    if (!vehicleChecks) {
+      return { seriousFaults: 0, drivingFaults: 0 };
+    }
+
+    const showMeQuestions: QuestionResult[] = get(vehicleChecks, 'showMeQuestions', []);
+    const tellMeQuestions: QuestionResult[] = get(vehicleChecks, 'tellMeQuestions', []);
+
+    const numberOfShowMeFaults: number = showMeQuestions.filter((showMeQuestion) => {
+      return showMeQuestion.outcome === CompetencyOutcome.DF;
+    }).length;
+    const numberOfTellMeFaults: number = tellMeQuestions.filter((tellMeQuestion) => {
+      return tellMeQuestion.outcome === CompetencyOutcome.DF;
+    }).length;
+
+    const totalFaultCount: number = numberOfShowMeFaults + numberOfTellMeFaults;
+
+    if (totalFaultCount === 2) {
+      return {
+        drivingFaults: 1,
+        seriousFaults: 1,
+      };
+    }
+    return {
+      drivingFaults: totalFaultCount,
+      seriousFaults: 0,
+    };
+  }
+
+  private static getDrivingFaultSumCountNonTrailer = (
+    data: CatDUniqueTypes.TestData | CatD1UniqueTypes.TestData,
+  ): number => {
+
+    // The way how we store the driving faults differs for certain competencies
+    // Because of this we need to pay extra attention on summing up all of them
+    const { drivingFaults, manoeuvres, vehicleChecks } = data;
+
+    let faultTotal: number = 0;
+    getCompetencyFaults(drivingFaults).forEach(fault => faultTotal = faultTotal + fault.faultCount);
+
+    const result =
+      faultTotal +
+      sumManoeuvreFaults(manoeuvres, CompetencyOutcome.DF) +
+      FaultCountDHelper.getVehicleChecksFaultCountCatD(vehicleChecks).drivingFaults;
+
+    return result;
+  }
+
+  private static getDrivingFaultSumCountTrailer = (
+    data: CatDEUniqueTypes.TestData | CatD1EUniqueTypes.TestData,
+  ): number => {
+
+    // The way how we store the driving faults differs for certain competencies
+    // Because of this we need to pay extra attention on summing up all of them
+    const { drivingFaults, manoeuvres, vehicleChecks, uncoupleRecouple } = data;
+
+    let faultTotal: number = 0;
+    getCompetencyFaults(drivingFaults).forEach(fault => faultTotal = faultTotal + fault.faultCount);
+    const uncoupleRecoupleHasDrivingFault =
+      (uncoupleRecouple && uncoupleRecouple.fault === CompetencyOutcome.DF) ? 1 : 0;
+
+    const result =
+      faultTotal +
+      sumManoeuvreFaults(manoeuvres, CompetencyOutcome.DF) +
+      FaultCountDHelper.getVehicleChecksFaultCountCatD(vehicleChecks).drivingFaults +
+      uncoupleRecoupleHasDrivingFault;
+
+    return result;
+  }
+
+  private static getSeriousFaultSumCountNonTrailer = (
+    data: CatDUniqueTypes.TestData | CatD1UniqueTypes.TestData,
+  ): number => {
+
+    // The way how we store serious faults differs for certain competencies
+    // Because of this we need to pay extra attention on summing up all of them
+    const { seriousFaults, manoeuvres, vehicleChecks } = data;
+
+    const seriousFaultSumOfSimpleCompetencies = Object.keys(pickBy(seriousFaults)).length;
+    const vehicleCheckSeriousFaults =
+      vehicleChecks ? FaultCountDHelper.getVehicleChecksFaultCountCatD(vehicleChecks).seriousFaults : 0;
+
+    const result =
+      seriousFaultSumOfSimpleCompetencies +
+      sumManoeuvreFaults(manoeuvres, CompetencyOutcome.S) +
+      vehicleCheckSeriousFaults;
+
+    return result;
+  }
+
+  private static getSeriousFaultSumCountTrailer = (
+    data: CatDEUniqueTypes.TestData | CatD1EUniqueTypes.TestData,
+    ): number => {
+
+    // The way how we store serious faults differs for certain competencies
+    // Because of this we need to pay extra attention on summing up all of them
+    const { seriousFaults, manoeuvres, vehicleChecks, uncoupleRecouple } = data;
+
+    const seriousFaultSumOfSimpleCompetencies = Object.keys(pickBy(seriousFaults)).length;
+    const vehicleCheckSeriousFaults =
+      vehicleChecks ? FaultCountDHelper.getVehicleChecksFaultCountCatD(vehicleChecks).seriousFaults : 0;
+    const uncoupleRecoupleSeriousFaults =
+      (uncoupleRecouple && uncoupleRecouple.fault === CompetencyOutcome.S) ? 1 : 0;
+
+    const result =
+      seriousFaultSumOfSimpleCompetencies +
+      sumManoeuvreFaults(manoeuvres, CompetencyOutcome.S) +
+      vehicleCheckSeriousFaults +
+      uncoupleRecoupleSeriousFaults;
+
+    return result;
+  }
+
+  private static getDangerousFaultSumCountNonTrailer = (
+    data: CatDUniqueTypes.TestData | CatD1UniqueTypes.TestData,
+  ): number => {
+
+    // The way how we store serious faults differs for certain competencies
+    // Because of this we need to pay extra attention on summing up all of them
+    const { dangerousFaults, manoeuvres } = data;
+
+    const dangerousFaultSumOfSimpleCompetencies = Object.keys(pickBy(dangerousFaults)).length;
+
+    const result =
+      dangerousFaultSumOfSimpleCompetencies +
+      sumManoeuvreFaults(manoeuvres, CompetencyOutcome.D);
+
+    return result;
+  }
+
+  private static getDangerousFaultSumCountTrailer = (
+    data: CatDEUniqueTypes.TestData | CatD1EUniqueTypes.TestData,
+    ): number => {
+
+    // The way how we store serious faults differs for certain competencies
+    // Because of this we need to pay extra attention on summing up all of them
+    const { dangerousFaults, manoeuvres, uncoupleRecouple } = data;
+
+    const dangerousFaultSumOfSimpleCompetencies = Object.keys(pickBy(dangerousFaults)).length;
+    const uncoupleRecoupleDangerousFaults =
+      (uncoupleRecouple && uncoupleRecouple.fault === CompetencyOutcome.D) ? 1 : 0;
+
+    const result =
+      dangerousFaultSumOfSimpleCompetencies +
+      sumManoeuvreFaults(manoeuvres, CompetencyOutcome.D) +
+      uncoupleRecoupleDangerousFaults;
+
+    return result;
+  }
+
+}

--- a/src/providers/fault-count/fault-count.ts
+++ b/src/providers/fault-count/fault-count.ts
@@ -7,6 +7,7 @@ import { VehicleChecksScore } from '../../shared/models/vehicle-checks-score.mod
 import { FaultCountBHelper }  from './cat-b/fault-count.cat-b';
 import { FaultCountBEHelper } from './cat-be/fault-count.cat-be';
 import { FaultCountCHelper } from './cat-c/fault-count.cat-c';
+import { FaultCountDHelper } from './cat-d/fault-count.cat-d';
 
 import { sumManoeuvreFaults } from '../../shared/helpers/faults';
 import { FaultCountAM1Helper } from './cat-a-mod1/fault-count.cat-a-mod1';
@@ -27,6 +28,10 @@ export class FaultCountProvider {
       case TestCategory.CE: return FaultCountCHelper.getDrivingFaultSumCountCatCE(data);
       case TestCategory.C: return FaultCountCHelper.getDrivingFaultSumCountCatC(data);
       case TestCategory.EUAM1: return FaultCountAM1Helper.getRidingFaultSumCountCatAM1(data);
+      case TestCategory.D1: return FaultCountDHelper.getDrivingFaultSumCountCatD1(data);
+      case TestCategory.D1E: return FaultCountDHelper.getDrivingFaultSumCountCatD1E(data);
+      case TestCategory.DE: return FaultCountDHelper.getDrivingFaultSumCountCatDE(data);
+      case TestCategory.D: return FaultCountDHelper.getDrivingFaultSumCountCatD(data);
       default: throw new Error(FaultCountProvider.getFaultSumCountErrMsg);
     }
   }
@@ -40,6 +45,10 @@ export class FaultCountProvider {
       case TestCategory.CE: return FaultCountCHelper.getSeriousFaultSumCountCatCE(data);
       case TestCategory.C: return FaultCountCHelper.getSeriousFaultSumCountCatC(data);
       case TestCategory.EUAM1: return FaultCountAM1Helper.getSeriousFaultSumCountCatAM1(data);
+      case TestCategory.D1: return FaultCountDHelper.getSeriousFaultSumCountCatD1(data);
+      case TestCategory.D1E: return FaultCountDHelper.getSeriousFaultSumCountCatD1E(data);
+      case TestCategory.DE: return FaultCountDHelper.getSeriousFaultSumCountCatDE(data);
+      case TestCategory.D: return FaultCountDHelper.getSeriousFaultSumCountCatD(data);
       default: throw new Error(FaultCountProvider.getFaultSumCountErrMsg);
     }
   }
@@ -53,6 +62,10 @@ export class FaultCountProvider {
       case TestCategory.CE: return FaultCountCHelper.getDangerousFaultSumCountCatCE(data);
       case TestCategory.C: return FaultCountCHelper.getDangerousFaultSumCountCatC(data);
       case TestCategory.EUAM1: return FaultCountAM1Helper.getDangerousFaultSumCountCatAM1(data);
+      case TestCategory.D1: return FaultCountDHelper.getDangerousFaultSumCountCatD1(data);
+      case TestCategory.D1E: return FaultCountDHelper.getDangerousFaultSumCountCatD1E(data);
+      case TestCategory.DE: return FaultCountDHelper.getDangerousFaultSumCountCatDE(data);
+      case TestCategory.D: return FaultCountDHelper.getDangerousFaultSumCountCatD(data);
       default: throw new Error(FaultCountProvider.getFaultSumCountErrMsg);
     }
   }
@@ -65,6 +78,10 @@ export class FaultCountProvider {
       case TestCategory.C1E:
       case TestCategory.CE:
       case TestCategory.C: return sumManoeuvreFaults(data, faultType);
+      case TestCategory.D1:
+      case TestCategory.D1E:
+      case TestCategory.DE:
+      case TestCategory.D: return sumManoeuvreFaults(data, faultType);
       // TODO: To be implemented properly in MES-4420
       case TestCategory.EUAM1: return sumManoeuvreFaults(data, faultType);
       default: throw new Error(FaultCountProvider.getFaultSumCountErrMsg);
@@ -78,6 +95,10 @@ export class FaultCountProvider {
       case TestCategory.C1E: return FaultCountCHelper.getVehicleChecksFaultCountCatC1E(data);
       case TestCategory.CE: return FaultCountCHelper.getVehicleChecksFaultCountCatCE(data);
       case TestCategory.C: return FaultCountCHelper.getVehicleChecksFaultCountCatC(data);
+      case TestCategory.D1: return FaultCountDHelper.getVehicleChecksFaultCountCatD1(data);
+      case TestCategory.D1E: return FaultCountDHelper.getVehicleChecksFaultCountCatD1E(data);
+      case TestCategory.DE: return FaultCountDHelper.getVehicleChecksFaultCountCatDE(data);
+      case TestCategory.D: return FaultCountDHelper.getVehicleChecksFaultCountCatD(data);
       // TODO: To be implemented properly in MES-4420
       case TestCategory.EUAM1: return FaultCountBEHelper.getVehicleChecksFaultCountCatBE(data);
       case TestCategory.EUAM2: return FaultCountBEHelper.getVehicleChecksFaultCountCatBE(data);

--- a/src/providers/fault-summary/__tests__/fault-summary.spec.ts
+++ b/src/providers/fault-summary/__tests__/fault-summary.spec.ts
@@ -85,6 +85,8 @@ describe('faultSummaryProvider', () => {
     spyOn(FaultSummaryCatCHelper, 'getDrivingFaultsTrailer').and.callThrough();
     spyOn(FaultSummaryCatCHelper, 'getSeriousFaultsTrailer').and.callThrough();
     spyOn(FaultSummaryCatCHelper, 'getDangerousFaultsTrailer').and.callThrough();
+    spyOn(FaultSummaryCatDHelper, 'getDrivingFaultsNonTrailer').and.callThrough();
+    spyOn(FaultSummaryCatDHelper, 'getSeriousFaultsNonTrailer').and.callThrough();
     spyOn(FaultSummaryCatDHelper, 'getDangerousFaultsNonTrailer').and.callThrough();
     spyOn(FaultSummaryCatDHelper, 'getDrivingFaultsTrailer').and.callThrough();
     spyOn(FaultSummaryCatDHelper, 'getSeriousFaultsTrailer').and.callThrough();

--- a/src/providers/fault-summary/__tests__/fault-summary.spec.ts
+++ b/src/providers/fault-summary/__tests__/fault-summary.spec.ts
@@ -3,12 +3,14 @@ import { TestBed } from '@angular/core/testing';
 import { TestData } from '@dvsa/mes-test-schema/categories/common';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
-import { FaultCountProvider } from '../../fault-count/fault-count';
 import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
 import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
+import { FaultCountProvider } from '../../fault-count/fault-count';
 import { FaultSummaryCatCHelper } from '../cat-c/fault-summary.cat-c';
 import { FaultSummaryCatBHelper } from '../cat-b/fault-summary.cat-b';
 import { FaultSummaryCatBEHelper } from '../cat-be/fault-summary.cat-be';
+import { FaultSummaryCatDHelper } from '../cat-d/fault-summary.cat-d';
 import { showMe2DFTellMe3DF, showMe2DFTellMe2DF, showMe1DFTellMe1DF, showMe0DFTellMe1DF } from './fault-summary.mock';
 import { configureTestSuite } from 'ng-bullet';
 
@@ -28,6 +30,29 @@ describe('faultSummaryProvider', () => {
       showMeTellMeSemiFaults: showMe0DFTellMe1DF,
     },
     { category: TestCategory.CE,
+      showMeTellMeAllFaults: showMe1DFTellMe1DF,
+      showMeTellMeSemiFaults: showMe0DFTellMe1DF,
+    },
+  ];
+
+  const categoryD = [
+    {
+      category: TestCategory.D,
+      showMeTellMeAllFaults: showMe2DFTellMe3DF,
+      showMeTellMeSemiFaults: showMe2DFTellMe2DF,
+    },
+    {
+      category: TestCategory.D1,
+      showMeTellMeAllFaults: showMe2DFTellMe3DF,
+      showMeTellMeSemiFaults: showMe2DFTellMe2DF,
+    },
+    {
+      category: TestCategory.D1E,
+      showMeTellMeAllFaults: showMe1DFTellMe1DF,
+      showMeTellMeSemiFaults: showMe0DFTellMe1DF,
+    },
+    {
+      category: TestCategory.DE,
       showMeTellMeAllFaults: showMe1DFTellMe1DF,
       showMeTellMeSemiFaults: showMe0DFTellMe1DF,
     },
@@ -60,6 +85,10 @@ describe('faultSummaryProvider', () => {
     spyOn(FaultSummaryCatCHelper, 'getDrivingFaultsTrailer').and.callThrough();
     spyOn(FaultSummaryCatCHelper, 'getSeriousFaultsTrailer').and.callThrough();
     spyOn(FaultSummaryCatCHelper, 'getDangerousFaultsTrailer').and.callThrough();
+    spyOn(FaultSummaryCatDHelper, 'getDangerousFaultsNonTrailer').and.callThrough();
+    spyOn(FaultSummaryCatDHelper, 'getDrivingFaultsTrailer').and.callThrough();
+    spyOn(FaultSummaryCatDHelper, 'getSeriousFaultsTrailer').and.callThrough();
+    spyOn(FaultSummaryCatDHelper, 'getDangerousFaultsTrailer').and.callThrough();
   });
 
   describe('getDrivingFaultsList', () => {
@@ -223,6 +252,49 @@ describe('faultSummaryProvider', () => {
         });
         it('should correctly return any manoeuvre faults', () => {
           const data: CatCUniqueTypes.TestData = {
+            manoeuvres: {
+              reverseLeft: {
+                selected: true,
+                controlFault: 'DF',
+                observationFault: 'DF',
+              },
+            },
+          };
+          const result = faultSummaryProvider.getDrivingFaultsList(data, cat.category);
+          expect(result.length).toEqual(2);
+          expect(result[0].competencyDisplayName).toEqual('Reverse - Control');
+          expect(result[1].competencyDisplayName).toEqual('Reverse - Observation');
+        });
+        it('should correctly return any vehicle checks faults when there are 4 driving faults', () => {
+          const result = faultSummaryProvider.getDrivingFaultsList(cat.showMeTellMeSemiFaults.testData, cat.category);
+          expect(result.length).toEqual(1);
+          expect(result[0].faultCount).toEqual(cat.showMeTellMeSemiFaults.drivingFaults);
+        });
+        it('should correctly return 4 driving faults as the fault count when there are 5', () => {
+          const result = faultSummaryProvider.getDrivingFaultsList(cat.showMeTellMeAllFaults.testData, cat.category);
+          expect(result.length).toEqual(1);
+          expect(result[0].faultCount).toEqual(cat.showMeTellMeAllFaults.drivingFaults);
+        });
+      });
+    });
+    categoryD.forEach((cat) => {
+      describe(`Category ${cat.category}`, () => {
+        it('should return an empty array if there are no driving faults', () => {
+          const result = faultSummaryProvider.getDrivingFaultsList({}, cat.category);
+          expect(result.length).toEqual(0);
+        });
+        it('should return an array matching the number of driving faults > 0', () => {
+          const data: TestData = {
+            drivingFaults: {
+              useOfMirrorsChangeDirection: 1,
+              useOfMirrorsSignalling: 2,
+            },
+          };
+          const result = faultSummaryProvider.getDrivingFaultsList(data, cat.category);
+          expect(result.length).toEqual(2);
+        });
+        it('should correctly return any manoeuvre faults', () => {
+          const data: CatDUniqueTypes.TestData = {
             manoeuvres: {
               reverseLeft: {
                 selected: true,
@@ -431,7 +503,55 @@ describe('faultSummaryProvider', () => {
         });
       });
     });
-
+    categoryD.forEach((cat) => {
+      describe(`Category ${cat.category}`, () => {
+        it('should return an empty array if there are no serious faults', () => {
+          const result = faultSummaryProvider.getSeriousFaultsList({}, cat.category);
+          expect(result.length).toEqual(0);
+        });
+        it('should return an array matching the number of serious faults set to true', () => {
+          const data: TestData = {
+            seriousFaults: {
+              ancillaryControls: true,
+              awarenessPlanning: true,
+            },
+          };
+          const result = faultSummaryProvider.getSeriousFaultsList(data, cat.category);
+          expect(result.length).toEqual(2);
+        });
+        it('should correctly return any manoeuvre faults', () => {
+          const data: CatDUniqueTypes.TestData = {
+            manoeuvres: {
+              reverseLeft: {
+                selected: true,
+                controlFault: 'S',
+                observationFault: 'S',
+              },
+            },
+          };
+          const result = faultSummaryProvider.getSeriousFaultsList(data, cat.category);
+          expect(result.length).toEqual(2);
+        });
+        it('should correctly return any vehicle checks faults ', () => {
+          const data: CatDUniqueTypes.TestData = {
+            vehicleChecks: {
+              tellMeQuestions: [
+                { outcome: 'DF' },
+                { outcome: 'DF' },
+                { outcome: 'DF' },
+              ],
+              showMeQuestions: [
+                { outcome: 'DF' },
+                { outcome: 'DF' },
+              ],
+            },
+          };
+          const result = faultSummaryProvider.getSeriousFaultsList(data, cat.category);
+          expect(result.length).toEqual(1);
+          expect(result[0].faultCount).toEqual(1);
+        });
+      });
+    });
   });
 
   describe('getDangerousFaultsList', () => {
@@ -542,6 +662,37 @@ describe('faultSummaryProvider', () => {
         });
         it('should correctly return any manoeuvre faults', () => {
           const data: CatCUniqueTypes.TestData = {
+            manoeuvres: {
+              reverseLeft: {
+                selected: true,
+                controlFault: 'D',
+                observationFault: 'D',
+              },
+            },
+          };
+          const result = faultSummaryProvider.getDangerousFaultsList(data, cat.category);
+          expect(result.length).toEqual(2);
+        });
+      });
+    });
+    categoryD.forEach((cat) => {
+      describe(`Category ${cat.category}`, () => {
+        it('should return an empty array if there are no serious faults', () => {
+          const result = faultSummaryProvider.getDangerousFaultsList({}, cat.category);
+          expect(result.length).toEqual(0);
+        });
+        it('should return an array matching the number of serious faults set to true', () => {
+          const data: TestData = {
+            dangerousFaults: {
+              ancillaryControls: true,
+              awarenessPlanning: true,
+            },
+          };
+          const result = faultSummaryProvider.getDangerousFaultsList(data, cat.category);
+          expect(result.length).toEqual(2);
+        });
+        it('should correctly return any manoeuvre faults', () => {
+          const data: CatDUniqueTypes.TestData = {
             manoeuvres: {
               reverseLeft: {
                 selected: true,

--- a/src/providers/fault-summary/cat-d/fault-summary.cat-d.ts
+++ b/src/providers/fault-summary/cat-d/fault-summary.cat-d.ts
@@ -1,0 +1,197 @@
+import { endsWith, forOwn, get, transform } from 'lodash';
+import { QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+import { CommentSource, CompetencyIdentifiers, FaultSummary } from '../../../shared/models/fault-marking.model';
+import { CompetencyDisplayName } from '../../../shared/models/competency-display-name';
+import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
+import { ManoeuvreTypes } from '../../../modules/tests/test-data/test-data.constants';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { getCompetencyFaults, getCompetencyComment } from '../../../shared/helpers/competency';
+import {
+  manoeuvreCompetencyLabelsCatD,
+  manoeuvreTypeLabelsCatD,
+} from '../../../shared/constants/competencies/catd-manoeuvres';
+import { VehicleChecksScore } from '../../../shared/models/vehicle-checks-score.model';
+import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
+import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
+import { CatDEUniqueTypes } from '@dvsa/mes-test-schema/categories/DE';
+import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
+
+export class FaultSummaryCatDHelper {
+
+  public static getDrivingFaultsNonTrailer(
+    data: CatDUniqueTypes.TestData | CatD1UniqueTypes.TestData,
+    category: TestCategory,
+    vehicleChecksScore: VehicleChecksScore,
+  ): FaultSummary[] {
+    return [
+      ...getCompetencyFaults(data.drivingFaults),
+      ...this.getManoeuvreFaultsCatD(data.manoeuvres, CompetencyOutcome.DF),
+      ...this.getVehicleCheckDrivingFaultsCatD(data.vehicleChecks, category, vehicleChecksScore),
+    ];
+  }
+
+  public static getSeriousFaultsNonTrailer(
+    data: CatDUniqueTypes.TestData | CatD1UniqueTypes.TestData,
+    ): FaultSummary[] {
+    return [
+      ...getCompetencyFaults(data.seriousFaults),
+      ...this.getManoeuvreFaultsCatD(data.manoeuvres, CompetencyOutcome.S),
+      ...this.getVehicleCheckSeriousFaultsCatD(data.vehicleChecks),
+    ];
+  }
+
+  public static getDangerousFaultsNonTrailer(
+    data: CatDUniqueTypes.TestData | CatD1UniqueTypes.TestData,
+  ): FaultSummary[] {
+    return [
+      ...getCompetencyFaults(data.dangerousFaults),
+      ...this.getManoeuvreFaultsCatD(data.manoeuvres, CompetencyOutcome.D),
+    ];
+  }
+
+  public static getDrivingFaultsTrailer(
+    data: CatDEUniqueTypes.TestData | CatD1EUniqueTypes.TestData,
+    category: TestCategory,
+    vehicleChecksScore: VehicleChecksScore,
+  ): FaultSummary[] {
+    return [
+      ...getCompetencyFaults(data.drivingFaults),
+      ...this.getManoeuvreFaultsCatD(data.manoeuvres, CompetencyOutcome.DF),
+      ...this.getUncoupleRecoupleFault(data.uncoupleRecouple, CompetencyOutcome.DF),
+      ...this.getVehicleCheckDrivingFaultsCatD(data.vehicleChecks, category, vehicleChecksScore),
+    ];
+  }
+
+  public static getSeriousFaultsTrailer(
+    data: CatDEUniqueTypes.TestData | CatD1EUniqueTypes.TestData,
+  ): FaultSummary[] {
+    return [
+      ...getCompetencyFaults(data.seriousFaults),
+      ...this.getManoeuvreFaultsCatD(data.manoeuvres, CompetencyOutcome.S),
+      ...this.getUncoupleRecoupleFault(data.uncoupleRecouple, CompetencyOutcome.S),
+      ...this.getVehicleCheckSeriousFaultsCatD(data.vehicleChecks),
+    ];
+  }
+
+  public static getDangerousFaultsTrailer(
+    data: CatDEUniqueTypes.TestData | CatD1EUniqueTypes.TestData,
+  ): FaultSummary[] {
+    return [
+      ...getCompetencyFaults(data.dangerousFaults),
+      ...this.getManoeuvreFaultsCatD(data.manoeuvres, CompetencyOutcome.D),
+      ...this.getUncoupleRecoupleFault(data.uncoupleRecouple, CompetencyOutcome.D),
+    ];
+  }
+
+  private static createManoeuvreFaultCatD(key: string, type: ManoeuvreTypes, competencyComment: string): FaultSummary {
+    const manoeuvreFaultSummary: FaultSummary = {
+      comment: competencyComment || '',
+      competencyIdentifier: `${type}${manoeuvreCompetencyLabelsCatD[key]}`,
+      competencyDisplayName: `${manoeuvreTypeLabelsCatD[type]} - ${manoeuvreCompetencyLabelsCatD[key]}`,
+      source: `${CommentSource.MANOEUVRES}-${type}-${manoeuvreCompetencyLabelsCatD[key]}`,
+      faultCount: 1,
+    };
+    return manoeuvreFaultSummary;
+  }
+
+  private static getManoeuvreFaultsCatD(manoeuvres: CatDUniqueTypes.Manoeuvres, faultType: CompetencyOutcome)
+    : FaultSummary[] {
+    const faultsEncountered: FaultSummary[] = [];
+
+    // TODO: Replace any with Manoeuvres and change the transform function
+    forOwn(manoeuvres, (manoeuvre: any, type: ManoeuvreTypes) => {
+      const faults = !manoeuvre.selected ? [] : transform(manoeuvre, (result, value, key: string) => {
+
+        if (endsWith(key, CompetencyIdentifiers.FAULT_SUFFIX) && value === faultType) {
+
+          const competencyComment = getCompetencyComment(
+            key,
+            manoeuvre.controlFaultComments,
+            manoeuvre.observationFaultComments);
+
+          result.push(this.createManoeuvreFaultCatD(key, type, competencyComment));
+        }
+      }, []);
+      faultsEncountered.push(...faults);
+    });
+    return faultsEncountered;
+  }
+
+  private static getVehicleCheckDrivingFaultsCatD(
+    vehicleChecks: CatDUniqueTypes.VehicleChecks,
+    category: TestCategory,
+    vehicleCheckFaults: VehicleChecksScore,
+  )
+    : FaultSummary[] {
+    const result: FaultSummary[] = [];
+    if (!vehicleChecks || !vehicleChecks.showMeQuestions || !vehicleChecks.tellMeQuestions) {
+      return result;
+    }
+
+    const dangerousFaults = vehicleChecks.showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.D);
+    const seriousFaults = vehicleChecks.showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.S);
+
+    if (dangerousFaults.length > 0 || seriousFaults.length > 0) {
+      return result;
+    }
+
+    if (vehicleCheckFaults.drivingFaults > 0) {
+      const competency: FaultSummary = {
+        comment: vehicleChecks.showMeTellMeComments || '',
+        competencyIdentifier: CommentSource.VEHICLE_CHECKS,
+        competencyDisplayName: CompetencyDisplayName.VEHICLE_CHECKS,
+        source: CommentSource.VEHICLE_CHECKS,
+        faultCount: vehicleCheckFaults.drivingFaults,
+      };
+      result.push(competency);
+    }
+    return result;
+  }
+
+  private static getVehicleCheckSeriousFaultsCatD(vehicleChecks: CatDUniqueTypes.VehicleChecks): FaultSummary[] {
+    const result: FaultSummary[] = [];
+
+    if (!vehicleChecks) {
+      return result;
+    }
+
+    const showMeQuestions: QuestionResult[] = get(vehicleChecks, 'showMeQuestions', []);
+    const tellMeQuestions: QuestionResult[] = get(vehicleChecks, 'tellMeQuestions', []);
+
+    const showMeFaults = showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.DF);
+    const tellMeFaults = tellMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.DF);
+
+    const seriousFaultCount = showMeFaults.length + tellMeFaults.length === 5 ? 1 : 0;
+    const competency: FaultSummary = {
+      comment: vehicleChecks.showMeTellMeComments || '',
+      competencyIdentifier: CommentSource.VEHICLE_CHECKS,
+      competencyDisplayName: CompetencyDisplayName.VEHICLE_CHECKS,
+      source: CommentSource.VEHICLE_CHECKS,
+      faultCount: seriousFaultCount,
+    };
+    seriousFaultCount > 0 && result.push(competency);
+
+    return result;
+  }
+
+  private static getUncoupleRecoupleFault(
+    uncoupleRecouple: CatDEUniqueTypes.UncoupleRecouple | CatD1EUniqueTypes.UncoupleRecouple,
+    faultType: CompetencyOutcome,
+  )
+    : FaultSummary[] {
+    const returnCompetencies = [];
+    if (!uncoupleRecouple || uncoupleRecouple.fault !== faultType) {
+      return returnCompetencies;
+    }
+    const result: FaultSummary = {
+      competencyDisplayName: CompetencyDisplayName.UNCOUPLE_RECOUPLE,
+      competencyIdentifier: 'uncoupleRecouple',
+      comment: uncoupleRecouple.faultComments || '',
+      source: CommentSource.UNCOUPLE_RECOUPLE,
+      faultCount: 1,
+    };
+    returnCompetencies.push(result);
+    return returnCompetencies;
+  }
+
+}

--- a/src/providers/fault-summary/fault-summary.ts
+++ b/src/providers/fault-summary/fault-summary.ts
@@ -66,7 +66,7 @@ export class FaultSummaryProvider {
             (<CatC1EUniqueTypes.TestData>data).vehicleChecks,
           ));
       case TestCategory.D:
-        return FaultSummaryCatCHelper.getDrivingFaultsNonTrailer(
+        return FaultSummaryCatDHelper.getDrivingFaultsNonTrailer(
           data,
           TestCategory.D,
           this.faultCountProvider.getVehicleChecksFaultCount(
@@ -74,7 +74,7 @@ export class FaultSummaryProvider {
             (<CatDUniqueTypes.TestData>data).vehicleChecks,
           ));
       case TestCategory.D1:
-        return FaultSummaryCatCHelper.getDrivingFaultsNonTrailer(
+        return FaultSummaryCatDHelper.getDrivingFaultsNonTrailer(
           data,
           TestCategory.D1,
           this.faultCountProvider.getVehicleChecksFaultCount(
@@ -82,7 +82,7 @@ export class FaultSummaryProvider {
             (<CatD1UniqueTypes.TestData>data).vehicleChecks,
           ));
       case TestCategory.DE:
-        return FaultSummaryCatCHelper.getDrivingFaultsTrailer(
+        return FaultSummaryCatDHelper.getDrivingFaultsTrailer(
           data,
           TestCategory.DE,
           this.faultCountProvider.getVehicleChecksFaultCount(
@@ -90,7 +90,7 @@ export class FaultSummaryProvider {
             (<CatDEUniqueTypes.TestData>data).vehicleChecks,
           ));
       case TestCategory.D1E:
-        return FaultSummaryCatCHelper.getDrivingFaultsTrailer(
+        return FaultSummaryCatDHelper.getDrivingFaultsTrailer(
           data,
           TestCategory.D1E,
           this.faultCountProvider.getVehicleChecksFaultCount(

--- a/src/providers/fault-summary/fault-summary.ts
+++ b/src/providers/fault-summary/fault-summary.ts
@@ -6,10 +6,15 @@ import { FaultCountProvider } from '../fault-count/fault-count';
 import { FaultSummaryCatBHelper } from './cat-b/fault-summary.cat-b';
 import { FaultSummaryCatBEHelper } from './cat-be/fault-summary.cat-be';
 import { FaultSummaryCatCHelper } from './cat-c/fault-summary.cat-c';
+import { FaultSummaryCatDHelper } from './cat-d/fault-summary.cat-d';
 import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
 import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
 import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
 import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
+import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
+import { CatDEUniqueTypes } from '@dvsa/mes-test-schema/categories/DE';
+import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
+import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
 import { FaultSummaryCatAM1Helper } from './cat-a-mod1/fault-summary.cat-a-mod1';
 
 @Injectable()
@@ -60,6 +65,38 @@ export class FaultSummaryProvider {
             TestCategory.C1E,
             (<CatC1EUniqueTypes.TestData>data).vehicleChecks,
           ));
+      case TestCategory.D:
+        return FaultSummaryCatCHelper.getDrivingFaultsNonTrailer(
+          data,
+          TestCategory.D,
+          this.faultCountProvider.getVehicleChecksFaultCount(
+            TestCategory.D,
+            (<CatDUniqueTypes.TestData>data).vehicleChecks,
+          ));
+      case TestCategory.D1:
+        return FaultSummaryCatCHelper.getDrivingFaultsNonTrailer(
+          data,
+          TestCategory.D1,
+          this.faultCountProvider.getVehicleChecksFaultCount(
+            TestCategory.D1,
+            (<CatD1UniqueTypes.TestData>data).vehicleChecks,
+          ));
+      case TestCategory.DE:
+        return FaultSummaryCatCHelper.getDrivingFaultsTrailer(
+          data,
+          TestCategory.DE,
+          this.faultCountProvider.getVehicleChecksFaultCount(
+            TestCategory.DE,
+            (<CatDEUniqueTypes.TestData>data).vehicleChecks,
+          ));
+      case TestCategory.D1E:
+        return FaultSummaryCatCHelper.getDrivingFaultsTrailer(
+          data,
+          TestCategory.D1E,
+          this.faultCountProvider.getVehicleChecksFaultCount(
+            TestCategory.D1E,
+            (<CatD1EUniqueTypes.TestData>data).vehicleChecks,
+          ));
       case TestCategory.EUAM1:
       case TestCategory.EUA1M1:
       case TestCategory.EUA2M1:
@@ -82,6 +119,12 @@ export class FaultSummaryProvider {
       case TestCategory.C1E:
       case TestCategory.CE:
         return FaultSummaryCatCHelper.getSeriousFaultsTrailer(data);
+      case TestCategory.D1:
+      case TestCategory.D:
+        return FaultSummaryCatDHelper.getSeriousFaultsNonTrailer(data);
+      case TestCategory.D1E:
+      case TestCategory.DE:
+        return FaultSummaryCatDHelper.getSeriousFaultsTrailer(data);
       case TestCategory.EUAM1:
       case TestCategory.EUA1M1:
       case TestCategory.EUA2M1:
@@ -104,6 +147,12 @@ export class FaultSummaryProvider {
       case TestCategory.C1E:
       case TestCategory.CE:
         return FaultSummaryCatCHelper.getDangerousFaultsTrailer(data);
+      case TestCategory.D1:
+      case TestCategory.D:
+        return FaultSummaryCatDHelper.getDangerousFaultsNonTrailer(data);
+      case TestCategory.D1E:
+      case TestCategory.DE:
+        return FaultSummaryCatDHelper.getDangerousFaultsTrailer(data);
       case TestCategory.EUAM1:
       case TestCategory.EUA1M1:
       case TestCategory.EUA2M1:

--- a/src/shared/constants/competencies/catd-manoeuvres.ts
+++ b/src/shared/constants/competencies/catd-manoeuvres.ts
@@ -1,0 +1,12 @@
+export enum manoeuvreTypeLabelsCatD {
+  reverseLeft = 'Reverse',
+}
+
+interface ManoeuvreCompetencyLabel {
+  [key: string]: 'Control' | 'Observation';
+}
+
+export const manoeuvreCompetencyLabelsCatD: ManoeuvreCompetencyLabel = {
+  controlFault: 'Control',
+  observationFault: 'Observation',
+};


### PR DESCRIPTION
## Description
- Adds support for D categories to the fault count and fault summary providers.
- Note that further updates may be required when we implement the Safety questions and PCV Door exercise.
- Fault counts/summary will be validated once we are able to progress to the Debrief page in the CAT D journey.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
