### PR TITLE
Updating UI tests to screenshot on error by default but can be overridden by command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ You can also run an individual tag e.g. `npm run test:e2e-simulator-bdd -- --cuc
 
 To run against a simulator with a different iOS version e.g. `npm run test:e2e-simulator-bdd -- --capabilities.platformVersion='12.2'`
 
+By default screenshots are only taken on scenario error but you can override this passing the screenshotAlways argument e.g. `npm run test:e2e-simulator-bdd -- --screenshotAlways=true`
+
 #### Troubleshooting
 
 ##### Bad app... paths need to be absolute

--- a/e2e-simulator-bdd.conf.js
+++ b/e2e-simulator-bdd.conf.js
@@ -37,5 +37,6 @@ exports.config = {
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir);
     }
-  }
+  },
+  screenshotAlways: false
 };

--- a/test/e2e/step-definitions/generic-steps.ts
+++ b/test/e2e/step-definitions/generic-steps.ts
@@ -9,6 +9,7 @@ const {
   When,
   setDefaultTimeout,
   After,
+  Status,
 } = require('cucumber');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
@@ -28,6 +29,11 @@ setDefaultTimeout(TEST_CONFIG.DEFAULT_TIMEOUT);
 
 // Turn off syncronisation with Angular
 browser.ignoreSynchronization = true;
+
+let screenshotAlways = false;
+browser.getProcessedConfig().then((config) => {
+  screenshotAlways = config.screenshotAlways;
+});
 
 Given('I am not logged in', () => {
 
@@ -226,10 +232,11 @@ When('I click go to my Journal', () => {
  * Take a screenshot of the page at the end of the scenario.
  */
 After(function (testCase) {
-  return browser.driver.takeScreenshot().then((screenShot) => {
-    // screenShot is a base-64 encoded PNG
-    this.attach(screenShot, 'image/png');
-  });
+  if (screenshotAlways || testCase.result.status === Status.FAILED) {
+    return browser.driver.takeScreenshot().then((screenShot) => {
+      this.attach(screenShot, 'image/png');
+    });
+  }
 });
 
 //////////////////////////////////////////// SHARED FUNCTIONS ////////////////////////////////////////////


### PR DESCRIPTION
Changed the UI tests to only take a screenshot of the page if an error has occurred.

This can be overridden by command line by adding the command line argument `--screenshotAlways=true`

For example 
Command to run UI tests normally `npm run test:e2e-simulator-bdd`
Command to run UI tests with screenshot on every scenario `npm run test:e2e-simulator-bdd -- --screenshotAlways=true`
