### PR TITLE
Feature mes 4741 green visual cue

### DIFF
--- a/src/pages/test-report/cat-d/components/safety-questions/safety-questions.cat-d.scss
+++ b/src/pages/test-report/cat-d/components/safety-questions/safety-questions.cat-d.scss
@@ -19,7 +19,6 @@ safety-questions-cat-d {
     }
 
     .competency-label {
-      margin-left: 5px;
       font-size: 15px;
       margin-right: 4px;
     }

--- a/src/pages/test-report/components/multi-legal-requirement/multi-legal-requirement.html
+++ b/src/pages/test-report/components/multi-legal-requirement/multi-legal-requirement.html
@@ -3,7 +3,7 @@
   [onPress]="toggleLegalRequirement"
   [ripple]="false"
   [ngClass]="{
-    'complete': ticked
+    'complete': requirement1Ticked && requirement2Ticked
   }"
 >
   <div class="tickwrapper">


### PR DESCRIPTION
Legal requirements highlight the button and text of the button in green when the legal requirement has been met.  This wasn't working for multi-legal-requirement  buttons.  Fixed so this now shows correctly.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number
