### PR TITLE
MES-4118 Vehicle Check Faults Display Fix + Termination Error

### DIFF
--- a/src/pages/debrief/components/vehicle-checks-card/__mocks__/vehicle-checks-card.mock.ts
+++ b/src/pages/debrief/components/vehicle-checks-card/__mocks__/vehicle-checks-card.mock.ts
@@ -1,42 +1,28 @@
 import { QuestionResult } from '@dvsa/mes-test-schema/categories/common';
 
-export class VehicleChecksCardMock {
-
-  private static instance: VehicleChecksCardMock;
-
-  private constructor() { }
-
-  public static getInstance(): VehicleChecksCardMock {
-    if (!VehicleChecksCardMock.instance) {
-      VehicleChecksCardMock.instance = new VehicleChecksCardMock();
-    }
-    return VehicleChecksCardMock.instance;
-  }
-
-  public getMalformedVehicleChecks(): QuestionResult[] {
-    return [
-      {
-        code: 'T1',
-        description: 'Safety factors while loading',
-      },
-      {
-        code: 'T2',
-        description: 'Reflectors condition',
-        outcome: 'DF',
-      },
-      {
-        code: 'S1',
-        description: 'All doors secure',
-      },
-      {
-        code: 'S2',
-        description: 'Air leaks',
-        outcome: 'P',
-      },
-      {
-        code: 'S4',
-        description: 'Mudguards condition',
-      },
-    ];
-  }
-}
+export const getMalformedVehicleChecks = (): QuestionResult[] => {
+  return [
+    {
+      code: 'T1',
+      description: 'Safety factors while loading',
+    },
+    {
+      code: 'T2',
+      description: 'Reflectors condition',
+      outcome: 'DF',
+    },
+    {
+      code: 'S1',
+      description: 'All doors secure',
+    },
+    {
+      code: 'S2',
+      description: 'Air leaks',
+      outcome: 'P',
+    },
+    {
+      code: 'S4',
+      description: 'Mudguards condition',
+    },
+  ];
+};

