### PR TITLE
MES-4731 test debrief page - driving faults to riding faults

### DIFF
--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -200,6 +200,7 @@
     "dangerousFaultsCardDescription": "Namau peryglus",
     "drivingFault": "Nam gyrru",
     "drivingFaultsCardDescription": "Namau gyrru",
+    "ridingFaultsCardDescription": "namau reidio",
     "ecoBoth": "Rheoli a Chynllunio",
     "ecoControl": "Rheolaeth",
     "ecoHeader": "ECO",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -202,6 +202,7 @@
     "dangerousFaultsCardDescription": "dangerous faults",
     "drivingFault": "Driving fault",
     "drivingFaultsCardDescription": "driving faults",
+    "ridingFaultsCardDescription": "riding faults",
     "ecoBoth": "Control and Planning",
     "ecoControl": "Control",
     "ecoHeader": "ECO",

--- a/src/pages/debrief/cat-a-mod1/debrief.cat-a-mod1.page.html
+++ b/src/pages/debrief/cat-a-mod1/debrief.cat-a-mod1.page.html
@@ -12,7 +12,7 @@
   <eta-debrief-card [hasPhysicalEta]="hasPhysicalEta" [hasVerbalEta]="hasVerbalEta"></eta-debrief-card>
   <dangerous-faults-debrief-card [dangerousFaults]="pageState.dangerousFaults$ | async"></dangerous-faults-debrief-card>
   <serious-faults-debrief-card [seriousFaults]="pageState.seriousFaults$ | async"></serious-faults-debrief-card>
-  <driving-faults-debrief-card [drivingFaults]="pageState.drivingFaults$ | async" [drivingFaultCount]="pageState.drivingFaultCount$ | async"></driving-faults-debrief-card>
+  <driving-faults-debrief-card [drivingFaults]="pageState.drivingFaults$ | async" [drivingFaultCount]="pageState.drivingFaultCount$ | async" [testCategory]="category"></driving-faults-debrief-card>
 </ion-content>
 <ion-footer>
   <div id="end-debrief-background">

--- a/src/pages/debrief/cat-a-mod1/debrief.cat-a-mod1.page.ts
+++ b/src/pages/debrief/cat-a-mod1/debrief.cat-a-mod1.page.ts
@@ -58,6 +58,7 @@ export class DebriefCatAMod1Page extends BasePageComponent {
   pageState: DebriefPageState;
   subscription: Subscription;
   isPassed: boolean;
+  category: TestCategory = TestCategory.EUAM1;
 
   // Used for now to test displaying pass/fail/terminated messages
   public outcome: string;

--- a/src/pages/debrief/components/driving-faults-debrief-card/__tests__/driving-faults-debrief-card.spec.ts
+++ b/src/pages/debrief/components/driving-faults-debrief-card/__tests__/driving-faults-debrief-card.spec.ts
@@ -12,6 +12,7 @@ import { FaultSummary } from '../../../../../shared/models/fault-marking.model';
 import { configureI18N } from '../../../../../shared/helpers/translation.helpers';
 import { Language } from '../../../../../modules/tests/communication-preferences/communication-preferences.model';
 import { configureTestSuite } from 'ng-bullet';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 describe('DrivingFaultsDebriefCardComponent', () => {
   let fixture: ComponentFixture<DrivingFaultsDebriefCardComponent>;
@@ -102,6 +103,28 @@ describe('DrivingFaultsDebriefCardComponent', () => {
       component.drivingFaultCount = 0;
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css('#driving-fault'))).toBeNull();
+    });
+  });
+
+  describe('drivingFaultsCardDescriptionSwitch', () => {
+    it('Should return debrief.ridingFaultsCardDescription when cat is EUA1M1', () => {
+      const value = component.drivingFaultsCardDescriptionSwitch(TestCategory.EUA1M1);
+      expect(value).toEqual('debrief.ridingFaultsCardDescription');
+    });
+
+    it('Should return debrief.ridingFaultsCardDescription when cat is EUA1M2', () => {
+      const value = component.drivingFaultsCardDescriptionSwitch(TestCategory.EUA1M2);
+      expect(value).toEqual('debrief.ridingFaultsCardDescription');
+    });
+
+    it('Should return debrief.drivingFaultsCardDescription when cat is B', () => {
+      const value = component.drivingFaultsCardDescriptionSwitch(TestCategory.B);
+      expect(value).toEqual('debrief.drivingFaultsCardDescription');
+    });
+
+    it('Should return debrief.drivingFaultsCardDescription when cat is BE', () => {
+      const value = component.drivingFaultsCardDescriptionSwitch(TestCategory.BE);
+      expect(value).toEqual('debrief.drivingFaultsCardDescription');
     });
   });
 });

