### PR TITLE
fix rsis issue due to independent driving component

### DIFF
--- a/src/pages/office/cat-a-mod1/office.cat-a-mod1.page.html
+++ b/src/pages/office/cat-a-mod1/office.cat-a-mod1.page.html
@@ -50,7 +50,7 @@
               (routeNumberChange)="routeNumberChanged($event)" [formGroup]="form">
             </route-number>
 
-            <independent-driving [display]="pageState.displayIndependentDriving$ | async" option1="Diagram" option2="Traffic Signs" [formGroup]="form"
+            <independent-driving [display]="pageState.displayIndependentDriving$ | async" option1="Diagram" option1label="Diagram" option2="Traffic signs" option2label="Traffic Signs" [formGroup]="form"
               [outcome]="pageState.testOutcome$ | async" [independentDriving]="pageState.independentDriving$ | async"
               (independentDrivingChange)="independentDrivingChanged($event)"></independent-driving>
 

--- a/src/pages/office/cat-a-mod2/office.cat-a-mod2.page.html
+++ b/src/pages/office/cat-a-mod2/office.cat-a-mod2.page.html
@@ -50,7 +50,7 @@
               (routeNumberChange)="routeNumberChanged($event)" [formGroup]="form">
             </route-number>
 
-            <independent-driving [display]="pageState.displayIndependentDriving$ | async" option1="Diagram" option2="Traffic Signs" [formGroup]="form"
+            <independent-driving [display]="pageState.displayIndependentDriving$ | async" option1="Diagram" option1label="Diagram" option2="Traffic signs" option2label="Traffic Signs" [formGroup]="form"
               [outcome]="pageState.testOutcome$ | async" [independentDriving]="pageState.independentDriving$ | async"
               (independentDrivingChange)="independentDrivingChanged($event)"></independent-driving>
 

--- a/src/pages/office/cat-b/office.cat-b.page.html
+++ b/src/pages/office/cat-b/office.cat-b.page.html
@@ -49,7 +49,7 @@
               [outcome]="pageState.testOutcome$ | async" (routeNumberChange)="routeNumberChanged($event)" [formGroup]="form">
             </route-number>
 
-            <independent-driving [display]="pageState.displayIndependentDriving$ | async" option1="Sat Nav" option2="Traffic Signs" [formGroup]="form" [outcome]="pageState.testOutcome$ | async"
+            <independent-driving [display]="pageState.displayIndependentDriving$ | async" option1="Sat nav" option1label="Sat Nav" option2="Traffic signs" option2label="Traffic Signs" [formGroup]="form" [outcome]="pageState.testOutcome$ | async"
               [independentDriving]="pageState.independentDriving$ | async" (independentDrivingChange)="independentDrivingChanged($event)"></independent-driving>
 
             <candidate-description [display]="pageState.displayCandidateDescription$ | async" [formGroup]="form"

--- a/src/pages/office/cat-be/office.cat-be.page.html
+++ b/src/pages/office/cat-be/office.cat-be.page.html
@@ -50,7 +50,7 @@
               (routeNumberChange)="routeNumberChanged($event)" [formGroup]="form">
             </route-number>
 
-            <independent-driving [display]="pageState.displayIndependentDriving$ | async" option1="Diagram" option2="Traffic Signs" [formGroup]="form"
+            <independent-driving [display]="pageState.displayIndependentDriving$ | async" option1="Diagram" option1label="Diagram" option2="Traffic signs" option2label="Traffic Signs" [formGroup]="form"
               [outcome]="pageState.testOutcome$ | async" [independentDriving]="pageState.independentDriving$ | async"
               (independentDrivingChange)="independentDrivingChanged($event)"></independent-driving>
 

--- a/src/pages/office/cat-c/office.cat-c.page.html
+++ b/src/pages/office/cat-c/office.cat-c.page.html
@@ -48,7 +48,7 @@
               [outcome]="pageState.testOutcome$ | async" (routeNumberChange)="routeNumberChanged($event)" [formGroup]="form">
             </route-number>
 
-            <independent-driving [display]="pageState.displayIndependentDriving$ | async" option1="Diagram" option2="Traffic Signs" [formGroup]="form" [outcome]="pageState.testOutcome$ | async"
+            <independent-driving [display]="pageState.displayIndependentDriving$ | async" option1="Diagram" option1label="Diagram" option2="Traffic signs" option2label="Traffic Signs" [formGroup]="form" [outcome]="pageState.testOutcome$ | async"
               [independentDriving]="pageState.independentDriving$ | async" (independentDrivingChange)="independentDrivingChanged($event)"></independent-driving>
 
             <candidate-description [display]="pageState.displayCandidateDescription$ | async" [formGroup]="form"

--- a/src/pages/office/components/independent-driving/independent-driving.html
+++ b/src/pages/office/components/independent-driving/independent-driving.html
@@ -12,14 +12,14 @@
         <input type="radio" [id]="getIndependentDrivingInputId(option1)" class="gds-radio-button"
           formControlName="independentDriving" name="independentDriving" [value]="option1" [class.ng-invalid]="invalid"
           [checked]="independentDriving === option1" (change)="independentDrivingChanged(option1)">
-        <label [for]="getIndependentDrivingInputId(option1)" class="radio-label">{{option1}}</label>
+        <label [for]="getIndependentDrivingInputId(option1)" class="radio-label">{{option1label}}</label>
       </ion-col>
       <ion-col align-self-center>
         <input type="radio" [id]="getIndependentDrivingInputId(option2)" class="gds-radio-button"
           formControlName="independentDriving" name="independentDriving" [value]="option2"
                [class.ng-invalid]="invalid" [checked]="independentDriving === option2"
           (change)="independentDrivingChanged(option2)">
-        <label [for]="getIndependentDrivingInputId(option2)" class="radio-label">{{option2}}</label>
+        <label [for]="getIndependentDrivingInputId(option2)" class="radio-label">{{option2label}}</label>
       </ion-col>
       <ion-col align-self-center [hidden]="!showNotApplicable">
         <input type="radio" id="independent-driving-na" class="gds-radio-button" formControlName="independentDriving"

--- a/src/pages/office/components/independent-driving/independent-driving.ts
+++ b/src/pages/office/components/independent-driving/independent-driving.ts
@@ -25,6 +25,12 @@ export class IndependentDrivingComponent implements OnChanges {
   option2: IndependentDriving;
 
   @Input()
+  option1label: string;
+
+  @Input()
+  option2label: string;
+
+  @Input()
   independentDriving: IndependentDriving;
 
   @Input()


### PR DESCRIPTION
Due to change made to independent driving component incorrect values for independent driving were being placed in the schema. Submitted tests then failed validation in RSIS resulting in no RSIS queue entry being created.

Fixed issue by separating the label from the value - Label was init capped, value to be submitted should not have been.  

Future PR will apply this fix to develop.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