--- a/src/pages/debrief/components/vehicle-checks-card/__mocks__/vehicle-checks-card.mock.ts
+++ b/src/pages/debrief/components/vehicle-checks-card/__mocks__/vehicle-checks-card.mock.ts
@@ -1,0 +1,42 @@
+import { QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+
+export class VehicleChecksCardMock {
+
+  private static instance: VehicleChecksCardMock;
+
+  private constructor() { }
+
+  public static getInstance(): VehicleChecksCardMock {
+    if (!VehicleChecksCardMock.instance) {
+      VehicleChecksCardMock.instance = new VehicleChecksCardMock();
+    }
+    return VehicleChecksCardMock.instance;
+  }
+
+  public getMalformedVehicleChecks(): QuestionResult[] {
+    return [
+      {
+        code: 'T1',
+        description: 'Safety factors while loading',
+      },
+      {
+        code: 'T2',
+        description: 'Reflectors condition',
+        outcome: 'DF',
+      },
+      {
+        code: 'S1',
+        description: 'All doors secure',
+      },
+      {
+        code: 'S2',
+        description: 'Air leaks',
+        outcome: 'P',
+      },
+      {
+        code: 'S4',
+        description: 'Mudguards condition',
+      },
+    ];
+  }
+}

--- a/src/pages/debrief/components/vehicle-checks-card/__tests__/vehicle-checks-card.spec.ts
+++ b/src/pages/debrief/components/vehicle-checks-card/__tests__/vehicle-checks-card.spec.ts
@@ -10,13 +10,12 @@ import * as welshTranslations from '../../../../../assets/i18n/cy.json';
 import * as englishTranslations from '../../../../../assets/i18n/en.json';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { configureTestSuite } from 'ng-bullet';
-import { VehicleChecksCardMock } from '../__mocks__/vehicle-checks-card.mock';
+import { getMalformedVehicleChecks } from '../__mocks__/vehicle-checks-card.mock';
 
 describe('VehicleChecksCardComponent', () => {
   let fixture: ComponentFixture<VehicleChecksCardComponent>;
   let component: VehicleChecksCardComponent;
   let translate: TranslateService;
-  const mockFile: VehicleChecksCardMock = VehicleChecksCardMock.getInstance();
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
@@ -49,7 +48,7 @@ describe('VehicleChecksCardComponent', () => {
       it('should remove any SMTM questions which have no outcome provided', () => {
         component.category = TestCategory.BE;
         // 2 questions are provided with an outcome here.
-        component.tellMeShowMeQuestions = mockFile.getMalformedVehicleChecks();
+        component.tellMeShowMeQuestions = getMalformedVehicleChecks();
         component.ngOnInit();
         expect(component.tellMeShowMeQuestions.length).toEqual(2);
       });

--- a/src/pages/debrief/components/vehicle-checks-card/__tests__/vehicle-checks-card.spec.ts
+++ b/src/pages/debrief/components/vehicle-checks-card/__tests__/vehicle-checks-card.spec.ts
@@ -10,11 +10,13 @@ import * as welshTranslations from '../../../../../assets/i18n/cy.json';
 import * as englishTranslations from '../../../../../assets/i18n/en.json';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { configureTestSuite } from 'ng-bullet';
+import { VehicleChecksCardMock } from '../__mocks__/vehicle-checks-card.mock';
 
 describe('VehicleChecksCardComponent', () => {
   let fixture: ComponentFixture<VehicleChecksCardComponent>;
   let component: VehicleChecksCardComponent;
   let translate: TranslateService;
+  const mockFile: VehicleChecksCardMock = VehicleChecksCardMock.getInstance();
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
@@ -44,6 +46,13 @@ describe('VehicleChecksCardComponent', () => {
 
   describe('DOM', () => {
     describe('Vehicle check reporting', () => {
+      it('should remove any SMTM questions which have no outcome provided', () => {
+        component.category = TestCategory.BE;
+        // 2 questions are provided with an outcome here.
+        component.tellMeShowMeQuestions = mockFile.getMalformedVehicleChecks();
+        component.ngOnInit();
+        expect(component.tellMeShowMeQuestions.length).toEqual(2);
+      });
       it('should show results', () => {
         component.category = TestCategory.BE;
         component.tellMeShowMeQuestions = [

--- a/src/pages/debrief/components/vehicle-checks-card/vehicle-checks-card.ts
+++ b/src/pages/debrief/components/vehicle-checks-card/vehicle-checks-card.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { CategoryCode, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
 import { CompetencyOutcome } from '../../../../shared/models/competency-outcome';
 
@@ -6,7 +6,7 @@ import { CompetencyOutcome } from '../../../../shared/models/competency-outcome'
   selector: 'vehicle-checks-card',
   templateUrl: 'vehicle-checks-card.html',
 })
-export class VehicleChecksCardComponent {
+export class VehicleChecksCardComponent implements OnInit {
 
   @Input()
   category: CategoryCode;
@@ -17,4 +17,12 @@ export class VehicleChecksCardComponent {
   constructor() { }
 
   questionHasFault = (result: QuestionResult): boolean => result.outcome !== CompetencyOutcome.P;
+
+  ngOnInit(): void {
+    this.tellMeShowMeQuestions.forEach((value: QuestionResult, index: number, array: QuestionResult[]): void => {
+      if (!value.hasOwnProperty('outcome')) {
+        this.tellMeShowMeQuestions.splice(index, 1);
+      }
+    });
+  }
 }

--- a/src/pages/debrief/components/vehicle-checks-card/vehicle-checks-card.ts
+++ b/src/pages/debrief/components/vehicle-checks-card/vehicle-checks-card.ts
@@ -19,10 +19,8 @@ export class VehicleChecksCardComponent implements OnInit {
   questionHasFault = (result: QuestionResult): boolean => result.outcome !== CompetencyOutcome.P;
 
   ngOnInit(): void {
-    this.tellMeShowMeQuestions.forEach((value: QuestionResult, index: number, array: QuestionResult[]): void => {
-      if (!value.hasOwnProperty('outcome')) {
-        this.tellMeShowMeQuestions.splice(index, 1);
-      }
+    this.tellMeShowMeQuestions = this.tellMeShowMeQuestions.filter((result: QuestionResult) => {
+      return result.hasOwnProperty('outcome');
     });
   }
 }

--- a/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.html
+++ b/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.html
@@ -2,7 +2,7 @@
   <ion-navbar hideBackButton>
     <ion-title>{{pageState.candidateName$ | async}}</ion-title>
     <ion-buttons end>
-      <end-test-link category="C"></end-test-link>
+      <end-test-link category="D"></end-test-link>
     </ion-buttons>
   </ion-navbar>
 </ion-header>


### PR DESCRIPTION
## Description
**Issue**
If a DE selects a ShowMeTellMe Question but does not provide an outcome for the question before terminating, the question will show up as a fault on debrief page.
**Fix**
NgOnInit added to VehicleChecksCard to capture and remove any ShowMeTellMe provided without an outcome from the state.
**Explanation**
This in turn will mean that the vehicle checks card will not show if a DE selected a question and did not provide an outcome for that question before terminating the test. Previously; it would include the question as a fault if the outcome didn't match to a pass, therefore if the property did not exist it would mark it as a fault, meaning the vehicle checks card would show in instances where unnecessary/unwanted.
**Note**
If a DE selects 2 or more ShowMeTellMe Questions, and provides an outcome for only 1 of the questions, only the question with an outcome provided will display in the debrief page.

**Also fixed** 
Terminating the test on the WRTC page for Cat D tests will now point to the correct Debrief page for Cat D. 
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
