### PR TITLE
MES-4890 - Debrief Page for Home Tests

### DIFF
--- a/src/pages/debrief/cat-home-test/__tests__/debrief.cat-home-test.page.spec.ts
+++ b/src/pages/debrief/cat-home-test/__tests__/debrief.cat-home-test.page.spec.ts
@@ -43,6 +43,7 @@ import { FaultSummaryProvider } from '../../../../providers/fault-summary/fault-
 import { of } from 'rxjs/observable/of';
 import { TestOutcome } from '../../../../shared/models/test-outcome';
 import { configureTestSuite } from 'ng-bullet';
+import { TestDataByCategoryProvider } from '../../../../providers/test-data-by-category/test-data-by-category';
 
 describe('DebriefCatHomeTestPage', () => {
   let fixture: ComponentFixture<DebriefCatHomeTestPage>;
@@ -122,6 +123,7 @@ describe('DebriefCatHomeTestPage', () => {
         { provide: ScreenOrientation, useClass: ScreenOrientationMock },
         { provide: Insomnia, useClass: InsomniaMock },
         { provide: FaultSummaryProvider, useClass: FaultSummaryProvider },
+        TestDataByCategoryProvider,
       ],
     });
   });

--- a/src/pages/debrief/cat-home-test/__tests__/debrief.cat-home-test.page.spec.ts
+++ b/src/pages/debrief/cat-home-test/__tests__/debrief.cat-home-test.page.spec.ts
@@ -12,30 +12,14 @@ import { By } from '@angular/platform-browser';
 import { ComponentsModule } from '../../../../components/common/common-components.module';
 import { StoreModel } from '../../../../shared/models/store.model';
 import { StoreModule, Store } from '@ngrx/store';
-import {
-  AddDangerousFault,
-} from '../../../../modules/tests/test-data/common/dangerous-faults/dangerous-faults.actions';
-import { AddSeriousFault } from '../../../../modules/tests/test-data/common/serious-faults/serious-faults.actions';
-import { AddDrivingFault } from '../../../../modules/tests/test-data/common/driving-faults/driving-faults.actions';
-import {
-  EyesightTestFailed,
-  EyesightTestPassed,
-} from '../../../../modules/tests/test-data/common/eyesight-test/eyesight-test.actions';
-import { Competencies } from '../../../../modules/tests/test-data/test-data.constants';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
 import { InsomniaMock } from '../../../../shared/mocks/insomnia.mock';
 import { ScreenOrientationMock } from '../../../../shared/mocks/screen-orientation.mock';
 import { TranslateModule, TranslateService } from 'ng2-translate';
-import { fullCompetencyLabels } from '../../../../shared/constants/competencies/competencies';
 import { TestSlotAttributes } from '@dvsa/mes-test-schema/categories/common';
-import { PopulateTestSlotAttributes }
-  from '../../../../modules/tests/journal-data/common/test-slot-attributes/test-slot-attributes.actions';
 import { EndDebrief } from '../../debrief.actions';
-import * as welshTranslations from '../../../../assets/i18n/cy.json';
 import { CAT_HOME_TEST } from '../../../page-names.constants';
-import { Language } from '../../../../modules/tests/communication-preferences/communication-preferences.model';
-import { configureI18N } from '../../../../shared/helpers/translation.helpers';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { CatHUniqueTypes } from '@dvsa/mes-test-schema/categories/H';
 import { FaultSummaryProvider } from '../../../../providers/fault-summary/fault-summary';

--- a/src/pages/debrief/cat-home-test/__tests__/debrief.cat-home-test.page.spec.ts
+++ b/src/pages/debrief/cat-home-test/__tests__/debrief.cat-home-test.page.spec.ts
@@ -22,7 +22,6 @@ import {
   EyesightTestPassed,
 } from '../../../../modules/tests/test-data/common/eyesight-test/eyesight-test.actions';
 import { Competencies } from '../../../../modules/tests/test-data/test-data.constants';
-import { DebriefComponentsModule } from '../../components/debrief-components.module';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { Insomnia } from '@ionic-native/insomnia';
 import { InsomniaMock } from '../../../../shared/mocks/insomnia.mock';
@@ -44,6 +43,22 @@ import { of } from 'rxjs/observable/of';
 import { TestOutcome } from '../../../../shared/models/test-outcome';
 import { configureTestSuite } from 'ng-bullet';
 import { TestDataByCategoryProvider } from '../../../../providers/test-data-by-category/test-data-by-category';
