### PR TITLE
Mes 4900 state management setup

### DIFF
--- a/src/modules/tests/journal-data/cat-home/candidate/candidate.cat-home.actions.ts
+++ b/src/modules/tests/journal-data/cat-home/candidate/candidate.cat-home.actions.ts
@@ -1,0 +1,12 @@
+import { Action } from '@ngrx/store';
+import { CatFUniqueTypes } from '@dvsa/mes-test-schema/categories/F';
+
+export const POPULATE_CANDIDATE_DETAILS_CAT_HOME = '[CatHome] [JournalEffects] Populate Candidate Details';
+
+export class PopulateCandidateDetailsCatHome implements Action {
+  readonly type = POPULATE_CANDIDATE_DETAILS_CAT_HOME;
+  constructor(public payload: CatFUniqueTypes.Candidate) {}
+}
+
+export type Types =
+  | PopulateCandidateDetailsCatHome;

--- a/src/modules/tests/journal-data/cat-home/candidate/candidate.cat-home.reducer.ts
+++ b/src/modules/tests/journal-data/cat-home/candidate/candidate.cat-home.reducer.ts
@@ -1,0 +1,36 @@
+import { CatFUniqueTypes } from '@dvsa/mes-test-schema/categories/F';
+import { createFeatureSelector } from '@ngrx/store';
+import * as candidateActions from './candidate.cat-home.actions';
+
+export const initialState: CatFUniqueTypes.Candidate = {
+  candidateId: null,
+  candidateName: {},
+  driverNumber: null,
+  dateOfBirth: null,
+  gender: null,
+  candidateAddress: {},
+  primaryTelephone: null,
+  secondaryTelephone: null,
+  mobileTelephone: null,
+  emailAddress: null,
+  prn: null,
+  previousADITests: null,
+  ethnicityCode: null,
+  businessAddress: {},
+  businessName: null,
+  businessTelephone: null,
+};
+
+export function candidateCatHomeReducer(
+  state = initialState,
+  action: candidateActions.Types,
+): CatFUniqueTypes.Candidate {
+  switch (action.type) {
+    case candidateActions.POPULATE_CANDIDATE_DETAILS_CAT_HOME:
+      return action.payload;
+    default:
+      return state;
+  }
+}
+
+export const getCandidate = createFeatureSelector<CatFUniqueTypes.Candidate>('candidate');

--- a/src/modules/tests/journal-data/cat-home/journal-data.cat-home.reducer.ts
+++ b/src/modules/tests/journal-data/cat-home/journal-data.cat-home.reducer.ts
@@ -1,0 +1,55 @@
+import { CatFUniqueTypes } from '@dvsa/mes-test-schema/categories/F';
+import { createFeatureSelector, combineReducers, Action } from '@ngrx/store';
+import { examinerReducer } from '../common/examiner/examiner.reducer';
+import { testCentreReducer } from '../common/test-centre/test-centre.reducer';
+import { testSlotsAttributesReducer } from '../common/test-slot-attributes/test-slot-attributes.reducer';
+import { candidateCatHomeReducer } from './candidate/candidate.cat-home.reducer';
+import { applicationReferenceReducer } from '../common/application-reference/application-reference.reducer';
+
+export const initialState: CatFUniqueTypes.JournalData = {
+  applicationReference: {
+    applicationId: null,
+    bookingSequence: null,
+    checkDigit: null,
+  },
+  candidate: {},
+  examiner: {
+    // TODO - we don't use this anywhere in the code.
+    individualId: null,
+    staffNumber: null,
+  },
+  testCentre: {
+    centreId: null,
+    centreName: null,
+    costCode: null,
+  },
+  testSlotAttributes: {
+    entitlementCheck: null,
+    examinerVisiting: null,
+    extendedTest: null,
+    previousCancellation: null,
+    slotId: null,
+    slotType: null,
+    specialNeeds: null,
+    specialNeedsArray: null,
+    specialNeedsCode: null,
+    start: null,
+    vehicleTypeCode: null,
+    welshTest: null,
+  },
+};
+
+export function journalDataCatHomeReducer(
+  state = initialState,
+  action: Action,
+): Required<CatFUniqueTypes.JournalData> {
+  return combineReducers({
+    examiner: examinerReducer,
+    testCentre: testCentreReducer,
+    testSlotAttributes: testSlotsAttributesReducer,
+    candidate: candidateCatHomeReducer,
+    applicationReference: applicationReferenceReducer,
+  })(state as Required<CatFUniqueTypes.JournalData>, action);
+}
+
+export const getJournalData = createFeatureSelector<CatFUniqueTypes.JournalData>('journalData');

