### PR TITLE
MES-4627 | feat(ADI2): implement ADI2 FaultSummary provider and wire up to debrief

### DIFF
--- a/src/pages/debrief/cat-adi-part2/debrief.cat-adi-part2.page.ts
+++ b/src/pages/debrief/cat-adi-part2/debrief.cat-adi-part2.page.ts
@@ -98,21 +98,18 @@ export class DebriefCatADIPart2Page extends BasePageComponent {
       seriousFaults$: currentTest$.pipe(
         select(getTestData),
         map(data =>
-          // TO-DO ADI Part2: Implement correct category
-          this.faultSummaryProvider.getSeriousFaultsList(data, TestCategory.BE)
+          this.faultSummaryProvider.getSeriousFaultsList(data, TestCategory.ADI2)
           .map(fault => fault.competencyIdentifier)),
       ),
       dangerousFaults$: currentTest$.pipe(
         select(getTestData),
         map(data =>
-          // TO-DO ADI Part2: Implement correct category
-          this.faultSummaryProvider.getDangerousFaultsList(data, TestCategory.BE)
+          this.faultSummaryProvider.getDangerousFaultsList(data, TestCategory.ADI2)
           .map(fault => fault.competencyIdentifier)),
       ),
       drivingFaults$: currentTest$.pipe(
         select(getTestData),
-        // TO-DO ADI Part2: Implement correct category
-        map(data => this.faultSummaryProvider.getDrivingFaultsList(data, TestCategory.BE)),
+        map(data => this.faultSummaryProvider.getDrivingFaultsList(data, TestCategory.ADI2)),
       ),
       drivingFaultCount$: currentTest$.pipe(
         select(getTestData),

--- a/src/providers/fault-summary/cat-adi-part2/fault-summary.cat-adi-part2.ts
+++ b/src/providers/fault-summary/cat-adi-part2/fault-summary.cat-adi-part2.ts
@@ -1,0 +1,178 @@
+import { get } from 'lodash';
+import { EyesightTest, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+import { CommentSource, CompetencyIdentifiers, FaultSummary } from '../../../shared/models/fault-marking.model';
+import { CompetencyDisplayName } from '../../../shared/models/competency-display-name';
+import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
+import { CatADI2UniqueTypes } from '@dvsa/mes-test-schema/categories/ADI2';
+// TODO(MES-5031): uncomment as part of manoeuvres build
+// import { ManoeuvreTypes } from '../../../modules/tests/test-data/test-data.constants';
+// import {
+//   manoeuvreCompetencyLabels as manoeuvreCompetencyLabelsCatAdiPart2,
+//   manoeuvreTypeLabels as manoeuvreTypeLabelsCatAdiPart2,
+// } from '../../../shared/constants/competencies/catb-manoeuvres';
+import { getCompetencyFaults/*, getCompetencyComment*/ } from '../../../shared/helpers/get-competency-faults';
+import { VehicleChecksScore } from '../../../shared/models/vehicle-checks-score.model';
+
+export class FaultSummaryCatAdiPart2Helper {
+
+  public static getDrivingFaultsCatAdiPart2(
+    data: CatADI2UniqueTypes.TestData,
+    vehicleChecksScore: VehicleChecksScore,
+  ): FaultSummary[] {
+    return [
+      ...getCompetencyFaults(data.drivingFaults),
+      ...this.getManoeuvreFaultsCatAdiPart2(data.manoeuvres, CompetencyOutcome.DF),
+      ...this.getControlledStopFault(data.controlledStop, CompetencyOutcome.DF),
+      ...this.getVehicleCheckDrivingFaultsCatAdiPart2(data.vehicleChecks, vehicleChecksScore),
+    ];
+  }
+
+  public static getSeriousFaultsCatAdiPart2(data: CatADI2UniqueTypes.TestData): FaultSummary[] {
+    return [
+      ...getCompetencyFaults(data.seriousFaults),
+      ...this.getManoeuvreFaultsCatAdiPart2(data.manoeuvres, CompetencyOutcome.S),
+      ...this.getControlledStopFault(data.controlledStop, CompetencyOutcome.S),
+      ...this.getVehicleCheckSeriousFaultsCatAdiPart2(data.vehicleChecks),
+      ...this.getEyesightTestSeriousFault(data.eyesightTest),
+    ];
+  }
+
+  public static getDangerousFaultsCatAdiPart2(data: CatADI2UniqueTypes.TestData): FaultSummary[] {
+    return [
+      ...getCompetencyFaults(data.dangerousFaults),
+      ...this.getManoeuvreFaultsCatAdiPart2(data.manoeuvres, CompetencyOutcome.D),
+      ...this.getControlledStopFault(data.controlledStop, CompetencyOutcome.D),
+    ];
+  }
+
+  private static getEyesightTestSeriousFault(eyesightTest: EyesightTest): FaultSummary[] {
+    if (!eyesightTest || !eyesightTest.seriousFault) {
+      return [];
+    }
+    return [{
+      competencyDisplayName: CompetencyDisplayName.EYESIGHT_TEST,
+      competencyIdentifier: CompetencyIdentifiers.EYESIGHT_TEST,
+      comment: eyesightTest.faultComments || '',
+      source: CommentSource.EYESIGHT_TEST,
+      faultCount: 1,
+    }];
+  }
+
+  private static getControlledStopFault(controlledStop: CatADI2UniqueTypes.ControlledStop, faultType: CompetencyOutcome)
+    : FaultSummary[] {
+    const returnCompetencies: FaultSummary[] = [];
+    if (!controlledStop || controlledStop.fault !== faultType) {
+      return returnCompetencies;
+    }
+    const result: FaultSummary = {
+      competencyDisplayName: CompetencyDisplayName.CONTROLLED_STOP,
+      competencyIdentifier: CompetencyIdentifiers.CONTROLLED_STOP,
+      comment: controlledStop.faultComments || '',
+      source: CommentSource.CONTROLLED_STOP,
+      faultCount: 1,
+    };
+    returnCompetencies.push(result);
+    return returnCompetencies;
+  }
+
+  // TODO(MES-5031): implement as part of manoeuvres build
+  // private static createManoeuvreFaultCatAdiPart2(
+  //   key: string,
+  //   type: ManoeuvreTypes,
+  //   competencyComment: string,
+  // ): FaultSummary {
+  //   const manoeuvreFaultSummary: FaultSummary = {
+  //     comment: competencyComment || '',
+  //     competencyIdentifier: `${type}${manoeuvreCompetencyLabelsCatAdiPart2[key]}`,
+  //     competencyDisplayName:
+  //       `${manoeuvreTypeLabelsCatAdiPart2[type]} - ${manoeuvreCompetencyLabelsCatAdiPart2[key]}`,
+  //     source: `${CommentSource.MANOEUVRES}-${type}-${manoeuvreCompetencyLabelsCatAdiPart2[key]}`,
+  //     faultCount: 1,
+  //   };
+  //   return manoeuvreFaultSummary;
+  // }
+
+  private static getVehicleCheckDrivingFaultsCatAdiPart2(
+    vehicleChecks: CatADI2UniqueTypes.VehicleChecks,
+    vehicleCheckFaults: VehicleChecksScore,
+  ): FaultSummary[] {
+    const result: FaultSummary[] = [];
+    if (!vehicleChecks || !vehicleChecks.showMeQuestions || !vehicleChecks.tellMeQuestions) {
+      return result;
+    }
+
+    const dangerousFaults = vehicleChecks.showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.D);
+    const seriousFaults = vehicleChecks.showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.S);
+
+    if (dangerousFaults.length > 0 || seriousFaults.length > 0) {
+      return result;
+    }
+
+    if (vehicleCheckFaults.drivingFaults > 0) {
+      const competency: FaultSummary = {
+        comment: vehicleChecks.showMeTellMeComments || '',
+        competencyIdentifier: CommentSource.VEHICLE_CHECKS,
+        competencyDisplayName: CompetencyDisplayName.VEHICLE_CHECKS,
+        source: CommentSource.VEHICLE_CHECKS,
+        faultCount: vehicleCheckFaults.drivingFaults,
+      };
+      result.push(competency);
+    }
+    return result;
+  }
+
+  private static getVehicleCheckSeriousFaultsCatAdiPart2(
+      vehicleChecks: CatADI2UniqueTypes.VehicleChecks,
+  ): FaultSummary[] {
+    const result: FaultSummary[] = [];
+
+    if (!vehicleChecks) {
+      return result;
+    }
+
+    const showMeQuestions: QuestionResult[] = get(vehicleChecks, 'showMeQuestions', []);
+    const tellMeQuestions: QuestionResult[] = get(vehicleChecks, 'tellMeQuestions', []);
+
+    const showMeFaults = showMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.DF);
+    const tellMeFaults = tellMeQuestions.filter(fault => fault.outcome === CompetencyOutcome.DF);
+
+    const seriousFaultCount = showMeFaults.length + tellMeFaults.length === 5 ? 1 : 0;
+    const competency: FaultSummary = {
+      comment: vehicleChecks.showMeTellMeComments || '',
+      competencyIdentifier: CommentSource.VEHICLE_CHECKS,
+      competencyDisplayName: CompetencyDisplayName.VEHICLE_CHECKS,
+      source: CommentSource.VEHICLE_CHECKS,
+      faultCount: seriousFaultCount,
+    };
+    seriousFaultCount > 0 && result.push(competency);
+
+    return result;
+  }
+
+  // TODO(MES-5031): implement as part of manoeuvres build
+  private static getManoeuvreFaultsCatAdiPart2(
+    manoeuvres: CatADI2UniqueTypes.Manoeuvres[],
+    faultType: CompetencyOutcome,
+  ): FaultSummary[] {
+    // const faultsEncountered: FaultSummary[] = [];
+
+    // TODO: Replace any with Manoeuvres and change the transform function
+    // forOwn(manoeuvres, (manoeuvre: any, type: ManoeuvreTypes) => {
+    //   const faults = !manoeuvre.selected ? [] : transform(manoeuvre, (result, value, key: string) => {
+
+    //     if (endsWith(key, CompetencyIdentifiers.FAULT_SUFFIX) && value === faultType) {
+
+    //       const competencyComment = getCompetencyComment(
+    //         key,
+    //         manoeuvre.controlFaultComments,
+    //         manoeuvre.observationFaultComments);
+
+    //       result.push(this.createManoeuvreFaultCatAdiPart2(key, type, competencyComment));
+    //     }
+    //   }, []);
+    //   faultsEncountered.push(...faults);
+    // });
+    // return faultsEncountered;
+    return [];
+  }
+}