+import { MockComponent } from 'ng-mocks';
+import { VehicleChecksCardComponent } from '../../components/vehicle-checks-card/vehicle-checks-card';
+import { EtaDebriefCardComponent } from '../../components/eta-debrief-card/eta-debrief-card';
+import {
+  DangerousFaultsDebriefCardComponent,
+} from '../../components/dangerous-faults-debrief-card/dangerous-faults-debrief-card';
+import {
+  SeriousFaultsDebriefCardComponent,
+} from '../../components/serious-faults-debrief-card/serious-faults-debrief-card';
+import {
+  DrivingFaultsDebriefCardComponent,
+} from '../../components/driving-faults-debrief-card/driving-faults-debrief-card';
+import {
+  TestOutcomeDebriefCardComponent,
+} from '../../components/test-outcome-debrief-card/test-outcome-debrief-card';
+import { EcoDebriefCardComponent } from '../../components/eco-debrief-card/eco-debrief-card';
 
 describe('DebriefCatHomeTestPage', () => {
   let fixture: ComponentFixture<DebriefCatHomeTestPage>;
@@ -77,12 +92,20 @@ describe('DebriefCatHomeTestPage', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      declarations: [DebriefCatHomeTestPage],
+      declarations: [
+        DebriefCatHomeTestPage,
+        MockComponent(VehicleChecksCardComponent),
+        MockComponent(EtaDebriefCardComponent),
+        MockComponent(DangerousFaultsDebriefCardComponent),
+        MockComponent(SeriousFaultsDebriefCardComponent),
+        MockComponent(DrivingFaultsDebriefCardComponent),
+        MockComponent(EcoDebriefCardComponent),
+        MockComponent(TestOutcomeDebriefCardComponent),
+      ],
       imports: [
         IonicModule,
         AppModule,
         ComponentsModule,
-        DebriefComponentsModule,
         StoreModule.forRoot({
           tests: () => ({
             currentTest: {
@@ -138,35 +161,31 @@ describe('DebriefCatHomeTestPage', () => {
     translate.setDefaultLang('en');
   }));
 
+  describe('Class', () => {
+    describe('endDebrief', () => {
+      it('should dispatch the PersistTests action', () => {
+        component.endDebrief();
+        expect(store$.dispatch).toHaveBeenCalledWith(new EndDebrief);
+      });
+      it('should navigate to PassFinalisationPage when outcome = pass', () => {
+        component.outcome = TestOutcome.PASS;
+        component.endDebrief();
+        expect(navController.push).toHaveBeenCalledWith(CAT_HOME_TEST.PASS_FINALISATION_PAGE);
+      });
+      it('should navigate to BackToOfficePage when outcome = fail', () => {
+        component.outcome = TestOutcome.FAIL;
+        component.endDebrief();
+        expect(navController.push).toHaveBeenCalledWith(CAT_HOME_TEST.POST_DEBRIEF_HOLDING_PAGE);
+      });
+      it('should navigate to the BackToOfficePage when outcomes = terminated', () => {
+        component.outcome = 'Terminated';
+        component.endDebrief();
+        expect(navController.push).toHaveBeenCalledWith(CAT_HOME_TEST.POST_DEBRIEF_HOLDING_PAGE);
+      });
+    });
+  });
+
   describe('DOM', () => {
-    it('should display passed container if outcome is `passed`', () => {
-      fixture.detectChanges();
-      component.outcome = TestOutcome.PASS;
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.query(By.css('.passed'))).not.toBeNull();
-      expect(fixture.debugElement.query(By.css('.failed'))).toBeNull();
-      expect(fixture.debugElement.query(By.css('.terminated'))).toBeNull();
-    });
-    it('should display failed container if outcome is `fail`', () => {
-      fixture.detectChanges();
-      component.outcome = TestOutcome.FAIL;
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.query(By.css('.failed'))).not.toBeNull();
-      expect(fixture.debugElement.query(By.css('.passed'))).toBeNull();
-      expect(fixture.debugElement.query(By.css('.terminated'))).toBeNull();
-    });
-    it('should display terminated container if outcome is `terminated`', () => {
-      fixture.detectChanges();
-      component.outcome = 'Terminated';
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.query(By.css('.terminated'))).not.toBeNull();
-      expect(fixture.debugElement.query(By.css('.passed'))).toBeNull();
-      expect(fixture.debugElement.query(By.css('.failed'))).toBeNull();
-    });
-
     it('should display the candidate name in the title', () => {
       fixture.detectChanges();
       component.pageState.candidateName$ = of('John Doe');
@@ -175,116 +194,5 @@ describe('DebriefCatHomeTestPage', () => {
       expect(title.nativeElement.textContent).toEqual('Debrief - John Doe');
     });
 
-  });
-
-  it('should not display dangerous faults container if there are no dangerous faults', () => {
-    fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('#dangerous-fault'))).toBeNull();
-  });
-
-  it('should not display serious faults container if there are no serious faults', () => {
-    fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('#serious-fault'))).toBeNull();
-  });
-
-  it('should not display driving faults container if there are no driving faults', () => {
-    fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('#driving-fault'))).toBeNull();
-  });
-
-  it('should display dangerous faults container if there are dangerous faults', () => {
-    store$.dispatch(new AddDangerousFault(Competencies.controlsClutch));
-    fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('#dangerous-fault'))).not.toBeNull();
-  });
-
-  it('should display serious faults container if there are serious faults', () => {
-    store$.dispatch(new AddSeriousFault(Competencies.controlsClutch));
-    fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('#serious-fault'))).not.toBeNull();
-  });
-
-  it('should display driving faults container if there are driving faults', () => {
-    store$.dispatch(new AddDrivingFault({ competency: Competencies.controlsClutch, newFaultCount: 1 }));
-    fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('#driving-fault'))).not.toBeNull();
-  });
-
-  describe('endDebrief', () => {
-    it('should dispatch the PersistTests action', () => {
-      component.endDebrief();
-      expect(store$.dispatch).toHaveBeenCalledWith(new EndDebrief);
-    });
-    it('should navigate to PassFinalisationPage when outcome = pass', () => {
-      component.outcome = TestOutcome.PASS;
-      component.endDebrief();
-      expect(navController.push).toHaveBeenCalledWith(CAT_HOME_TEST.PASS_FINALISATION_PAGE);
-    });
-    it('should navigate to BackToOfficePage when outcome = fail', () => {
-      component.outcome = TestOutcome.FAIL;
-      component.endDebrief();
-      expect(navController.push).toHaveBeenCalledWith(CAT_HOME_TEST.POST_DEBRIEF_HOLDING_PAGE);
-    });
-    it('should navigate to the BackToOfficePage when outcomes = terminated', () => {
-      component.outcome = 'Terminated';
-      component.endDebrief();
-      expect(navController.push).toHaveBeenCalledWith(CAT_HOME_TEST.POST_DEBRIEF_HOLDING_PAGE);
-    });
-  });
-
-  describe('translation of fault competencies', () => {
-    it('should display fault competencies in English by default', () => {
-      store$.dispatch(new AddDrivingFault({ competency: Competencies.moveOffSafety, newFaultCount: 1 }));
-      store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsSignalling));
-      store$.dispatch(new AddDangerousFault(Competencies.useOfMirrorsChangeDirection));
-      fixture.detectChanges();
-      const drivingFaultLabel = fixture.debugElement.query(By.css('#driving-fault .counter-label')).nativeElement;
-      const seriousLabel = fixture.debugElement.query(By.css('#serious-fault .counter-label')).nativeElement;
-      const dangerousLabel = fixture.debugElement.query(By.css('#dangerous-fault .counter-label')).nativeElement;
-
-      expect(drivingFaultLabel.innerHTML).toBe(fullCompetencyLabels.moveOffSafety);
-      expect(seriousLabel.innerHTML).toBe(fullCompetencyLabels.useOfMirrorsSignalling);
-      expect(dangerousLabel.innerHTML).toBe(fullCompetencyLabels.useOfMirrorsChangeDirection);
-    });
-    it('should display fault competencies in Welsh for a Welsh test', (done) => {
-      store$.dispatch(new AddDrivingFault({ competency: Competencies.moveOffSafety, newFaultCount: 1 }));
-      store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsSignalling));
-      store$.dispatch(new AddDangerousFault(Competencies.useOfMirrorsChangeDirection));
-      fixture.detectChanges();
-      configureI18N(Language.CYMRAEG, translate);
-      translate.onLangChange.subscribe(() => {
-        fixture.detectChanges();
-        const drivingFaultLabel = fixture.debugElement.query(By.css('#driving-fault .counter-label')).nativeElement;
-        const seriousLabel = fixture.debugElement.query(By.css('#serious-fault .counter-label')).nativeElement;
-        const dangerousLabel = fixture.debugElement.query(By.css('#dangerous-fault .counter-label')).nativeElement;
-
-        const expectedDrivingFaultTranslation = (<any>welshTranslations).debrief.competencies.moveOffSafety;
-        const expectedSeriousFaultTranslation = (<any>welshTranslations).debrief.competencies.useOfMirrorsSignalling;
-        const expectedDangerousFaultTranslation =
-          (<any>welshTranslations).debrief.competencies.useOfMirrorsChangeDirection;
-
-        expect(drivingFaultLabel.innerHTML).toBe(expectedDrivingFaultTranslation);
-        expect(seriousLabel.innerHTML).toBe(expectedSeriousFaultTranslation);
-        expect(dangerousLabel.innerHTML).toBe(expectedDangerousFaultTranslation);
-        done();
-      });
-      store$.dispatch(new PopulateTestSlotAttributes({ ...testSlotAttributes, welshTest: true }));
-    });
-  });
-
-  describe('Eyesight Test', () => {
-    it('should display the eyesight test serious fault', () => {
-      store$.dispatch(new EyesightTestFailed());
-      fixture.detectChanges();
-      const seriousLabel = fixture.debugElement.query(By.css('#serious-fault .counter-label')).nativeElement;
-      expect(seriousLabel.innerHTML).toBe(fullCompetencyLabels.eyesightTest);
-    });
-
-    it('should not display a eyesight test serious fault if the test is passed', () => {
-      store$.dispatch(new EyesightTestPassed());
-      fixture.detectChanges();
-      const label = fixture.debugElement.query(By.css('#serious-fault .counter-label'));
-      expect(label).toBeNull();
-    });
   });
 });

