### PR TITLE
fix(labels): change use of "driving" to "riding" for Cat A components

### DIFF
--- a/src/pages/debrief/cat-a-mod2/debrief.cat-a-mod2.page.html
+++ b/src/pages/debrief/cat-a-mod2/debrief.cat-a-mod2.page.html
@@ -9,11 +9,25 @@
 </ion-header>
 
 <ion-content>
-  <eta-debrief-card [hasPhysicalEta]="hasPhysicalEta" [hasVerbalEta]="hasVerbalEta"></eta-debrief-card>
-  <dangerous-faults-debrief-card [dangerousFaults]="pageState.dangerousFaults$ | async"></dangerous-faults-debrief-card>
-  <serious-faults-debrief-card [seriousFaults]="pageState.seriousFaults$ | async"></serious-faults-debrief-card>
-  <driving-faults-debrief-card [drivingFaults]="pageState.drivingFaults$ | async" [drivingFaultCount]="pageState.drivingFaultCount$ | async"></driving-faults-debrief-card>
-  <eco-debrief-card [adviceGivenControl]="adviceGivenControl" [adviceGivenPlanning]="adviceGivenPlanning"></eco-debrief-card>
+  <eta-debrief-card
+    [hasPhysicalEta]="hasPhysicalEta"
+    [hasVerbalEta]="hasVerbalEta"
+  ></eta-debrief-card>
+  <dangerous-faults-debrief-card
+    [dangerousFaults]="pageState.dangerousFaults$ | async"
+  ></dangerous-faults-debrief-card>
+  <serious-faults-debrief-card
+    [seriousFaults]="pageState.seriousFaults$ | async"
+  ></serious-faults-debrief-card>
+  <driving-faults-debrief-card
+    [drivingFaults]="pageState.drivingFaults$ | async"
+    [drivingFaultCount]="pageState.drivingFaultCount$ | async"
+    [testCategory]="pageState.category$ | async"
+  ></driving-faults-debrief-card>
+  <eco-debrief-card
+    [adviceGivenControl]="adviceGivenControl"
+    [adviceGivenPlanning]="adviceGivenPlanning"
+  ></eco-debrief-card>
   <safety-and-balance-card-cat-a-mod2></safety-and-balance-card-cat-a-mod2>
 </ion-content>
 <ion-footer>

--- a/src/pages/debrief/cat-a-mod2/debrief.cat-a-mod2.page.ts
+++ b/src/pages/debrief/cat-a-mod2/debrief.cat-a-mod2.page.ts
@@ -45,6 +45,7 @@ interface DebriefPageState {
   testResult$: Observable<string>;
   conductedLanguage$: Observable<string>;
   candidateName$: Observable<string>;
+  category$: Observable<TestCategory>;
 }
 
 @IonicPage()
