### PR TITLE
MES-4238 - Stopped Toggle Analytics when it is programatically fired

### DIFF
--- a/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -40,7 +40,7 @@ import {
   manoeuvreCompetencyLabels,
   manoeuvreTypeLabels,
 } from '../../../shared/constants/competencies/catb-manoeuvres';
-import { AnalyticRecorded } from '../../../providers/analytics/analytics.actions';
+import { AnalyticRecorded, AnalyticNotRecorded } from '../../../providers/analytics/analytics.actions';
 import {
   legalRequirementsLabels,
   legalRequirementToggleValues,
@@ -119,11 +119,11 @@ describe('Test Report Analytics Effects', () => {
   });
 
   describe('toggleRemoveFaultMode', () => {
-    it('should call logEvent for this competency', (done) => {
+    it('should call logEvent when the action is user generated', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
-      actions$.next(new testReportActions.ToggleRemoveFaultMode());
+      actions$.next(new testReportActions.ToggleRemoveFaultMode(true));
       // ASSERT
       effects.toggleRemoveFaultMode$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
@@ -135,11 +135,11 @@ describe('Test Report Analytics Effects', () => {
         done();
       });
     });
-    it('should call logEvent for this competency, prefixed with practice test', (done) => {
+    it('should call logEvent when the action is user generated, prefixed with practice test', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions$.next(new testReportActions.ToggleRemoveFaultMode());
+      actions$.next(new testReportActions.ToggleRemoveFaultMode(true));
       // ASSERT
       effects.toggleRemoveFaultMode$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
@@ -151,14 +151,26 @@ describe('Test Report Analytics Effects', () => {
         done();
       });
     });
-  });
-
-  describe('toggleSeriousFaultMode', () => {
-    it('should call logEvent for this competency', (done) => {
+    it('should not call logEvent when the action is not user generated', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
-      actions$.next(new testReportActions.ToggleSeriousFaultMode());
+      actions$.next(new testReportActions.ToggleRemoveFaultMode());
+      // ASSERT
+      effects.toggleRemoveFaultMode$.subscribe((result) => {
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
+  describe('toggleSeriousFaultMode', () => {
+    it('should call logEvent when action is user generated', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
+      // ACT
+      actions$.next(new testReportActions.ToggleSeriousFaultMode(true));
       // ASSERT
       effects.toggleSeriousFaultMode$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
@@ -170,11 +182,11 @@ describe('Test Report Analytics Effects', () => {
         done();
       });
     });
-    it('should call logEvent for this competency, prefixed with practice test', (done) => {
+    it('should call logEvent when action is user generated, prefixed with practice test', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions$.next(new testReportActions.ToggleSeriousFaultMode());
+      actions$.next(new testReportActions.ToggleSeriousFaultMode(true));
       // ASSERT
       effects.toggleSeriousFaultMode$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
@@ -186,14 +198,26 @@ describe('Test Report Analytics Effects', () => {
         done();
       });
     });
-  });
-
-  describe('toggleDangerousFaultMode', () => {
-    it('should call logEvent for this competency', (done) => {
+    it('should not call logEvent when action is not user generated', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
       // ACT
-      actions$.next(new testReportActions.ToggleDangerousFaultMode());
+      actions$.next(new testReportActions.ToggleSeriousFaultMode());
+      // ASSERT
+      effects.toggleSeriousFaultMode$.subscribe((result) => {
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
+  describe('toggleDangerousFaultMode', () => {
+    it('should call logEvent when action is user generated', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
+      // ACT
+      actions$.next(new testReportActions.ToggleDangerousFaultMode(true));
       // ASSERT
       effects.toggleDangerousFaultMode$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
@@ -205,11 +229,11 @@ describe('Test Report Analytics Effects', () => {
         done();
       });
     });
-    it('should call logEvent for this competency, prefixed with practice test', (done) => {
+    it('should call logEvent when action is user generated prefixed with practice test', (done) => {
       // ARRANGE
       store$.dispatch(new testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
-      actions$.next(new testReportActions.ToggleDangerousFaultMode());
+      actions$.next(new testReportActions.ToggleDangerousFaultMode(true));
       // ASSERT
       effects.toggleDangerousFaultMode$.subscribe((result) => {
         expect(result instanceof AnalyticRecorded).toBe(true);
@@ -218,6 +242,18 @@ describe('Test Report Analytics Effects', () => {
           `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
           `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.SELECT_DANGEROUS_MODE}`,
         );
+        done();
+      });
+    });
+    it('should not call logEvent when action is not user generated', (done) => {
+      // ARRANGE
+      store$.dispatch(new testsActions.StartTest(123456, TestCategory.B));
+      // ACT
+      actions$.next(new testReportActions.ToggleDangerousFaultMode());
+      // ASSERT
+      effects.toggleDangerousFaultMode$.subscribe((result) => {
+        expect(result instanceof AnalyticNotRecorded).toBe(true);
+        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
         done();
       });
     });

--- a/src/pages/test-report/components/toolbar/__tests__/toolbar.spec.ts
+++ b/src/pages/test-report/components/toolbar/__tests__/toolbar.spec.ts
@@ -54,14 +54,14 @@ describe('ToolbarComponent', () => {
       it('should dispatch a TOGGLE_REMOVE_FAULT_MODE action', () => {
         component.toggleRemoveFaultMode();
 
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode());
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleRemoveFaultMode(true));
       });
     });
     describe('toggleSeriousMode', () => {
       it('should dispatch a TOGGLE_SERIOUS_FAULT_MODE action', () => {
         component.toggleSeriousMode();
 
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleSeriousFaultMode());
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleSeriousFaultMode(true));
       });
       it('should dispatch a TOGGLE_DANGEROUS_FAULT_MODE action if dangerous mode is active', () => {
         component.isDangerousMode = true;
@@ -76,7 +76,7 @@ describe('ToolbarComponent', () => {
       it('should dispatch a TOGGLE_DANGEROUS_FAULT_MODE action', () => {
         component.toggleDangerousMode();
 
-        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleDangerousFaultMode());
+        expect(storeDispatchSpy).toHaveBeenCalledWith(new ToggleDangerousFaultMode(true));
       });
     });
   });

--- a/src/pages/test-report/components/toolbar/toolbar.ts
+++ b/src/pages/test-report/components/toolbar/toolbar.ts
@@ -62,21 +62,21 @@ export class ToolbarComponent {
   }
 
   toggleRemoveFaultMode(): void {
-    this.store$.dispatch(new ToggleRemoveFaultMode());
+    this.store$.dispatch(new ToggleRemoveFaultMode(true));
   }
 
   toggleSeriousMode(): void {
     if (this.isDangerousMode) {
       this.store$.dispatch(new ToggleDangerousFaultMode());
     }
-    this.store$.dispatch(new ToggleSeriousFaultMode());
+    this.store$.dispatch(new ToggleSeriousFaultMode(true));
   }
 
   toggleDangerousMode(): void {
     if (this.isSeriousMode) {
       this.store$.dispatch(new ToggleSeriousFaultMode());
     }
-    this.store$.dispatch(new ToggleDangerousFaultMode());
+    this.store$.dispatch(new ToggleDangerousFaultMode(true));
   }
 
 }

--- a/src/pages/test-report/test-report.actions.ts
+++ b/src/pages/test-report/test-report.actions.ts
@@ -12,16 +12,22 @@ export const START_TIMER = '[TestReportPage] Start Timer';
 export class TestReportViewDidEnter implements Action {
   readonly type = TEST_REPORT_VIEW_DID_ENTER;
 }
+
+// The aim of isUserGenerated in the actions below is so we know if we should track the event in analytics.
+// by default we don't as most of the time we programatically toggling the mode which we don't want to record
 export class ToggleRemoveFaultMode implements Action {
   readonly type = TOGGLE_REMOVE_FAULT_MODE;
+  constructor(public isUserGenerated: boolean = false) {}
 }
 
 export class ToggleSeriousFaultMode implements Action {
   readonly type = TOGGLE_SERIOUS_FAULT_MODE;
+  constructor(public isUserGenerated: boolean = false) {}
 }
 
 export class ToggleDangerousFaultMode implements Action {
   readonly type = TOGGLE_DANGEROUS_FAULT_MODE;
+  constructor(public isUserGenerated: boolean = false) {}
 }
 
 export class CalculateTestResult implements Action {

--- a/src/pages/test-report/test-report.analytics.effects.ts
+++ b/src/pages/test-report/test-report.analytics.effects.ts
@@ -27,7 +27,7 @@ import {
   manoeuvreCompetencyLabels,
   manoeuvreTypeLabels,
 } from '../../shared/constants/competencies/catb-manoeuvres';
-import { AnalyticRecorded } from '../../providers/analytics/analytics.actions';
+import { AnalyticRecorded, AnalyticNotRecorded } from '../../providers/analytics/analytics.actions';
 import { TestsModel } from '../../modules/tests/tests.model';
 import { formatAnalyticsText } from '../../shared/helpers/format-analytics-text';
 import { legalRequirementsLabels, legalRequirementToggleValues }
@@ -103,6 +103,10 @@ export class TestReportAnalyticsEffects {
       ),
     )),
     concatMap(([action, tests]: [testReportActions.ToggleRemoveFaultMode, TestsModel]) => {
+      if (!action.isUserGenerated) {
+        return of(new AnalyticNotRecorded());
+      }
+
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
         formatAnalyticsText(AnalyticsEvents.SELECT_REMOVE_MODE, tests),
@@ -122,6 +126,10 @@ export class TestReportAnalyticsEffects {
       ),
     )),
     concatMap(([action, tests]: [testReportActions.ToggleSeriousFaultMode, TestsModel]) => {
+      if (!action.isUserGenerated) {
+        return of(new AnalyticNotRecorded());
+      }
+
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
         formatAnalyticsText(AnalyticsEvents.SELECT_SERIOUS_MODE, tests),
@@ -141,6 +149,9 @@ export class TestReportAnalyticsEffects {
       ),
     )),
     concatMap(([action, tests]: [testReportActions.ToggleDangerousFaultMode, TestsModel]) => {
+      if (!action.isUserGenerated) {
+        return of(new AnalyticNotRecorded());
+      }
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
         formatAnalyticsText(AnalyticsEvents.SELECT_DANGEROUS_MODE, tests),

--- a/src/providers/analytics/analytics.actions.ts
+++ b/src/providers/analytics/analytics.actions.ts
@@ -1,7 +1,7 @@
 import { Action } from '@ngrx/store';
 
 export const ANALYTIC_RECORDED = '[Analytics] Analytic Recorded';
-export const ANALYTIC_NOT_RECORDED = '[Analytics] Analytic Recorded';
+export const ANALYTIC_NOT_RECORDED = '[Analytics] Analytic Not Recorded';
 
 export class AnalyticRecorded implements Action {
   readonly type = ANALYTIC_RECORDED;


### PR DESCRIPTION
## Description
Pam noticed when we fire a TOGGLE_SERIOUS_MODE , TOGGLE_DANGEROUS_MODE and TOGGLE_REMOVE_FAULT_MODE action we always send something to GA no matter if the event is user-generated or programmatically generated.  Which is incorrect

This PR adds a toggle which allows us to decide if the action should trigger analytics or not.

I also fixed the Analytic Not Fired action as it had the same title as the Analytic Fired Action

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