--- a/src/pages/debrief/cat-home-test/__tests__/debrief.cat-home-test.page.spec.ts
+++ b/src/pages/debrief/cat-home-test/__tests__/debrief.cat-home-test.page.spec.ts
@@ -1,0 +1,288 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { IonicModule, NavController, NavParams, Config, Platform } from 'ionic-angular';
+import { NavControllerMock, NavParamsMock, ConfigMock, PlatformMock } from 'ionic-mocks';
+
+import { AppModule } from '../../../../app/app.module';
+import { DebriefCatHomeTestPage } from '../debrief.cat-home-test.page';
+import { AuthenticationProvider } from '../../../../providers/authentication/authentication';
+import { AuthenticationProviderMock } from '../../../../providers/authentication/__mocks__/authentication.mock';
+import { DateTimeProvider } from '../../../../providers/date-time/date-time';
+import { DateTimeProviderMock } from '../../../../providers/date-time/__mocks__/date-time.mock';
+import { By } from '@angular/platform-browser';
+import { ComponentsModule } from '../../../../components/common/common-components.module';
+import { StoreModel } from '../../../../shared/models/store.model';
+import { StoreModule, Store } from '@ngrx/store';
+import {
+  AddDangerousFault,
+} from '../../../../modules/tests/test-data/common/dangerous-faults/dangerous-faults.actions';
+import { AddSeriousFault } from '../../../../modules/tests/test-data/common/serious-faults/serious-faults.actions';
+import { AddDrivingFault } from '../../../../modules/tests/test-data/common/driving-faults/driving-faults.actions';
+import {
+  EyesightTestFailed,
+  EyesightTestPassed,
+} from '../../../../modules/tests/test-data/common/eyesight-test/eyesight-test.actions';
+import { Competencies } from '../../../../modules/tests/test-data/test-data.constants';
+import { DebriefComponentsModule } from '../../components/debrief-components.module';
+import { ScreenOrientation } from '@ionic-native/screen-orientation';
+import { Insomnia } from '@ionic-native/insomnia';
+import { InsomniaMock } from '../../../../shared/mocks/insomnia.mock';
+import { ScreenOrientationMock } from '../../../../shared/mocks/screen-orientation.mock';
+import { TranslateModule, TranslateService } from 'ng2-translate';
+import { fullCompetencyLabels } from '../../../../shared/constants/competencies/competencies';
+import { TestSlotAttributes } from '@dvsa/mes-test-schema/categories/common';
+import { PopulateTestSlotAttributes }
+  from '../../../../modules/tests/journal-data/common/test-slot-attributes/test-slot-attributes.actions';
+import { EndDebrief } from '../../debrief.actions';
+import * as welshTranslations from '../../../../assets/i18n/cy.json';
+import { CAT_HOME_TEST } from '../../../page-names.constants';
+import { Language } from '../../../../modules/tests/communication-preferences/communication-preferences.model';
+import { configureI18N } from '../../../../shared/helpers/translation.helpers';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { CatHUniqueTypes } from '@dvsa/mes-test-schema/categories/H';
+import { FaultSummaryProvider } from '../../../../providers/fault-summary/fault-summary';
+import { of } from 'rxjs/observable/of';
+import { TestOutcome } from '../../../../shared/models/test-outcome';
+import { configureTestSuite } from 'ng-bullet';
+
+describe('DebriefCatHomeTestPage', () => {
+  let fixture: ComponentFixture<DebriefCatHomeTestPage>;
+  let component: DebriefCatHomeTestPage;
+  let navController: NavController;
+  let store$: Store<StoreModel>;
+  let translate: TranslateService;
+
+  const testSlotAttributes: TestSlotAttributes = {
+    welshTest: false,
+    extendedTest: false,
+    slotId: 123,
+    specialNeeds: false,
+    start: '',
+    vehicleTypeCode: '',
+  };
+
+  const exampleTestData: CatHUniqueTypes.TestData  = {
+    dangerousFaults: {},
+    drivingFaults: {},
+    manoeuvres: {},
+    seriousFaults: {},
+    testRequirements: {},
+    ETA: {},
+    eco: {},
+    vehicleChecks: {
+      tellMeQuestions: [{}],
+      showMeQuestions: [{}],
+    },
+  };
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [DebriefCatHomeTestPage],
+      imports: [
+        IonicModule,
+        AppModule,
+        ComponentsModule,
+        DebriefComponentsModule,
+        StoreModule.forRoot({
+          tests: () => ({
+            currentTest: {
+              slotId: '123',
+            },
+            testStatus: {},
+            startedTests: {
+              123: {
+                testSlotAttributes,
+                category: TestCategory.H,
+                vehicleDetails: {},
+                accompaniment: {},
+                testData: exampleTestData,
+                journalData: {
+                  candidate: {
+                    candidateName: 'Joe Bloggs',
+                  },
+                },
+              },
+            },
+          }),
+          testReport: () => ({
+            seriousMode: false,
+            dangerousMode: false,
+            removeFaultMode: false,
+            isValid: false,
+          }),
+        }),
+        TranslateModule,
+      ],
+      providers: [
+        { provide: NavController, useFactory: () => NavControllerMock.instance() },
+        { provide: NavParams, useFactory: () => NavParamsMock.instance() },
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+        { provide: Platform, useFactory: () => PlatformMock.instance() },
+        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
+        { provide: DateTimeProvider, useClass: DateTimeProviderMock },
+        { provide: ScreenOrientation, useClass: ScreenOrientationMock },
+        { provide: Insomnia, useClass: InsomniaMock },
+        { provide: FaultSummaryProvider, useClass: FaultSummaryProvider },
+      ],
+    });
+  });
+
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(DebriefCatHomeTestPage);
+    component = fixture.componentInstance;
+    navController = TestBed.get(NavController);
+    store$ = TestBed.get(Store);
+    spyOn(store$, 'dispatch').and.callThrough();
+    translate = TestBed.get(TranslateService);
+    translate.setDefaultLang('en');
+  }));
+
+  describe('DOM', () => {
+    it('should display passed container if outcome is `passed`', () => {
+      fixture.detectChanges();
+      component.outcome = TestOutcome.PASS;
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.passed'))).not.toBeNull();
+      expect(fixture.debugElement.query(By.css('.failed'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('.terminated'))).toBeNull();
+    });
+    it('should display failed container if outcome is `fail`', () => {
+      fixture.detectChanges();
+      component.outcome = TestOutcome.FAIL;
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.failed'))).not.toBeNull();
+      expect(fixture.debugElement.query(By.css('.passed'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('.terminated'))).toBeNull();
+    });
+    it('should display terminated container if outcome is `terminated`', () => {
+      fixture.detectChanges();
+      component.outcome = 'Terminated';
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.terminated'))).not.toBeNull();
+      expect(fixture.debugElement.query(By.css('.passed'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('.failed'))).toBeNull();
+    });
+
+    it('should display the candidate name in the title', () => {
+      fixture.detectChanges();
+      component.pageState.candidateName$ = of('John Doe');
+      fixture.detectChanges();
+      const title = fixture.debugElement.query(By.css('ion-title'));
+      expect(title.nativeElement.textContent).toEqual('Debrief - John Doe');
+    });
+
+  });
+
+  it('should not display dangerous faults container if there are no dangerous faults', () => {
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#dangerous-fault'))).toBeNull();
+  });
+
+  it('should not display serious faults container if there are no serious faults', () => {
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#serious-fault'))).toBeNull();
+  });
+
+  it('should not display driving faults container if there are no driving faults', () => {
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#driving-fault'))).toBeNull();
+  });
+
+  it('should display dangerous faults container if there are dangerous faults', () => {
+    store$.dispatch(new AddDangerousFault(Competencies.controlsClutch));
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#dangerous-fault'))).not.toBeNull();
+  });
+
+  it('should display serious faults container if there are serious faults', () => {
+    store$.dispatch(new AddSeriousFault(Competencies.controlsClutch));
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#serious-fault'))).not.toBeNull();
+  });
+
+  it('should display driving faults container if there are driving faults', () => {
+    store$.dispatch(new AddDrivingFault({ competency: Competencies.controlsClutch, newFaultCount: 1 }));
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('#driving-fault'))).not.toBeNull();
+  });
+
+  describe('endDebrief', () => {
+    it('should dispatch the PersistTests action', () => {
+      component.endDebrief();
+      expect(store$.dispatch).toHaveBeenCalledWith(new EndDebrief);
+    });
+    it('should navigate to PassFinalisationPage when outcome = pass', () => {
+      component.outcome = TestOutcome.PASS;
+      component.endDebrief();
+      expect(navController.push).toHaveBeenCalledWith(CAT_HOME_TEST.PASS_FINALISATION_PAGE);
+    });
+    it('should navigate to BackToOfficePage when outcome = fail', () => {
+      component.outcome = TestOutcome.FAIL;
+      component.endDebrief();
+      expect(navController.push).toHaveBeenCalledWith(CAT_HOME_TEST.POST_DEBRIEF_HOLDING_PAGE);
+    });
+    it('should navigate to the BackToOfficePage when outcomes = terminated', () => {
+      component.outcome = 'Terminated';
+      component.endDebrief();
+      expect(navController.push).toHaveBeenCalledWith(CAT_HOME_TEST.POST_DEBRIEF_HOLDING_PAGE);
+    });
+  });
+
+  describe('translation of fault competencies', () => {
+    it('should display fault competencies in English by default', () => {
+      store$.dispatch(new AddDrivingFault({ competency: Competencies.moveOffSafety, newFaultCount: 1 }));
+      store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsSignalling));
+      store$.dispatch(new AddDangerousFault(Competencies.useOfMirrorsChangeDirection));
+      fixture.detectChanges();
+      const drivingFaultLabel = fixture.debugElement.query(By.css('#driving-fault .counter-label')).nativeElement;
+      const seriousLabel = fixture.debugElement.query(By.css('#serious-fault .counter-label')).nativeElement;
+      const dangerousLabel = fixture.debugElement.query(By.css('#dangerous-fault .counter-label')).nativeElement;
+
+      expect(drivingFaultLabel.innerHTML).toBe(fullCompetencyLabels.moveOffSafety);
+      expect(seriousLabel.innerHTML).toBe(fullCompetencyLabels.useOfMirrorsSignalling);
+      expect(dangerousLabel.innerHTML).toBe(fullCompetencyLabels.useOfMirrorsChangeDirection);
+    });
+    it('should display fault competencies in Welsh for a Welsh test', (done) => {
+      store$.dispatch(new AddDrivingFault({ competency: Competencies.moveOffSafety, newFaultCount: 1 }));
+      store$.dispatch(new AddSeriousFault(Competencies.useOfMirrorsSignalling));
+      store$.dispatch(new AddDangerousFault(Competencies.useOfMirrorsChangeDirection));
+      fixture.detectChanges();
+      configureI18N(Language.CYMRAEG, translate);
+      translate.onLangChange.subscribe(() => {
+        fixture.detectChanges();
+        const drivingFaultLabel = fixture.debugElement.query(By.css('#driving-fault .counter-label')).nativeElement;
+        const seriousLabel = fixture.debugElement.query(By.css('#serious-fault .counter-label')).nativeElement;
+        const dangerousLabel = fixture.debugElement.query(By.css('#dangerous-fault .counter-label')).nativeElement;
+
+        const expectedDrivingFaultTranslation = (<any>welshTranslations).debrief.competencies.moveOffSafety;
+        const expectedSeriousFaultTranslation = (<any>welshTranslations).debrief.competencies.useOfMirrorsSignalling;
+        const expectedDangerousFaultTranslation =
+          (<any>welshTranslations).debrief.competencies.useOfMirrorsChangeDirection;
+
+        expect(drivingFaultLabel.innerHTML).toBe(expectedDrivingFaultTranslation);
+        expect(seriousLabel.innerHTML).toBe(expectedSeriousFaultTranslation);
+        expect(dangerousLabel.innerHTML).toBe(expectedDangerousFaultTranslation);
+        done();
+      });
+      store$.dispatch(new PopulateTestSlotAttributes({ ...testSlotAttributes, welshTest: true }));
+    });
+  });
+
+  describe('Eyesight Test', () => {
+    it('should display the eyesight test serious fault', () => {
+      store$.dispatch(new EyesightTestFailed());
+      fixture.detectChanges();
+      const seriousLabel = fixture.debugElement.query(By.css('#serious-fault .counter-label')).nativeElement;
+      expect(seriousLabel.innerHTML).toBe(fullCompetencyLabels.eyesightTest);
+    });
+
+    it('should not display a eyesight test serious fault if the test is passed', () => {
+      store$.dispatch(new EyesightTestPassed());
+      fixture.detectChanges();
+      const label = fixture.debugElement.query(By.css('#serious-fault .counter-label'));
+      expect(label).toBeNull();
+    });
+  });
+});

