### PR TITLE
Mes 5048 reversing diagram calculation rounding

### DIFF
--- a/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.scss
+++ b/src/pages/test-report/components/reverse-diagram-modal/reverse-diagram-modal.scss
@@ -62,7 +62,7 @@ reverse-diagram-modal {
         padding: 8px 0;
         text-align: center;
         background-color: map-get($colors, reverseLightBlue);
-        font-size: 30px;
+        font-size: 20px;
         font-weight: bold;
       }
     }

--- a/src/providers/reversing-distances/__tests__/reversing-distances.spec.ts
+++ b/src/providers/reversing-distances/__tests__/reversing-distances.spec.ts
@@ -25,174 +25,303 @@ describe('ReversingDistancesProvider', () => {
       vehicleWidth: 2,
     };
 
+    const vehicleDetailsDecimal: VehicleDetailsUnion = {
+      vehicleLength: 15.55,
+      vehicleWidth: 2,
+    };
     const longVehicleDetails: VehicleDetailsUnion = {
       vehicleLength: 20,
       vehicleWidth: 2,
     };
 
+    const longVehicleDetailsDecimal: VehicleDetailsUnion = {
+      vehicleLength: 16.75,
+      vehicleWidth: 2,
+    };
+
     // CAT C
     describe('Category C', () => {
-      it('should return a start distance value 3 and a half times the vehicle length', () => {
+      it('should return a start value 3 and a half times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.C);
         expect(result.startDistance).toEqual(52.5);
       });
 
-      it('should return a value 3 and a half times vehicle length if greater than 16.5', () => {
+      it('should return a start value 3 and a half times vehicle length if > 16.5', () => {
         const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.C);
         expect(result.startDistance).toEqual(70);
       });
 
-      it('should return a middle distance value 1 and a half times the vehicle length', () => {
+      it('should return a start value 3 and a half times vehicle length to 2 fixed decimal places', () => {
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetailsDecimal, TestCategory.C);
+        expect(result.startDistance).toEqual(58.63);
+      });
+
+      it('should return a middle value 1 and a half times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.C);
         expect(result.middleDistance).toEqual(22.5);
+      });
+
+      it('should return a middle value 1 and a half times the vehicle length to 2 fixed decimal places', () => {
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetailsDecimal, TestCategory.C);
+        expect(result.middleDistance).toEqual(23.33);
       });
     });
 
     describe('Category C+E', () => {
-      it('should return a start distance 4 times the vehicle length', () => {
+      it('should return a start value 4 times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.CE);
         expect(result.startDistance).toEqual(60);
       });
 
-      it('should return a start distance of 66 if the vehicle length is greater than 16.5', () => {
+      it('should return a start value of 66 if the vehicle length > than 16.5', () => {
         const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.CE);
         expect(result.startDistance).toEqual(66);
       });
 
-      it('should return the correct middle distance if the vehicle length is greater than 16.5', () => {
+      it('should return the correct middle value if the vehicle length is > 16.5', () => {
         // Calculation: 66 - 2 x vehicle length
         const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.CE);
         expect(result.middleDistance).toEqual(26);
       });
 
-      it('should return the correct middle distance if the vehicle length is less than 16.5', () => {
+      it('should return the correct middle value for vehicles > 16.5 with decimal places', () => {
+        // Calculation: 66 - 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetailsDecimal, TestCategory.CE);
+        expect(result.middleDistance).toEqual(32.5);
+      });
+
+      it('should return the correct middle value for vehicles > 16.5 with decimal places', () => {
+        // Calculation: 66 - 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength({
+          ...longVehicleDetailsDecimal, vehicleLength: 17.25,
+        }, TestCategory.CE);
+        expect(result.middleDistance).toEqual(31.5);
+      });
+
+      it('should return the correct middle value if the vehicle length is < 16.5', () => {
         // Calculation: 2 x vehicle length
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.CE);
         expect(result.middleDistance).toEqual(30);
+      });
+
+      it('should return the correct middle value for vehicles < 16.5 with decimal places ', () => {
+        // Calculation: 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetailsDecimal, TestCategory.CE);
+        expect(result.middleDistance).toEqual(31.1);
       });
     });
 
     describe('Category C1', () => {
-      it('should return a start distance value 3 and a half times the vehicle length', () => {
+      it('should return a start value 3 and a half times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.C1);
         expect(result.startDistance).toEqual(52.5);
       });
 
-      it('should return a value 3 and a half times vehicle length if greater than 16.5', () => {
+      it('should return a start value 3 and a half times vehicle length if > 16.5', () => {
         const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.C1);
         expect(result.startDistance).toEqual(70);
       });
 
-      it('should return a middle distance value 1 and a half times the vehicle length', () => {
+      it('should return a start value 3 and a half times vehicle length to 2 fixed decimal places', () => {
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetailsDecimal, TestCategory.C1);
+        expect(result.startDistance).toEqual(58.63);
+      });
+
+      it('should return a middle value 1 and a half times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.C1);
         expect(result.middleDistance).toEqual(22.5);
+      });
+
+      it('should return a middle value 1 and a half times the vehicle length to 2 fixed decimal places', () => {
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetailsDecimal, TestCategory.C);
+        expect(result.middleDistance).toEqual(23.33);
       });
     });
 
     describe('Category C1+E', () => {
-      it('should return a start distance 4 times the vehicle length', () => {
+      it('should return a start value 4 times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.C1E);
         expect(result.startDistance).toEqual(60);
       });
 
-      it('should return a start distance of 66 if the vehicle length is greater than 16.5', () => {
+      it('should return a start value of 66 if the vehicle length is > 16.5', () => {
         const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.C1E);
         expect(result.startDistance).toEqual(66);
       });
 
-      it('should return the correct middle distance if the vehicle length is greater than 16.5', () => {
+      it('should return the correct middle value if the vehicle length is > 16.5', () => {
         // Calculation: 66 - 2 x vehicle length
         const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.C1E);
         expect(result.middleDistance).toEqual(26);
       });
 
-      it('should return the correct middle distance if the vehicle length is less than 16.5', () => {
+      it('should return the correct middle value for vehicles > 16.5 with decimal places', () => {
+        // Calculation: 66 - 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetailsDecimal, TestCategory.C1E);
+        expect(result.middleDistance).toEqual(32.5);
+      });
+
+      it('should return the correct middle value for vehicles > 16.5 with decimal places', () => {
+        // Calculation: 66 - 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength({
+          ...longVehicleDetailsDecimal, vehicleLength: 18.25,
+        }, TestCategory.C1E);
+        expect(result.middleDistance).toEqual(29.5);
+      });
+
+      it('should return the correct middle distance if the vehicle length is < 16.5', () => {
         // Calculation: 2 x vehicle length
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.C1E);
         expect(result.middleDistance).toEqual(30);
+      });
+
+      it('should return the correct middle value for vehicles < 16.5 with decimal places ', () => {
+        // Calculation: 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetailsDecimal, TestCategory.C1E);
+        expect(result.middleDistance).toEqual(31.1);
       });
     });
 
     // CAT D
     describe('Category D', () => {
-      it('should return a start distance value 3 and a half times the vehicle length', () => {
+      it('should return a start value 3 and a half times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.D);
         expect(result.startDistance).toEqual(52.5);
       });
 
-      it('should return a value 3 and a half times vehicle length if greater than 16.5', () => {
+      it('should return a start value 3 and a half times vehicle length if > 16.5', () => {
         const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.D);
         expect(result.startDistance).toEqual(70);
       });
 
-      it('should return a middle distance value 1 and a half times the vehicle length', () => {
+      it('should return a start value 3 and a half times vehicle length to 2 fixed decimal places', () => {
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetailsDecimal, TestCategory.D);
+        expect(result.startDistance).toEqual(58.63);
+      });
+
+      it('should return a middle value 1 and a half times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.D);
         expect(result.middleDistance).toEqual(22.5);
+      });
+
+      it('should return a middle value 1 and a half times the vehicle length to 2 fixed decimal places', () => {
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetailsDecimal, TestCategory.D);
+        expect(result.middleDistance).toEqual(23.33);
       });
     });
 
     describe('Category D+E', () => {
-      it('should return a start distance 4 times the vehicle length', () => {
+      it('should return a start value 4 times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.DE);
         expect(result.startDistance).toEqual(60);
       });
 
-      it('should return a start distance of 66 if the vehicle length is greater than 16.5', () => {
+      it('should return a start value of 66 if the vehicle length is > 16.5', () => {
         const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.DE);
         expect(result.startDistance).toEqual(66);
       });
 
-      it('should return the correct middle distance if the vehicle length is greater than 16.5', () => {
+      it('should return the correct middle distance if the vehicle length is > 16.5', () => {
         // Calculation: 66 - 2 x vehicle length
         const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.DE);
         expect(result.middleDistance).toEqual(26);
       });
 
-      it('should return the correct middle distance if the vehicle length is less than 16.5', () => {
+      it('should return the correct middle value for vehicles > 16.5 with decimal places', () => {
+        // Calculation: 66 - 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetailsDecimal, TestCategory.DE);
+        expect(result.middleDistance).toEqual(32.5);
+      });
+
+      it('should return the correct middle value for vehicles > 16.5 with decimal places', () => {
+        // Calculation: 66 - 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength({
+          ...longVehicleDetailsDecimal, vehicleLength: 17.25,
+        }, TestCategory.DE);
+        expect(result.middleDistance).toEqual(31.5);
+      });
+
+      it('should return the correct middle distance if the vehicle length is < 16.5', () => {
         // Calculation: 2 x vehicle length
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.DE);
         expect(result.middleDistance).toEqual(30);
+      });
+
+      it('should return the correct middle value for vehicles < 16.5 with decimal places ', () => {
+        // Calculation: 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetailsDecimal, TestCategory.DE);
+        expect(result.middleDistance).toEqual(31.1);
       });
     });
 
     describe('Category D1', () => {
-      it('should return a start distance value 3 and a half times the vehicle length', () => {
+      it('should return a start value 3 and a half times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.D1);
         expect(result.startDistance).toEqual(52.5);
       });
 
-      it('should return a value 3 and a half times vehicle length if greater than 16.5', () => {
+      it('should return a start value 3 and a half times vehicle length if > 16.5', () => {
         const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.D1);
         expect(result.startDistance).toEqual(70);
       });
 
-      it('should return a middle distance value 1 and a half times the vehicle length', () => {
+      it('should return a start value 3 and a half times vehicle length to 2 fixed decimal places', () => {
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetailsDecimal, TestCategory.D1);
+        expect(result.startDistance).toEqual(58.63);
+      });
+
+      it('should return a middle value 1 and a half times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.D1);
         expect(result.middleDistance).toEqual(22.5);
+      });
+
+      it('should return a middle value 1 and a half times the vehicle length to 2 fixed decimal places', () => {
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetailsDecimal, TestCategory.D1);
+        expect(result.middleDistance).toEqual(23.33);
       });
     });
 
     describe('Category D1+E', () => {
-      it('should return a start distance 4 times the vehicle length', () => {
+      it('should return a start value 4 times the vehicle length', () => {
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.D1E);
         expect(result.startDistance).toEqual(60);
       });
 
-      it('should return a start distance of 66 if the vehicle length is greater than 16.5', () => {
+      it('should return a start value of 66 if the vehicle length is > 16.5', () => {
         const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.D1E);
         expect(result.startDistance).toEqual(66);
       });
 
-      it('should return the correct middle distance if the vehicle length is greater than 16.5', () => {
+      it('should return the correct middle distance if the vehicle length is > 16.5', () => {
         // Calculation: 66 - 2 x vehicle length
         const result = reversingDistancesProvider.getDistanceLength(longVehicleDetails, TestCategory.D1E);
         expect(result.middleDistance).toEqual(26);
       });
 
-      it('should return the correct middle distance if the vehicle length is less than 16.5', () => {
+      it('should return the correct middle value for vehicles > 16.5 with decimal places', () => {
+        // Calculation: 66 - 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(longVehicleDetailsDecimal, TestCategory.D1E);
+        expect(result.middleDistance).toEqual(32.5);
+      });
+
+      it('should return the correct middle value for vehicles > 16.5 with decimal places', () => {
+        // Calculation: 66 - 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength({
+          ...longVehicleDetailsDecimal, vehicleLength: 18.25,
+        }, TestCategory.C1E);
+        expect(result.middleDistance).toEqual(29.5);
+      });
+
+      it('should return the correct middle distance if the vehicle length is < 16.5', () => {
         // Calculation: 2 x vehicle length
         const result = reversingDistancesProvider.getDistanceLength(vehicleDetails, TestCategory.D1E);
         expect(result.middleDistance).toEqual(30);
+      });
+
+      it('should return the correct middle value for vehicles < 16.5 with decimal places ', () => {
+        // Calculation: 2 x vehicle length
+        const result = reversingDistancesProvider.getDistanceLength(vehicleDetailsDecimal, TestCategory.D1E);
+        expect(result.middleDistance).toEqual(31.1);
       });
     });
   });

--- a/src/providers/reversing-distances/reversing-distances.ts
+++ b/src/providers/reversing-distances/reversing-distances.ts
@@ -63,15 +63,15 @@ export class ReversingDistancesProvider {
       case TestCategory.DE:
       case TestCategory.D1E:
         return ({
-          startDistance: data.vehicleLength > 16.5 ? 66 : Math.round(distanceFromStart * 100) / 100,
+          startDistance: data.vehicleLength > 16.5 ? 66 : Number(distanceFromStart.toFixed(2)),
           middleDistance: data.vehicleLength > 16.5
-            ? Math.round(66 - (data.vehicleLength * 2))
-            : Math.round(distanceFromMiddle * 100) / 100,
+            ? Number((66 - (data.vehicleLength * 2)).toFixed(2))
+            : Number(distanceFromMiddle.toFixed(2)),
         });
       default:
         return ({
-          startDistance:  Math.round(distanceFromStart * 100) / 100,
-          middleDistance: Math.round(distanceFromMiddle * 100) / 100,
+          startDistance: Number(distanceFromStart.toFixed(2)),
+          middleDistance: Number(distanceFromMiddle.toFixed(2)),
         });
     }
   }
@@ -81,7 +81,7 @@ export class ReversingDistancesProvider {
       return 3;
     }
     const distanceOfBayWidth = data.vehicleWidth * this.distanceValues.get(category).widthMultiplier;
-    return Math.round(distanceOfBayWidth * 100) / 100;
+    return Number(distanceOfBayWidth.toFixed(2));
   }
 
 }


### PR DESCRIPTION
## Description
Changes the calculations on the reversing diagram modal:

- Removes rounding on ALL calculations
- Limits number of decimal places to no more than 2
- Reduces the font size of the calculation values to match the labels (20px)

**Note:** Testing on a real device is required to ensure calculation values do not wrap onto 2 lines when displayed with 2 decimal places e.g. 23.33

## Checklist

- [x] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![Ionic App (1)](https://user-images.githubusercontent.com/54100299/77168926-91230080-6ab0-11ea-84a1-c74b184ad3bf.png)
![Ionic App](https://user-images.githubusercontent.com/54100299/77168931-92542d80-6ab0-11ea-9005-e09704664553.png)
