### PR TITLE
Adding UI test run data to HTML report

### DIFF
--- a/generateTestReport.js
+++ b/generateTestReport.js
@@ -1,11 +1,38 @@
+var fs = require('fs');
+var xml2js = require('xml2js');
 var reporter = require('cucumber-html-reporter');
+
+var parser = new xml2js.Parser();
+let xml_string = fs.readFileSync("config.xml", "utf8");
+var appVersion = '1.0.0';
+parser.parseString(xml_string, function (err, result) {
+  appVersion = result['widget'].$.version;
+});
+
+let e2eTestConfig = fs.readFileSync('test-reports/e2e-test-config.json');
+let e2eConfig = JSON.parse(e2eTestConfig);
+
+let metaDataContent = {};
+metaDataContent["App Version"] = appVersion,
+metaDataContent["Platform Name"] = e2eConfig.capabilities.platformName;
+metaDataContent["Platform Version"] = e2eConfig.capabilities.platformVersion;
+metaDataContent["Device Name"] = e2eConfig.capabilities.deviceName;
+metaDataContent["Date"] = new Date();
+metaDataContent["Tags"] = (e2eConfig.cucumberOpts.tags == undefined) ? 'Not specified' : e2eConfig.cucumberOpts.tags;
+
+let features = '<br/>'
+e2eConfig.specs.forEach((spec) => {
+  features = features + spec.substr(spec.indexOf("/test/"), spec.length) + '<br/>';
+});
+metaDataContent["Feature Files"] = features;
 
 var options = {
   theme: 'bootstrap',
   jsonFile: 'test-reports/cucumber-report.json',
   output: 'test-reports/cucumber-report.html',
   reportSuiteAsScenarios: true,
-  launchReport: false
+  launchReport: false,
+  metadata: metaDataContent
 };
 
 reporter.generate(options);

--- a/test/e2e/step-definitions/generic-steps.ts
+++ b/test/e2e/step-definitions/generic-steps.ts
@@ -10,11 +10,13 @@ const {
   setDefaultTimeout,
   After,
   Status,
+  AfterAll,
 } = require('cucumber');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 const expect = chai.expect;
+const fs = require('fs');
 
 this.testCategory = 'b';
 
@@ -245,6 +247,19 @@ After(function (testCase) {
       this.attach(screenShot, 'image/png');
     });
   }
+});
+
+/**
+ * Output the UI processed config so it may be included in the HTML report.
+ */
+AfterAll(() => {
+  browser.getProcessedConfig().then((config) => {
+    fs.writeFile('./test-reports/e2e-test-config.json', JSON.stringify(config), (err) => {
+      if (err) {
+        return console.log(err);
+      }
+    });
+  });
 });
 
 //////////////////////////////////////////// SHARED FUNCTIONS ////////////////////////////////////////////


### PR DESCRIPTION
Updated UI tests to output some of the run config into the HTML report so it is clear what was run.

Note that the version is taken from the config.xml file so might not be accurate if it has not been updated.