--- a/src/pages/debrief/cat-home-test/debrief.cat-home-test.page.html
+++ b/src/pages/debrief/cat-home-test/debrief.cat-home-test.page.html
@@ -1,0 +1,25 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>{{ 'debrief.title' | translate }} - {{pageState.candidateName$ | async}}</ion-title>
+    <ion-buttons end *ngIf="authenticationProvider.logoutEnabled()">
+      <button ion-button (click)="logout()">Sign Out</button>
+    </ion-buttons>
+  </ion-navbar>
+  <test-outcome-debrief-card [outcome]="outcome"></test-outcome-debrief-card>
+</ion-header>
+
+<ion-content>
+  <eta-debrief-card [hasPhysicalEta]="hasPhysicalEta" [hasVerbalEta]="hasVerbalEta"></eta-debrief-card>
+  <dangerous-faults-debrief-card [dangerousFaults]="pageState.dangerousFaults$ | async"></dangerous-faults-debrief-card>
+  <serious-faults-debrief-card [seriousFaults]="pageState.seriousFaults$ | async"></serious-faults-debrief-card>
+  <driving-faults-debrief-card [drivingFaults]="pageState.drivingFaults$ | async" [drivingFaultCount]="pageState.drivingFaultCount$ | async"></driving-faults-debrief-card>
+  <eco-debrief-card [adviceGivenControl]="adviceGivenControl" [adviceGivenPlanning]="adviceGivenPlanning"></eco-debrief-card>
+  <vehicle-checks-card [category]="pageState.category$ | async" [tellMeShowMeQuestions]="pageState.tellMeShowMeQuestions$ | async"></vehicle-checks-card>
+</ion-content>
+<ion-footer>
+  <div id="end-debrief-background">
+    <button ion-button id="end-debrief-button" class="mes-primary-button" (click)="endDebrief()">
+      <h3>{{ 'debrief.end' | translate }}</h3>
+    </button>
+  </div>
+</ion-footer>