--- a/src/modules/tests/test-data/cat-home/controlled-stop/__tests__/controlled-stop.reducer.spec.ts
+++ b/src/modules/tests/test-data/cat-home/controlled-stop/__tests__/controlled-stop.reducer.spec.ts
@@ -1,0 +1,74 @@
+import { CatFUniqueTypes } from '@dvsa/mes-test-schema/categories/F';
+import { controlledStopReducer } from '../controlled-stop.reducer';
+import {
+  ToggleControlledStop,
+  ControlledStopAddDrivingFault,
+  ControlledStopAddSeriousFault,
+  ControlledStopAddDangerousFault,
+  ControlledStopRemoveFault,
+  AddControlledStopComment,
+} from '../controlled-stop.actions';
+import { CompetencyOutcome } from '../../../../../../shared/models/competency-outcome';
+
+describe('Controlled Stop Reducer' , () => {
+
+  describe('TOGGLE_CONTROLLED_STOP', () => {
+    it('should toggle the controlled stop (true when dispatched first time)', () => {
+      const state: CatFUniqueTypes.ControlledStop = {};
+      const result = controlledStopReducer(state, new ToggleControlledStop());
+      expect(result.selected).toEqual(true);
+    });
+    it('should remove the controlled stop property when dispatched second time', () => {
+      const state: CatFUniqueTypes.ControlledStop = {};
+      const modifiedState = controlledStopReducer(state, new ToggleControlledStop());
+      const result = controlledStopReducer(modifiedState, new ToggleControlledStop());
+      expect(result.selected).toEqual(false);
+    });
+  });
+
+  describe('CONTROLLED_STOP_ADD_DRIVING_FAULT', () => {
+    it('should add the correct fault', () => {
+      const state: CatFUniqueTypes.ControlledStop = {};
+      const result = controlledStopReducer(state, new ControlledStopAddDrivingFault());
+      expect(result.selected).toEqual(true);
+      expect(result.fault).toEqual(CompetencyOutcome.DF);
+    });
+  });
+
+  describe('CONTROLLED_STOP_ADD_SERIOUS_FAULT', () => {
+    it('should add the correct fault', () => {
+      const state: CatFUniqueTypes.ControlledStop = {};
+      const result = controlledStopReducer(state, new ControlledStopAddSeriousFault());
+      expect(result.selected).toEqual(true);
+      expect(result.fault).toEqual(CompetencyOutcome.S);
+    });
+  });
+
+  describe('CONTROLLED_STOP_ADD_DANGEROUS_FAULT', () => {
+    it('should add the correct fault', () => {
+      const state: CatFUniqueTypes.ControlledStop = {};
+      const result = controlledStopReducer(state, new ControlledStopAddDangerousFault());
+      expect(result.selected).toEqual(true);
+      expect(result.fault).toEqual(CompetencyOutcome.D);
+    });
+  });
+
+  describe('CONTROLLED_STOP_REMOVE_FAULT', () => {
+    it('should remove the fault', () => {
+      const state: CatFUniqueTypes.ControlledStop = {};
+      const modifiedState = controlledStopReducer(state, new ControlledStopAddDangerousFault());
+      const result = controlledStopReducer(modifiedState, new ControlledStopRemoveFault());
+      expect(result.selected).toEqual(true);
+      expect(result.fault).toBeUndefined();
+      expect(result.faultComments).toBeUndefined();
+    });
+  });
+
+  describe('ADD_CONTROLLED_STOP_COMMENT', () => {
+    it('should add a fault comment', () => {
+      const state: CatFUniqueTypes.ControlledStop = {};
+      const result = controlledStopReducer(state, new AddControlledStopComment('Test'));
+      expect(result.faultComments).toEqual('Test');
+    });
+  });
+});

--- a/src/modules/tests/test-data/cat-home/controlled-stop/controlled-stop.actions.ts
+++ b/src/modules/tests/test-data/cat-home/controlled-stop/controlled-stop.actions.ts
@@ -1,0 +1,40 @@
+import { Action } from '@ngrx/store';
+
+export const TOGGLE_CONTROLLED_STOP = '[ControlledStop] Toggle Controlled Stop';
+export const CONTROLLED_STOP_ADD_DRIVING_FAULT = '[ControlledStop] Add Driving Fault';
+export const CONTROLLED_STOP_ADD_SERIOUS_FAULT = '[ControlledStop] Add Serious Fault';
+export const CONTROLLED_STOP_ADD_DANGEROUS_FAULT = '[ControlledStop] Add Dangerous Fault';
+export const CONTROLLED_STOP_REMOVE_FAULT = '[ControlledStop] Remove Fault';
+export const ADD_CONTROLLED_STOP_COMMENT = '[ControlledStop] Add Comment';
+
+export class ToggleControlledStop implements Action {
+  readonly type = TOGGLE_CONTROLLED_STOP;
+}
+
+export class ControlledStopAddDrivingFault implements Action {
+  readonly type = CONTROLLED_STOP_ADD_DRIVING_FAULT;
+}
+export class ControlledStopAddSeriousFault implements Action {
+  readonly type = CONTROLLED_STOP_ADD_SERIOUS_FAULT;
+}
+
+export class ControlledStopAddDangerousFault implements Action {
+  readonly type = CONTROLLED_STOP_ADD_DANGEROUS_FAULT;
+}
+
+export class ControlledStopRemoveFault implements Action {
+  readonly type = CONTROLLED_STOP_REMOVE_FAULT;
+}
+
+export class AddControlledStopComment implements Action {
+  readonly type = ADD_CONTROLLED_STOP_COMMENT;
+  constructor(public comment: string) { }
+}
+
+export type Types =
+  | ToggleControlledStop
+  | ControlledStopAddDrivingFault
+  | ControlledStopAddSeriousFault
+  | ControlledStopAddDangerousFault
+  | ControlledStopRemoveFault
+  | AddControlledStopComment;

