### PR TITLE
Tech/journal performance

### DIFF
--- a/src/providers/slot/__tests__/slot.spec.ts
+++ b/src/providers/slot/__tests__/slot.spec.ts
@@ -443,4 +443,18 @@ describe('SlotProvider', () => {
     });
   });
 
+  describe('dateDiffInDays', () => {
+    it('should return 0 days as the date is the same as the periodDate', () => {
+      const date: Date = new Date('2019-01-10');
+      const periodDate: Date = new Date('2019-01-10');
+      expect(slotProvider.dateDiffInDays(date, periodDate)).toEqual(0);
+    });
+
+    it('should return 3 days difference between the date and the periodDate', () => {
+      const date: Date = new Date('2019-01-07');
+      const periodDate: Date = new Date('2019-01-10');
+      expect(slotProvider.dateDiffInDays(date, periodDate)).toEqual(3);
+    });
+  });
+
 });

--- a/src/providers/slot/slot.ts
+++ b/src/providers/slot/slot.ts
@@ -73,7 +73,7 @@ export class SlotProvider {
       numberOfDaysToView,
       (d: number): string => this.dateTimeProvider.now().add(d, Duration.DAY).format('YYYY-MM-DD'),
     );
-    const emptyDays = days.reduce((days: { [k: string]: SlotItem[] }, day: string) => ({...days, [day]: []}), {});
+    const emptyDays = days.reduce((days: { [k: string]: SlotItem[] }, day: string) => ({ ...days, [day]: [] }), {});
 
     return {
       ...emptyDays,
@@ -99,7 +99,7 @@ export class SlotProvider {
   getSlotDate = (slot: SlotItem): string => DateTime.at(slot.slotData.slotDetail.start).format('YYYY-MM-DD');
 
   canStartTest(testSlot: TestSlot): boolean {
-    const {testPermissionPeriods} = this.appConfigProvider.getAppConfig().journal;
+    const { testPermissionPeriods } = this.appConfigProvider.getAppConfig().journal;
     const testCategory = get(testSlot, 'booking.application.testCategory');
     const startDate = new DateTime(testSlot.slotDetail.start);
     const slotStartDate: Date = new Date(testSlot.slotDetail.start);
@@ -116,19 +116,20 @@ export class SlotProvider {
     return periodsPermittingStart.length > 0;
   }
 
-  private dateDiffInDays = (startDate: Date, periodDate: Date) => {
-    if (!periodDate) {
-      // Discard the time and time-zone information.
-      const utc1: number = Date.UTC(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
-      const utc2: number = Date.UTC(periodDate.getFullYear(), periodDate.getMonth(), periodDate.getDate());
-      return Math.floor((utc2 - utc1) / MS_PER_DAY);
-    }
-    return false;
+  private dateDiffInDays = (startDate: Date, periodDate: Date): number => {
+    // Discard the time and time-zone information.
+    const utc1: number = Date.UTC(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+    const utc2: number = Date.UTC(periodDate.getFullYear(), periodDate.getMonth(), periodDate.getDate());
+    return Math.floor((utc2 - utc1) / MS_PER_DAY);
   }
 
   private hasPeriodStartCriteria = (slotDate: Date, periodFrom: string): boolean =>
-    this.dateDiffInDays(slotDate, new Date(periodFrom)) <= 0;
+    this.dateDiffInDays(slotDate, new Date(periodFrom)) <= 0
 
-  private hasPeriodEndCriteria = (slotDate: Date, periodFrom: string): boolean =>
-    this.dateDiffInDays(slotDate, new Date(periodFrom)) >= 0;
+  private hasPeriodEndCriteria = (slotDate: Date, periodFrom: string): boolean => {
+    if (!periodFrom) {
+      return true;
+    }
+    return this.dateDiffInDays(slotDate, new Date(periodFrom)) >= 0;
+  }
 }

--- a/src/providers/slot/slot.ts
+++ b/src/providers/slot/slot.ts
@@ -116,7 +116,7 @@ export class SlotProvider {
     return periodsPermittingStart.length > 0;
   }
 
-  private dateDiffInDays = (startDate: Date, periodDate: Date): number => {
+  public dateDiffInDays = (startDate: Date, periodDate: Date): number => {
     // Discard the time and time-zone information.
     const utc1: number = Date.UTC(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
     const utc2: number = Date.UTC(periodDate.getFullYear(), periodDate.getMonth(), periodDate.getDate());
@@ -126,10 +126,10 @@ export class SlotProvider {
   private hasPeriodStartCriteria = (slotDate: Date, periodFrom: string): boolean =>
     this.dateDiffInDays(slotDate, new Date(periodFrom)) <= 0
 
-  private hasPeriodEndCriteria = (slotDate: Date, periodFrom: string): boolean => {
-    if (!periodFrom) {
+  private hasPeriodEndCriteria = (slotDate: Date, periodTo: string): boolean => {
+    if (!periodTo) {
       return true;
     }
-    return this.dateDiffInDays(slotDate, new Date(periodFrom)) >= 0;
+    return this.dateDiffInDays(slotDate, new Date(periodTo)) >= 0;
   }
 }


### PR DESCRIPTION
## Description
After some digging around, noticed that the canStartTest function in the Slot provider was causing the performance issue. Then subsequently traced the source of the problem to the use of moment in the DateTime class. The use of Moment was in a loop that was firing extensively and causing memory issues. After using the JS date functions instead started to notice vast improvements. Not sure if its worth investigating using a different version of Moment as a test to see if that has any bearing.
## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
