### PR TITLE
MES-4660: Final tweaks to End Test logic & Attempted Speed Inputs

### DIFF
--- a/src/pages/test-report/cat-a-mod1/__tests__/test-report.cat-a-mod1.page.spec.ts
+++ b/src/pages/test-report/cat-a-mod1/__tests__/test-report.cat-a-mod1.page.spec.ts
@@ -45,11 +45,15 @@ import { SpeedCheckComponent } from '../components/speed-check/speed-check';
 import { SetActivityCode } from '../../../../modules/tests/activity-code/activity-code.actions';
 import { StoreModel } from '../../../../shared/models/store.model';
 import { CalculateTestResult, TerminateTestFromTestReport } from '../../test-report.actions';
+import { SpeedCheckState } from '../../../../providers/test-report-validator/test-report-validator.constants';
+import { speedCheckLabels } from '../../../../shared/constants/competencies/cata-mod1-competencies';
+import { ModalReason } from '../components/activity-code-4-modal/activity-code-4-modal.constants';
 
 describe('TestReportCatAMod1Page', () => {
   let fixture: ComponentFixture<TestReportCatAMod1Page>;
   let component: TestReportCatAMod1Page;
   let navController: NavController;
+  let modalController: ModalController;
   let store$: Store<StoreModel>;
 
   configureTestSuite(() => {
@@ -104,6 +108,7 @@ describe('TestReportCatAMod1Page', () => {
     fixture = TestBed.createComponent(TestReportCatAMod1Page);
     component = fixture.componentInstance;
     navController = TestBed.get(NavController);
+    modalController = TestBed.get(ModalController);
     store$ = TestBed.get(Store);
   }));
 
@@ -111,6 +116,18 @@ describe('TestReportCatAMod1Page', () => {
     describe('onModalDismiss', () => {
       it('should navigate to debrief page when passed a CONTINUE event', () => {
         component.onModalDismiss(ModalEvent.CONTINUE);
+        const { calls } = navController.push as jasmine.Spy;
+        expect(calls.argsFor(0)[0]).toBe(CAT_A_MOD1.DEBRIEF_PAGE);
+      });
+
+      it('should navigate to debrief page when passed a TERMINATE event', () => {
+        component.onModalDismiss(ModalEvent.TERMINATE);
+        const { calls } = navController.push as jasmine.Spy;
+        expect(calls.argsFor(0)[0]).toBe(CAT_A_MOD1.DEBRIEF_PAGE);
+      });
+
+      it('should navigate to debrief page when passed a END_WITH_ACTIVITY_CODE_4', () => {
+        component.onModalDismiss(ModalEvent.END_WITH_ACTIVITY_CODE_4);
         const { calls } = navController.push as jasmine.Spy;
         expect(calls.argsFor(0)[0]).toBe(CAT_A_MOD1.DEBRIEF_PAGE);
       });
@@ -129,12 +146,6 @@ describe('TestReportCatAMod1Page', () => {
         expect(storeDispatchSpy).toHaveBeenCalledWith(new CalculateTestResult());
       });
 
-      it('should navigate to debrief page when passed a TERMINATE event', () => {
-        component.onModalDismiss(ModalEvent.TERMINATE);
-        const { calls } = navController.push as jasmine.Spy;
-        expect(calls.argsFor(0)[0]).toBe(CAT_A_MOD1.DEBRIEF_PAGE);
-      });
-
       it('should dispatch TerminateTestFromTestReport action', () => {
         const storeDispatchSpy = spyOn(store$, 'dispatch');
 
@@ -144,6 +155,212 @@ describe('TestReportCatAMod1Page', () => {
       });
     });
 
+    describe('createEtaInvalidModal', () => {
+      it('should create an EtaInvalidModal when isEtaValid is false', () => {
+        component.isEtaValid = false;
+
+        const options = {
+          optionProperty: 'optionProperty',
+        };
+        const modalName = 'EtaInvalidModal';
+        const { calls } = modalController.create as jasmine.Spy;
+
+        component.createEtaInvalidModal(options);
+
+        expect(calls.count()).toBe(1);
+        expect(calls.argsFor(0)[0]).toBe(modalName);
+        expect(calls.argsFor(0)[1]).toEqual({});
+        expect(calls.argsFor(0)[2]).toEqual(options);
+      });
+
+      it('should return null when isEtaValid is true', () => {
+        component.isEtaValid = true;
+        const options = {
+          optionProperty: 'optionProperty',
+        };
+
+        const result = component.createEtaInvalidModal(options);
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('createEndTestModal', () => {
+      it('should create an EndTestModal when speedCheckState is VALID', () => {
+        component.speedCheckState = SpeedCheckState.VALID;
+
+        const options = {
+          optionProperty: 'optionProperty',
+        };
+        const modalName = 'EndTestModal';
+        const { calls } = modalController.create as jasmine.Spy;
+
+        component.createEndTestModal(options);
+
+        expect(calls.count()).toBe(1);
+        expect(calls.argsFor(0)[0]).toBe(modalName);
+        expect(calls.argsFor(0)[1]).toEqual({});
+        expect(calls.argsFor(0)[2]).toEqual(options);
+      });
+
+      it('should return null when speedCheckState is not VALID', () => {
+        component.speedCheckState = SpeedCheckState.NOT_MET;
+        const options = {
+          optionProperty: 'optionProperty',
+        };
+
+        const result = component.createEndTestModal(options);
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('createSpeedCheckModal', () => {
+      it('should create the right SpeedCheckModal when EMERGENCY_STOP_AND_AVOIDANCE_MISSING', () => {
+        component.speedCheckState = SpeedCheckState.EMERGENCY_STOP_AND_AVOIDANCE_MISSING;
+
+        const options = {
+          optionProperty: 'optionProperty',
+        };
+        const modalName = 'SpeedCheckModal';
+        const { calls } = modalController.create as jasmine.Spy;
+
+        component.createSpeedCheckModal(options);
+
+        expect(calls.count()).toBe(1);
+        expect(calls.argsFor(0)[0]).toBe(modalName);
+        expect(calls.argsFor(0)[1]).toEqual({
+          speedChecksNeedCompleting: [
+            speedCheckLabels.speedCheckEmergency,
+            speedCheckLabels.speedCheckAvoidance,
+          ],
+        });
+        expect(calls.argsFor(0)[2]).toEqual(options);
+      });
+
+      it('should create the right SpeedCheckModal when EMERGENCY_STOP_MISSING', () => {
+        component.speedCheckState = SpeedCheckState.EMERGENCY_STOP_MISSING;
+
+        const options = {
+          optionProperty: 'optionProperty',
+        };
+        const modalName = 'SpeedCheckModal';
+        const { calls } = modalController.create as jasmine.Spy;
+
+        component.createSpeedCheckModal(options);
+
+        expect(calls.count()).toBe(1);
+        expect(calls.argsFor(0)[0]).toBe(modalName);
+        expect(calls.argsFor(0)[1]).toEqual({
+          speedChecksNeedCompleting: [
+            speedCheckLabels.speedCheckEmergency,
+          ],
+        });
+        expect(calls.argsFor(0)[2]).toEqual(options);
+      });
+
+      it('should create the right SpeedCheckModal when AVOIDANCE_MISSING', () => {
+        component.speedCheckState = SpeedCheckState.AVOIDANCE_MISSING;
+
+        const options = {
+          optionProperty: 'optionProperty',
+        };
+        const modalName = 'SpeedCheckModal';
+        const { calls } = modalController.create as jasmine.Spy;
+
+        component.createSpeedCheckModal(options);
+
+        expect(calls.count()).toBe(1);
+        expect(calls.argsFor(0)[0]).toBe(modalName);
+        expect(calls.argsFor(0)[1]).toEqual({
+          speedChecksNeedCompleting: [
+            speedCheckLabels.speedCheckAvoidance,
+          ],
+        });
+        expect(calls.argsFor(0)[2]).toEqual(options);
+      });
+
+      it('should return null when nor emergency stop nor avoidance is missing', () => {
+        component.speedCheckState = SpeedCheckState.VALID;
+        const options = {
+          optionProperty: 'optionProperty',
+        };
+
+        const result = component.createSpeedCheckModal(options);
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('createActivityCode4Modal', () => {
+      it('should create the right ActivityCode4Modal when speedCheckState is NOT_MET', () => {
+        component.speedCheckState = SpeedCheckState.NOT_MET;
+
+        const options = {
+          optionProperty: 'optionProperty',
+        };
+        const modalName = 'ActivityCode4Modal';
+        const { calls } = modalController.create as jasmine.Spy;
+
+        component.createActivityCode4Modal(options);
+
+        expect(calls.count()).toBe(1);
+        expect(calls.argsFor(0)[0]).toBe(modalName);
+        expect(calls.argsFor(0)[1]).toEqual({
+          modalReason: ModalReason.SPEED_REQUIREMENTS,
+        });
+        expect(calls.argsFor(0)[2]).toEqual(options);
+      });
+
+      it('should create the right ActivityCode4Modal when speedCheckState is EMERGENCY_STOP_DANGEROUS_FAULT', () => {
+        component.speedCheckState = SpeedCheckState.EMERGENCY_STOP_DANGEROUS_FAULT;
+
+        const options = {
+          optionProperty: 'optionProperty',
+        };
+        const modalName = 'ActivityCode4Modal';
+        const { calls } = modalController.create as jasmine.Spy;
+
+        component.createActivityCode4Modal(options);
+
+        expect(calls.count()).toBe(1);
+        expect(calls.argsFor(0)[0]).toBe(modalName);
+        expect(calls.argsFor(0)[1]).toEqual({
+          modalReason: ModalReason.EMERGENCY_STOP_DANGEROUS,
+        });
+        expect(calls.argsFor(0)[2]).toEqual(options);
+      });
+
+      it('should create the right ActivityCode4Modal whe speedCheckState is EMERGENCY_STOP_SERIOUS_FAULT', () => {
+        component.speedCheckState = SpeedCheckState.EMERGENCY_STOP_SERIOUS_FAULT;
+
+        const options = {
+          optionProperty: 'optionProperty',
+        };
+        const modalName = 'ActivityCode4Modal';
+        const { calls } = modalController.create as jasmine.Spy;
+
+        component.createActivityCode4Modal(options);
+
+        expect(calls.count()).toBe(1);
+        expect(calls.argsFor(0)[0]).toBe(modalName);
+        expect(calls.argsFor(0)[1]).toEqual({
+          modalReason: ModalReason.EMERGENCY_STOP_SERIOUS,
+        });
+        expect(calls.argsFor(0)[2]).toEqual(options);
+      });
+
+      it('should return null speed req is met and not serious or dangerous fault on Emergency Stop', () => {
+        component.speedCheckState = SpeedCheckState.VALID;
+        const options = {
+          optionProperty: 'optionProperty',
+        };
+
+        const result = component.createActivityCode4Modal(options);
+
+        expect(result).toBeNull();
+      });
+    });
   });
 
   describe('DOM', () => {

--- a/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check.ts
+++ b/src/pages/test-report/cat-a-mod1/components/speed-check/speed-check.ts
@@ -287,21 +287,21 @@ export class SpeedCheckComponent {
 
   onFirstAttemptChange = (attemptedSpeed: number): void => {
     if (this.competency === Competencies.speedCheckEmergency) {
-      this.store$.dispatch(new RecordEmergencyStopFirstAttempt(attemptedSpeed));
+      this.store$.dispatch(new RecordEmergencyStopFirstAttempt(Number(attemptedSpeed)));
     }
 
     if (this.competency === Competencies.speedCheckAvoidance) {
-      this.store$.dispatch(new RecordAvoidanceFirstAttempt(attemptedSpeed));
+      this.store$.dispatch(new RecordAvoidanceFirstAttempt(Number(attemptedSpeed)));
     }
   }
 
   onSecondAttemptChange = (attemptedSpeed: number): void => {
     if (this.competency === Competencies.speedCheckEmergency) {
-      this.store$.dispatch(new RecordEmergencyStopSecondAttempt(attemptedSpeed));
+      this.store$.dispatch(new RecordEmergencyStopSecondAttempt(Number(attemptedSpeed)));
     }
 
     if (this.competency === Competencies.speedCheckAvoidance) {
-      this.store$.dispatch(new RecordAvoidanceSecondAttempt(attemptedSpeed));
+      this.store$.dispatch(new RecordAvoidanceSecondAttempt(Number(attemptedSpeed)));
     }
   }
 

--- a/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
+++ b/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
@@ -261,6 +261,66 @@ describe('TestReportValidator', () => {
 
       expect(result).toBe(SpeedCheckState.EMERGENCY_STOP_DANGEROUS_FAULT);
     });
+
+    it('should return SpeedCheckState.EMERGENCY_STOP_AND_AVOIDANCE_MISSING', () => {
+      const testData = {
+        emergencyStop: {
+          firstAttempt: undefined,
+        },
+        avoidance: {
+          firstAttempt: undefined,
+        },
+      } as CatAMod1TestData;
+
+      const result = testReportValidatorProvider.validateSpeedChecksCatAMod1(testData);
+
+      expect(result).toBe(SpeedCheckState.EMERGENCY_STOP_AND_AVOIDANCE_MISSING);
+    });
+
+    it('should return SpeedCheckState.EMERGENCY_STOP_MISSING', () => {
+      const testData = {
+        emergencyStop: {
+          firstAttempt: undefined,
+        },
+        avoidance: {
+          firstAttempt: 48,
+        },
+      } as CatAMod1TestData;
+
+      const result = testReportValidatorProvider.validateSpeedChecksCatAMod1(testData);
+
+      expect(result).toBe(SpeedCheckState.EMERGENCY_STOP_MISSING);
+    });
+
+    it('should return SpeedCheckState.AVOIDANCE_MISSING', () => {
+      const testData = {
+        emergencyStop: {
+          firstAttempt: 48,
+        },
+        avoidance: {
+          firstAttempt: undefined,
+        },
+      } as CatAMod1TestData;
+
+      const result = testReportValidatorProvider.validateSpeedChecksCatAMod1(testData);
+
+      expect(result).toBe(SpeedCheckState.AVOIDANCE_MISSING);
+    });
+
+    it('should return SpeedCheckState.VALID', () => {
+      const testData = {
+        emergencyStop: {
+          firstAttempt: 48,
+        },
+        avoidance: {
+          firstAttempt: 49,
+        },
+      } as CatAMod1TestData;
+
+      const result = testReportValidatorProvider.validateSpeedChecksCatAMod1(testData);
+
+      expect(result).toBe(SpeedCheckState.VALID);
+    });
   });
 
 });

--- a/src/providers/test-report-validator/test-report-validator.ts
+++ b/src/providers/test-report-validator/test-report-validator.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { get, isEmpty } from 'lodash';
+import { get } from 'lodash';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
 import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
@@ -89,15 +89,15 @@ export class TestReportValidatorProvider {
     const emergencyStopFirstAttempt = get(data, 'emergencyStop.firstAttempt');
     const avoidanceFirstAttempt = get(data, 'avoidance.firstAttempt');
 
-    if (isEmpty(emergencyStopFirstAttempt) && isEmpty(avoidanceFirstAttempt)) {
+    if (emergencyStopFirstAttempt === undefined && avoidanceFirstAttempt === undefined) {
       return SpeedCheckState.EMERGENCY_STOP_AND_AVOIDANCE_MISSING;
     }
 
-    if (isEmpty(emergencyStopFirstAttempt)) {
+    if (emergencyStopFirstAttempt === undefined) {
       return SpeedCheckState.EMERGENCY_STOP_MISSING;
     }
 
-    if (isEmpty(avoidanceFirstAttempt)) {
+    if (avoidanceFirstAttempt === undefined) {
       return SpeedCheckState.AVOIDANCE_MISSING;
     }
 


### PR DESCRIPTION
## Description

- Refactoring the way End Test Modals are created
- Unit testing the logic that creates the correct modal on End Test
- Test Report validator now is corrected and properly unit tested
- Making sure that first & second attempt is saved as a number

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
