### PR TITLE
Fix uppercase directive

### DIFF
--- a/src/directives/__tests__/input-restriction-uppercasealphanum.directive.spec.ts
+++ b/src/directives/__tests__/input-restriction-uppercasealphanum.directive.spec.ts
@@ -22,7 +22,7 @@ describe('Directive: InputRestrictionUppercaseAlphanumDirective', () => {
     });
     fixture = TestBed.createComponent(TestAlphaNumComponent);
   });
-  it('should remove spaces, non alpha numeric chars and upper case input', () => {
+  it('should upper case input and remove spaces and non alpha numeric chars', () => {
     fixture.detectChanges();
     inputElement = fixture.debugElement.query(By.css('input'));
     inputElement.nativeElement.value = '_aBc!@ £$%^&123)(*&^%$£@   []{}`~';

--- a/src/directives/__tests__/input-restriction-uppercasealphanum.directive.spec.ts
+++ b/src/directives/__tests__/input-restriction-uppercasealphanum.directive.spec.ts
@@ -1,0 +1,33 @@
+import { Component, DebugElement } from '@angular/core';
+import { InputRestrictionUppercaseAlphanumDirective } from '../input-restriction-uppercasealphanum.directive';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+@Component({
+  template: `<input type="text" uppercaseAlphanumOnly>`,
+})
+class TestAlphaNumComponent {
+}
+
+fdescribe('Directive: InputRestrictionUppercaseAlphanumDirective', () => {
+  let fixture: ComponentFixture<TestAlphaNumComponent>;
+  let inputElement: DebugElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TestAlphaNumComponent,
+        InputRestrictionUppercaseAlphanumDirective,
+      ],
+    });
+    fixture = TestBed.createComponent(TestAlphaNumComponent);
+  });
+  it('should remove spaces, non alpha numeric chars and upper case input', () => {
+    fixture.detectChanges();
+    inputElement = fixture.debugElement.query(By.css('input'));
+
+    inputElement.nativeElement.value = 'aBc!@ £$%^&123';
+    inputElement.nativeElement.dispatchEvent(new Event('input'));
+    expect(inputElement.nativeElement.value).toEqual('ABC123')
+  });
+});

--- a/src/directives/__tests__/input-restriction-uppercasealphanum.directive.spec.ts
+++ b/src/directives/__tests__/input-restriction-uppercasealphanum.directive.spec.ts
@@ -9,7 +9,7 @@ import { By } from '@angular/platform-browser';
 class TestAlphaNumComponent {
 }
 
-fdescribe('Directive: InputRestrictionUppercaseAlphanumDirective', () => {
+describe('Directive: InputRestrictionUppercaseAlphanumDirective', () => {
   let fixture: ComponentFixture<TestAlphaNumComponent>;
   let inputElement: DebugElement;
 
@@ -25,9 +25,8 @@ fdescribe('Directive: InputRestrictionUppercaseAlphanumDirective', () => {
   it('should remove spaces, non alpha numeric chars and upper case input', () => {
     fixture.detectChanges();
     inputElement = fixture.debugElement.query(By.css('input'));
-
-    inputElement.nativeElement.value = 'aBc!@ £$%^&123';
+    inputElement.nativeElement.value = '_aBc!@ £$%^&123)(*&^%$£@   []{}`~';
     inputElement.nativeElement.dispatchEvent(new Event('input'));
-    expect(inputElement.nativeElement.value).toEqual('ABC123')
+    expect(inputElement.nativeElement.value).toEqual('ABC123');
   });
 });

--- a/src/directives/input-restriction-uppercasealphanum.directive.ts
+++ b/src/directives/input-restriction-uppercasealphanum.directive.ts
@@ -1,48 +1,15 @@
 import { Directive, ElementRef, HostListener } from '@angular/core';
-import { includes } from 'lodash';
 
 @Directive({
   selector: '[uppercaseAlphanumOnly]',
 })
 export class InputRestrictionUppercaseAlphanumDirective {
-  constructor(public el: ElementRef) {}
+  constructor(public ref: ElementRef) { }
 
-  // Allow usage of control keys aswell as numbers, useful for the browser
-  controlKeys = ['ArrowRight', 'ArrowLeft', 'Backspace'];
-
-  @HostListener('keydown', ['$event'])
-  onKeyDown(e: KeyboardEvent) {
-    let { key } = e;
-
-    if (includes(this.controlKeys, key)) {
-      return;
-    }
-
-    // Transform lowercase alphas to uppercase, dispatch a replacement event
-    if (this.isLowerCase(key)) {
-      e.preventDefault();
-      key = key.toUpperCase();
-      e.target['value'] += key;
-      const evt = document.createEvent('HTMLEvents');
-      evt.initEvent('input', false, true);
-      e.target.dispatchEvent(evt);
-      return;
-    }
-
-    if (!this.isUppercaseAlphanum(key)) {
-      e.preventDefault();
-    }
-  }
-
-  isLowerCase(key: string): boolean {
-    return key >= 'a' && key <= 'z';
-  }
-
-  isNumeric(key: string): boolean {
-    return key >= '0' && key <= '9';
-  }
-
-  isUppercaseAlphanum(key: string): boolean {
-    return (key >= '0' && key <= '9') || (key >= 'A' && key <= 'Z');
+  @HostListener('input', ['$event']) onInput(event) {
+    this.ref.nativeElement.value = event.target.value
+      .replace(/[^\w\s]/gi, '')
+      .trim()
+      .toUpperCase();
   }
 }

--- a/src/directives/input-restriction-uppercasealphanum.directive.ts
+++ b/src/directives/input-restriction-uppercasealphanum.directive.ts
@@ -4,11 +4,12 @@ import { Directive, ElementRef, HostListener } from '@angular/core';
   selector: '[uppercaseAlphanumOnly]',
 })
 export class InputRestrictionUppercaseAlphanumDirective {
-  constructor(public ref: ElementRef) { }
+  constructor(public ref: ElementRef) {
+  }
 
   @HostListener('input', ['$event']) onInput(event) {
     this.ref.nativeElement.value = event.target.value
-      .replace(/[^\w\s]/gi, '')
+      .replace(/[^0-9a-z]/gi, '')
       .trim()
       .toUpperCase();
   }


### PR DESCRIPTION
## Description
- Simplifies InputRestrictionUppercaseAlphanumDirective directive and removes deprecated [initEvent](https://developer.mozilla.org/en-US/docs/Web/API/Event/initEvent) method.
- Fixes error in Chrome where completing Vehicle Registration with Alpha chars only fails to update NGRX store 

## Checklist

- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
