### PR TITLE
[cherry-pick] MES-5027: Making test validation valid when avoidance speed not met (…

### DIFF
--- a/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
+++ b/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
@@ -167,7 +167,7 @@ describe('TestReportValidator', () => {
       expect(result).toBe(SpeedCheckState.AVOIDANCE_MISSING);
     });
 
-    it('should return SpeedCheckState.NOT_MET when avoidance speed not met is true & speed is recorded', () => {
+    it('should return SpeedCheckState.VALID when avoidance speed not met is true & speed is recorded', () => {
       const testData = {
         avoidance: {
           firstAttempt: 48,
@@ -177,7 +177,7 @@ describe('TestReportValidator', () => {
 
       const result = testReportValidatorProvider.validateSpeedChecksCatAMod1(testData);
 
-      expect(result).toBe(SpeedCheckState.NOT_MET);
+      expect(result).toBe(SpeedCheckState.VALID);
     });
 
     it('should return VALID when avoidance speed not met first attempt is recorded but has Serious fault', () => {

--- a/src/providers/test-report-validator/test-report-validator.ts
+++ b/src/providers/test-report-validator/test-report-validator.ts
@@ -130,11 +130,7 @@ export class TestReportValidatorProvider {
         return SpeedCheckState.AVOIDANCE_MISSING;
       }
 
-      if (avoidanceOutcome === CompetencyOutcome.S || avoidanceOutcome === CompetencyOutcome.D) {
-        return SpeedCheckState.VALID;
-      }
-
-      return SpeedCheckState.NOT_MET;
+      return SpeedCheckState.VALID;
     }
 
     if (emergencyStopFirstAttempt === undefined && avoidanceFirstAttempt === undefined) {


### PR DESCRIPTION
…#1406)

* Making test validation valid when avoidance speed not met

* Removing comments

## Description

Just a cherry-pick from `develop`

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
