### PR TITLE
MES-5027: Making test validation valid when avoidance speed not met

### DIFF
--- a/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
+++ b/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
@@ -168,7 +168,7 @@ describe('TestReportValidator', () => {
       expect(result).toBe(SpeedCheckState.AVOIDANCE_MISSING);
     });
 
-    it('should return SpeedCheckState.NOT_MET when avoidance speed not met is true & speed is recorded', () => {
+    it('should return SpeedCheckState.VALID when avoidance speed not met is true & speed is recorded', () => {
       const testData = {
         avoidance: {
           firstAttempt: 48,
@@ -178,7 +178,7 @@ describe('TestReportValidator', () => {
 
       const result = testReportValidatorProvider.validateSpeedChecksCatAMod1(testData);
 
-      expect(result).toBe(SpeedCheckState.NOT_MET);
+      expect(result).toBe(SpeedCheckState.VALID);
     });
 
     it('should return VALID when avoidance speed not met first attempt is recorded but has Serious fault', () => {

--- a/src/providers/test-report-validator/test-report-validator.ts
+++ b/src/providers/test-report-validator/test-report-validator.ts
@@ -132,11 +132,11 @@ export class TestReportValidatorProvider {
         return SpeedCheckState.AVOIDANCE_MISSING;
       }
 
-      if (avoidanceOutcome === CompetencyOutcome.S || avoidanceOutcome === CompetencyOutcome.D) {
-        return SpeedCheckState.VALID;
-      }
+      // if (avoidanceOutcome === CompetencyOutcome.S || avoidanceOutcome === CompetencyOutcome.D) {
+      //   return SpeedCheckState.VALID;
+      // }
 
-      return SpeedCheckState.NOT_MET;
+      return SpeedCheckState.VALID;
     }
 
     if (emergencyStopFirstAttempt === undefined && avoidanceFirstAttempt === undefined) {

--- a/src/providers/test-report-validator/test-report-validator.ts
+++ b/src/providers/test-report-validator/test-report-validator.ts
@@ -132,10 +132,6 @@ export class TestReportValidatorProvider {
         return SpeedCheckState.AVOIDANCE_MISSING;
       }
 
-      // if (avoidanceOutcome === CompetencyOutcome.S || avoidanceOutcome === CompetencyOutcome.D) {
-      //   return SpeedCheckState.VALID;
-      // }
-
       return SpeedCheckState.VALID;
     }
 


### PR DESCRIPTION
## Description

Changing Modal after ending the test when speed is not met on avoidance competency.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
