### PR TITLE
Mes 5048 reversing diagram calculation updates

### DIFF
--- a/src/pages/test-report/components/reverse-diagram-modal/__mocks__/reverse-diagram-modal.mock.ts
+++ b/src/pages/test-report/components/reverse-diagram-modal/__mocks__/reverse-diagram-modal.mock.ts
@@ -7,6 +7,7 @@ export interface VehicleData {
   expStartDist: number; // Expected distanceFromStart
   expMidDist: number; // Expected distanceFromMiddle
   expWidthDist: number; // Expected distanceOfBayWidth
+  expMidDistMultiplier: string; // Expected multiplierText
 }
 
 export class ReverseDiagramModalMock implements OnInit {
@@ -24,15 +25,78 @@ export class ReverseDiagramModalMock implements OnInit {
   ngOnInit(): void {
     this.cappedStartDistance = [TestCategory.C1E, TestCategory.CE, TestCategory.DE, TestCategory.D1E];
     this.vehicleDetails = new Map([
-      [TestCategory.BE, { vLength: 10, vWidth: 2.75, expStartDist: 40, expMidDist: 20, expWidthDist: 4.13 }],
-      [TestCategory.C, { vLength: 10, vWidth: 2.75, expStartDist: 35, expMidDist: 20, expWidthDist: 4.13 }],
-      [TestCategory.CE, { vLength: 10, vWidth: 2.75, expStartDist: 40, expMidDist: 20, expWidthDist: 4.13 }],
-      [TestCategory.C1, { vLength: 10, vWidth: 2.75, expStartDist: 35, expMidDist: 20, expWidthDist: 4.13 }],
-      [TestCategory.C1E, { vLength: 10, vWidth: 2.75, expStartDist: 40, expMidDist: 20, expWidthDist: 4.13 }],
-      [TestCategory.D, { vLength: 10, vWidth: 2.75, expStartDist: 35, expMidDist: 20, expWidthDist: 4.13 }],
-      [TestCategory.DE, { vLength: 10, vWidth: 2.75, expStartDist: 40, expMidDist: 20, expWidthDist: 4.13 }],
-      [TestCategory.D1, { vLength: 10, vWidth: 2.75, expStartDist: 35, expMidDist: 20, expWidthDist: 4.13 }],
-      [TestCategory.D1E, { vLength: 10, vWidth: 2.75, expStartDist: 40, expMidDist: 20, expWidthDist: 4.13 }],
+      [TestCategory.BE, {
+        vLength: 10,
+        vWidth: 2.75,
+        expStartDist: 40,
+        expMidDist: 20,
+        expWidthDist: 4.13,
+        expMidDistMultiplier: '2',
+      }],
+      [TestCategory.C, {
+        vLength: 10,
+        vWidth: 2.75,
+        expStartDist: 35,
+        expMidDist: 15,
+        expWidthDist: 4.13,
+        expMidDistMultiplier: '1 1/2',
+      }],
+      [TestCategory.CE, {
+        vLength: 10,
+        vWidth: 2.75,
+        expStartDist: 40,
+        expMidDist: 20,
+        expWidthDist: 4.13,
+        expMidDistMultiplier: '2',
+      }],
+      [TestCategory.C1, {
+        vLength: 10,
+        vWidth: 2.75,
+        expStartDist: 35,
+        expMidDist: 15,
+        expWidthDist: 4.13,
+        expMidDistMultiplier: '1 1/2',
+      }],
+      [TestCategory.C1E, {
+        vLength: 10,
+        vWidth: 2.75,
+        expStartDist: 40,
+        expMidDist: 20,
+        expWidthDist: 4.13,
+        expMidDistMultiplier: '2',
+      }],
+      [TestCategory.D, {
+        vLength: 10,
+        vWidth: 2.75,
+        expStartDist: 35,
+        expMidDist: 15,
+        expWidthDist: 4.13,
+        expMidDistMultiplier: '1 1/2',
+      }],
+      [TestCategory.DE, {
+        vLength: 10,
+        vWidth: 2.75,
+        expStartDist: 40,
+        expMidDist: 20,
+        expWidthDist: 4.13,
+        expMidDistMultiplier: '2',
+      }],
+      [TestCategory.D1, {
+        vLength: 10,
+        vWidth: 2.75,
+        expStartDist: 35,
+        expMidDist: 15,
+        expWidthDist: 4.13,
+        expMidDistMultiplier: '1 1/2',
+      }],
+      [TestCategory.D1E, {
+        vLength: 10,
+        vWidth: 2.75,
+        expStartDist: 40,
+        expMidDist: 20,
+        expWidthDist: 4.13,
+        expMidDistMultiplier: '2',
+      }],
     ]);
   }
 }

--- a/src/pages/test-report/components/reverse-diagram-modal/__tests__/reverse-diagram-modal.spec.ts
+++ b/src/pages/test-report/components/reverse-diagram-modal/__tests__/reverse-diagram-modal.spec.ts
@@ -107,7 +107,7 @@ describe('reverseDiagramModal', () => {
       const cappedStartDistanceCategories = mockFile.getCappedStartDistanceCategories();
       describe(`Category ${testCategory}`, () => {
         describe(`ngOnInit`, () => {
-          it(`should set the distance based on booked in vehicle length`, (done: DoneFn) => {
+          it('should set the distance based on booked in vehicle length', (done: DoneFn) => {
             component.category = testCategory;
             component.ngOnInit();
             component.componentState.vehicleLength$.subscribe((result) => {
@@ -115,7 +115,7 @@ describe('reverseDiagramModal', () => {
               done();
             });
           });
-          it(`should set the distance based on booked in vehicle width`, (done: DoneFn) => {
+          it('should set the distance based on booked in vehicle width', (done: DoneFn) => {
             component.category = testCategory;
             component.ngOnInit();
             component.componentState.vehicleWidth$.subscribe((result) => {
@@ -124,7 +124,7 @@ describe('reverseDiagramModal', () => {
             });
           });
         });
-        describe(`calculateReversingLengths`, () => {
+        describe('calculateReversingLengths', () => {
           it(`should resolve aAndA1 to ${value.expStartDist}`, () => {
             spyOn(component, 'calculateReversingLengths').and.callThrough();
             component.category = testCategory;
@@ -156,7 +156,7 @@ describe('reverseDiagramModal', () => {
             expect(result).toEqual(value.expMidDist);
           });
         });
-        describe(`calculateReversingWidth`, () => {
+        describe('calculateReversingWidth', () => {
           it(`should resolve aToA1 to ${value.expWidthDist}`, () => {
             component.category = testCategory;
             spyOn(component, 'calculateReversingWidth').and.callThrough();
@@ -170,6 +170,14 @@ describe('reverseDiagramModal', () => {
             expect(result).toEqual(value.expWidthDist);
           });
         });
+        describe('calculateAtoBMultiplierText', () => {
+          it(`should return the A to B multiplier text of ${value.expMidDistMultiplier}`, () => {
+            component.category = testCategory;
+            component.calculateAtoBMultiplierText();
+            const result = component.multiplierText;
+            expect(result).toEqual(value.expMidDistMultiplier);
+          });
+        });
       });
     }
 
@@ -177,10 +185,12 @@ describe('reverseDiagramModal', () => {
       it('should calculate the distances if vehicle dimensions are populated', () => {
         const calculateDistanceLengthSpy = spyOn(component, 'calculateReversingLengths');
         const calculateDistanceWidthSpy = spyOn(component, 'calculateReversingWidth');
+        const calculateAtoBMultiplierTextSpy = spyOn(component, 'calculateAtoBMultiplierText');
         component.ngOnInit();
         const result = component.ionViewWillEnter();
         expect(calculateDistanceLengthSpy).toHaveBeenCalled();
         expect(calculateDistanceWidthSpy).toHaveBeenCalled();
+        expect(calculateAtoBMultiplierTextSpy).toHaveBeenCalled();
         expect(result).toEqual(true);
       });
     });

--- a/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.html
+++ b/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.html
@@ -87,7 +87,7 @@
               <h2 class="cones-header">CONE MEASUREMENTS</h2>
               <ul>
                 <li>A to A1 = 1 1/2 times the width of the vehicle.</li>
-                <li>A to B = 2 times the length of the vehicle.</li>
+                <li>A to B = {{ multiplierText }} times the length of the vehicle.</li>
                 <li>The width of the bay will be 1 1/2 times the width of the vehicle.</li>
               </ul>
             </ion-row>

--- a/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.scss
+++ b/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.scss
@@ -62,7 +62,7 @@ reverse-diagram-modal {
         padding: 8px 0;
         text-align: center;
         background-color: map-get($colors, reverseLightBlue);
-        font-size: 34px;
+        font-size: 30px;
         font-weight: bold;
       }
     }

--- a/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.ts
+++ b/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.ts
@@ -46,6 +46,7 @@ export class ReverseDiagramPage implements OnInit {
   reversingLengthStart: number;
   reversingLengthMiddle: number;
   reversingWidth: number;
+  multiplierText: string;
   category: TestCategory;
   onClose: OnCloseFunc;
   vehicleDetails: CategorySpecificVehicleDetails;
@@ -115,11 +116,24 @@ export class ReverseDiagramPage implements OnInit {
     this.vehicleWidth = vehicleWidth;
   }
 
+  calculateAtoBMultiplierText() {
+    switch (this.category) {
+      case TestCategory.C:
+      case TestCategory.C1:
+      case TestCategory.D:
+      case TestCategory.D1:
+        return this.multiplierText = '1 1/2';
+      default:
+        return this.multiplierText = '2';
+    }
+  }
+
   ionViewWillEnter(): boolean {
     if (this.merged$) {
       this.subscription = this.merged$.subscribe();
       this.calculateReversingLengths(this.vehicleLength);
       this.calculateReversingWidth(this.vehicleWidth);
+      this.calculateAtoBMultiplierText();
     }
 
     return true;

--- a/src/providers/reversing-distances/__tests__/reversing-distances.spec.ts
+++ b/src/providers/reversing-distances/__tests__/reversing-distances.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { configureTestSuite } from 'ng-bullet';
 
-describe('ReversingDistancesProvider', () => {
+fdescribe('ReversingDistancesProvider', () => {
 
   let reversingDistancesProvider: ReversingDistancesProvider;
 
@@ -30,6 +30,7 @@ describe('ReversingDistancesProvider', () => {
       vehicleWidth: 2,
     };
 
+    // CAT C
     describe('Category C', () => {
       it('should return a start distance value 3 and a half times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.C);
@@ -41,9 +42,9 @@ describe('ReversingDistancesProvider', () => {
         expect(result.startDistance).toEqual(70);
       });
 
-      it('should return a middle distance value 2 times the vehicle length', () => {
+      it('should return a middle distance value 1 and a half times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.C);
-        expect(result.middleDistance).toEqual(30);
+        expect(result.middleDistance).toEqual(22.5);
       });
     });
 
@@ -58,7 +59,14 @@ describe('ReversingDistancesProvider', () => {
         expect(result.startDistance).toEqual(66);
       });
 
-      it('should return a middle distance value 2 times the vehicle length', () => {
+      it('should return the correct middle distance if the vehicle length is greater than 16.5', () => {
+        // Calculation: 66 - 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.CE);
+        expect(result.middleDistance).toEqual(26);
+      });
+
+      it('should return the correct middle distance if the vehicle length is less than 16.5', () => {
+        // Calculation: 2 x vehicle length
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.CE);
         expect(result.middleDistance).toEqual(30);
       });
@@ -75,9 +83,9 @@ describe('ReversingDistancesProvider', () => {
         expect(result.startDistance).toEqual(70);
       });
 
-      it('should return a middle distance value 2 times the vehicle length', () => {
+      it('should return a middle distance value 1 and a half times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.C1);
-        expect(result.middleDistance).toEqual(30);
+        expect(result.middleDistance).toEqual(22.5);
       });
     });
 
@@ -92,8 +100,98 @@ describe('ReversingDistancesProvider', () => {
         expect(result.startDistance).toEqual(66);
       });
 
-      it('should return a middle distance value 2 times the vehicle length', () => {
+      it('should return the correct middle distance if the vehicle length is greater than 16.5', () => {
+        // Calculation: 66 - 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.C1E);
+        expect(result.middleDistance).toEqual(26);
+      });
+
+      it('should return the correct middle distance if the vehicle length is less than 16.5', () => {
+        // Calculation: 2 x vehicle length
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.C1E);
+        expect(result.middleDistance).toEqual(30);
+      });
+    });
+
+    // CAT D
+    describe('Category D', () => {
+      it('should return a start distance value 3 and a half times the vehicle length', () => {
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.D);
+        expect(result.startDistance).toEqual(52.5);
+      });
+
+      it('should return a value 3 and a half times vehicle length if greater than 16.5', () => {
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.D);
+        expect(result.startDistance).toEqual(70);
+      });
+
+      it('should return a middle distance value 1 and a half times the vehicle length', () => {
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.D);
+        expect(result.middleDistance).toEqual(22.5);
+      });
+    });
+
+    describe('Category D+E', () => {
+      it('should return a start distance 4 times the vehicle length', () => {
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.DE);
+        expect(result.startDistance).toEqual(60);
+      });
+
+      it('should return a start distance of 66 if the vehicle length is greater than 16.5', () => {
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.DE);
+        expect(result.startDistance).toEqual(66);
+      });
+
+      it('should return the correct middle distance if the vehicle length is greater than 16.5', () => {
+        // Calculation: 66 - 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.DE);
+        expect(result.middleDistance).toEqual(26);
+      });
+
+      it('should return the correct middle distance if the vehicle length is less than 16.5', () => {
+        // Calculation: 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.DE);
+        expect(result.middleDistance).toEqual(30);
+      });
+    });
+
+    describe('Category D1', () => {
+      it('should return a start distance value 3 and a half times the vehicle length', () => {
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.D1);
+        expect(result.startDistance).toEqual(52.5);
+      });
+
+      it('should return a value 3 and a half times vehicle length if greater than 16.5', () => {
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.D1);
+        expect(result.startDistance).toEqual(70);
+      });
+
+      it('should return a middle distance value 1 and a half times the vehicle length', () => {
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.D1);
+        expect(result.middleDistance).toEqual(22.5);
+      });
+    });
+
+    describe('Category D1+E', () => {
+      it('should return a start distance 4 times the vehicle length', () => {
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.D1E);
+        expect(result.startDistance).toEqual(60);
+      });
+
+      it('should return a start distance of 66 if the vehicle length is greater than 16.5', () => {
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.D1E);
+        expect(result.startDistance).toEqual(66);
+      });
+
+      it('should return the correct middle distance if the vehicle length is greater than 16.5', () => {
+        // Calculation: 66 - 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.D1E);
+        expect(result.middleDistance).toEqual(26);
+      });
+
+      it('should return the correct middle distance if the vehicle length is less than 16.5', () => {
+        // Calculation: 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.D1E);
         expect(result.middleDistance).toEqual(30);
       });
     });
@@ -105,6 +203,7 @@ describe('ReversingDistancesProvider', () => {
       vehicleWidth: 2,
     };
 
+    // CAT C
     describe('Category C', () => {
       it('should return a value 1 and a half times the vehicle width', () => {
         const result = reversingDistancesProvider.getDistanceWidth(vehicleDetails, TestCategory.C);
@@ -129,6 +228,35 @@ describe('ReversingDistancesProvider', () => {
     describe('Category C1+E', () => {
       it('should return a value 1 and a half times the vehicle width', () => {
         const result = reversingDistancesProvider.getDistanceWidth(vehicleDetails, TestCategory.C1E);
+        expect(result).toEqual(3);
+      });
+    });
+
+    // CAT D
+    describe('Category D', () => {
+      it('should return a value 1 and a half times the vehicle width', () => {
+        const result = reversingDistancesProvider.getDistanceWidth(vehicleDetails, TestCategory.D);
+        expect(result).toEqual(3);
+      });
+    });
+
+    describe('Category D+E', () => {
+      it('should return a value 1 and a half times the vehicle width', () => {
+        const result = reversingDistancesProvider.getDistanceWidth(vehicleDetails, TestCategory.DE);
+        expect(result).toEqual(3);
+      });
+    });
+
+    describe('Category D1', () => {
+      it('should return a value 1 and a half times the vehicle width', () => {
+        const result = reversingDistancesProvider.getDistanceWidth(vehicleDetails, TestCategory.D1);
+        expect(result).toEqual(3);
+      });
+    });
+
+    describe('Category D1+E', () => {
+      it('should return a value 1 and a half times the vehicle width', () => {
+        const result = reversingDistancesProvider.getDistanceWidth(vehicleDetails, TestCategory.D1E);
         expect(result).toEqual(3);
       });
     });

--- a/src/providers/reversing-distances/__tests__/reversing-distances.spec.ts
+++ b/src/providers/reversing-distances/__tests__/reversing-distances.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { configureTestSuite } from 'ng-bullet';
 
-fdescribe('ReversingDistancesProvider', () => {
+describe('ReversingDistancesProvider', () => {
 
   let reversingDistancesProvider: ReversingDistancesProvider;
 

--- a/src/providers/reversing-distances/reversing-distances.ts
+++ b/src/providers/reversing-distances/reversing-distances.ts
@@ -25,6 +25,7 @@ export type VehicleDetailsUnion =
 interface VehicleMultipliers {
   widthMultiplier: number;
   lengthMultiplier: number;
+  distanceMultiplier: number;
 }
 
 @Injectable()
@@ -35,15 +36,15 @@ export class ReversingDistancesProvider {
   public getDistanceValues() : Map<TestCategory, VehicleMultipliers> {
     if (!this.distanceValues) {
       this.distanceValues = new Map([
-        [TestCategory.BE, { lengthMultiplier: 4, widthMultiplier: 1.5 }],
-        [TestCategory.C, { lengthMultiplier: 3.5, widthMultiplier: 1.5 }],
-        [TestCategory.CE, { lengthMultiplier: 4, widthMultiplier: 1.5 }],
-        [TestCategory.C1, { lengthMultiplier: 3.5, widthMultiplier: 1.5 }],
-        [TestCategory.C1E, { lengthMultiplier: 4, widthMultiplier: 1.5 }],
-        [TestCategory.D, { lengthMultiplier: 3.5, widthMultiplier: 1.5 }],
-        [TestCategory.DE, { lengthMultiplier: 4, widthMultiplier: 1.5 }],
-        [TestCategory.D1, { lengthMultiplier: 3.5, widthMultiplier: 1.5 }],
-        [TestCategory.D1E, { lengthMultiplier: 4, widthMultiplier: 1.5 }],
+        [TestCategory.BE, { lengthMultiplier: 4, widthMultiplier: 1.5, distanceMultiplier: 2 }],
+        [TestCategory.C, { lengthMultiplier: 3.5, widthMultiplier: 1.5, distanceMultiplier: 1.5 }],
+        [TestCategory.CE, { lengthMultiplier: 4, widthMultiplier: 1.5, distanceMultiplier: 2 }],
+        [TestCategory.C1, { lengthMultiplier: 3.5, widthMultiplier: 1.5, distanceMultiplier: 1.5 }],
+        [TestCategory.C1E, { lengthMultiplier: 4, widthMultiplier: 1.5, distanceMultiplier: 2 }],
+        [TestCategory.D, { lengthMultiplier: 3.5, widthMultiplier: 1.5, distanceMultiplier: 1.5 }],
+        [TestCategory.DE, { lengthMultiplier: 4, widthMultiplier: 1.5, distanceMultiplier: 2 }],
+        [TestCategory.D1, { lengthMultiplier: 3.5, widthMultiplier: 1.5, distanceMultiplier: 1.5 }],
+        [TestCategory.D1E, { lengthMultiplier: 4, widthMultiplier: 1.5, distanceMultiplier: 2 }],
       ]);
     }
     return this.distanceValues;
@@ -54,7 +55,8 @@ export class ReversingDistancesProvider {
       return { startDistance: 52.5, middleDistance: 30 };
     }
     const distanceFromStart = data.vehicleLength * this.distanceValues.get(category).lengthMultiplier;
-    const distanceFromMiddle = data.vehicleLength * 2;
+    const distanceFromMiddle = data.vehicleLength * this.distanceValues.get(category).distanceMultiplier;
+
     switch (category) {
       case TestCategory.CE:
       case TestCategory.C1E:
@@ -62,7 +64,9 @@ export class ReversingDistancesProvider {
       case TestCategory.D1E:
         return ({
           startDistance: data.vehicleLength > 16.5 ? 66 : Math.round(distanceFromStart * 100) / 100,
-          middleDistance: Math.round(distanceFromMiddle * 100) / 100,
+          middleDistance: data.vehicleLength > 16.5
+            ? Math.round(66 - (data.vehicleLength * 2))
+            : Math.round(distanceFromMiddle * 100) / 100,
         });
       default:
         return ({


### PR DESCRIPTION
## Description
Adds some updates to the Reversing Diagram Modal.

- Distance of A/A1 to B for rigid vehicles is now calculated at 1.5 x vehicle length instead of 2
- Value of B is calculated differently for articulated vehicles  over 16.5 metres
- Reduced font size of calculated values to limit wrapping

## Checklist

- [x] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
