### PR TITLE
Page name constants was incorrect, now goes to correct page

### DIFF
--- a/src/pages/page-names.constants.ts
+++ b/src/pages/page-names.constants.ts
@@ -134,7 +134,7 @@ export const CAT_HOME_TEST = {
   WAITING_ROOM_PAGE: 'WaitingRoomCatHomeTestPage',
   WAITING_ROOM_TO_CAR_PAGE: 'WaitingRoomToCarCatHomeTestPage',
   POST_DEBRIEF_HOLDING_PAGE: 'PostDebriefHoldingCatHomeTestPage',
-  REKEY_REASON_PAGE: 'RekeyReasonCatDHomeTestPage',
+  REKEY_REASON_PAGE: 'RekeyReasonCatHomeTestPage',
   NON_PASS_FINALISATION_PAGE: 'NonPassFinalisationCatHomeTestPage',
   VEHICLE_CHECKS_MODAL: 'VehicleChecksCatHomeTestModal',
   VIEW_TEST_RESULT_PAGE: 'ViewTestResultCatHomeTestPage',


### PR DESCRIPTION
## Description

Page name constant now points to correct rekey reason page for home tests.

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