--- a/src/pages/debrief/cat-home-test/debrief.cat-home-test.page.module.ts
+++ b/src/pages/debrief/cat-home-test/debrief.cat-home-test.page.module.ts
@@ -1,0 +1,30 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { DebriefCatHomeTestPage } from './debrief.cat-home-test.page';
+import { EffectsModule } from '@ngrx/effects';
+import { DebriefAnalyticsEffects } from '../debrief.analytics.effects';
+import { ComponentsModule } from '../../../components/common/common-components.module';
+import { DebriefComponentsModule } from '../components/debrief-components.module';
+import { TranslateModule } from 'ng2-translate';
+import { DebriefEffects } from '../debrief.effects';
+import { FaultSummaryProvider } from '../../../providers/fault-summary/fault-summary';
+
+@NgModule({
+  declarations: [
+    DebriefCatHomeTestPage,
+  ],
+  imports: [
+    DebriefComponentsModule,
+    IonicPageModule.forChild(DebriefCatHomeTestPage),
+    EffectsModule.forFeature([
+      DebriefEffects,
+      DebriefAnalyticsEffects,
+    ]),
+    ComponentsModule,
+    TranslateModule,
+  ],
+  providers: [
+    FaultSummaryProvider,
+  ],
+})
+export class DebriefCatHomeTestPageModule { }

