### PR TITLE
chore(optimisation): reintroduce prettier and utilise tslint for ts-specific issues only

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,23 @@
+{
+  "arrowParens": "avoid",
+  "htmlWhitespaceSensitivity": "css",
+  "endOfLine": "lf",
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "trailingComma": "all",
+  "printWidth": 120,
+  "bracketSpacing": true,
+  "useTabs": false,
+  "tabWidth": 2,
+  "semi": true,
+  "overrides": [
+    {
+      "files": [
+        "*.html"
+      ],
+      "options": {
+        "parser": "angular"
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26440,6 +26440,12 @@
         }
       }
     },
+    "tslint-config-prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
+      "dev": true
+    },
     "tslint-consistent-codestyle": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.14.1.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "serve:ipad": "npm run config:dev && npm run schema-version && ionic cordova run ios -- --buildFlag='-UseModernBuildSystem=0 -allowProvisioningUpdates' --codeSignIdentity='iPhone Developer' --developmentTeam='K84TL26V3P' --packageType='development'",
     "serve:ipad-prod": "npm run config:dev && npm run schema-version && ionic cordova run ios -- --prod --buildFlag='-UseModernBuildSystem=0 -allowProvisioningUpdates' --codeSignIdentity='iPhone Developer' --developmentTeam='K84TL26V3P' --packageType='development'",
     "ionic:deploy": "git push ionic master",
-    "format:all": "npx prettier --write \"src/**/*{.ts,.js,.json,.css,.scss}\"",
+    "format:all": "prettier --write \"src/**/*.{ts,js,json,html,css,scss,md}\"",
     "test": "npm run update-mock-data && npm run schema-version && npm run test:jasmine",
     "test:jasmine": "karma start ./test-config/karma.conf.js",
     "test:jasmine-reload": "karma start ./test-config/karma.conf.js --no-single-run",
@@ -167,6 +167,7 @@
     "ngrx-store-localstorage": "^8.0.0",
     "npm-run-all": "^4.1.3",
     "null-loader": "^0.1.1",
+    "prettier": "1.19.1",
     "protractor": "^5.4.1",
     "protractor-cucumber-framework": "^6.1.1",
     "remotedev": "^0.2.9",
@@ -179,6 +180,7 @@
     "ts-node": "^7.0.1",
     "tslint": "^5.16.0",
     "tslint-config-airbnb": "^5.11.1",
+    "tslint-config-prettier": "^1.18.0",
     "typescript": "^2.8.4",
     "xml2js": "^0.4.19"
   },
@@ -220,7 +222,11 @@
     }
   },
   "lint-staged": {
+    "./src/**/*.{js,json,html,css,scss,md}": [
+      "prettier --write"
+    ],
     "./src/**/*.ts": [
+      "prettier --write",
       "npm run lint:fix"
     ]
   }

--- a/tslint.json
+++ b/tslint.json
@@ -1,15 +1,12 @@
 {
   "extends": [
     "tslint-config-airbnb",
-    "rxjs-tslint-rules"
+    "rxjs-tslint-rules",
+    "tslint-config-prettier"
   ],
   "rules": {
     "no-duplicate-variable": true,
     "no-unused-variable": false,
-    "quotemark": [true, "single"],
-    "indent": [true, "spaces", 2],
-    "max-line-length": [true, 120],
-    "align": [true, "parameters", "statements"],
     "rxjs-add": { "severity": "error" },
     "rxjs-no-operator": { "severity": "error" },
     "rxjs-no-patched": { "severity": "error" },


### PR DESCRIPTION
# Description

Pushing branch that I've had lying around for a while.

- Use Prettier for code formatting - only format staged files initially. Note: Will result in partially formatted codebase until full format is performed. 
- Replace tslint config items with Prettier equivalents. 
- Limit tslint's involvement to only ts-specific linting issues. 
- Add Prettier auto-fix ( `prettier --write` ) to pre-commit hook. 
- No longer enforce max-line-length for single item imports ( default or destructured ). Common consensus is that it does not improve readability / maintainability to do so. Besides which, once a file path passes the 120 char limit there is no amount of formatting ( besides tslint-disable ) that will resolve the line length overflow. 

## Checklist

- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
