### PR TITLE
remove NA option

### DIFF
--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -62,8 +62,7 @@
         "S15": "Clirio'r sgrîn wynt",
         "S16": "Diniwlio’r sgrîn wynt",
         "S17": "Goleuadau niwl cefn",
-        "S18": "Wedi'u dipio i'r brif olau",
-        "N/A": "[Cy] Not applicable"
+        "S18": "Wedi'u dipio i'r brif olau"
       },
       "C1": {
         "T1": "Ffactorau diogelwch wrth lwytho",
@@ -93,8 +92,7 @@
         "S15": "Clirio'r sgrîn wynt",
         "S16": "Diniwlio’r sgrîn wynt",
         "S17": "Goleuadau niwl cefn",
-        "S18": "Wedi'u dipio i'r brif olau",
-        "N/A": "[Cy] Not applicable"
+        "S18": "Wedi'u dipio i'r brif olau"
       },
       "C+E": {
         "T1": "Cyflwr y ffrâm",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -62,8 +62,7 @@
         "S15": "Clean windscreen",
         "S16": "Demist windscreen",
         "S17": "Rear fog lights",
-        "S18": "Dipped to main beam",
-        "N/A": "Not applicable"
+        "S18": "Dipped to main beam"
       },
       "C1": {
         "T1": "Safety factors while loading",
@@ -93,8 +92,7 @@
         "S15": "Clean windscreen",
         "S16": "Demist windscreen",
         "S17": "Rear fog lights",
-        "S18": "Dipped to main beam",
-        "N/A": "Not applicable"
+        "S18": "Dipped to main beam"
       },
       "C+E": {
         "T1": "Body condition",
@@ -113,8 +111,7 @@
         "S8": "Demist windscreen",
         "S9": "Rear fog lights",
         "S10": "Dipped to main beam",
-        "S11": "Brake lights",
-        "N/A": "Not applicable"
+        "S11": "Brake lights"
       },
       "C1+E": {
         "T1": "Body condition",
@@ -133,8 +130,7 @@
         "S8": "Demist windscreen",
         "S9": "Rear fog lights",
         "S10": "Dipped to main beam",
-        "S11": "Brake lights",
-        "N/A": "Not applicable"
+        "S11": "Brake lights"
       }
     },
     "competencies": {

--- a/src/shared/constants/show-me-questions/show-me-questions.vocational-trailer.constants.ts
+++ b/src/shared/constants/show-me-questions/show-me-questions.vocational-trailer.constants.ts
@@ -61,12 +61,6 @@ export default [
     description: 'Show me how you would check that the brake lights are working on this vehicle. (I can assist you, if you need to switch the ignition on, please don’t start the engine)',
     shortName: 'Brake lights',
   },
-  {
-    code: 'N/A',
-    description: 'Not applicable.',
-    shortName: 'Not applicable',
-  },
-
 ] as VehicleChecksQuestion[];
 
 export const NUMBER_OF_SHOW_ME_QUESTIONS = 1;

--- a/src/shared/constants/show-me-questions/show-me-questions.vocational.constants.ts
+++ b/src/shared/constants/show-me-questions/show-me-questions.vocational.constants.ts
@@ -85,12 +85,6 @@ export default [
     description: 'Show me how you switch your headlight from dipped to main beam',
     shortName: 'Dipped to main beam',
   },
-  {
-    code: 'N/A',
-    description: 'Not applicable.',
-    shortName: 'Not applicable',
-  },
-
 ] as VehicleChecksQuestion[];
 
 export const NUMBER_OF_SHOW_ME_QUESTIONS = 3;


### PR DESCRIPTION
Show me questions for Cat C and sub categories appear with N/A as an option.
This can be chosen and a driving fault allocated it against it.

The fix is to remove N/A as an option for Cat C and subcats

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number
