### PR TITLE
Adds school bike toggle action to cat a vehicle details reducer

### DIFF
--- a/src/modules/tests/vehicle-details/cat-a-mod1/vehicle-details.cat-a-mod1.reducer.ts
+++ b/src/modules/tests/vehicle-details/cat-a-mod1/vehicle-details.cat-a-mod1.reducer.ts
@@ -26,6 +26,11 @@ export const vehicleDetailsCatAMod1Reducer = (
         ...state,
         gearboxCategory: null,
       };
+    case vehicleDetailsActions.SCHOOL_BIKE_TOGGLED:
+      return {
+        ...state,
+        schoolBike: !state.schoolBike,
+      };
     default:
       return state;
   }

--- a/src/modules/tests/vehicle-details/common/vehicle-details.actions.ts
+++ b/src/modules/tests/vehicle-details/common/vehicle-details.actions.ts
@@ -42,6 +42,7 @@ export class PopulateVehicleDimensions implements Action {
 export type Types =
   | VehicleRegistrationChanged
   | SchoolCarToggled
+  | SchoolBikeToggled
   | DualControlsToggled
   | GearboxCategoryChanged
   | ClearGearboxCategory


### PR DESCRIPTION
## Description
- Fixes issue with Cat A Mod 1 School Bike toggle not updating ngrx store.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