--- a/src/modules/tests/test-data/cat-home/controlled-stop/controlled-stop.reducer.ts
+++ b/src/modules/tests/test-data/cat-home/controlled-stop/controlled-stop.reducer.ts
@@ -1,0 +1,47 @@
+import { CatFUniqueTypes } from '@dvsa/mes-test-schema/categories/F';
+import * as controlledStopActions from './controlled-stop.actions';
+import { CompetencyOutcome } from '../../../../../shared/models/competency-outcome';
+
+export const initialState: CatFUniqueTypes.ControlledStop = {};
+
+export function controlledStopReducer(
+  state = initialState,
+  action: controlledStopActions.Types,
+): CatFUniqueTypes.ControlledStop {
+  switch (action.type) {
+    case controlledStopActions.TOGGLE_CONTROLLED_STOP:
+      return {
+        ...state,
+        selected: !state.selected,
+      };
+    case controlledStopActions.CONTROLLED_STOP_ADD_DRIVING_FAULT:
+      return {
+        ...state,
+        fault: CompetencyOutcome.DF,
+        selected: true,
+      };
+    case controlledStopActions.CONTROLLED_STOP_ADD_SERIOUS_FAULT:
+      return {
+        ...state,
+        fault: CompetencyOutcome.S,
+        selected: true,
+      };
+    case controlledStopActions.CONTROLLED_STOP_ADD_DANGEROUS_FAULT:
+      return {
+        ...state,
+        fault: CompetencyOutcome.D,
+        selected: true,
+      };
+    case controlledStopActions.CONTROLLED_STOP_REMOVE_FAULT:
+      return {
+        selected: state.selected,
+      };
+    case controlledStopActions.ADD_CONTROLLED_STOP_COMMENT:
+      return {
+        ...state,
+        faultComments: action.comment,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/modules/tests/test-data/cat-home/test-data.cat-f.reducer.ts
+++ b/src/modules/tests/test-data/cat-home/test-data.cat-f.reducer.ts
@@ -1,0 +1,50 @@
+import { CatFUniqueTypes } from '@dvsa/mes-test-schema/categories/F';
+import { createFeatureSelector, combineReducers, Action } from '@ngrx/store';
+
+import { dangerousFaultsReducer } from '../common/dangerous-faults/dangerous-faults.reducer';
+import { drivingFaultsReducer } from '../common/driving-faults/driving-faults.reducer';
+import { ecoReducer } from '../common/eco/eco.reducer';
+import { etaReducer } from '../common/eta/eta.reducer';
+import { seriousFaultsReducer } from '../common/serious-faults/serious-faults.reducer';
+import { controlledStopReducer } from './controlled-stop/controlled-stop.reducer';
+import { testRequirementsCatHomeReducer } from './test-requirements/test-requirements.cat-home.reducer';
+import { eyesightTestReducer } from '../common/eyesight-test/eyesight-test.reducer';
+import { manoeuvresReducer } from '../common/manoeuvres/manoeuvres.reducer';
+
+export const initialState: CatFUniqueTypes.TestData = {
+  dangerousFaults: {},
+  drivingFaults: {},
+  manoeuvres: {},
+  seriousFaults: {},
+  testRequirements: {},
+  ETA: {},
+  eco: {},
+  controlledStop: {},
+  eyesightTest: {},
+  highwayCodeSafety: {},
+  vehicleChecks: {
+    tellMeQuestions: [],
+    showMeQuestions: [],
+  },
+};
+
+export function testDataCatFReducer(
+  state: CatFUniqueTypes.TestData,
+  action: Action,
+): Required<CatFUniqueTypes.TestData> {
+  return combineReducers({
+    drivingFaults: drivingFaultsReducer,
+    dangerousFaults: dangerousFaultsReducer,
+    seriousFaults: seriousFaultsReducer,
+    vehicleChecks: null,
+    controlledStop: controlledStopReducer,
+    highwayCodeSafety: null,
+    eco: ecoReducer,
+    ETA: etaReducer,
+    eyesightTest: eyesightTestReducer,
+    manoeuvres: manoeuvresReducer,
+    testRequirements: testRequirementsCatHomeReducer,
+  })(state as Required<CatFUniqueTypes.TestData>, action);
+}
+
+export const getTestData = createFeatureSelector<CatFUniqueTypes.TestData>('testData');

--- a/src/modules/tests/test-data/cat-home/test-data.cat-g.reducer.ts
+++ b/src/modules/tests/test-data/cat-home/test-data.cat-g.reducer.ts
@@ -1,0 +1,50 @@
+import { CatGUniqueTypes } from '@dvsa/mes-test-schema/categories/G';
+import { createFeatureSelector, combineReducers, Action } from '@ngrx/store';
+
+import { dangerousFaultsReducer } from '../common/dangerous-faults/dangerous-faults.reducer';
+import { drivingFaultsReducer } from '../common/driving-faults/driving-faults.reducer';
+import { ecoReducer } from '../common/eco/eco.reducer';
+import { etaReducer } from '../common/eta/eta.reducer';
+import { seriousFaultsReducer } from '../common/serious-faults/serious-faults.reducer';
+import { controlledStopReducer } from './controlled-stop/controlled-stop.reducer';
+import { testRequirementsCatHomeReducer } from './test-requirements/test-requirements.cat-home.reducer';
+import { eyesightTestReducer } from '../common/eyesight-test/eyesight-test.reducer';
+import { manoeuvresReducer } from '../common/manoeuvres/manoeuvres.reducer';
+
+export const initialState: CatGUniqueTypes.TestData = {
+  dangerousFaults: {},
+  drivingFaults: {},
+  manoeuvres: {},
+  seriousFaults: {},
+  testRequirements: {},
+  ETA: {},
+  eco: {},
+  controlledStop: {},
+  eyesightTest: {},
+  highwayCodeSafety: {},
+  vehicleChecks: {
+    tellMeQuestions: [],
+    showMeQuestions: [],
+  },
+};
+
+export function testDataCatGReducer(
+  state: CatGUniqueTypes.TestData,
+  action: Action,
+): Required<CatGUniqueTypes.TestData> {
+  return combineReducers({
+    drivingFaults: drivingFaultsReducer,
+    dangerousFaults: dangerousFaultsReducer,
+    seriousFaults: seriousFaultsReducer,
+    vehicleChecks: null,
+    controlledStop: controlledStopReducer,
+    highwayCodeSafety: null,
+    eco: ecoReducer,
+    ETA: etaReducer,
+    eyesightTest: eyesightTestReducer,
+    manoeuvres: manoeuvresReducer,
+    testRequirements: testRequirementsCatHomeReducer,
+  })(state as Required<CatGUniqueTypes.TestData>, action);
+}
+
+export const getTestData = createFeatureSelector<CatGUniqueTypes.TestData>('testData');

--- a/src/modules/tests/test-data/cat-home/test-data.cat-h.reducer.ts
+++ b/src/modules/tests/test-data/cat-home/test-data.cat-h.reducer.ts
@@ -1,0 +1,50 @@
+import { CatHUniqueTypes } from '@dvsa/mes-test-schema/categories/H';
+import { createFeatureSelector, combineReducers, Action } from '@ngrx/store';
+
+import { dangerousFaultsReducer } from '../common/dangerous-faults/dangerous-faults.reducer';
+import { drivingFaultsReducer } from '../common/driving-faults/driving-faults.reducer';
+import { ecoReducer } from '../common/eco/eco.reducer';
+import { etaReducer } from '../common/eta/eta.reducer';
+import { seriousFaultsReducer } from '../common/serious-faults/serious-faults.reducer';
+import { controlledStopReducer } from './controlled-stop/controlled-stop.reducer';
+import { testRequirementsCatHomeReducer } from './test-requirements/test-requirements.cat-home.reducer';
+import { eyesightTestReducer } from '../common/eyesight-test/eyesight-test.reducer';
+import { manoeuvresReducer } from '../common/manoeuvres/manoeuvres.reducer';
+
+export const initialState: CatHUniqueTypes.TestData = {
+  dangerousFaults: {},
+  drivingFaults: {},
+  manoeuvres: {},
+  seriousFaults: {},
+  testRequirements: {},
+  ETA: {},
+  eco: {},
+  controlledStop: {},
+  eyesightTest: {},
+  highwayCodeSafety: {},
+  vehicleChecks: {
+    tellMeQuestions: [],
+    showMeQuestions: [],
+  },
+};
+
+export function testDataCatHReducer(
+  state: CatHUniqueTypes.TestData,
+  action: Action,
+): Required<CatHUniqueTypes.TestData> {
+  return combineReducers({
+    drivingFaults: drivingFaultsReducer,
+    dangerousFaults: dangerousFaultsReducer,
+    seriousFaults: seriousFaultsReducer,
+    vehicleChecks: null,
+    controlledStop: controlledStopReducer,
+    highwayCodeSafety: null,
+    eco: ecoReducer,
+    ETA: etaReducer,
+    eyesightTest: eyesightTestReducer,
+    manoeuvres: manoeuvresReducer,
+    testRequirements: testRequirementsCatHomeReducer,
+  })(state as Required<CatHUniqueTypes.TestData>, action);
+}
+
+export const getTestData = createFeatureSelector<CatHUniqueTypes.TestData>('testData');

--- a/src/modules/tests/test-data/cat-home/test-data.cat-k.reducer.ts
+++ b/src/modules/tests/test-data/cat-home/test-data.cat-k.reducer.ts
@@ -1,0 +1,47 @@
+import { CatKUniqueTypes } from '@dvsa/mes-test-schema/categories/K';
+import { createFeatureSelector, combineReducers, Action } from '@ngrx/store';
+
+import { dangerousFaultsReducer } from '../common/dangerous-faults/dangerous-faults.reducer';
+import { drivingFaultsReducer } from '../common/driving-faults/driving-faults.reducer';
+import { ecoReducer } from '../common/eco/eco.reducer';
+import { etaReducer } from '../common/eta/eta.reducer';
+import { seriousFaultsReducer } from '../common/serious-faults/serious-faults.reducer';
+import { controlledStopReducer } from './controlled-stop/controlled-stop.reducer';
+import { testRequirementsCatHomeReducer } from './test-requirements/test-requirements.cat-home.reducer';
+import { eyesightTestReducer } from '../common/eyesight-test/eyesight-test.reducer';
+
+export const initialState: CatKUniqueTypes.TestData = {
+  dangerousFaults: {},
+  drivingFaults: {},
+  seriousFaults: {},
+  testRequirements: {},
+  ETA: {},
+  eco: {},
+  controlledStop: {},
+  eyesightTest: {},
+  highwayCodeSafety: {},
+  vehicleChecks: {
+    tellMeQuestions: [],
+    showMeQuestions: [],
+  },
+};
+
+export function testDataCatKReducer(
+  state: CatKUniqueTypes.TestData,
+  action: Action,
+): Required<CatKUniqueTypes.TestData> {
+  return combineReducers({
+    drivingFaults: drivingFaultsReducer,
+    dangerousFaults: dangerousFaultsReducer,
+    seriousFaults: seriousFaultsReducer,
+    vehicleChecks: null,
+    controlledStop: controlledStopReducer,
+    highwayCodeSafety: null,
+    eco: ecoReducer,
+    ETA: etaReducer,
+    eyesightTest: eyesightTestReducer,
+    testRequirements: testRequirementsCatHomeReducer,
+  })(state as Required<CatKUniqueTypes.TestData>, action);
+}
+
+export const getTestData = createFeatureSelector<CatKUniqueTypes.TestData>('testData');

--- a/src/modules/tests/test-data/cat-home/test-requirements/test-requirements.cat-home.reducer.ts
+++ b/src/modules/tests/test-data/cat-home/test-requirements/test-requirements.cat-home.reducer.ts
@@ -1,0 +1,23 @@
+import * as testRequirementsActions from '../../common/test-requirements/test-requirements.actions';
+import { CatFUniqueTypes } from '@dvsa/mes-test-schema/categories/F';
+import { createFeatureSelector } from '@ngrx/store';
+
+export const initialState: CatFUniqueTypes.TestRequirements = {};
+
+export function testRequirementsCatHomeReducer(
+  state = initialState,
+  action: testRequirementsActions.Types,
+): CatFUniqueTypes.TestRequirements {
+  switch (action.type) {
+    case testRequirementsActions.TOGGLE_LEGAL_REQUIREMENT:
+      return {
+        ...state,
+        [action.payload]: !state[action.payload],
+      };
+    default:
+      return state;
+  }
+}
+
+export const getTestRequirementsCatHome =
+  createFeatureSelector<CatFUniqueTypes.TestRequirements>('testRequirements');

--- a/src/modules/tests/tests-reducer-factory.ts
+++ b/src/modules/tests/tests-reducer-factory.ts
@@ -10,6 +10,10 @@ import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
 import { CatDEUniqueTypes } from '@dvsa/mes-test-schema/categories/DE';
 import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
 import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
+import { CatFUniqueTypes } from '@dvsa/mes-test-schema/categories/F';
+import { CatGUniqueTypes } from '@dvsa/mes-test-schema/categories/G';
+import { CatHUniqueTypes } from '@dvsa/mes-test-schema/categories/H';
+import { CatKUniqueTypes } from '@dvsa/mes-test-schema/categories/K';
 import { TestResultCatAM1Schema } from '@dvsa/mes-test-schema/categories/AM1';
 import { TestResultCatAM2Schema } from '@dvsa/mes-test-schema/categories/AM2';
 import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories/index';
@@ -26,6 +30,11 @@ import { testsCatDReducer } from './tests.cat-d.reducer';
 import { testsCatDEReducer } from './tests.cat-de.reducer';
 import { testsCatD1Reducer } from './tests.cat-d1.reducer';
 import { testsCatD1EReducer } from './tests.cat-d1e.reducer';
+import { testsCatFReducer } from './tests.cat-f.reducer';
+import { testsCatGReducer } from './tests.cat-g.reducer';
+import { testsCatHReducer } from './tests.cat-h.reducer';
+import { testsCatKReducer } from './tests.cat-k.reducer';
+
 export function testsReducerFactory(
   category: TestCategory | null, action: Action, state: TestResultSchemasUnion,
 ): TestResultSchemasUnion {
@@ -60,6 +69,14 @@ export function testsReducerFactory(
       return testsCatD1Reducer(action, state as Required<CatD1UniqueTypes.TestResult>);
     case TestCategory.D1E:
       return testsCatD1EReducer(action, state as Required<CatD1EUniqueTypes.TestResult>);
+    case TestCategory.F:
+      return testsCatFReducer(action, state as Required<CatFUniqueTypes.TestResult>);
+    case TestCategory.G:
+      return testsCatGReducer(action, state as Required<CatGUniqueTypes.TestResult>);
+    case TestCategory.H:
+      return testsCatHReducer(action, state as Required<CatHUniqueTypes.TestResult>);
+    case TestCategory.K:
+      return testsCatKReducer(action, state as Required<CatKUniqueTypes.TestResult>);
     default:
       // TODO (low priority): throw an exception here instead of using category b reducer
       return testsCatBReducer(action, state as Required<CatBUniqueTypes.TestResult>);

--- a/src/modules/tests/tests.cat-f.reducer.ts
+++ b/src/modules/tests/tests.cat-f.reducer.ts
@@ -18,7 +18,7 @@ import { changeMarkerReducer } from './change-marker/change-marker';
 import { activityCodeReducer } from './activity-code/activity-code.reducer';
 import { journalDataCatHomeReducer } from './journal-data/cat-home/journal-data.cat-home.reducer';
 import { testDataCatFReducer } from './test-data/cat-home/test-data.cat-f.reducer';
-import { vehicleDetailsCatHomeReducer } from './vehicle-details/cat-home/vehicle-details.cat-home.reducer';
+import { vehicleDetailsReducer } from './vehicle-details/common/vehicle-details.reducer';
 import { passCompletionReducer } from './pass-completion/pass-completion.reducer';
 
 export function testsCatFReducer(
@@ -31,7 +31,7 @@ export function testsCatFReducer(
       journalData: journalDataCatHomeReducer,
       preTestDeclarations: preTestDeclarationsReducer,
       accompaniment: accompanimentReducer,
-      vehicleDetails: vehicleDetailsCatHomeReducer,
+      vehicleDetails: vehicleDetailsReducer,
       testData: testDataCatFReducer,
       passCompletion: passCompletionReducer,
       postTestDeclarations: postTestDeclarationsReducer,

--- a/src/modules/tests/tests.cat-f.reducer.ts
+++ b/src/modules/tests/tests.cat-f.reducer.ts
@@ -1,0 +1,51 @@
+
+import { Action, combineReducers } from '@ngrx/store';
+import { CatFUniqueTypes } from '@dvsa/mes-test-schema/categories/F';
+import { schemaVersionReducer } from './schema-version/schema-version.reducer';
+import { categoryReducer } from './category/category.reducer';
+import { preTestDeclarationsReducer } from './pre-test-declarations/common/pre-test-declarations.reducer';
+import { accompanimentReducer } from './accompaniment/accompaniment.reducer';
+import { postTestDeclarationsReducer } from './post-test-declarations/post-test-declarations.reducer';
+import { testSummaryReducer } from './test-summary/common/test-summary.reducer';
+import { communicationPreferencesReducer } from './communication-preferences/communication-preferences.reducer';
+import { rekeyReducer } from './rekey/rekey.reducer';
+import { rekeyDateReducer } from './rekey-date/rekey-date.reducer';
+import { rekeyReasonReducer } from './rekey-reason/rekey-reason.reducer';
+import { examinerBookedReducer } from './examiner-booked/examiner-booked.reducer';
+import { examinerConductedReducer } from './examiner-conducted/examiner-conducted.reducer';
+import { examinerKeyedReducer } from './examiner-keyed/examiner-keyed.reducer';
+import { changeMarkerReducer } from './change-marker/change-marker';
+import { activityCodeReducer } from './activity-code/activity-code.reducer';
+import { journalDataCatHomeReducer } from './journal-data/cat-home/journal-data.cat-home.reducer';
+import { testDataCatFReducer } from './test-data/cat-home/test-data.cat-f.reducer';
+import { vehicleDetailsCatHomeReducer } from './vehicle-details/cat-home/vehicle-details.cat-home.reducer';
+import { passCompletionReducer } from './pass-completion/pass-completion.reducer';
+
+export function testsCatFReducer(
+  action: Action, state: CatFUniqueTypes.TestResult): Required<CatFUniqueTypes.TestResult> {
+  return combineReducers(
+    {
+      version: schemaVersionReducer,
+      category: categoryReducer,
+      activityCode: activityCodeReducer,
+      journalData: journalDataCatHomeReducer,
+      preTestDeclarations: preTestDeclarationsReducer,
+      accompaniment: accompanimentReducer,
+      vehicleDetails: vehicleDetailsCatHomeReducer,
+      testData: testDataCatFReducer,
+      passCompletion: passCompletionReducer,
+      postTestDeclarations: postTestDeclarationsReducer,
+      testSummary: testSummaryReducer,
+      communicationPreferences: communicationPreferencesReducer,
+      rekey: rekeyReducer,
+      rekeyDate: rekeyDateReducer,
+      rekeyReason: rekeyReasonReducer,
+      examinerBooked: examinerBookedReducer,
+      examinerConducted: examinerConductedReducer,
+      examinerKeyed: examinerKeyedReducer,
+      changeMarker: changeMarkerReducer,
+    })(
+      state as Required<CatFUniqueTypes.TestResult>,
+      action,
+    );
+}

--- a/src/modules/tests/tests.cat-g.reducer.ts
+++ b/src/modules/tests/tests.cat-g.reducer.ts
@@ -18,7 +18,7 @@ import { changeMarkerReducer } from './change-marker/change-marker';
 import { activityCodeReducer } from './activity-code/activity-code.reducer';
 import { journalDataCatHomeReducer } from './journal-data/cat-home/journal-data.cat-home.reducer';
 import { testDataCatGReducer } from './test-data/cat-home/test-data.cat-g.reducer';
-import { vehicleDetailsCatHomeReducer } from './vehicle-details/cat-home/vehicle-details.cat-home.reducer';
+import { vehicleDetailsReducer } from './vehicle-details/common/vehicle-details.reducer';
 import { passCompletionReducer } from './pass-completion/pass-completion.reducer';
 
 export function testsCatGReducer(
@@ -31,7 +31,7 @@ export function testsCatGReducer(
       journalData: journalDataCatHomeReducer,
       preTestDeclarations: preTestDeclarationsReducer,
       accompaniment: accompanimentReducer,
-      vehicleDetails: vehicleDetailsCatHomeReducer,
+      vehicleDetails: vehicleDetailsReducer,
       testData: testDataCatGReducer,
       passCompletion: passCompletionReducer,
       postTestDeclarations: postTestDeclarationsReducer,

--- a/src/modules/tests/tests.cat-g.reducer.ts
+++ b/src/modules/tests/tests.cat-g.reducer.ts
@@ -1,0 +1,51 @@
+
+import { Action, combineReducers } from '@ngrx/store';
+import { CatGUniqueTypes } from '@dvsa/mes-test-schema/categories/G';
+import { schemaVersionReducer } from './schema-version/schema-version.reducer';
+import { categoryReducer } from './category/category.reducer';
+import { preTestDeclarationsReducer } from './pre-test-declarations/common/pre-test-declarations.reducer';
+import { accompanimentReducer } from './accompaniment/accompaniment.reducer';
+import { postTestDeclarationsReducer } from './post-test-declarations/post-test-declarations.reducer';
+import { testSummaryReducer } from './test-summary/common/test-summary.reducer';
+import { communicationPreferencesReducer } from './communication-preferences/communication-preferences.reducer';
+import { rekeyReducer } from './rekey/rekey.reducer';
+import { rekeyDateReducer } from './rekey-date/rekey-date.reducer';
+import { rekeyReasonReducer } from './rekey-reason/rekey-reason.reducer';
+import { examinerBookedReducer } from './examiner-booked/examiner-booked.reducer';
+import { examinerConductedReducer } from './examiner-conducted/examiner-conducted.reducer';
+import { examinerKeyedReducer } from './examiner-keyed/examiner-keyed.reducer';
+import { changeMarkerReducer } from './change-marker/change-marker';
+import { activityCodeReducer } from './activity-code/activity-code.reducer';
+import { journalDataCatHomeReducer } from './journal-data/cat-home/journal-data.cat-home.reducer';
+import { testDataCatGReducer } from './test-data/cat-home/test-data.cat-g.reducer';
+import { vehicleDetailsCatHomeReducer } from './vehicle-details/cat-home/vehicle-details.cat-home.reducer';
+import { passCompletionReducer } from './pass-completion/pass-completion.reducer';
+
+export function testsCatGReducer(
+  action: Action, state: CatGUniqueTypes.TestResult): Required<CatGUniqueTypes.TestResult> {
+  return combineReducers(
+    {
+      version: schemaVersionReducer,
+      category: categoryReducer,
+      activityCode: activityCodeReducer,
+      journalData: journalDataCatHomeReducer,
+      preTestDeclarations: preTestDeclarationsReducer,
+      accompaniment: accompanimentReducer,
+      vehicleDetails: vehicleDetailsCatHomeReducer,
+      testData: testDataCatGReducer,
+      passCompletion: passCompletionReducer,
+      postTestDeclarations: postTestDeclarationsReducer,
+      testSummary: testSummaryReducer,
+      communicationPreferences: communicationPreferencesReducer,
+      rekey: rekeyReducer,
+      rekeyDate: rekeyDateReducer,
+      rekeyReason: rekeyReasonReducer,
+      examinerBooked: examinerBookedReducer,
+      examinerConducted: examinerConductedReducer,
+      examinerKeyed: examinerKeyedReducer,
+      changeMarker: changeMarkerReducer,
+    })(
+      state as Required<CatGUniqueTypes.TestResult>,
+      action,
+    );
+}

--- a/src/modules/tests/tests.cat-h.reducer.ts
+++ b/src/modules/tests/tests.cat-h.reducer.ts
@@ -1,0 +1,51 @@
+
+import { Action, combineReducers } from '@ngrx/store';
+import { CatHUniqueTypes } from '@dvsa/mes-test-schema/categories/H';
+import { schemaVersionReducer } from './schema-version/schema-version.reducer';
+import { categoryReducer } from './category/category.reducer';
+import { preTestDeclarationsReducer } from './pre-test-declarations/common/pre-test-declarations.reducer';
+import { accompanimentReducer } from './accompaniment/accompaniment.reducer';
+import { postTestDeclarationsReducer } from './post-test-declarations/post-test-declarations.reducer';
+import { testSummaryReducer } from './test-summary/common/test-summary.reducer';
+import { communicationPreferencesReducer } from './communication-preferences/communication-preferences.reducer';
+import { rekeyReducer } from './rekey/rekey.reducer';
+import { rekeyDateReducer } from './rekey-date/rekey-date.reducer';
+import { rekeyReasonReducer } from './rekey-reason/rekey-reason.reducer';
+import { examinerBookedReducer } from './examiner-booked/examiner-booked.reducer';
+import { examinerConductedReducer } from './examiner-conducted/examiner-conducted.reducer';
+import { examinerKeyedReducer } from './examiner-keyed/examiner-keyed.reducer';
+import { changeMarkerReducer } from './change-marker/change-marker';
+import { activityCodeReducer } from './activity-code/activity-code.reducer';
+import { journalDataCatHomeReducer } from './journal-data/cat-home/journal-data.cat-home.reducer';
+import { testDataCatHReducer } from './test-data/cat-home/test-data.cat-h.reducer';
+import { vehicleDetailsCatHomeReducer } from './vehicle-details/cat-home/vehicle-details.cat-home.reducer';
+import { passCompletionReducer } from './pass-completion/pass-completion.reducer';
+
+export function testsCatHReducer(
+  action: Action, state: CatHUniqueTypes.TestResult): Required<CatHUniqueTypes.TestResult> {
+  return combineReducers(
+    {
+      version: schemaVersionReducer,
+      category: categoryReducer,
+      activityCode: activityCodeReducer,
+      journalData: journalDataCatHomeReducer,
+      preTestDeclarations: preTestDeclarationsReducer,
+      accompaniment: accompanimentReducer,
+      vehicleDetails: vehicleDetailsCatHomeReducer,
+      testData: testDataCatHReducer,
+      passCompletion: passCompletionReducer,
+      postTestDeclarations: postTestDeclarationsReducer,
+      testSummary: testSummaryReducer,
+      communicationPreferences: communicationPreferencesReducer,
+      rekey: rekeyReducer,
+      rekeyDate: rekeyDateReducer,
+      rekeyReason: rekeyReasonReducer,
+      examinerBooked: examinerBookedReducer,
+      examinerConducted: examinerConductedReducer,
+      examinerKeyed: examinerKeyedReducer,
+      changeMarker: changeMarkerReducer,
+    })(
+      state as Required<CatHUniqueTypes.TestResult>,
+      action,
+    );
+}

--- a/src/modules/tests/tests.cat-h.reducer.ts
+++ b/src/modules/tests/tests.cat-h.reducer.ts
@@ -18,7 +18,7 @@ import { changeMarkerReducer } from './change-marker/change-marker';
 import { activityCodeReducer } from './activity-code/activity-code.reducer';
 import { journalDataCatHomeReducer } from './journal-data/cat-home/journal-data.cat-home.reducer';
 import { testDataCatHReducer } from './test-data/cat-home/test-data.cat-h.reducer';
-import { vehicleDetailsCatHomeReducer } from './vehicle-details/cat-home/vehicle-details.cat-home.reducer';
+import { vehicleDetailsReducer } from './vehicle-details/common/vehicle-details.reducer';
 import { passCompletionReducer } from './pass-completion/pass-completion.reducer';
 
 export function testsCatHReducer(
@@ -31,7 +31,7 @@ export function testsCatHReducer(
       journalData: journalDataCatHomeReducer,
       preTestDeclarations: preTestDeclarationsReducer,
       accompaniment: accompanimentReducer,
-      vehicleDetails: vehicleDetailsCatHomeReducer,
+      vehicleDetails: vehicleDetailsReducer,
       testData: testDataCatHReducer,
       passCompletion: passCompletionReducer,
       postTestDeclarations: postTestDeclarationsReducer,

--- a/src/modules/tests/tests.cat-k.reducer.ts
+++ b/src/modules/tests/tests.cat-k.reducer.ts
@@ -1,0 +1,51 @@
+
+import { Action, combineReducers } from '@ngrx/store';
+import { CatKUniqueTypes } from '@dvsa/mes-test-schema/categories/K';
+import { schemaVersionReducer } from './schema-version/schema-version.reducer';
+import { categoryReducer } from './category/category.reducer';
+import { preTestDeclarationsReducer } from './pre-test-declarations/common/pre-test-declarations.reducer';
+import { accompanimentReducer } from './accompaniment/accompaniment.reducer';
+import { postTestDeclarationsReducer } from './post-test-declarations/post-test-declarations.reducer';
+import { testSummaryReducer } from './test-summary/common/test-summary.reducer';
+import { communicationPreferencesReducer } from './communication-preferences/communication-preferences.reducer';
+import { rekeyReducer } from './rekey/rekey.reducer';
+import { rekeyDateReducer } from './rekey-date/rekey-date.reducer';
+import { rekeyReasonReducer } from './rekey-reason/rekey-reason.reducer';
+import { examinerBookedReducer } from './examiner-booked/examiner-booked.reducer';
+import { examinerConductedReducer } from './examiner-conducted/examiner-conducted.reducer';
+import { examinerKeyedReducer } from './examiner-keyed/examiner-keyed.reducer';
+import { changeMarkerReducer } from './change-marker/change-marker';
+import { activityCodeReducer } from './activity-code/activity-code.reducer';
+import { journalDataCatHomeReducer } from './journal-data/cat-home/journal-data.cat-home.reducer';
+import { testDataCatKReducer } from './test-data/cat-home/test-data.cat-k.reducer';
+import { vehicleDetailsCatHomeReducer } from './vehicle-details/cat-home/vehicle-details.cat-home.reducer';
+import { passCompletionReducer } from './pass-completion/pass-completion.reducer';
+
+export function testsCatKReducer(
+  action: Action, state: CatKUniqueTypes.TestResult): Required<CatKUniqueTypes.TestResult> {
+  return combineReducers(
+    {
+      version: schemaVersionReducer,
+      category: categoryReducer,
+      activityCode: activityCodeReducer,
+      journalData: journalDataCatHomeReducer,
+      preTestDeclarations: preTestDeclarationsReducer,
+      accompaniment: accompanimentReducer,
+      vehicleDetails: vehicleDetailsCatHomeReducer,
+      testData: testDataCatKReducer,
+      passCompletion: passCompletionReducer,
+      postTestDeclarations: postTestDeclarationsReducer,
+      testSummary: testSummaryReducer,
+      communicationPreferences: communicationPreferencesReducer,
+      rekey: rekeyReducer,
+      rekeyDate: rekeyDateReducer,
+      rekeyReason: rekeyReasonReducer,
+      examinerBooked: examinerBookedReducer,
+      examinerConducted: examinerConductedReducer,
+      examinerKeyed: examinerKeyedReducer,
+      changeMarker: changeMarkerReducer,
+    })(
+      state as Required<CatKUniqueTypes.TestResult>,
+      action,
+    );
+}

--- a/src/modules/tests/tests.cat-k.reducer.ts
+++ b/src/modules/tests/tests.cat-k.reducer.ts
@@ -18,7 +18,7 @@ import { changeMarkerReducer } from './change-marker/change-marker';
 import { activityCodeReducer } from './activity-code/activity-code.reducer';
 import { journalDataCatHomeReducer } from './journal-data/cat-home/journal-data.cat-home.reducer';
 import { testDataCatKReducer } from './test-data/cat-home/test-data.cat-k.reducer';
-import { vehicleDetailsCatHomeReducer } from './vehicle-details/cat-home/vehicle-details.cat-home.reducer';
+import { vehicleDetailsReducer } from './vehicle-details/common/vehicle-details.reducer';
 import { passCompletionReducer } from './pass-completion/pass-completion.reducer';
 
 export function testsCatKReducer(
@@ -31,7 +31,7 @@ export function testsCatKReducer(
       journalData: journalDataCatHomeReducer,
       preTestDeclarations: preTestDeclarationsReducer,
       accompaniment: accompanimentReducer,
-      vehicleDetails: vehicleDetailsCatHomeReducer,
+      vehicleDetails: vehicleDetailsReducer,
       testData: testDataCatKReducer,
       passCompletion: passCompletionReducer,
       postTestDeclarations: postTestDeclarationsReducer,

--- a/src/modules/tests/vehicle-details/cat-home/vehicle-details.cat-home.reducer.ts
+++ b/src/modules/tests/vehicle-details/cat-home/vehicle-details.cat-home.reducer.ts
@@ -1,0 +1,34 @@
+import * as vehicleDetailsActions from '../common/vehicle-details.actions';
+import { VehicleDetails } from '@dvsa/mes-test-schema/categories/common';
+import { createFeatureSelector } from '@ngrx/store';
+
+const initialState: VehicleDetails = {
+  registrationNumber: '',
+};
+
+export const vehicleDetailsCatHomeReducer = (
+  state: VehicleDetails = initialState,
+  action: vehicleDetailsActions.Types,
+): VehicleDetails => {
+  switch (action.type) {
+    case vehicleDetailsActions.VEHICLE_REGISTRATION_CHANGED:
+      return {
+        ...state,
+        registrationNumber: action.vehicleRegistration,
+      };
+    case vehicleDetailsActions.GEARBOX_CATEGORY_CHANGED:
+      return {
+        ...state,
+        gearboxCategory: action.gearboxCategory,
+      };
+    case vehicleDetailsActions.CLEAR_GEARBOX_CATEGORY:
+      return {
+        ...state,
+        gearboxCategory: null,
+      };
+    default:
+      return state;
+  }
+};
+
+export const getVehicleDetails = createFeatureSelector<VehicleDetails>('vehicleDetails');

--- a/src/modules/tests/vehicle-details/common/__tests__/vehicle-details.reducer.spec.ts
+++ b/src/modules/tests/vehicle-details/common/__tests__/vehicle-details.reducer.spec.ts
@@ -1,0 +1,18 @@
+import { vehicleDetailsReducer } from '../vehicle-details.reducer';
+import {
+  VehicleRegistrationChanged,
+  GearboxCategoryChanged,
+} from '../../common/vehicle-details.actions';
+
+describe('vehicle details reducer', () => {
+  it('should put the registration number into the state on vehicle registration changed action', () => {
+    const result = vehicleDetailsReducer({}, new VehicleRegistrationChanged('abc123'));
+    expect(result.registrationNumber).toBe('abc123');
+  });
+
+  it('should change the gearbox category when the gearbox change action is received', () => {
+    const result = vehicleDetailsReducer({}, new GearboxCategoryChanged('Automatic'));
+    expect(result.gearboxCategory).toBe('Automatic');
+  });
+
+});

--- a/src/modules/tests/vehicle-details/common/__tests__/vehicle-details.selector.spec.ts
+++ b/src/modules/tests/vehicle-details/common/__tests__/vehicle-details.selector.spec.ts
@@ -1,0 +1,24 @@
+import { VehicleDetails } from '@dvsa/mes-test-schema/categories/common';
+import {
+  getRegistrationNumber,
+  getGearboxCategory,
+} from '../../common/vehicle-details.selector';
+
+describe('vehicle details selector', () => {
+  const state: VehicleDetails = {
+    gearboxCategory: 'Manual',
+    registrationNumber: '11AAA',
+  };
+
+  describe('getRegistrationNumber', () => {
+    it('should retrieve the registration number from the vehicle details', () => {
+      expect(getRegistrationNumber(state)).toBe('11AAA');
+    });
+  });
+
+  describe('getGearboxCategory', () => {
+    it('should retrieve the gearbox category from the vehicle details', () => {
+      expect(getGearboxCategory(state)).toBe('Manual');
+    });
+  });
+});

--- a/src/modules/tests/vehicle-details/common/vehicle-details.reducer.ts
+++ b/src/modules/tests/vehicle-details/common/vehicle-details.reducer.ts
@@ -1,4 +1,4 @@
-import * as vehicleDetailsActions from '../common/vehicle-details.actions';
+import * as vehicleDetailsActions from './vehicle-details.actions';
 import { VehicleDetails } from '@dvsa/mes-test-schema/categories/common';
 import { createFeatureSelector } from '@ngrx/store';
 
@@ -6,7 +6,7 @@ const initialState: VehicleDetails = {
   registrationNumber: '',
 };
 
-export const vehicleDetailsCatHomeReducer = (
+export const vehicleDetailsReducer = (
   state: VehicleDetails = initialState,
   action: vehicleDetailsActions.Types,
 ): VehicleDetails => {


### PR DESCRIPTION
## Description
Adds home categories(F,G,H,K) to the Reducer Factory, including reducer composition of:

 - Tests
 - Test Data
 - Journal Data
 - Vehicle Details

state for Vehicle Checks and Highway Safety Code Reducers currently return null and reducers will be completed in specific stories associated with that functionality.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
