### PR TITLE
MES-4140: Implemented Pass Test and Fail Test buttons to Test Report page

### DIFF
--- a/src/pages/test-report/cat-d/test-report.cat-d.page.html
+++ b/src/pages/test-report/cat-d/test-report.cat-d.page.html
@@ -1,6 +1,10 @@
 <ion-header>
   <ion-navbar hideBackButton>
     <ion-title>Test report - {{pageState.candidateUntitledName$ | async}}</ion-title>
+    <ion-buttons start>
+      <button ion-button (click)="passTest()">Pass Test</button>
+      <button ion-button (click)="failTest()">Fail Test</button>
+    </ion-buttons>
     <ion-buttons end>
       <button ion-button (click)="onEndTestClick()" id="end-test-button">End test</button>
     </ion-buttons>
@@ -71,7 +75,7 @@
         <ion-row>
           <ion-col>
             <reverse-left-cat-d [completed]="manoeuvresCompleted" [controlLabel]="'Reverse Left'"
-                          [clickCallback]="getCallback()" [testCategory]="pageState.testCategory$ | async">
+                                [clickCallback]="getCallback()" [testCategory]="pageState.testCategory$ | async">
               <reverse-left-popover-cat-d></reverse-left-popover-cat-d>
             </reverse-left-cat-d>
           </ion-col>

--- a/src/pages/test-report/cat-d/test-report.cat-d.page.ts
+++ b/src/pages/test-report/cat-d/test-report.cat-d.page.ts
@@ -45,8 +45,11 @@ import { getCandidate } from '../../../modules/tests/journal-data/cat-d/candidat
 import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
 import { hasManoeuvreBeenCompletedCatD } from '../../../modules/tests/test-data/cat-d/test-data.cat-d.selector';
 import { getTestRequirementsCatD }
-from '../../../modules/tests/test-data/cat-d/test-requirements/test-requirements.cat-d.reducer';
+  from '../../../modules/tests/test-data/cat-d/test-requirements/test-requirements.cat-d.reducer';
 import { getTestData } from '../../../modules/tests/test-data/cat-d/test-data.cat-d.reducer';
+import { AddDrivingFault } from '../../../modules/tests/test-data/common/driving-faults/driving-faults.actions';
+import { SetActivityCode } from '../../../modules/tests/activity-code/activity-code.actions';
+import { AddSeriousFault } from '../../../modules/tests/test-data/common/serious-faults/serious-faults.actions';
 
 interface TestReportPageState {
   candidateUntitledName$: Observable<string>;
@@ -237,6 +240,42 @@ export class TestReportCatDPage extends BasePageComponent {
 
   onTerminate = (): void => {
     this.modal.dismiss().then(() => this.navController.push(CAT_D.DEBRIEF_PAGE));
+  }
+
+  passTest = (): void => {
+    this.store$.dispatch(new AddDrivingFault({
+      competency: Competencies.clearance,
+      newFaultCount: 3,
+    }));
+    this.store$.dispatch(new AddDrivingFault({
+      competency: Competencies.followingDistance,
+      newFaultCount: 1,
+    }));
+    this.store$.dispatch(new AddDrivingFault({
+      competency: Competencies.moveOffSafety,
+      newFaultCount: 2,
+    }));
+    this.store$.dispatch(new SetActivityCode('1'));
+    this.navController.push(CAT_D.DEBRIEF_PAGE);
+  }
+
+  failTest = (): void => {
+    this.store$.dispatch(new AddDrivingFault({
+      competency: Competencies.pedestrianCrossings,
+      newFaultCount: 3,
+    }));
+    this.store$.dispatch(new AddDrivingFault({
+      competency: Competencies.positioningLaneDiscipline,
+      newFaultCount: 1,
+    }));
+    this.store$.dispatch(new AddDrivingFault({
+      competency: Competencies.signalsCorrectly,
+      newFaultCount: 2,
+    }));
+    this.store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsChangeSpeed));
+    this.store$.dispatch(new AddSeriousFault(Competencies.useOfSpeed));
+    this.store$.dispatch(new AddSeriousFault(Competencies.responseToSignsTrafficLights));
+    this.navController.push(CAT_D.DEBRIEF_PAGE);
   }
 
   showUncoupleRecouple = (): boolean => this.testCategory === TestCategory.DE || this.testCategory === TestCategory.D1E;


### PR DESCRIPTION
## Description
Buttons added to TestReport page to allow users to bypass the page for accessing and developing portions of the category which appear later on in the flow.
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![Screenshot 2020-02-06 at 13 05 45](https://user-images.githubusercontent.com/28736958/73939969-7458b200-48e2-11ea-8d40-5bdf170c06f4.png)
![Screenshot 2020-02-06 at 13 05 59](https://user-images.githubusercontent.com/28736958/73939973-7753a280-48e2-11ea-985b-2c4a659d1dec.png)
![Screenshot 2020-02-06 at 13 06 52](https://user-images.githubusercontent.com/28736958/73939977-791d6600-48e2-11ea-84ce-5489f69f0465.png)

