### PR TITLE
Mes 4756 ui tweaks treatment for speed check

### DIFF
--- a/src/pages/test-report/cat-a-mod1/components/activity-code-4-modal/activity-code-4-modal.scss
+++ b/src/pages/test-report/cat-a-mod1/components/activity-code-4-modal/activity-code-4-modal.scss
@@ -20,7 +20,7 @@ activity-code-4-modal {
   .end-test-button {
       @extend .mes-return-button;
     background: map-get($colors-gds, gds-bright-red);
-    &.activated {
+    &.activated, &:active{
       background:  map-get($colors-gds, gds-red);
     }
     h3 {

--- a/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check.html
+++ b/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check.html
@@ -24,8 +24,8 @@
     </competency-button>
   </ion-col>
   <ion-col col-32>
-    <input (change)="onFirstAttemptChange($event.target.value)" [value]="getFirstAttempt()" type="text" class="speed-input first-speed-input" maxlength="3">
-    <input (change)="onSecondAttemptChange($event.target.value)" [value]="getSecondAttempt()" type="text" class="speed-input second-speed-input" maxlength="3">
+    <input type=number (change)="onFirstAttemptChange($event.target.value)" [value]="getFirstAttempt()" type="text" class="speed-input first-speed-input" maxlength="3" numbersOnly>
+    <input [disabled]="!firstAttempt" type=number (change)="onSecondAttemptChange($event.target.value)" [value]="getSecondAttempt()" type="text" class="speed-input second-speed-input" maxlength="3" numbersOnly>
   </ion-col>
   <ion-col col-16>
     <competency-button

--- a/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check.html
+++ b/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check.html
@@ -24,8 +24,8 @@
     </competency-button>
   </ion-col>
   <ion-col col-32>
-    <input type=number (change)="onFirstAttemptChange($event.target.value)" [value]="getFirstAttempt()" type="text" class="speed-input first-speed-input" maxlength="3" numbersOnly>
-    <input [disabled]="!firstAttempt" type=number (change)="onSecondAttemptChange($event.target.value)" [value]="getSecondAttempt()" type="text" class="speed-input second-speed-input" maxlength="3" numbersOnly>
+    <input (change)="onFirstAttemptChange($event.target.value)" [value]="getFirstAttempt()" type="text" class="speed-input first-speed-input" maxlength="3" numbersOnly>
+    <input [disabled]="!firstAttempt" (change)="onSecondAttemptChange($event.target.value)" [value]="getSecondAttempt()" type="text" class="speed-input second-speed-input" maxlength="3" numbersOnly>
   </ion-col>
   <ion-col col-16>
     <competency-button


### PR DESCRIPTION
## Description
Mes 4756 ui tweaks treatment for speed check:
- fixing grey button in hover mode for end test serious/dangerous faults on avoidance/emergency stop
- only allowing numeric input on speed attempt
- second attempt field greyed out until first attempt entered 

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
