### PR TITLE
Mes 4906 comment boxes missing on office screen for failed test mod1

### DIFF
--- a/src/pages/office/cat-a-mod1/office.cat-a-mod1.page.html
+++ b/src/pages/office/cat-a-mod1/office.cat-a-mod1.page.html
@@ -134,6 +134,7 @@
         [outcome]="pageState.testOutcome$ | async"
         faultType="dangerous"
         header="Dangerous faults"
+        [maxFaultCount]=5
         (faultCommentsChange)="dangerousFaultCommentChanged($event)"
       >
       </fault-comment-card>
@@ -143,6 +144,7 @@
         [faultComments]="pageState.seriousFaults$ | async"
         [shouldRender]="(pageState.seriousFaults$ | async).length > 0  && pageState.displaySeriousFault$ | async"
         [outcome]="pageState.testOutcome$ | async"
+        [maxFaultCount]=5
         faultType="serious"
         header="Serious faults"
         (faultCommentsChange)="seriousFaultCommentChanged($event)"
@@ -155,6 +157,7 @@
         [faultComments]="pageState.drivingFaults$ | async"
         [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && (pageState.displayDrivingFault$ | async)"
         [outcome]="pageState.testOutcome$ | async"
+        [maxFaultCount]=5
         faultType="driving"
         header="Driving faults"
         [faultCount]="pageState.drivingFaultCount$ | async"

--- a/src/pages/office/cat-a-mod1/office.cat-a-mod1.page.html
+++ b/src/pages/office/cat-a-mod1/office.cat-a-mod1.page.html
@@ -134,7 +134,7 @@
         [outcome]="pageState.testOutcome$ | async"
         faultType="dangerous"
         header="Dangerous faults"
-        [maxFaultCount]=5
+        [maxFaultCount]="maxFaultCount"
         (faultCommentsChange)="dangerousFaultCommentChanged($event)"
       >
       </fault-comment-card>
@@ -144,7 +144,7 @@
         [faultComments]="pageState.seriousFaults$ | async"
         [shouldRender]="(pageState.seriousFaults$ | async).length > 0  && pageState.displaySeriousFault$ | async"
         [outcome]="pageState.testOutcome$ | async"
-        [maxFaultCount]=5
+        [maxFaultCount]="maxFaultCount"
         faultType="serious"
         header="Serious faults"
         (faultCommentsChange)="seriousFaultCommentChanged($event)"
@@ -157,7 +157,7 @@
         [faultComments]="pageState.drivingFaults$ | async"
         [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && (pageState.displayDrivingFault$ | async)"
         [outcome]="pageState.testOutcome$ | async"
-        [maxFaultCount]=5
+        [maxFaultCount]="maxFaultCount"
         faultType="driving"
         header="Driving faults"
         [faultCount]="pageState.drivingFaultCount$ | async"

--- a/src/pages/office/cat-a-mod1/office.cat-a-mod1.page.ts
+++ b/src/pages/office/cat-a-mod1/office.cat-a-mod1.page.ts
@@ -148,6 +148,7 @@ export class OfficeCatAMod1Page extends BasePageComponent {
   drivingFaultCtrl: String = 'drivingFaultCtrl';
   seriousFaultCtrl: String = 'seriousFaultCtrl';
   dangerousFaultCtrl: String = 'dangerousFaultCtrl';
+  static readonly maxFaultCount = 5;
 
   weatherConditions: WeatherConditionSelection[];
   activityCodeOptions: ActivityCodeModel[];

--- a/src/pages/office/cat-a-mod1/office.cat-a-mod1.page.ts
+++ b/src/pages/office/cat-a-mod1/office.cat-a-mod1.page.ts
@@ -554,6 +554,6 @@ export class OfficeCatAMod1Page extends BasePageComponent {
     const seriousFaultCount: number = this.faultCountProvider.getSeriousFaultSumCount(category, data);
     const dangerousFaultCount: number = this.faultCountProvider.getDangerousFaultSumCount(category, data);
 
-    return dangerousFaultCount === 0 && seriousFaultCount === 0 && drivingFaultCount > 15;
+    return dangerousFaultCount === 0 && seriousFaultCount === 0 && drivingFaultCount > 5;
   }
 }

--- a/src/pages/office/cat-a-mod2/office.cat-a-mod2.page.html
+++ b/src/pages/office/cat-a-mod2/office.cat-a-mod2.page.html
@@ -117,21 +117,21 @@
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.dangerousFaults$ | async"
         [shouldRender]="(pageState.dangerousFaults$ | async).length > 0 && pageState.displayDangerousFault$ | async"
         [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults"
-        [maxFaultCount]=5
+        [maxFaultCount]="maxFaultCount"
         (faultCommentsChange)="dangerousFaultCommentChanged($event)">
       </fault-comment-card>
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.seriousFaults$ | async"
         [shouldRender]="(pageState.seriousFaults$ | async).length > 0  && pageState.displaySeriousFault$ | async"
         [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults"
-        [maxFaultCount]=5
+        [maxFaultCount]="maxFaultCount"
         (faultCommentsChange)="seriousFaultCommentChanged($event)">
       </fault-comment-card>
 
       <fault-comment-card id="driving-fault-comment-card" [formGroup]="form" [faultComments]="pageState.drivingFaults$ | async"
         [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && (pageState.displayDrivingFault$ | async)"
         [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async"
-        [maxFaultCount]=5
+        [maxFaultCount]="maxFaultCount"
         (faultCommentsChange)="drivingFaultCommentChanged($event)">
       </fault-comment-card>
 

--- a/src/pages/office/cat-a-mod2/office.cat-a-mod2.page.html
+++ b/src/pages/office/cat-a-mod2/office.cat-a-mod2.page.html
@@ -117,18 +117,21 @@
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.dangerousFaults$ | async"
         [shouldRender]="(pageState.dangerousFaults$ | async).length > 0 && pageState.displayDangerousFault$ | async"
         [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults"
+        [maxFaultCount]=5
         (faultCommentsChange)="dangerousFaultCommentChanged($event)">
       </fault-comment-card>
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.seriousFaults$ | async"
         [shouldRender]="(pageState.seriousFaults$ | async).length > 0  && pageState.displaySeriousFault$ | async"
         [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults"
+        [maxFaultCount]=5
         (faultCommentsChange)="seriousFaultCommentChanged($event)">
       </fault-comment-card>
 
       <fault-comment-card id="driving-fault-comment-card" [formGroup]="form" [faultComments]="pageState.drivingFaults$ | async"
         [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && (pageState.displayDrivingFault$ | async)"
         [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async"
+        [maxFaultCount]=5
         (faultCommentsChange)="drivingFaultCommentChanged($event)">
       </fault-comment-card>
 

--- a/src/pages/office/cat-a-mod2/office.cat-a-mod2.page.ts
+++ b/src/pages/office/cat-a-mod2/office.cat-a-mod2.page.ts
@@ -164,6 +164,7 @@ export class OfficeCatAMod2Page extends BasePageComponent {
   drivingFaultCtrl: String = 'drivingFaultCtrl';
   seriousFaultCtrl: String = 'seriousFaultCtrl';
   dangerousFaultCtrl: String = 'dangerousFaultCtrl';
+  static readonly maxFaultCount = 5;
 
   weatherConditions: WeatherConditionSelection[];
   activityCodeOptions: ActivityCodeModel[];

--- a/src/pages/office/cat-b/office.cat-b.page.html
+++ b/src/pages/office/cat-b/office.cat-b.page.html
@@ -124,17 +124,17 @@
       </ion-card>
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.dangerousFaults$ | async" [shouldRender]="(pageState.dangerousFaults$ | async).length > 0 && pageState.displayDangerousFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults" [maxFaultCount]=15
+        [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults" [maxFaultCount]="maxFaultCount"
         (faultCommentsChange)="dangerousFaultCommentChanged($event)">
       </fault-comment-card>
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.seriousFaults$ | async" [shouldRender]="(pageState.seriousFaults$ | async).length > 0  && pageState.displaySeriousFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" (faultCommentsChange)="seriousFaultCommentChanged($event)" [maxFaultCount]=15>
+        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" (faultCommentsChange)="seriousFaultCommentChanged($event)" [maxFaultCount]="maxFaultCount">
       </fault-comment-card>
 
       <fault-comment-card id="driving-fault-comment-card" [formGroup]="form" [faultComments]="pageState.drivingFaults$ | async"
         [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && pageState.displayDrivingFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async" [maxFaultCount]=15
+        [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async" [maxFaultCount]="maxFaultCount"
         (faultCommentsChange)="drivingFaultCommentChanged($event)">
       </fault-comment-card>
 

--- a/src/pages/office/cat-b/office.cat-b.page.html
+++ b/src/pages/office/cat-b/office.cat-b.page.html
@@ -124,17 +124,17 @@
       </ion-card>
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.dangerousFaults$ | async" [shouldRender]="(pageState.dangerousFaults$ | async).length > 0 && pageState.displayDangerousFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults"
+        [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults" [maxFaultCount]=15
         (faultCommentsChange)="dangerousFaultCommentChanged($event)">
       </fault-comment-card>
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.seriousFaults$ | async" [shouldRender]="(pageState.seriousFaults$ | async).length > 0  && pageState.displaySeriousFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" (faultCommentsChange)="seriousFaultCommentChanged($event)">
+        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" (faultCommentsChange)="seriousFaultCommentChanged($event)" [maxFaultCount]=15>
       </fault-comment-card>
 
       <fault-comment-card id="driving-fault-comment-card" [formGroup]="form" [faultComments]="pageState.drivingFaults$ | async"
         [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && pageState.displayDrivingFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async"
+        [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async" [maxFaultCount]=15
         (faultCommentsChange)="drivingFaultCommentChanged($event)">
       </fault-comment-card>
 

--- a/src/pages/office/cat-b/office.cat-b.page.ts
+++ b/src/pages/office/cat-b/office.cat-b.page.ts
@@ -166,6 +166,7 @@ export class OfficeCatBPage extends PracticeableBasePageComponent {
   drivingFaultCtrl: String = 'drivingFaultCtrl';
   seriousFaultCtrl: String = 'seriousFaultCtrl';
   dangerousFaultCtrl: String = 'dangerousFaultCtrl';
+  static readonly maxFaultCount = 15;
 
   weatherConditions: WeatherConditionSelection[];
   showMeQuestions: VehicleChecksQuestion[];

--- a/src/pages/office/cat-be/office.cat-be.page.html
+++ b/src/pages/office/cat-be/office.cat-be.page.html
@@ -116,19 +116,20 @@
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.dangerousFaults$ | async"
         [shouldRender]="(pageState.dangerousFaults$ | async).length > 0 && pageState.displayDangerousFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults"
+        [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults" [maxFaultCount]=15
         (faultCommentsChange)="dangerousFaultCommentChanged($event)">
       </fault-comment-card>
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.seriousFaults$ | async"
         [shouldRender]="(pageState.seriousFaults$ | async).length > 0  && pageState.displaySeriousFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults"
+        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" [maxFaultCount]=15
         (faultCommentsChange)="seriousFaultCommentChanged($event)">
       </fault-comment-card>
 
       <fault-comment-card id="driving-fault-comment-card" [formGroup]="form" [faultComments]="pageState.drivingFaults$ | async"
         [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && (pageState.displayDrivingFault$ | async)"
         [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async"
+        [maxFaultCount]=15
         (faultCommentsChange)="drivingFaultCommentChanged($event)">
       </fault-comment-card>
 

--- a/src/pages/office/cat-be/office.cat-be.page.html
+++ b/src/pages/office/cat-be/office.cat-be.page.html
@@ -116,20 +116,20 @@
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.dangerousFaults$ | async"
         [shouldRender]="(pageState.dangerousFaults$ | async).length > 0 && pageState.displayDangerousFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults" [maxFaultCount]=15
+        [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults" [maxFaultCount]="maxFaultCount"
         (faultCommentsChange)="dangerousFaultCommentChanged($event)">
       </fault-comment-card>
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.seriousFaults$ | async"
         [shouldRender]="(pageState.seriousFaults$ | async).length > 0  && pageState.displaySeriousFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" [maxFaultCount]=15
+        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" [maxFaultCount]="maxFaultCount"
         (faultCommentsChange)="seriousFaultCommentChanged($event)">
       </fault-comment-card>
 
       <fault-comment-card id="driving-fault-comment-card" [formGroup]="form" [faultComments]="pageState.drivingFaults$ | async"
         [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && (pageState.displayDrivingFault$ | async)"
         [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async"
-        [maxFaultCount]=15
+        [maxFaultCount]="maxFaultCount"
         (faultCommentsChange)="drivingFaultCommentChanged($event)">
       </fault-comment-card>
 

--- a/src/pages/office/cat-be/office.cat-be.page.ts
+++ b/src/pages/office/cat-be/office.cat-be.page.ts
@@ -157,6 +157,7 @@ export class OfficeCatBEPage extends BasePageComponent {
   drivingFaultCtrl: String = 'drivingFaultCtrl';
   seriousFaultCtrl: String = 'seriousFaultCtrl';
   dangerousFaultCtrl: String = 'dangerousFaultCtrl';
+  static readonly maxFaultCount = 15;
 
   weatherConditions: WeatherConditionSelection[];
   activityCodeOptions: ActivityCodeModel[];

--- a/src/pages/office/cat-c/office.cat-c.page.html
+++ b/src/pages/office/cat-c/office.cat-c.page.html
@@ -108,17 +108,17 @@
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.dangerousFaults$ | async" [shouldRender]="(pageState.dangerousFaults$ | async).length > 0 && pageState.displayDangerousFault$ | async"
         [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults"
-        (faultCommentsChange)="dangerousFaultCommentChanged($event)" [maxFaultCount]=15>
+        (faultCommentsChange)="dangerousFaultCommentChanged($event)" [maxFaultCount]="maxFaultCount">
       </fault-comment-card>
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.seriousFaults$ | async" [shouldRender]="(pageState.seriousFaults$ | async).length > 0  && pageState.displaySeriousFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" (faultCommentsChange)="seriousFaultCommentChanged($event)" [maxFaultCount]=15>
+        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" (faultCommentsChange)="seriousFaultCommentChanged($event)" [maxFaultCount]="maxFaultCount">
       </fault-comment-card>
 
       <fault-comment-card id="driving-fault-comment-card" [formGroup]="form" [faultComments]="pageState.drivingFaults$ | async"
         [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && (pageState.displayDrivingFault$ | async)"
         [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async"
-        (faultCommentsChange)="drivingFaultCommentChanged($event)" [maxFaultCount]=15>
+        (faultCommentsChange)="drivingFaultCommentChanged($event)" [maxFaultCount]="maxFaultCount">
       </fault-comment-card>
 
       <ion-card id="driving-fault-no-commentary" *ngIf="!(pageState.displayDrivingFaultComments$ | async) && (pageState.drivingFaultCount$ | async) > 0 && pageState.displayDrivingFault$ | async">

--- a/src/pages/office/cat-c/office.cat-c.page.html
+++ b/src/pages/office/cat-c/office.cat-c.page.html
@@ -108,17 +108,17 @@
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.dangerousFaults$ | async" [shouldRender]="(pageState.dangerousFaults$ | async).length > 0 && pageState.displayDangerousFault$ | async"
         [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults"
-        (faultCommentsChange)="dangerousFaultCommentChanged($event)">
+        (faultCommentsChange)="dangerousFaultCommentChanged($event)" [maxFaultCount]=15>
       </fault-comment-card>
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.seriousFaults$ | async" [shouldRender]="(pageState.seriousFaults$ | async).length > 0  && pageState.displaySeriousFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" (faultCommentsChange)="seriousFaultCommentChanged($event)">
+        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" (faultCommentsChange)="seriousFaultCommentChanged($event)" [maxFaultCount]=15>
       </fault-comment-card>
 
       <fault-comment-card id="driving-fault-comment-card" [formGroup]="form" [faultComments]="pageState.drivingFaults$ | async"
         [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && (pageState.displayDrivingFault$ | async)"
         [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async"
-        (faultCommentsChange)="drivingFaultCommentChanged($event)">
+        (faultCommentsChange)="drivingFaultCommentChanged($event)" [maxFaultCount]=15>
       </fault-comment-card>
 
       <ion-card id="driving-fault-no-commentary" *ngIf="!(pageState.displayDrivingFaultComments$ | async) && (pageState.drivingFaultCount$ | async) > 0 && pageState.displayDrivingFault$ | async">

--- a/src/pages/office/cat-c/office.cat-c.page.ts
+++ b/src/pages/office/cat-c/office.cat-c.page.ts
@@ -163,6 +163,7 @@ export class OfficeCatCPage extends BasePageComponent {
   drivingFaultCtrl: String = 'drivingFaultCtrl';
   seriousFaultCtrl: String = 'seriousFaultCtrl';
   dangerousFaultCtrl: String = 'dangerousFaultCtrl';
+  static readonly maxFaultCount = 15;
 
   weatherConditions: WeatherConditionSelection[];
   activityCodeOptions: ActivityCodeModel[];

--- a/src/pages/office/cat-d/office.cat-d.page.html
+++ b/src/pages/office/cat-d/office.cat-d.page.html
@@ -108,17 +108,17 @@
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.dangerousFaults$ | async" [shouldRender]="(pageState.dangerousFaults$ | async).length > 0 && pageState.displayDangerousFault$ | async"
         [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults"
-        (faultCommentsChange)="dangerousFaultCommentChanged($event)" [maxFaultCount]=15>
+        (faultCommentsChange)="dangerousFaultCommentChanged($event)" [maxFaultCount]="maxFaultCount">
       </fault-comment-card>
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.seriousFaults$ | async" [shouldRender]="(pageState.seriousFaults$ | async).length > 0  && pageState.displaySeriousFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" (faultCommentsChange)="seriousFaultCommentChanged($event)" [maxFaultCount]=15>
+        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" (faultCommentsChange)="seriousFaultCommentChanged($event)" [maxFaultCount]="maxFaultCount">
       </fault-comment-card>
 
       <fault-comment-card id="driving-fault-comment-card" [formGroup]="form" [faultComments]="pageState.drivingFaults$ | async"
         [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && (pageState.displayDrivingFault$ | async)"
         [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async"
-        (faultCommentsChange)="drivingFaultCommentChanged($event)" [maxFaultCount]=15>
+        (faultCommentsChange)="drivingFaultCommentChanged($event)" [maxFaultCount]="maxFaultCount">
       </fault-comment-card>
 
       <ion-card id="driving-fault-no-commentary" *ngIf="!(pageState.displayDrivingFaultComments$ | async) && (pageState.drivingFaultCount$ | async) > 0 && pageState.displayDrivingFault$ | async">

--- a/src/pages/office/cat-d/office.cat-d.page.html
+++ b/src/pages/office/cat-d/office.cat-d.page.html
@@ -108,17 +108,17 @@
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.dangerousFaults$ | async" [shouldRender]="(pageState.dangerousFaults$ | async).length > 0 && pageState.displayDangerousFault$ | async"
         [outcome]="pageState.testOutcome$ | async" faultType="dangerous" header="Dangerous faults"
-        (faultCommentsChange)="dangerousFaultCommentChanged($event)">
+        (faultCommentsChange)="dangerousFaultCommentChanged($event)" [maxFaultCount]=15>
       </fault-comment-card>
 
       <fault-comment-card [formGroup]="form" [faultComments]="pageState.seriousFaults$ | async" [shouldRender]="(pageState.seriousFaults$ | async).length > 0  && pageState.displaySeriousFault$ | async"
-        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" (faultCommentsChange)="seriousFaultCommentChanged($event)">
+        [outcome]="pageState.testOutcome$ | async" faultType="serious" header="Serious faults" (faultCommentsChange)="seriousFaultCommentChanged($event)" [maxFaultCount]=15>
       </fault-comment-card>
 
       <fault-comment-card id="driving-fault-comment-card" [formGroup]="form" [faultComments]="pageState.drivingFaults$ | async"
         [shouldRender]="(pageState.displayDrivingFaultComments$ | async) && (pageState.displayDrivingFault$ | async)"
         [outcome]="pageState.testOutcome$ | async" faultType="driving" header="Driving faults" [faultCount]="pageState.drivingFaultCount$ | async"
-        (faultCommentsChange)="drivingFaultCommentChanged($event)">
+        (faultCommentsChange)="drivingFaultCommentChanged($event)" [maxFaultCount]=15>
       </fault-comment-card>
 
       <ion-card id="driving-fault-no-commentary" *ngIf="!(pageState.displayDrivingFaultComments$ | async) && (pageState.drivingFaultCount$ | async) > 0 && pageState.displayDrivingFault$ | async">

--- a/src/pages/office/cat-d/office.cat-d.page.ts
+++ b/src/pages/office/cat-d/office.cat-d.page.ts
@@ -163,6 +163,7 @@ export class OfficeCatDPage extends BasePageComponent {
   drivingFaultCtrl: String = 'drivingFaultCtrl';
   seriousFaultCtrl: String = 'seriousFaultCtrl';
   dangerousFaultCtrl: String = 'dangerousFaultCtrl';
+  static readonly maxFaultCount = 15;
 
   weatherConditions: WeatherConditionSelection[];
   activityCodeOptions: ActivityCodeModel[];

--- a/src/pages/office/components/fault-comment-card/fault-comment-card.html
+++ b/src/pages/office/components/fault-comment-card/fault-comment-card.html
@@ -6,7 +6,7 @@
     <ion-card-content >
       <ion-row class="mes-validated-row mes-row-separator" *ngFor="let faultComment of faultComments">
         <fault-comment [parentForm]="formGroup" [faultComment]="faultComment" [faultType]="faultType" [shouldRender]="shouldRender"
-          [faultCount]="faultCount" [outcome]="outcome" (faultCommentChange)="faultCommentChanged($event)">
+          [faultCount]="faultCount" [outcome]="outcome" (faultCommentChange)="faultCommentChanged($event)" [maxFaultCount]="maxFaultCount">
         </fault-comment>
       </ion-row>
     </ion-card-content>

--- a/src/pages/office/components/fault-comment-card/fault-comment-card.ts
+++ b/src/pages/office/components/fault-comment-card/fault-comment-card.ts
@@ -28,6 +28,9 @@ export class FaultCommentCardComponent {
   @Input()
   faultCount: number;
 
+  @Input()
+  maxFaultCount: number;
+
   @Output()
   faultCommentsChange = new EventEmitter<FaultSummary>();
 

--- a/src/pages/office/components/fault-comment/fault-comment.ts
+++ b/src/pages/office/components/fault-comment/fault-comment.ts
@@ -18,7 +18,7 @@ enum ValidFaultTypes {
 })
 
 export class FaultCommentComponent implements OnChanges {
-  static readonly maxFaultCount = 15;
+
   @Input()
   outcome: string;
 
@@ -36,6 +36,9 @@ export class FaultCommentComponent implements OnChanges {
 
   @Input()
   shouldRender: boolean;
+
+  @Input()
+  maxFaultCount: number;
 
   @Output()
   faultCommentChange = new EventEmitter<FaultSummary>();
@@ -65,7 +68,7 @@ export class FaultCommentComponent implements OnChanges {
       return true;
     }
 
-    if (this.faultCount && this.faultCount <= FaultCommentComponent.maxFaultCount) {
+    if (this.faultCount && this.maxFaultCount && this.faultCount <= this.maxFaultCount) {
       return true;
     }
   }


### PR DESCRIPTION
## Description
Mes-4906 corrected driving fault count on office page to be 5 not 15. Added maxfaultcount input instead of constant to office pages in order for catA to show comments on the office screen.
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