--- a/src/pages/debrief/cat-home-test/debrief.cat-home-test.page.ts
+++ b/src/pages/debrief/cat-home-test/debrief.cat-home-test.page.ts
@@ -1,0 +1,206 @@
+import { NavController, NavParams, Platform, IonicPage } from 'ionic-angular';
+import { Store, select } from '@ngrx/store';
+import { StoreModel } from '../../../shared/models/store.model';
+import { AuthenticationProvider } from '../../../providers/authentication/authentication';
+import { getCurrentTest, getJournalData } from '../../../modules/tests/tests.selector';
+import { DebriefViewDidEnter, EndDebrief } from '../debrief.actions';
+import { Observable } from 'rxjs/Observable';
+import { getTests } from '../../../modules/tests/tests.reducer';
+// TODO - CAT HOME , Switch to using the Test Data Provider
+import { getTestData } from '../../../modules/tests/test-data/cat-be/test-data.cat-be.reducer';
+import { getETA, getEco } from '../../../modules/tests/test-data/common/test-data.selector';
+import { map, tap, withLatestFrom } from 'rxjs/operators';
+import { Component } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
+import { merge } from 'rxjs/observable/merge';
+import { getTestOutcome } from '../debrief.selector';
+import { FaultSummary } from '../../../shared/models/fault-marking.model';
+import { ScreenOrientation } from '@ionic-native/screen-orientation';
+import { Insomnia } from '@ionic-native/insomnia';
+import { TranslateService } from 'ng2-translate';
+import { ETA, Eco, CategoryCode, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+import {
+  getCommunicationPreference,
+} from '../../../modules/tests/communication-preferences/communication-preferences.reducer';
+import { getConductedLanguage } from
+  '../../../modules/tests/communication-preferences/communication-preferences.selector';
+import { CAT_HOME_TEST } from '../../page-names.constants';
+import { Language } from '../../../modules/tests/communication-preferences/communication-preferences.model';
+import { configureI18N } from '../../../shared/helpers/translation.helpers';
+import { BasePageComponent } from '../../../shared/classes/base-page';
+import { FaultCountProvider } from '../../../providers/fault-count/fault-count';
+import { getTestCategory } from '../../../modules/tests/category/category.reducer';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { FaultSummaryProvider } from '../../../providers/fault-summary/fault-summary';
+import { getCandidate } from '../../../modules/tests/journal-data/common/candidate/candidate.reducer';
+import { getUntitledCandidateName } from '../../../modules/tests/journal-data/common/candidate/candidate.selector';
+import { TestOutcome } from '../../../shared/models/test-outcome';
+// TODO - Cat HOME - needs to use correct reducers
+import { getVehicleChecks } from '../../../modules/tests/test-data/cat-be/test-data.cat-be.selector';
+
+interface DebriefPageState {
+  seriousFaults$: Observable<string[]>;
+  dangerousFaults$: Observable<string[]>;
+  drivingFaults$: Observable<FaultSummary[]>;
+  drivingFaultCount$: Observable<number>;
+  etaFaults$: Observable<ETA>;
+  ecoFaults$: Observable<Eco>;
+  testResult$: Observable<string>;
+  conductedLanguage$: Observable<string>;
+  candidateName$: Observable<string>;
+  category$: Observable<CategoryCode>;
+  tellMeShowMeQuestions$: Observable<QuestionResult[]>;
+}
+
+@IonicPage()
+@Component({
+  selector: '.debrief-cat-home-test-page',
+  templateUrl: 'debrief.cat-home-test.page.html',
+})
+
+export class DebriefCatHomeTestPage extends BasePageComponent {
+
+  pageState: DebriefPageState;
+  subscription: Subscription;
+  isPassed: boolean;
+
+  // Used for now to test displaying pass/fail/terminated messages
+  public outcome: string;
+
+  public hasPhysicalEta: boolean = false;
+  public hasVerbalEta: boolean = false;
+
+  public adviceGivenControl: boolean = false;
+  public adviceGivenPlanning: boolean = false;
+
+  constructor(
+    public store$: Store<StoreModel>,
+    public navController: NavController,
+    public navParams: NavParams,
+    public platform: Platform,
+    public authenticationProvider: AuthenticationProvider,
+    public screenOrientation: ScreenOrientation,
+    public insomnia: Insomnia,
+    private translate: TranslateService,
+    private faultCountProvider: FaultCountProvider,
+    private faultSummaryProvider: FaultSummaryProvider,
+  ) {
+    super(platform, navController, authenticationProvider);
+  }
+
+  ngOnInit(): void {
+    const currentTest$ = this.store$.pipe(
+      select(getTests),
+      select(getCurrentTest),
+    );
+    const category$ = currentTest$.pipe(
+      select(getTestCategory),
+    );
+    this.pageState = {
+      seriousFaults$: currentTest$.pipe(
+        select(getTestData),
+        withLatestFrom(category$),
+        map(([data, category]) =>
+          this.faultSummaryProvider.getSeriousFaultsList(data, category as TestCategory)
+          .map(fault => fault.competencyIdentifier)),
+      ),
+      dangerousFaults$: currentTest$.pipe(
+        select(getTestData),
+        withLatestFrom(category$),
+        map(([data, category]) =>
+          this.faultSummaryProvider.getDangerousFaultsList(data, category as TestCategory)
+          .map(fault => fault.competencyIdentifier)),
+      ),
+      drivingFaults$: currentTest$.pipe(
+        select(getTestData),
+        withLatestFrom(category$),
+        map(([data, category]) => this.faultSummaryProvider.getDrivingFaultsList(data, category as TestCategory)),
+      ),
+      drivingFaultCount$: currentTest$.pipe(
+        select(getTestData),
+        withLatestFrom(category$),
+        map(([testData, category]) => {
+          return this.faultCountProvider.getDrivingFaultSumCount(category as TestCategory, testData);
+        }),
+      ),
+      etaFaults$: currentTest$.pipe(
+        select(getTestData),
+        select(getETA),
+      ),
+      ecoFaults$: currentTest$.pipe(
+        select(getTestData),
+        select(getEco),
+      ),
+      testResult$: currentTest$.pipe(
+        select(getTestOutcome),
+      ),
+      conductedLanguage$: currentTest$.pipe(
+        select(getCommunicationPreference),
+        select(getConductedLanguage),
+      ),
+      candidateName$: currentTest$.pipe(
+        select(getJournalData),
+        select(getCandidate),
+        select(getUntitledCandidateName),
+      ),
+      category$: currentTest$.pipe(
+        select(getTestCategory),
+      ),
+      tellMeShowMeQuestions$: currentTest$.pipe(
+        select(getTestData),
+        select(getVehicleChecks),
+        map(checks => [...checks.tellMeQuestions, ...checks.showMeQuestions]),
+        map(checks => checks.filter(c => c.code !== undefined)),
+      ),
+    };
+
+    const { testResult$, etaFaults$, ecoFaults$, conductedLanguage$ } = this.pageState;
+
+    this.subscription = merge(
+      testResult$.pipe(map(result => this.outcome = result)),
+      etaFaults$.pipe(
+        map((eta) => {
+          this.hasPhysicalEta = eta.physical;
+          this.hasVerbalEta = eta.verbal;
+        }),
+      ),
+      ecoFaults$.pipe(
+        map((eco) => {
+          this.adviceGivenControl = eco.adviceGivenControl;
+          this.adviceGivenPlanning = eco.adviceGivenPlanning;
+        }),
+      ),
+      conductedLanguage$.pipe(tap(value => configureI18N(value as Language, this.translate))),
+    ).subscribe();
+  }
+
+  ionViewDidEnter(): void {
+    this.store$.dispatch(new DebriefViewDidEnter());
+  }
+
+  ionViewDidLeave(): void {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+
+    }
+  }
+
+  endDebrief(): void {
+    this.store$.dispatch(new EndDebrief());
+    if (this.outcome === TestOutcome.PASS) {
+      this.navController.push(CAT_HOME_TEST.PASS_FINALISATION_PAGE);
+      return;
+    }
+    this.navController.push(CAT_HOME_TEST.POST_DEBRIEF_HOLDING_PAGE).then(() => {
+      const testReportPage = this.navController.getViews().find(view => view.id === CAT_HOME_TEST.TEST_REPORT_PAGE);
+      if (testReportPage) {
+        this.navController.removeView(testReportPage);
+      }
+      const debriefPage = this.navController.getViews().find(view => view.id === CAT_HOME_TEST.DEBRIEF_PAGE);
+      if (debriefPage) {
+        this.navController.removeView(debriefPage);
+      }
+    });
+  }
+
+}

