### PR TITLE
Feature mes 4978 home test pass finalisation

### DIFF
--- a/src/modules/tests/test-data/cat-home-test/vehicle-checks/vehicle-checks.cat-home-test.reducer.ts
+++ b/src/modules/tests/test-data/cat-home-test/vehicle-checks/vehicle-checks.cat-home-test.reducer.ts
@@ -8,7 +8,9 @@ import * as vehicleChecksCatHomeTestActionTypes from './vehicle-checks.cat-home-
 import {
   NUMBER_OF_SHOW_ME_QUESTIONS,
 } from '../../../../../shared/constants/show-me-questions/show-me-questions.cat-home-test.constants';
-import { NUMBER_OF_TELL_ME_QUESTIONS } from '../../../../../shared/constants/tell-me-questions/tell-me-questions.cat-home-test.constants';
+import {
+  NUMBER_OF_TELL_ME_QUESTIONS,
+} from '../../../../../shared/constants/tell-me-questions/tell-me-questions.cat-home-test.constants';
 
 export type VehicleChecksUnion =
   | CatFUniqueTypes.VehicleChecks

--- a/src/pages/pass-finalisation/cat-home-test/_tests_/pass-finalisation.cat-home-test.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-home-test/_tests_/pass-finalisation.cat-home-test.page.spec.ts
@@ -30,6 +30,7 @@ import { D255Yes, D255No, DebriefWitnessed, DebriefUnwitnessed } from
 import { CandidateChoseToProceedWithTestInWelsh, CandidateChoseToProceedWithTestInEnglish } from
     '../../../../modules/tests/communication-preferences/communication-preferences.actions';
 import { PassFinalisationCatHomeTestPage } from '../pass-finalisation.cat-home-test.page';
+import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { PASS_CERTIFICATE_NUMBER_CTRL }
   from '../../components/pass-certificate-number/pass-certificate-number.constants';
