### PR TITLE
Hiding the speed requirement card in debrief when no data is entered

### DIFF
--- a/src/pages/debrief/cat-a-mod1/components/speed-check-debrief-card/speed-check-debrief-card.html
+++ b/src/pages/debrief/cat-a-mod1/components/speed-check-debrief-card/speed-check-debrief-card.html
@@ -1,4 +1,4 @@
-<ion-card id="speed-check">
+<ion-card id="speed-check" *ngIf="emergencyStop.firstAttempt || avoidance.firstAttempt">
   <ion-card-header>
     <ion-card-title>
       <h4 class="fault-heading">{{ 'debrief.speedRequirementsHeader' | translate }}</h4>


### PR DESCRIPTION
## Description
Hides the speed requirement card in mod1 when the test is terminated without the competency being attempted.

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
