### PR TITLE
enable end test for home tests - fix waiting room link

### DIFF
--- a/src/components/common/end-test-link/end-test-link.ts
+++ b/src/components/common/end-test-link/end-test-link.ts
@@ -1,6 +1,14 @@
 import { Component, Input } from '@angular/core';
 import { ModalController, Modal, NavController } from 'ionic-angular';
-import { CAT_BE, CAT_B, CAT_C, CAT_D, CAT_A_MOD1, CAT_A_MOD2 } from '../../../pages/page-names.constants';
+import {
+  CAT_BE,
+  CAT_B,
+  CAT_C,
+  CAT_D,
+  CAT_A_MOD1,
+  CAT_A_MOD2,
+  CAT_HOME_TEST,
+} from '../../../pages/page-names.constants';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 @Component({
@@ -45,6 +53,12 @@ export class EndTestLinkComponent {
         break;
       case TestCategory.D:
         this.navController.push(CAT_D.DEBRIEF_PAGE);
+        break;
+      case TestCategory.F:
+      case TestCategory.G:
+      case TestCategory.H:
+      case TestCategory.K:
+        this.navController.push(CAT_HOME_TEST.DEBRIEF_PAGE);
         break;
       case TestCategory.EUA1M1:
       case TestCategory.EUA2M1:

--- a/src/pages/waiting-room/cat-home-test/waiting-room.cat-home-test.page.html
+++ b/src/pages/waiting-room/cat-home-test/waiting-room.cat-home-test.page.html
@@ -2,7 +2,7 @@
   <ion-navbar>
     <ion-title>{{ 'waitingRoom.title' | translate }} - {{pageState.candidateUntitledName$ | async}}</ion-title>
     <ion-buttons end>
-      <end-test-link category="pageState.category$ | async"></end-test-link>
+      <end-test-link category="{{pageState.category$ | async}}"></end-test-link>
     </ion-buttons>
   </ion-navbar>
 </ion-header>


### PR DESCRIPTION
MES-4951

Make end test link work for Home tests (F, G, H, K).  Fix issue with end test link on waiting room screen.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number