@@ -90,32 +91,34 @@ export class DebriefCatAMod2Page extends BasePageComponent {
     );
     const category$ = currentTest$.pipe(
       select(getTestCategory),
+      map(c => c as TestCategory),
     );
     this.pageState = {
+      category$,
       seriousFaults$: currentTest$.pipe(
         select(getTestData),
         withLatestFrom(category$),
         map(([data, category]) =>
-          this.faultSummaryProvider.getSeriousFaultsList(data, category as TestCategory)
+          this.faultSummaryProvider.getSeriousFaultsList(data, category)
           .map(fault => fault.competencyIdentifier)),
       ),
       dangerousFaults$: currentTest$.pipe(
         select(getTestData),
         withLatestFrom(category$),
         map(([data, category]) =>
-          this.faultSummaryProvider.getDangerousFaultsList(data, category as TestCategory)
+          this.faultSummaryProvider.getDangerousFaultsList(data, category)
           .map(fault => fault.competencyIdentifier)),
       ),
       drivingFaults$: currentTest$.pipe(
         select(getTestData),
         withLatestFrom(category$),
-        map(([data, category]) => this.faultSummaryProvider.getDrivingFaultsList(data, category as TestCategory)),
+        map(([data, category]) => this.faultSummaryProvider.getDrivingFaultsList(data, category)),
       ),
       drivingFaultCount$: currentTest$.pipe(
         select(getTestData),
         withLatestFrom(category$),
         map(([testData, category]) => {
-          return this.faultCountProvider.getDrivingFaultSumCount(category as TestCategory, testData);
+          return this.faultCountProvider.getDrivingFaultSumCount(category, testData);
         }),
       ),
       etaFaults$: currentTest$.pipe(

--- a/src/pages/office/cat-a-mod2/office.cat-a-mod2.page.html
+++ b/src/pages/office/cat-a-mod2/office.cat-a-mod2.page.html
@@ -70,6 +70,7 @@
               option1label="Diagram"
               option2="Traffic signs"
               option2label="Traffic Signs"
+              [category]="pageState.testCategory$ | async"
               [display]="pageState.displayIndependentDriving$ | async"
               [formGroup]="form"
               [outcome]="pageState.testOutcome$ | async"

--- a/src/pages/office/cat-a-mod2/office.cat-a-mod2.page.ts
+++ b/src/pages/office/cat-a-mod2/office.cat-a-mod2.page.ts
@@ -115,6 +115,7 @@ interface OfficePageState {
   startTime$: Observable<string>;
   testOutcome$: Observable<string>;
   testOutcomeText$: Observable<string>;
+  testCategory$: Observable<TestCategory>;
   isPassed$: Observable<boolean>;
   isTestOutcomeSet$: Observable<boolean>;
   candidateName$: Observable<string>;
@@ -204,6 +205,7 @@ export class OfficeCatAMod2Page extends BasePageComponent {
     );
 
     this.pageState = {
+      testCategory$,
       activityCode$: currentTest$.pipe(
         select(getActivityCode),
       ),

--- a/src/pages/office/components/independent-driving/independent-driving.html
+++ b/src/pages/office/components/independent-driving/independent-driving.html
@@ -3,34 +3,63 @@
   <div class="validation-bar" [class.ng-invalid]="invalid">
   </div>
   <ion-col class="component-label" col-32 align-self-center>
-    <label>Independent driving</label>
+    <label>{{componentTitle}}</label>
   </ion-col>
   <ion-col align-self-center padding-left>
     <ion-row class="spacing-row"></ion-row>
     <ion-row>
       <ion-col align-self-center>
-        <input type="radio" [id]="getIndependentDrivingInputId(option1)" class="gds-radio-button"
-          formControlName="independentDriving" name="independentDriving" [value]="option1" [class.ng-invalid]="invalid"
-          [checked]="independentDriving === option1" (change)="independentDrivingChanged(option1)">
-        <label [for]="getIndependentDrivingInputId(option1)" class="radio-label">{{option1label}}</label>
+        <input
+          type="radio"
+          [id]="getIndependentDrivingInputId(option1)"
+          class="gds-radio-button"
+          formControlName="independentDriving"
+          name="independentDriving"
+          [value]="option1"
+          [class.ng-invalid]="invalid"
+          [checked]="independentDriving === option1"
+          (change)="independentDrivingChanged(option1)"
+        />
+        <label [for]="getIndependentDrivingInputId(option1)" class="radio-label">{{
+          option1label
+        }}</label>
       </ion-col>
       <ion-col align-self-center>
-        <input type="radio" [id]="getIndependentDrivingInputId(option2)" class="gds-radio-button"
-          formControlName="independentDriving" name="independentDriving" [value]="option2"
-               [class.ng-invalid]="invalid" [checked]="independentDriving === option2"
-          (change)="independentDrivingChanged(option2)">
+        <input
+          type="radio"
+          class="gds-radio-button"
+          formControlName="independentDriving"
+          name="independentDriving"
+          [id]="getIndependentDrivingInputId(option2)"
+          [value]="option2"
+          [class.ng-invalid]="invalid"
+          [checked]="independentDriving === option2"
+          (change)="independentDrivingChanged(option2)"
+        />
         <label [for]="getIndependentDrivingInputId(option2)" class="radio-label">{{option2label}}</label>
       </ion-col>
       <ion-col align-self-center [hidden]="!showNotApplicable">
-        <input type="radio" id="independent-driving-na" class="gds-radio-button" formControlName="independentDriving"
-          name="independentDriving" value='N/A' [class.ng-invalid]="invalid" [checked]="independentDriving === 'N/A'"
-          (change)="independentDrivingChanged('N/A')">
+        <input
+          type="radio"
+          id="independent-driving-na"
+          class="gds-radio-button"
+          formControlName="independentDriving"
+          name="independentDriving"
+          value='N/A'
+          [class.ng-invalid]="invalid"
+          [checked]="independentDriving === 'N/A'"
+          (change)="independentDrivingChanged('N/A')"
+        />
         <label for="independent-driving-na" class="radio-label">N/A</label>
       </ion-col>
     </ion-row>
     <ion-row class="validation-message-row" align-items-center>
-      <div class="validation-text" [class.ng-invalid]="invalid" id="office-independent-driving-validation-text">
-        Select the method of independent driving
+      <div
+        class="validation-text"
+        id="office-independent-driving-validation-text"
+        [class.ng-invalid]="invalid"
+      >
+        {{componentWarningMessage}}
       </div>
     </ion-row>
   </ion-col>

--- a/src/pages/office/components/independent-driving/independent-driving.ts
+++ b/src/pages/office/components/independent-driving/independent-driving.ts
@@ -6,6 +6,8 @@ import {
   VisibilityType,
 } from '../../../../providers/outcome-behaviour-map/outcome-behaviour-map';
 import { removeNonAlphaNumeric } from '../../../../shared/helpers/formatters';
+import { getDrivingOrRidingLabel } from '../../../../shared/helpers/driver-type';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 @Component({
   selector: 'independent-driving',
@@ -17,6 +19,9 @@ export class IndependentDrivingComponent implements OnChanges {
 
   @Input()
   outcome: string;
+
+  @Input()
+  category: TestCategory | null;
 
   @Input()
   option1: IndependentDriving;
@@ -71,6 +76,14 @@ export class IndependentDrivingComponent implements OnChanges {
 
   getIndependentDrivingInputId(inputLabel: string): string {
     return `independent-driving-${removeNonAlphaNumeric(inputLabel).toLowerCase()}`;
+  }
+
+  get componentTitle(): string {
+    return `Independent ${getDrivingOrRidingLabel(this.category)}`;
+  }
+
+  get componentWarningMessage(): string {
+    return `Select the method of independent ${getDrivingOrRidingLabel(this.category)}`;
   }
 
   get invalid(): boolean {


### PR DESCRIPTION
## Description

Corrections for incorrect use of "driving" copy on Mod 2 pages. 

- Office : "Independent driving" => "Independent riding"
- Debrief: "_n_ driving faults" => "_n_ riding faults"

## Checklist

- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

![IMG_0009](https://user-images.githubusercontent.com/60922656/75892429-37bc9f80-5e29-11ea-8a0e-5ef802e76a93.PNG)

![IMG_0010](https://user-images.githubusercontent.com/60922656/75892441-3be8bd00-5e29-11ea-877d-cfe9557bcb60.PNG)

