### PR TITLE
Fix Test Report Formatting for HOME Tests

### DIFF
--- a/mock/generate-local-journal.ts
+++ b/mock/generate-local-journal.ts
@@ -992,6 +992,7 @@ const localJournal: ExaminerWorkSchedule = {
           secondaryTelephone: '04321 098765',
           dateOfBirth: '1950-02-27',
           ethnicityCode: 'A',
+          emailAddress: 'test@test.com',
         },
         business: {
           businessAddress: {
@@ -1059,6 +1060,7 @@ const localJournal: ExaminerWorkSchedule = {
           secondaryTelephone: '04321 098765',
           dateOfBirth: '1950-02-27',
           ethnicityCode: 'A',
+          emailAddress: 'test@test.com',
         },
         business: {
           businessAddress: {
@@ -1126,6 +1128,7 @@ const localJournal: ExaminerWorkSchedule = {
           secondaryTelephone: '04321 098765',
           dateOfBirth: '1950-02-27',
           ethnicityCode: 'A',
+          emailAddress: 'test@test.com',
         },
         business: {
           businessAddress: {
@@ -1193,6 +1196,7 @@ const localJournal: ExaminerWorkSchedule = {
           secondaryTelephone: '04321 098765',
           dateOfBirth: '1950-02-27',
           ethnicityCode: 'A',
+          emailAddress: 'test@test.com',
         },
       },
       slotDetail: {

--- a/src/pages/test-report/cat-home-test/test-report.cat-home-test.page.html
+++ b/src/pages/test-report/cat-home-test/test-report.cat-home-test.page.html
@@ -19,12 +19,7 @@
     <ion-row class="first-row-adjust">
       <!-- Column 1-->
       <ion-col col-32>
-        <ion-row>
-          <ion-col no-padding>
-            <span class="section-header">Test requirements</span>
-          </ion-col>
-        </ion-row>
-        <ion-row>
+        <ion-row class="padding-top-10 only-top-padding">
           <ion-col>
             <legal-requirement
               [legalRequirement]="legalRequirements.normalStart1"
@@ -57,7 +52,7 @@
           </ion-col>
         </ion-row>
         <ion-row>
-          <ion-col class="padding-top-18 only-top-padding">
+          <ion-col no-padding>
             <div class="dark-divider"></div>
           </ion-col>
         </ion-row>
@@ -89,7 +84,7 @@
         </ion-row>
         <ion-row>
           <ion-col no-padding>
-            <span class="section-header">Vehicle check</span>
+            <span class="section-header">Vehicle checks</span>
           </ion-col>
         </ion-row>
         <ion-row>
@@ -168,7 +163,7 @@
           </ion-col>
         </ion-row>
         <ion-row>
-          <ion-col class="padding-top-21 only-top-padding">
+          <ion-col no-padding>
             <div class="dark-divider"></div>
           </ion-col>
         </ion-row>


### PR DESCRIPTION
## Description
- Updated the formatting of the test report so it matches CAT D - https://github.com/dvsa/mes-mobile-app/pull/new/fix-test-report-format-cat-home
- Added email addresses to the mock data for HOME test slots

## Checklist

- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
