### PR TITLE
feat: allow automatic rehydration of store on page reload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -548,9 +548,9 @@
       }
     },
     "@dvsa/mes-config-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-config-schema/-/mes-config-schema-1.0.5.tgz",
-      "integrity": "sha512-X2Q6BHMOVuqZrpZR9Fb+Q7esnpu8jpE8qxT53mtdL1ia1E50Qhl+4azTinp/OSu6EmSKoGbKT1XXkpwMlAhAhw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-config-schema/-/mes-config-schema-1.0.6.tgz",
+      "integrity": "sha512-pS1N4Ghg4L8LuoK91f2lmSwmYlBbrrAdqKPrSGJYJ+ixHz3+Os7TZHpY75qOJbhyefSWth+N+PIvkIoJGNRofA==",
       "dev": true
     },
     "@dvsa/mes-journal-schema": {
@@ -10859,6 +10859,12 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+      "dev": true
+    },
     "default-require-extensions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
@@ -17692,6 +17698,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ng2-translate/-/ng2-translate-5.0.0.tgz",
       "integrity": "sha1-Ctu1EOtQB6LW3tX10miIwUdgrKU="
+    },
+    "ngrx-store-localstorage": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ngrx-store-localstorage/-/ngrx-store-localstorage-8.0.0.tgz",
+      "integrity": "sha512-3AHqw1AeXDXU/Hgxlh5fjP/srgGuP8BJR2uQ6ViGLeKwMEQDZuQfwd8zu9+bPZcvIxbAcxjWoGCVJXYEkBlxmg==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "^3.2.0"
+      }
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   "devDependencies": {
     "@angular/cli": "1.4.8",
     "@angular/compiler-cli": "^5.2.11",
-    "@dvsa/mes-config-schema": "1.0.5",
+    "@dvsa/mes-config-schema": "1.0.6",
     "@dvsa/mes-journal-schema": "1.2.0",
     "@dvsa/mes-search-schema": "1.1.0",
     "@dvsa/mes-test-schema": "3.19.2",
@@ -161,6 +161,7 @@
     "karma-webpack": "^2.0.13",
     "ng-bullet": "^1.0.3",
     "ng-mocks": "^7.1.3",
+    "ngrx-store-localstorage": "^8.0.0",
     "npm-run-all": "^4.1.3",
     "null-loader": "^0.1.1",
     "protractor": "^5.4.1",

--- a/src/environment/environment.local.ts
+++ b/src/environment/environment.local.ts
@@ -6,6 +6,7 @@ export const environment: LocalEnvironmentFile = {
   configUrl: 'https://dev.mes.dev-dvsacloud.uk/v1/configuration/dev',
   daysToCacheLogs: 7,
   enableDevTools: true,
+  enableRehydrationPlugin: true,
   googleAnalyticsId: 'UA-129489007-3',
   logsPostApiKey: '',
   logsApiUrl: 'https://dev.mes.dev-dvsacloud.uk/v1/logs',

--- a/src/providers/app-config/app-config.ts
+++ b/src/providers/app-config/app-config.ts
@@ -87,7 +87,13 @@ export class AppConfigProvider {
     }
   }
 
-  public getAppConfig = (): AppConfig => this.appConfig;
+  public getAppConfig = (): AppConfig => {
+    if (!this.appConfig) {
+      this.initialiseAppConfig();
+    }
+
+    return this.appConfig;
+  }
 
   public loadRemoteConfig = (): Promise<any> =>
     this.getRemoteData()


### PR DESCRIPTION
## Description

Prevent browser-based local environment bailing on live-reload.

- Integrate ngrx-store-localstorage plugin. 
- Allow AppConfig to be reinitialised from any entry route. 

## Checklist

- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