--- a/src/providers/fault-summary/fault-summary.ts
+++ b/src/providers/fault-summary/fault-summary.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@angular/core';
 import { FaultSummary } from '../../shared/models/fault-marking.model';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
-import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
 import { FaultCountProvider } from '../fault-count/fault-count';
 import { FaultSummaryCatBHelper } from './cat-b/fault-summary.cat-b';
 import { FaultSummaryCatBEHelper } from './cat-be/fault-summary.cat-be';
 import { FaultSummaryCatCHelper } from './cat-c/fault-summary.cat-c';
 import { FaultSummaryCatDHelper } from './cat-d/fault-summary.cat-d';
 import { FaultSummaryCatHomeTestHelper } from './cat-home-test/fault-summary.cat-home-test';
+import { CatADI2UniqueTypes } from '@dvsa/mes-test-schema/categories/ADI2';
+import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
 import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
 import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
 import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
@@ -18,6 +19,7 @@ import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
 import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
 import { FaultSummaryCatAM1Helper } from './cat-a-mod1/fault-summary.cat-a-mod1';
 import { FaultSummaryCatAM2Helper } from './cat-a-mod2/fault-summary.cat-a-mod2';
+import { FaultSummaryCatAdiPart2Helper } from './cat-adi-part2/fault-summary.cat-adi-part2';
 
 @Injectable()
 export class FaultSummaryProvider {
@@ -26,6 +28,13 @@ export class FaultSummaryProvider {
 
   public getDrivingFaultsList(data: object, category: TestCategory): FaultSummary[] {
     switch (category) {
+      case TestCategory.ADI2:
+        return FaultSummaryCatAdiPart2Helper.getDrivingFaultsCatAdiPart2(
+          data,
+          this.faultCountProvider.getVehicleChecksFaultCount(
+            TestCategory.ADI2,
+             (<CatADI2UniqueTypes.TestData>data).vehicleChecks,
+          ));
       case TestCategory.B:
         return FaultSummaryCatBHelper.getDrivingFaultsCatB(data);
       case TestCategory.BE:
@@ -121,6 +130,8 @@ export class FaultSummaryProvider {
 
   public getSeriousFaultsList(data: object, category: TestCategory): FaultSummary[] {
     switch (category) {
+      case TestCategory.ADI2:
+        return FaultSummaryCatAdiPart2Helper.getSeriousFaultsCatAdiPart2(data);
       case TestCategory.B:
         return FaultSummaryCatBHelper.getSeriousFaultsCatB(data);
       case TestCategory.BE:
@@ -159,6 +170,8 @@ export class FaultSummaryProvider {
 
   public getDangerousFaultsList(data: object, category: TestCategory): FaultSummary[] {
     switch (category) {
+      case TestCategory.ADI2:
+        return FaultSummaryCatAdiPart2Helper.getDangerousFaultsCatAdiPart2(data);
       case TestCategory.B:
         return FaultSummaryCatBHelper.getDangerousFaultsCatB(data);
       case TestCategory.BE:


### PR DESCRIPTION
## Description

Final wiring for ADI2 debrief page 
Note: Does not include Manoeuvres summary calc, covered in separate story.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