--- a/src/pages/debrief/components/driving-faults-debrief-card/driving-faults-debrief-card.html
+++ b/src/pages/debrief/components/driving-faults-debrief-card/driving-faults-debrief-card.html
@@ -2,7 +2,7 @@
   <ion-card-header>
     <ion-card-title>
       <h1 class="fault-heading">{{ drivingFaultCount }}</h1>
-      <h4 class="fault-heading">{{ 'debrief.drivingFaultsCardDescription' | translate }}</h4>
+      <h4 class="fault-heading">{{ drivingFaultsCardDescriptionSwitch(testCategory) | translate }}</h4>
     </ion-card-title>
   </ion-card-header>
   <ion-card-content>

--- a/src/pages/debrief/components/driving-faults-debrief-card/driving-faults-debrief-card.ts
+++ b/src/pages/debrief/components/driving-faults-debrief-card/driving-faults-debrief-card.ts
@@ -1,5 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { FaultSummary } from '../../../../shared/models/fault-marking.model';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { getDrivingOrRidingLabel } from '../../../../shared/helpers/driver-type';
 
 @Component({
   selector: 'driving-faults-debrief-card',
@@ -12,5 +14,15 @@ export class DrivingFaultsDebriefCardComponent {
 
   @Input()
   public drivingFaultCount: number;
+
+  @Input()
+  public testCategory: TestCategory;
+
+  constructor() {
+  }
+
+  drivingFaultsCardDescriptionSwitch(testCategory: TestCategory):string {
+    return `debrief.${getDrivingOrRidingLabel(testCategory)}FaultsCardDescription`;
+  }
 
 }

--- a/src/shared/helpers/__tests__/driver-type.spec.ts
+++ b/src/shared/helpers/__tests__/driver-type.spec.ts
@@ -1,0 +1,24 @@
+import { getDrivingOrRidingLabel } from '../driver-type';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+
+describe('getDrivingOrRidingLabel()', () => {
+  it('should return riding when a category equals EUAM1,', () => {
+    const driverType = getDrivingOrRidingLabel(TestCategory.EUAM1);
+    expect(driverType).toEqual('riding');
+  });
+
+  it('should return riding when a category equals EUA1M2,', () => {
+    const driverType = getDrivingOrRidingLabel(TestCategory.EUA1M2);
+    expect(driverType).toEqual('riding');
+  });
+
+  it('should return driving when a category equals B', () => {
+    const driverType = getDrivingOrRidingLabel(TestCategory.B);
+    expect(driverType).toEqual('driving');
+  });
+
+  it('should return driving when a category equals BE', () => {
+    const driverType = getDrivingOrRidingLabel(TestCategory.BE);
+    expect(driverType).toEqual('driving');
+  });
+});

--- a/src/shared/helpers/driver-type.ts
+++ b/src/shared/helpers/driver-type.ts
@@ -1,0 +1,14 @@
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+
+export enum drivingTypeDescription {
+  RIDING = 'riding',
+  DRIVING = 'driving',
+}
+
+export const getDrivingOrRidingLabel = (cat: TestCategory): drivingTypeDescription => {
+  // switch to determine driving or riding based upon category
+  if (cat && cat.includes('EUA')) {
+    return drivingTypeDescription.RIDING;
+  }
+  return drivingTypeDescription.DRIVING;
+};


### PR DESCRIPTION
## Description

Change driving faults to riding faults (and the equivalent welsh translation)on the test debrief page.  When test category is Mod1, then display riding

https://jira.dvsacloud.uk/browse/MES-4731

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