@@ -51,6 +52,7 @@ describe('PassFinalisationCatHomeTestPage', () => {
         MockComponent(DebriefWitnessedComponent),
         MockComponent(FinalisationHeaderComponent),
         MockComponent(LanguagePreferencesComponent),
+        MockComponent(WarningBannerComponent),
       ],
       imports: [IonicModule, AppModule],
       providers: [

--- a/src/pages/pass-finalisation/cat-home-test/_tests_/pass-finalisation.cat-home-test.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-home-test/_tests_/pass-finalisation.cat-home-test.page.spec.ts
@@ -30,7 +30,6 @@ import { D255Yes, D255No, DebriefWitnessed, DebriefUnwitnessed } from
 import { CandidateChoseToProceedWithTestInWelsh, CandidateChoseToProceedWithTestInEnglish } from
     '../../../../modules/tests/communication-preferences/communication-preferences.actions';
 import { PassFinalisationCatHomeTestPage } from '../pass-finalisation.cat-home-test.page';
-import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { PASS_CERTIFICATE_NUMBER_CTRL }
   from '../../components/pass-certificate-number/pass-certificate-number.constants';
@@ -52,7 +51,6 @@ describe('PassFinalisationCatHomeTestPage', () => {
         MockComponent(DebriefWitnessedComponent),
         MockComponent(FinalisationHeaderComponent),
         MockComponent(LanguagePreferencesComponent),
-        MockComponent(WarningBannerComponent),
       ],
       imports: [IonicModule, AppModule],
       providers: [

--- a/src/pages/pass-finalisation/cat-home-test/_tests_/pass-finalisation.cat-home-test.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-home-test/_tests_/pass-finalisation.cat-home-test.page.spec.ts
@@ -25,14 +25,12 @@ import {
   PassFinalisationViewDidEnter,
   PassFinalisationValidationError,
 } from '../../pass-finalisation.actions';
-import { GearboxCategoryChanged } from '../../../../modules/tests/vehicle-details/common/vehicle-details.actions';
 import { D255Yes, D255No, DebriefWitnessed, DebriefUnwitnessed } from
     '../../../../modules/tests/test-summary/common/test-summary.actions';
 import { CandidateChoseToProceedWithTestInWelsh, CandidateChoseToProceedWithTestInEnglish } from
     '../../../../modules/tests/communication-preferences/communication-preferences.actions';
 import { PassFinalisationCatHomeTestPage } from '../pass-finalisation.cat-home-test.page';
 import { WarningBannerComponent } from '../../../../components/common/warning-banner/warning-banner';
-import { TransmissionComponent } from '../../../../components/common/transmission/transmission';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { PASS_CERTIFICATE_NUMBER_CTRL }
   from '../../components/pass-certificate-number/pass-certificate-number.constants';
@@ -50,7 +48,6 @@ describe('PassFinalisationCatHomeTestPage', () => {
         PassFinalisationCatHomeTestPage,
         MockComponent(PassCertificateNumberComponent),
         MockComponent(LicenseProvidedComponent),
-        MockComponent(TransmissionComponent),
         MockComponent(D255Component),
         MockComponent(DebriefWitnessedComponent),
         MockComponent(FinalisationHeaderComponent),
@@ -96,13 +93,6 @@ describe('PassFinalisationCatHomeTestPage', () => {
       it('should dispatch the correct action when called', () => {
         component.provisionalLicenseNotReceived();
         expect(store$.dispatch).toHaveBeenCalledWith(new ProvisionalLicenseNotReceived());
-        expect(store$.dispatch).toHaveBeenCalledTimes(1);
-      });
-    });
-    describe('transmissionChanged', () => {
-      it('should dispatch the correct action when called', () => {
-        component.transmissionChanged('Manual');
-        expect(store$.dispatch).toHaveBeenCalledWith(new GearboxCategoryChanged('Manual'));
         expect(store$.dispatch).toHaveBeenCalledTimes(1);
       });
     });

--- a/src/pages/pass-finalisation/cat-home-test/pass-finalisation.cat-home-test.page.html
+++ b/src/pages/pass-finalisation/cat-home-test/pass-finalisation.cat-home-test.page.html
@@ -30,15 +30,6 @@
           (licenseNotReceived)="provisionalLicenseNotReceived()">
         </license-provided>
 
-        <transmission
-          [formGroup]="form"
-          [transmission]="pageState.transmission$ | async"
-          (transmissionChange)="transmissionChanged($event)">
-        </transmission>
-
-        <warning-banner *ngIf="displayTransmissionBanner()" warningText="An automatic licence will be issued.">
-        </warning-banner>
-
         <pass-certificate-number
           [form]="form"
           [passCertificateNumberInput]="pageState.passCertificateNumber$ | async"

--- a/src/pages/pass-finalisation/cat-home-test/pass-finalisation.cat-home-test.page.ts
+++ b/src/pages/pass-finalisation/cat-home-test/pass-finalisation.cat-home-test.page.ts
@@ -17,7 +17,7 @@ import {
   getPassCertificateNumber,
   isProvisionalLicenseProvided,
 } from '../../../modules/tests/pass-completion/pass-completion.selector';
-import { Observable, Subscription, merge } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 // TODO - Cat HOME - Use correct selector
 import { getCandidate } from '../../../modules/tests/journal-data/cat-be/candidate/candidate.cat-be.reducer';
 import {
@@ -33,9 +33,6 @@ import { getCurrentTest, getJournalData, getTestOutcomeText } from '../../../mod
 import { map } from 'rxjs/operators';
 import { getTests } from '../../../modules/tests/tests.reducer';
 import { PersistTests } from '../../../modules/tests/tests.actions';
-import { getVehicleDetails } from '../../../modules/tests/vehicle-details/common/vehicle-details.reducer';
-import { getGearboxCategory } from '../../../modules/tests/vehicle-details/common/vehicle-details.selector';
-import { GearboxCategoryChanged } from '../../../modules/tests/vehicle-details/common/vehicle-details.actions';
 import { CAT_HOME_TEST } from '../../page-names.constants';
 import { getTestSummary } from '../../../modules/tests/test-summary/common/test-summary.reducer';
 import { isDebriefWitnessed, getD255 } from '../../../modules/tests/test-summary/common/test-summary.selector';
@@ -61,9 +58,7 @@ import {
 } from '../../../modules/tests/communication-preferences/communication-preferences.selector';
 import { AuthenticationProvider } from '../../../providers/authentication/authentication';
 import { BasePageComponent } from '../../../shared/classes/base-page';
-import { GearboxCategory } from '@dvsa/mes-test-schema/categories/common';
 import { PASS_CERTIFICATE_NUMBER_CTRL } from '../components/pass-certificate-number/pass-certificate-number.constants';
-import { TransmissionType } from '../../../shared/models/transmission-type';
 
 interface PassFinalisationPageState {
   candidateName$: Observable<string>;
@@ -73,7 +68,6 @@ interface PassFinalisationPageState {
   applicationNumber$: Observable<string>;
   provisionalLicense$: Observable<boolean>;
   passCertificateNumber$: Observable<string>;
-  transmission$: Observable<GearboxCategory>;
   d255$: Observable<boolean>;
   debriefWitnessed$: Observable<boolean>;
   conductedLanguage$: Observable<string>;
@@ -92,7 +86,6 @@ export class PassFinalisationCatHomeTestPage extends BasePageComponent {
   testOutcome: string = ActivityCodes.PASS;
   form: FormGroup;
   merged$: Observable<string>;
-  transmission: GearboxCategory;
   subscription: Subscription;
 
   constructor(
@@ -148,10 +141,6 @@ export class PassFinalisationCatHomeTestPage extends BasePageComponent {
         select(getPassCompletion),
         select(getPassCertificateNumber),
       ),
-      transmission$: currentTest$.pipe(
-        select(getVehicleDetails),
-        select(getGearboxCategory),
-      ),
       debriefWitnessed$: currentTest$.pipe(
         select(getTestSummary),
         select(isDebriefWitnessed),
@@ -165,25 +154,10 @@ export class PassFinalisationCatHomeTestPage extends BasePageComponent {
         select(getConductedLanguage),
       ),
     };
-    const { transmission$ } = this.pageState;
-
-    this.merged$ = merge(
-      transmission$.pipe(map(value => this.transmission = value)),
-    );
-    this.subscription = this.merged$.subscribe();
-  }
-
-  ionViewDidLeave(): void {
-    if (this.subscription) {
-      this.subscription.unsubscribe();
-    }
   }
 
   ionViewDidEnter(): void {
     this.store$.dispatch(new PassFinalisationViewDidEnter());
-    if (this.subscription.closed && this.merged$) {
-      this.subscription = this.merged$.subscribe();
-    }
   }
 
   provisionalLicenseReceived(): void {
@@ -192,10 +166,6 @@ export class PassFinalisationCatHomeTestPage extends BasePageComponent {
 
   provisionalLicenseNotReceived(): void {
     this.store$.dispatch(new ProvisionalLicenseNotReceived());
-  }
-
-  transmissionChanged(transmission: GearboxCategory): void {
-    this.store$.dispatch(new GearboxCategoryChanged(transmission));
   }
 
   onSubmit() {
@@ -233,9 +203,5 @@ export class PassFinalisationCatHomeTestPage extends BasePageComponent {
         new CandidateChoseToProceedWithTestInWelsh('Cymraeg')
         : new CandidateChoseToProceedWithTestInEnglish('English'),
     );
-  }
-
-  displayTransmissionBanner(): boolean {
-    return !this.form.controls['transmissionCtrl'].pristine && this.transmission === TransmissionType.Automatic;
   }
 }

--- a/src/pages/waiting-room-to-car/cat-home-test/components/vehicle-checks-modal/vehicle-checks-modal.cat-home-test.page.ts
+++ b/src/pages/waiting-room-to-car/cat-home-test/components/vehicle-checks-modal/vehicle-checks-modal.cat-home-test.page.ts
@@ -35,7 +35,9 @@ import { TestDataByCategoryProvider } from '../../../../../providers/test-data-b
 import {
   NUMBER_OF_SHOW_ME_QUESTIONS,
 } from '../../../../../shared/constants/show-me-questions/show-me-questions.cat-home-test.constants';
-import { NUMBER_OF_TELL_ME_QUESTIONS } from '../../../../../shared/constants/tell-me-questions/tell-me-questions.cat-home-test.constants';
+import {
+  NUMBER_OF_TELL_ME_QUESTIONS,
+} from '../../../../../shared/constants/tell-me-questions/tell-me-questions.cat-home-test.constants';
 
 interface VehicleChecksModalCatHomeTestState {
   candidateName$: Observable<string>;

--- a/src/pages/waiting-room-to-car/cat-home-test/waiting-room-to-car.cat-home-test.page.ts
+++ b/src/pages/waiting-room-to-car/cat-home-test/waiting-room-to-car.cat-home-test.page.ts
@@ -57,9 +57,11 @@ import { getCandidate } from '../../../modules/tests/journal-data/cat-home/candi
 import {
   hasEyesightTestBeenCompleted,
   hasEyesightTestGotSeriousFault,
-} from '../../../modules/tests/test-data/common/eyesight-test/eyesight-test.selector';
+ } from '../../../modules/tests/test-data/common/eyesight-test/eyesight-test.selector';
 import { getVehicleDetails } from '../../../modules/tests/vehicle-details/common/vehicle-details.reducer';
-import { VehicleChecksUnion } from '../../../modules/tests/test-data/cat-home-test/vehicle-checks/vehicle-checks.cat-home-test.reducer';
+import {
+  VehicleChecksUnion,
+} from '../../../modules/tests/test-data/cat-home-test/vehicle-checks/vehicle-checks.cat-home-test.reducer';
 import { Subscription } from 'rxjs';
 
 interface WaitingRoomToCarPageState {

--- a/src/pages/waiting-room-to-car/cat-home-test/waiting-room-to-car.cat-home-test.page.ts
+++ b/src/pages/waiting-room-to-car/cat-home-test/waiting-room-to-car.cat-home-test.page.ts
@@ -63,6 +63,7 @@ import {
   VehicleChecksUnion,
 } from '../../../modules/tests/test-data/cat-home-test/vehicle-checks/vehicle-checks.cat-home-test.reducer';
 import { Subscription } from 'rxjs';
+import { getEyesightTest } from '../../../modules/tests/test-data/cat-a-mod2/test-data.cat-a-mod2.selector';
 
 interface WaitingRoomToCarPageState {
   candidateName$: Observable<string>;
@@ -167,9 +168,11 @@ export class WaitingRoomToCarCatHomeTestPage extends BasePageComponent {
         select(getInterpreterAccompaniment),
       ),
       eyesightTestComplete$: testData$.pipe(
+        select(getEyesightTest),
         select(hasEyesightTestBeenCompleted),
       ),
       eyesightTestFailed$: testData$.pipe(
+        select(getEyesightTest),
         select(hasEyesightTestGotSeriousFault),
       ),
       vehicleChecksScore$: testData$.pipe(

--- a/src/providers/question/question.ts
+++ b/src/providers/question/question.ts
@@ -20,8 +20,10 @@ import showMeQuestionsVocationalTrailerConstants
 import safetyQuestionsCatAMod2Constants from '../../shared/constants/safety-questions.cat-a-mod2.constants';
 import balanceQuestionsCatAMod2Constants from '../../shared/constants/balance-questions.cat-a-mod2.constants';
 import safetyQuestionsCatDConstants from '../../shared/constants/safety-questions.cat-d.constants';
-import showMeQuestionsCatHomeTestConstants from '../../shared/constants/show-me-questions/show-me-questions.cat-home-test.constants';
-import tellMeQuestionsCatHomeTestConstants from '../../shared/constants/tell-me-questions/tell-me-questions.cat-home-test.constants';
+import showMeQuestionsCatHomeTestConstants
+  from '../../shared/constants/show-me-questions/show-me-questions.cat-home-test.constants';
+import tellMeQuestionsCatHomeTestConstants
+  from '../../shared/constants/tell-me-questions/tell-me-questions.cat-home-test.constants';
 
 @Injectable()
 export class QuestionProvider {

--- a/src/shared/constants/show-me-questions/show-me-questions.cat-home-test.constants.ts
+++ b/src/shared/constants/show-me-questions/show-me-questions.cat-home-test.constants.ts
@@ -1,6 +1,7 @@
 import { VehicleChecksQuestion } from '../../../providers/question/vehicle-checks-question.model';
 export const NUMBER_OF_SHOW_ME_QUESTIONS = 1;
 export const questions: VehicleChecksQuestion[] = [
+// tslint:disable:max-line-length
   {
     code: 'H1',
     description: 'Show me how you would check that the direction indicators are working.',
@@ -64,3 +65,4 @@ export const questions: VehicleChecksQuestion[] = [
 ];
 
 export default questions;
+// tslint:enable:max-line-length

--- a/src/shared/constants/tell-me-questions/tell-me-questions.cat-home-test.constants.ts
+++ b/src/shared/constants/tell-me-questions/tell-me-questions.cat-home-test.constants.ts
@@ -3,6 +3,7 @@ import { VehicleChecksQuestion } from '../../../providers/question/vehicle-check
 export const NUMBER_OF_TELL_ME_QUESTIONS = 1;
 export const questions: VehicleChecksQuestion[] = [
   {
+    // tslint:disable:max-line-length
     code: 'H13',
     description: 'Tell me how you would check that the brakes are working before starting a journey.',
     shortName: 'Brakes',
@@ -35,3 +36,4 @@ export const questions: VehicleChecksQuestion[] = [
 ];
 
 export default questions;
+    // tslint:enable:max-line-length


### PR DESCRIPTION
Mes  4978 

Remove transmission from Pass finalisation page  for home test (F,G,H,K)
Fixed some linting issues on other pages found when pushing
Fixed persistence eyesight tests on WRTC page (found as a result of linting - Thanks @Cavalier07  for coming up with the fix.

## Checklist

- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [X] Code has been tested manually
- [X] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

