### PR TITLE
FIX - Made Cat C & D Test Data Reducers Required

### DIFF
--- a/src/modules/tests/test-data/cat-be/test-data.cat-be.reducer.ts
+++ b/src/modules/tests/test-data/cat-be/test-data.cat-be.reducer.ts
@@ -30,7 +30,7 @@ export const initialState: CatBEUniqueTypes.TestData = {
 export function testDataCatBEReducer(
   state: CatBEUniqueTypes.TestData,
   action: Action,
-): CatBEUniqueTypes.TestData {
+): Required<CatBEUniqueTypes.TestData> {
   return combineReducers({
     drivingFaults: drivingFaultsReducer,
     dangerousFaults: dangerousFaultsReducer,

--- a/src/modules/tests/test-data/cat-c/test-data.cat-c.reducer.ts
+++ b/src/modules/tests/test-data/cat-c/test-data.cat-c.reducer.ts
@@ -27,7 +27,7 @@ export const initialState: CatCUniqueTypes.TestData = {
 export function testDataCatCReducer(
   state: CatCUniqueTypes.TestData,
   action: Action,
-): CatCUniqueTypes.TestData {
+): Required<CatCUniqueTypes.TestData> {
   return combineReducers({
     drivingFaults: drivingFaultsReducer,
     dangerousFaults: dangerousFaultsReducer,

--- a/src/modules/tests/test-data/cat-c/test-data.cat-c1.reducer.ts
+++ b/src/modules/tests/test-data/cat-c/test-data.cat-c1.reducer.ts
@@ -27,7 +27,7 @@ export const initialState: CatC1UniqueTypes.TestData = {
 export function testDataCatC1Reducer(
   state: CatC1UniqueTypes.TestData,
   action: Action,
-): CatC1UniqueTypes.TestData {
+): Required<CatC1UniqueTypes.TestData> {
   return combineReducers({
     drivingFaults: drivingFaultsReducer,
     dangerousFaults: dangerousFaultsReducer,

--- a/src/modules/tests/test-data/cat-c/test-data.cat-c1e.reducer.ts
+++ b/src/modules/tests/test-data/cat-c/test-data.cat-c1e.reducer.ts
@@ -29,7 +29,7 @@ export const initialState: CatC1EUniqueTypes.TestData = {
 export function testDataCatC1EReducer(
   state: CatC1EUniqueTypes.TestData,
   action: Action,
-): CatC1EUniqueTypes.TestData {
+): Required<CatC1EUniqueTypes.TestData> {
   return combineReducers({
     drivingFaults: drivingFaultsReducer,
     dangerousFaults: dangerousFaultsReducer,

--- a/src/modules/tests/test-data/cat-c/test-data.cat-ce.reducer.ts
+++ b/src/modules/tests/test-data/cat-c/test-data.cat-ce.reducer.ts
@@ -29,7 +29,7 @@ export const initialState: CatCEUniqueTypes.TestData = {
 export function testDataCatCEReducer(
   state: CatCEUniqueTypes.TestData,
   action: Action,
-): CatCEUniqueTypes.TestData {
+): Required<CatCEUniqueTypes.TestData> {
   return combineReducers({
     drivingFaults: drivingFaultsReducer,
     dangerousFaults: dangerousFaultsReducer,

--- a/src/modules/tests/test-data/cat-d/test-data.cat-d.reducer.ts
+++ b/src/modules/tests/test-data/cat-d/test-data.cat-d.reducer.ts
@@ -27,7 +27,7 @@ export const initialState: CatDUniqueTypes.TestData = {
 export function testDataCatDReducer(
   state: CatDUniqueTypes.TestData,
   action: Action,
-): CatDUniqueTypes.TestData {
+): Required<CatDUniqueTypes.TestData> {
   return combineReducers({
     drivingFaults: drivingFaultsReducer,
     dangerousFaults: dangerousFaultsReducer,
@@ -37,6 +37,9 @@ export function testDataCatDReducer(
     ETA: etaReducer,
     manoeuvres: manoeuvresCatDReducer,
     testRequirements: testRequirementsCatDReducer,
+    // TODO - Cat D - To be implmented by relevant tickets
+    safetyQuestions: () => { return null; },
+    pcvDoorExercise: () => { return null; },
   })(state as Required<CatDUniqueTypes.TestData>, action);
 }
 

--- a/src/modules/tests/test-data/cat-d/test-data.cat-d.reducer.ts
+++ b/src/modules/tests/test-data/cat-d/test-data.cat-d.reducer.ts
@@ -37,7 +37,7 @@ export function testDataCatDReducer(
     ETA: etaReducer,
     manoeuvres: manoeuvresCatDReducer,
     testRequirements: testRequirementsCatDReducer,
-    // TODO - Cat D - To be implmented by relevant tickets
+    // TODO - Cat D - To be implmented by relevant tickets MES-4503 & MES-4129
     safetyQuestions: () => { return null; },
     pcvDoorExercise: () => { return null; },
   })(state as Required<CatDUniqueTypes.TestData>, action);

--- a/src/modules/tests/test-data/cat-d/test-data.cat-d1.reducer.ts
+++ b/src/modules/tests/test-data/cat-d/test-data.cat-d1.reducer.ts
@@ -37,7 +37,7 @@ export function testDataCatD1Reducer(
     ETA: etaReducer,
     manoeuvres: manoeuvresCatDReducer,
     testRequirements: testRequirementsCatDReducer,
-    // TODO - Cat D - To be implmented by relevant tickets
+    // TODO - Cat D - To be implmented by relevant tickets MES-4503 & MES-4129
     safetyQuestions: () => { return null; },
     pcvDoorExercise: () => { return null; },
   })(state as Required<CatD1UniqueTypes.TestData>, action);

--- a/src/modules/tests/test-data/cat-d/test-data.cat-d1.reducer.ts
+++ b/src/modules/tests/test-data/cat-d/test-data.cat-d1.reducer.ts
@@ -27,7 +27,7 @@ export const initialState: CatD1UniqueTypes.TestData = {
 export function testDataCatD1Reducer(
   state: CatD1UniqueTypes.TestData,
   action: Action,
-): CatD1UniqueTypes.TestData {
+): Required<CatD1UniqueTypes.TestData> {
   return combineReducers({
     drivingFaults: drivingFaultsReducer,
     dangerousFaults: dangerousFaultsReducer,
@@ -37,6 +37,9 @@ export function testDataCatD1Reducer(
     ETA: etaReducer,
     manoeuvres: manoeuvresCatDReducer,
     testRequirements: testRequirementsCatDReducer,
+    // TODO - Cat D - To be implmented by relevant tickets
+    safetyQuestions: () => { return null; },
+    pcvDoorExercise: () => { return null; },
   })(state as Required<CatD1UniqueTypes.TestData>, action);
 }
 

--- a/src/modules/tests/test-data/cat-d/test-data.cat-d1e.reducer.ts
+++ b/src/modules/tests/test-data/cat-d/test-data.cat-d1e.reducer.ts
@@ -29,7 +29,7 @@ export const initialState: CatD1EUniqueTypes.TestData = {
 export function testDataCatD1EReducer(
   state: CatD1EUniqueTypes.TestData,
   action: Action,
-): CatD1EUniqueTypes.TestData {
+): Required<CatD1EUniqueTypes.TestData> {
   return combineReducers({
     drivingFaults: drivingFaultsReducer,
     dangerousFaults: dangerousFaultsReducer,
@@ -40,6 +40,9 @@ export function testDataCatD1EReducer(
     manoeuvres: manoeuvresCatDReducer,
     testRequirements: testRequirementsCatDReducer,
     uncoupleRecouple: uncoupleRecoupleCatD1EReducer,
+    // TODO - Cat D - To be implmented by relevant tickets
+    safetyQuestions: () => { return null; },
+    pcvDoorExercise: () => { return null; },
   })(state as Required<CatD1EUniqueTypes.TestData>, action);
 }
 

--- a/src/modules/tests/test-data/cat-d/test-data.cat-d1e.reducer.ts
+++ b/src/modules/tests/test-data/cat-d/test-data.cat-d1e.reducer.ts
@@ -40,7 +40,7 @@ export function testDataCatD1EReducer(
     manoeuvres: manoeuvresCatDReducer,
     testRequirements: testRequirementsCatDReducer,
     uncoupleRecouple: uncoupleRecoupleCatD1EReducer,
-    // TODO - Cat D - To be implmented by relevant tickets
+    // TODO - Cat D - To be implmented by relevant tickets MES-4503 & MES-4129
     safetyQuestions: () => { return null; },
     pcvDoorExercise: () => { return null; },
   })(state as Required<CatD1EUniqueTypes.TestData>, action);

--- a/src/modules/tests/test-data/cat-d/test-data.cat-de.reducer.ts
+++ b/src/modules/tests/test-data/cat-d/test-data.cat-de.reducer.ts
@@ -40,7 +40,7 @@ export function testDataCatDEReducer(
     manoeuvres: manoeuvresCatDReducer,
     testRequirements: testRequirementsCatDReducer,
     uncoupleRecouple: uncoupleRecoupleCatDEReducer,
-    // TODO - Cat D - To be implmented by relevant tickets
+    // TODO - Cat D - To be implmented by relevant tickets MES-4503 & MES-4129
     safetyQuestions: () => { return null; },
     pcvDoorExercise: () => { return null; },
   })(state as Required<CatDEUniqueTypes.TestData>, action);

--- a/src/modules/tests/test-data/cat-d/test-data.cat-de.reducer.ts
+++ b/src/modules/tests/test-data/cat-d/test-data.cat-de.reducer.ts
@@ -29,7 +29,7 @@ export const initialState: CatDEUniqueTypes.TestData = {
 export function testDataCatDEReducer(
   state: CatDEUniqueTypes.TestData,
   action: Action,
-): CatDEUniqueTypes.TestData {
+): Required<CatDEUniqueTypes.TestData> {
   return combineReducers({
     drivingFaults: drivingFaultsReducer,
     dangerousFaults: dangerousFaultsReducer,
@@ -40,6 +40,9 @@ export function testDataCatDEReducer(
     manoeuvres: manoeuvresCatDReducer,
     testRequirements: testRequirementsCatDReducer,
     uncoupleRecouple: uncoupleRecoupleCatDEReducer,
+    // TODO - Cat D - To be implmented by relevant tickets
+    safetyQuestions: () => { return null; },
+    pcvDoorExercise: () => { return null; },
   })(state as Required<CatDEUniqueTypes.TestData>, action);
 }
 


### PR DESCRIPTION
## Description
- Have updated the typing on our test data reducers to make them required for Cat C and Cat D. This means they will now error if the combine reducers object contains an incorrect reducer.
- I have added a null reducer and TODO for the state management we are missing in Cat D currently.

Going to investigate the effort needed to do this to everything below TestData, there were lots of errors so I didn't want to spend ages getting it working.

## Checklist

- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
