### PR TITLE
add single app mode and tests to waiting romm cat c screen

### DIFF
--- a/src/pages/waiting-room/cat-c/__tests__/waiting-room.cat-c.page.spec.ts
+++ b/src/pages/waiting-room/cat-c/__tests__/waiting-room.cat-c.page.spec.ts
@@ -46,12 +46,15 @@ import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
 import { App } from '../../../../app/app.component';
 import { MockAppComponent } from '../../../../app/__mocks__/app.component.mock';
 import { configureTestSuite } from 'ng-bullet';
+import { DeviceProvider } from '../../../../providers/device/device';
+import { DeviceProviderMock } from '../../../../providers/device/__mocks__/device.mock';
 
 describe('WaitingRoomCatCPage', () => {
   let fixture: ComponentFixture<WaitingRoomCatCPage>;
   let component: WaitingRoomCatCPage;
   let store$: Store<StoreModel>;
   let deviceAuthenticationProvider: DeviceAuthenticationProvider;
+  let deviceProvider: DeviceProvider;
   let screenOrientation: ScreenOrientation;
   let insomnia: Insomnia;
   let translate: TranslateService;
@@ -108,6 +111,7 @@ describe('WaitingRoomCatCPage', () => {
         { provide: Platform, useFactory: () => PlatformMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
         { provide: DeviceAuthenticationProvider, useClass: DeviceAuthenticationProviderMock },
+        { provide: DeviceProvider, useClass: DeviceProviderMock },
         { provide: DateTimeProvider, useClass: DateTimeProviderMock },
         { provide: ScreenOrientation, useClass: ScreenOrientationMock },
         { provide: Insomnia, useClass: InsomniaMock },
@@ -122,6 +126,7 @@ describe('WaitingRoomCatCPage', () => {
     screenOrientation = TestBed.get(ScreenOrientation);
     insomnia = TestBed.get(Insomnia);
     deviceAuthenticationProvider = TestBed.get(DeviceAuthenticationProvider);
+    deviceProvider = TestBed.get(DeviceProvider);
     translate = TestBed.get(TranslateService);
     translate.setDefaultLang('en');
     store$ = TestBed.get(Store);
@@ -166,6 +171,10 @@ describe('WaitingRoomCatCPage', () => {
     });
 
     describe('ionViewDidEnter', () => {
+      it('should enable single app mode if on ios', () => {
+        component.ionViewDidEnter();
+        expect(deviceProvider.enableSingleAppMode).toHaveBeenCalled();
+      });
       it('should lock the screen orientation to Portrait Primary', () => {
         component.ionViewDidEnter();
         expect(screenOrientation.lock)

--- a/src/pages/waiting-room/cat-c/waiting-room.cat-c.page.ts
+++ b/src/pages/waiting-room/cat-c/waiting-room.cat-c.page.ts
@@ -52,6 +52,7 @@ import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
 import { isEmpty } from 'lodash';
 import { ErrorTypes } from '../../../shared/models/error-message';
 import { App } from '../../../app/app.component';
+import { DeviceProvider } from '../../../providers/device/device';
 
 interface WaitingRoomPageState {
   insuranceDeclarationAccepted$: Observable<boolean>;
@@ -88,6 +89,7 @@ export class WaitingRoomCatCPage extends BasePageComponent implements OnInit {
     public platform: Platform,
     public authenticationProvider: AuthenticationProvider,
     private deviceAuthenticationProvider: DeviceAuthenticationProvider,
+    private deviceProvider: DeviceProvider,
     private screenOrientation: ScreenOrientation,
     private insomnia: Insomnia,
     private translate: TranslateService,
@@ -104,6 +106,7 @@ export class WaitingRoomCatCPage extends BasePageComponent implements OnInit {
     if (super.isIos()) {
       this.screenOrientation.lock(this.screenOrientation.ORIENTATIONS.PORTRAIT_PRIMARY);
       this.insomnia.keepAwake();
+      this.deviceProvider.enableSingleAppMode();
     }
 
     this.navBar.backButtonClick = (e: UIEvent) => {


### PR DESCRIPTION
Put app into single app mode when going to waiting room screen on cat c
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number