--- a/src/providers/fault-count/fault-count.ts
+++ b/src/providers/fault-count/fault-count.ts
@@ -41,6 +41,10 @@ export class FaultCountProvider {
       case TestCategory.D1E: return FaultCountDHelper.getDrivingFaultSumCountCatD1E(data);
       case TestCategory.DE: return FaultCountDHelper.getDrivingFaultSumCountCatDE(data);
       case TestCategory.D: return FaultCountDHelper.getDrivingFaultSumCountCatD(data);
+      case TestCategory.F:
+      case TestCategory.G:
+      case TestCategory.H:
+      case TestCategory.K: return 0;
       default: throw new Error(FaultCountProvider.getFaultSumCountErrMsg);
     }
   }
@@ -65,6 +69,10 @@ export class FaultCountProvider {
       case TestCategory.D1E: return FaultCountDHelper.getSeriousFaultSumCountCatD1E(data);
       case TestCategory.DE: return FaultCountDHelper.getSeriousFaultSumCountCatDE(data);
       case TestCategory.D: return FaultCountDHelper.getSeriousFaultSumCountCatD(data);
+      case TestCategory.F:
+      case TestCategory.G:
+      case TestCategory.H:
+      case TestCategory.K: return 0;
       default: throw new Error(FaultCountProvider.getFaultSumCountErrMsg);
     }
   }
