### PR TITLE
mes-4503: move position of fault banner

### DIFF
--- a/src/pages/waiting-room-to-car/cat-d/components/vehicle-checks-modal/vehicle-checks-modal.cat-d.page.html
+++ b/src/pages/waiting-room-to-car/cat-d/components/vehicle-checks-modal/vehicle-checks-modal.cat-d.page.html
@@ -48,9 +48,9 @@
         (vehicleChecksQuestionChange)="tellMeQuestionChanged($event, i)"
         (vehicleChecksQuestionOutcomeChange)="tellMeQuestionOutcomeChanged($event, i)">
       </vehicle-checks-question-cat-d>
-
     </ion-card-content>
   </ion-card>
+  <warning-banner warningText="This will result in 4 driving faults and 1 serious fault" *ngIf="shouldDisplayBanner()"></warning-banner>
   <ion-card>
     <ion-card-header>
       <ion-card-title>
@@ -69,7 +69,6 @@
       </safety-question>
     </ion-card-content>
   </ion-card>
-  <warning-banner warningText="This will result in 4 driving faults and 1 serious fault" *ngIf="shouldDisplayBanner()"></warning-banner>
 </ion-content>
 
 <ion-footer>


### PR DESCRIPTION
## Description
Moves the position of the vehicle checks fault banner so it appears directly underneath the vehicle checks.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![localhost_8100_(Ipad DES) (3)](https://user-images.githubusercontent.com/54100299/74262331-91332200-4cf4-11ea-9d93-db8145a82127.png)
![localhost_8100_(Ipad DES) (4)](https://user-images.githubusercontent.com/54100299/74262341-942e1280-4cf4-11ea-803b-602d8983f2fe.png)
