### PR TITLE
Cleanup - Removed Practice Mode Banner Mocks from Non Cat B Pages

### DIFF
--- a/src/pages/back-to-office/cat-a-mod1/_tests_/back-to-office.cat-a-mod1.page.spec.ts
+++ b/src/pages/back-to-office/cat-a-mod1/_tests_/back-to-office.cat-a-mod1.page.spec.ts
@@ -16,8 +16,6 @@ import { DeviceProvider } from '../../../../providers/device/device';
 import { DeviceProviderMock } from '../../../../providers/device/__mocks__/device.mock';
 import { InsomniaMock } from '../../../../shared/mocks/insomnia.mock';
 import { ScreenOrientationMock } from '../../../../shared/mocks/screen-orientation.mock';
-import { MockComponent } from 'ng-mocks';
-import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
 import { configureTestSuite } from 'ng-bullet';
@@ -35,7 +33,6 @@ describe('BackToOfficeCatAMod1Page', () => {
     TestBed.configureTestingModule({
       declarations: [
         BackToOfficeCatAMod1Page,
-        MockComponent(PracticeModeBanner),
       ],
       imports: [
         IonicModule,

--- a/src/pages/non-pass-finalisation/cat-be/__tests__/non-pass-finalisation.cat-be.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-be/__tests__/non-pass-finalisation.cat-be.page.spec.ts
@@ -7,7 +7,6 @@ import { AuthenticationProviderMock } from '../../../../providers/authentication
 import { Store } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
 import { MockComponent } from 'ng-mocks';
-import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { NonPassFinalisationCatBEPage } from '../non-pass-finalisation.cat-be.page';
 import {
   NonPassFinalisationViewDidEnter,
@@ -40,7 +39,6 @@ describe('NonPassFinalisationCatBEPage', () => {
     TestBed.configureTestingModule({
       declarations: [
         NonPassFinalisationCatBEPage,
-        MockComponent(PracticeModeBanner),
         MockComponent(ActivityCodeComponent),
         MockComponent(D255Component),
         MockComponent(LanguagePreferencesComponent),

--- a/src/pages/post-debrief-holding/cat-be/__tests__/post-debrief-holding.cat-be.page.spec.ts
+++ b/src/pages/post-debrief-holding/cat-be/__tests__/post-debrief-holding.cat-be.page.spec.ts
@@ -6,8 +6,6 @@ import { AuthenticationProvider } from '../../../../providers/authentication/aut
 import { AuthenticationProviderMock } from '../../../../providers/authentication/__mocks__/authentication.mock';
 import { StoreModule, Store } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
-import { MockComponent } from 'ng-mocks';
-import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { PostDebriefHoldingViewDidEnter } from '../../post-debrief-holding.actions';
 import { PostDebriefHoldingCatBEPage } from '../post-debrief-holding.cat-be.page';
 import { configureTestSuite } from 'ng-bullet';
@@ -21,7 +19,6 @@ describe('PostDebriefHoldingCatBEPage', () => {
     TestBed.configureTestingModule({
       declarations: [
         PostDebriefHoldingCatBEPage,
-        MockComponent(PracticeModeBanner),
       ],
       imports: [
         IonicModule,

--- a/src/pages/waiting-room-to-car/cat-be/__tests__/waiting-room-to-car.cat-be.page.spec.ts
+++ b/src/pages/waiting-room-to-car/cat-be/__tests__/waiting-room-to-car.cat-be.page.spec.ts
@@ -27,7 +27,6 @@ import { AccompanimentCardComponent } from '../../components/accompaniment-card/
 import { AccompanimentComponent } from '../../components/accompaniment/accompaniment';
 import { EyesightTestComponent } from '../../components/eyesight-test/eyesight-test';
 import { EyesightTestReset } from '../../../../modules/tests/test-data/common/eyesight-test/eyesight-test.actions';
-import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { WaitingRoomToCarValidationError } from '../../waiting-room-to-car.actions';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
@@ -51,7 +50,6 @@ describe('WaitingRoomToCarCatBEPage', () => {
         MockComponent(VehicleDetailsComponent),
         MockComponent(AccompanimentCardComponent),
         MockComponent(AccompanimentComponent),
-        MockComponent(PracticeModeBanner),
         MockComponent(VehicleChecksCatBEComponent),
         MockComponent(WarningBannerComponent),
       ],

--- a/src/pages/waiting-room-to-car/cat-c/__tests__/waiting-room-to-car.cat-c.page.spec.ts
+++ b/src/pages/waiting-room-to-car/cat-c/__tests__/waiting-room-to-car.cat-c.page.spec.ts
@@ -20,7 +20,6 @@ import { VehicleDetailsCardComponent } from '../../components/vehicle-details-ca
 import { VehicleDetailsComponent } from '../../components/vehicle-details/vehicle-details';
 import { AccompanimentCardComponent } from '../../components/accompaniment-card/accompaniment-card';
 import { AccompanimentComponent } from '../../components/accompaniment/accompaniment';
-import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { WaitingRoomToCarValidationError } from '../../waiting-room-to-car.actions';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
@@ -42,7 +41,6 @@ describe('WaitingRoomToCarCatCPage', () => {
         MockComponent(VehicleDetailsComponent),
         MockComponent(AccompanimentCardComponent),
         MockComponent(AccompanimentComponent),
-        MockComponent(PracticeModeBanner),
         MockComponent(VehicleChecksCatCComponent),
         MockComponent(WarningBannerComponent),
       ],

--- a/src/pages/waiting-room-to-car/cat-d/__tests__/waiting-room-to-car.cat-d.page.spec.ts
+++ b/src/pages/waiting-room-to-car/cat-d/__tests__/waiting-room-to-car.cat-d.page.spec.ts
@@ -20,7 +20,6 @@ import { VehicleDetailsCardComponent } from '../../components/vehicle-details-ca
 import { VehicleDetailsComponent } from '../../components/vehicle-details/vehicle-details';
 import { AccompanimentCardComponent } from '../../components/accompaniment-card/accompaniment-card';
 import { AccompanimentComponent } from '../../components/accompaniment/accompaniment';
-import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { WaitingRoomToCarValidationError } from '../../waiting-room-to-car.actions';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
@@ -42,7 +41,6 @@ describe('WaitingRoomToCarCatDPage', () => {
         MockComponent(VehicleDetailsComponent),
         MockComponent(AccompanimentCardComponent),
         MockComponent(AccompanimentComponent),
-        MockComponent(PracticeModeBanner),
         MockComponent(VehicleChecksCatDComponent),
         MockComponent(WarningBannerComponent),
       ],

--- a/src/pages/waiting-room/cat-be/__tests__/waiting-room.cat-be.page.spec.ts
+++ b/src/pages/waiting-room/cat-be/__tests__/waiting-room.cat-be.page.spec.ts
@@ -39,7 +39,6 @@ import { ConductedLanguageComponent } from '../../components/conducted-language/
 import { InsuranceDeclarationComponent } from '../../components/insurance-declaration/insurance-declaration';
 import { ResidencyDeclarationComponent } from '../../components/residency-declaration/residency-declaration';
 import { SignatureComponent } from '../../components/signature/signature';
-import { PracticeModeBanner } from '../../../../components/common/practice-mode-banner/practice-mode-banner';
 import { EndTestLinkComponent } from '../../../../components/common/end-test-link/end-test-link';
 import { LockScreenIndicator } from '../../../../components/common/screen-lock-indicator/lock-screen-indicator';
 import { CandidateSectionComponent } from '../../../../components/common/candidate-section/candidate-section';
@@ -65,7 +64,6 @@ describe('WaitingRoomCatBEPage', () => {
     TestBed.configureTestingModule({
       declarations: [
         WaitingRoomCatBEPage,
-        MockComponent(PracticeModeBanner),
         MockComponent(EndTestLinkComponent),
         MockComponent(LockScreenIndicator),
         MockComponent(CandidateSectionComponent),


### PR DESCRIPTION
## Description
@appleabs noticed a Practice Mode Banner being mocked in a test file where it was never being used. This PR removes all cases of this across the app

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
