### PR TITLE
Cat-A-Mod2 fix to remove pre-populated transmission on pass finalisation for mod 2

### DIFF
--- a/src/pages/pass-finalisation/cat-a-mod2/pass-finalisation.cat-a-mod2.page.html
+++ b/src/pages/pass-finalisation/cat-a-mod2/pass-finalisation.cat-a-mod2.page.html
@@ -32,7 +32,6 @@
 
         <transmission
           [formGroup]="form"
-          [transmission]="pageState.transmission$ | async"
           (transmissionChange)="transmissionChanged($event)">
         </transmission>
 


### PR DESCRIPTION
## Description
Cat-A-Mod1 fix to remove pre-populated transmission on pass finalisation for mod 2
## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
