### PR TITLE
MES-5005: bump mes-test-schema version number to 3.20.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -566,9 +566,9 @@
       "dev": true
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.20.2.tgz",
-      "integrity": "sha512-/q9D+FDx+gcGJqwh3Z/6esWjf4YA5+iwUyeDhABMivo3N16sbiooyXWEhYnF+x1YocWwJ1Cvr2xxXNGIjcoWMQ==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.20.3.tgz",
+      "integrity": "sha512-Y9b+8y9T+hR4fxIKGs4KNbZUZgR0wL8sD8jcjmA9EKc3Sg6yt9uqxGPRxVHMI/IjEbPVGPmGXdsiAwoLFEhDLQ==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@dvsa/mes-config-schema": "1.0.6",
     "@dvsa/mes-journal-schema": "1.2.0",
     "@dvsa/mes-search-schema": "1.1.0",
-    "@dvsa/mes-test-schema": "^3.20.2",
+    "@dvsa/mes-test-schema": "3.20.3",
     "@hapi/joi": "^15.1.0",
     "@ionic-native-mocks/device": "^2.0.12",
     "@ionic-native-mocks/secure-storage": "^2.0.12",


### PR DESCRIPTION
## Description

Bumping package version number to 3.20.3 in order to have correct AMod1 validation.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
