### PR TITLE
MES-5043: Adding minDrivingFaultCount as configurable property of faults-data-row

### DIFF
--- a/src/pages/view-test-result/cat-a-mod1/components/debrief-card/debrief-card.html
+++ b/src/pages/view-test-result/cat-a-mod1/components/debrief-card/debrief-card.html
@@ -9,7 +9,8 @@
         [drivingFaults]="getDrivingFaults()"
         [seriousFaults]="getSeriousFaults()"
         [dangerousFaults]="getDangerousFaults()"
-        [drivingFaultCount]="getDrivingFaultCount()">
+        [drivingFaultCount]="getDrivingFaultCount()"
+        [minDrivingFaultCount]="5">
       </faults-data-row>
       <data-row [label]="'ETA'" [value]="getETA()"></data-row>
       <speed-card

--- a/src/pages/view-test-result/components/faults-data-row/__tests__/faults-data-row.spec.ts
+++ b/src/pages/view-test-result/components/faults-data-row/__tests__/faults-data-row.spec.ts
@@ -2,6 +2,14 @@ import { FaultsDataRowComponent } from '../faults-data-row';
 import { FaultSummary } from '../../../../../shared/models/fault-marking.model';
 
 describe('FaultsDataRowComponent', () => {
+  describe('deafultSettings', () => {
+    it('should have 15 as minDrivingFaultCount when the component is created', () => {
+      const component = new FaultsDataRowComponent();
+
+      expect(component.minDrivingFaultCount).toBe(15);
+    });
+  });
+
   describe('showFaultComment', () => {
     const faultSummary: FaultSummary = {
       competencyIdentifier: 'compId',

--- a/src/pages/view-test-result/components/faults-data-row/__tests__/faults-data-row.spec.ts
+++ b/src/pages/view-test-result/components/faults-data-row/__tests__/faults-data-row.spec.ts
@@ -1,0 +1,61 @@
+import { FaultsDataRowComponent } from '../faults-data-row';
+import { FaultSummary } from '../../../../../shared/models/fault-marking.model';
+
+describe('FaultsDataRowComponent', () => {
+  describe('showFaultComment', () => {
+    const faultSummary: FaultSummary = {
+      competencyIdentifier: 'compId',
+      competencyDisplayName: 'dispName',
+      faultCount: 2,
+      comment: 'comment',
+    };
+
+    it('should return false when drivingFaultCount is less than minDrivingFaultCount', () => {
+      const component = new FaultsDataRowComponent();
+
+      component.drivingFaultCount = 5;
+      component.minDrivingFaultCount = 6;
+
+      const result = component.showFaultComment(faultSummary);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when drivingFaultCount is equal to minDrivingFaultCount', () => {
+      const component = new FaultsDataRowComponent();
+
+      component.drivingFaultCount = 6;
+      component.minDrivingFaultCount = 6;
+
+      const result = component.showFaultComment(faultSummary);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when there are no comments', () => {
+      const localFaultSummary = {
+        ...faultSummary,
+        comment: undefined,
+      };
+      const component = new FaultsDataRowComponent();
+
+      component.drivingFaultCount = 7;
+      component.minDrivingFaultCount = 6;
+
+      const result = component.showFaultComment(localFaultSummary);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true when drivingFaultCount is greater than minDrivingFaultCount and has comments', () => {
+      const component = new FaultsDataRowComponent();
+
+      component.drivingFaultCount = 7;
+      component.minDrivingFaultCount = 6;
+
+      const result = component.showFaultComment(faultSummary);
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/pages/view-test-result/components/faults-data-row/faults-data-row.html
+++ b/src/pages/view-test-result/components/faults-data-row/faults-data-row.html
@@ -64,7 +64,7 @@
               <span class="mes-data">{{drivingFault.competencyDisplayName}}</span>
             </ion-col>
           </ion-row>
-          <ion-row *ngIf="drivingFaultCount > 15 && drivingFault.comment">
+          <ion-row *ngIf="showFaultComment(drivingFault)">
             <ion-col>
               <span class="mes-data">- {{drivingFault.comment}}</span>
             </ion-col>

--- a/src/pages/view-test-result/components/faults-data-row/faults-data-row.ts
+++ b/src/pages/view-test-result/components/faults-data-row/faults-data-row.ts
@@ -23,8 +23,16 @@ export class FaultsDataRowComponent {
   @Input()
   drivingFaultCount?: number;
 
-  showNoFaultsMessage = () : boolean =>
-  this.drivingFaultCount === 0 &&
-  this.seriousFaults.length === 0 &&
-  this.dangerousFaults.length === 0
+  @Input()
+  minDrivingFaultCount: number = 15;
+
+  showNoFaultsMessage = (): boolean =>
+    this.drivingFaultCount === 0 &&
+    this.seriousFaults.length === 0 &&
+    this.dangerousFaults.length === 0
+
+  showFaultComment = (drivingFault: FaultSummary): boolean =>
+    this.drivingFaultCount > this.minDrivingFaultCount &&
+    drivingFault.comment !== undefined
+
 }


### PR DESCRIPTION
## Description

Displaying riding fault comments on A Mod1 view test result page

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

![IMG_4E69E769B559-1](https://user-images.githubusercontent.com/7311745/77085094-c0296b80-69f7-11ea-8bd2-9399efbb6038.jpeg)