@@ -89,6 +97,10 @@ export class FaultCountProvider {
       case TestCategory.D1E: return FaultCountDHelper.getDangerousFaultSumCountCatD1E(data);
       case TestCategory.DE: return FaultCountDHelper.getDangerousFaultSumCountCatDE(data);
       case TestCategory.D: return FaultCountDHelper.getDangerousFaultSumCountCatD(data);
+      case TestCategory.F:
+      case TestCategory.G:
+      case TestCategory.H:
+      case TestCategory.K: return 0;
       default: throw new Error(FaultCountProvider.getFaultSumCountErrMsg);
     }
   }
@@ -109,6 +121,10 @@ export class FaultCountProvider {
       case TestCategory.EUA1M1:
       case TestCategory.EUA2M1:
       case TestCategory.EUAMM1: return sumManoeuvreFaults(data, faultType);
+      case TestCategory.F:
+      case TestCategory.G:
+      case TestCategory.H:
+      case TestCategory.K: return 0;
       default: throw new Error(FaultCountProvider.getFaultSumCountErrMsg);
     }
   }
@@ -124,6 +140,10 @@ export class FaultCountProvider {
       case TestCategory.D1E: return FaultCountDHelper.getVehicleChecksFaultCountCatD1E(data);
       case TestCategory.DE: return FaultCountDHelper.getVehicleChecksFaultCountCatDE(data);
       case TestCategory.D: return FaultCountDHelper.getVehicleChecksFaultCountCatD(data);
+      case TestCategory.F:
+      case TestCategory.G:
+      case TestCategory.H:
+      case TestCategory.K: return { drivingFaults: 0 , seriousFaults: 0 };
       default: throw new Error(FaultCountProvider.getFaultSumCountErrMsg);
     }
   }

--- a/src/providers/test-data-by-category/test-data-by-category.ts
+++ b/src/providers/test-data-by-category/test-data-by-category.ts
@@ -10,6 +10,10 @@ import { getTestData as getTestDataCatD } from '../../modules/tests/test-data/ca
 import { getTestData as getTestDataCatD1 } from '../../modules/tests/test-data/cat-d/test-data.cat-d1.reducer';
 import { getTestData as getTestDataCatDE } from '../../modules/tests/test-data/cat-d/test-data.cat-de.reducer';
 import { getTestData as getTestDataCatD1E } from '../../modules/tests/test-data/cat-d/test-data.cat-d1e.reducer';
+import { getTestData as getTestDataCatF } from '../../modules/tests/test-data/cat-home/test-data.cat-f.reducer';
+import { getTestData as getTestDataCatG } from '../../modules/tests/test-data/cat-home/test-data.cat-g.reducer';
+import { getTestData as getTestDataCatH } from '../../modules/tests/test-data/cat-home/test-data.cat-h.reducer';
+import { getTestData as getTestDataCatK } from '../../modules/tests/test-data/cat-home/test-data.cat-k.reducer';
 
 @Injectable()
 export class TestDataByCategoryProvider {
@@ -27,6 +31,10 @@ export class TestDataByCategoryProvider {
       case TestCategory.D1: return getTestDataCatD1;
       case TestCategory.DE: return getTestDataCatDE;
       case TestCategory.D1E: return getTestDataCatD1E;
+      case TestCategory.F: return getTestDataCatF;
+      case TestCategory.G: return getTestDataCatG;
+      case TestCategory.H: return getTestDataCatH;
+      case TestCategory.K: return getTestDataCatK;
       default: throw new Error(TestDataByCategoryProvider.getTestDataByCategoryCodeErrMsg);
     }
   }


### PR DESCRIPTION
## Description
- Created the debrief page for use on home tests.
- Removed a lot of unit tests that are in the other pages which tested sub-components. Will fix this in a new PR.
- Updated selectors to get test data based on category.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
