### PR TITLE
Feature mes 5096 use correct label types

### DIFF
--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -363,7 +363,7 @@
       "positioningNormalRiding": "Lleoli ar y ffordd - Beicio arferol",
       "bends": "Troeon",
       "clearanceOrObstructions" : "Clirio / Rhwystrau",
-      "highwayCodeSafety": "[CY]Highway Code/ Safety"
+      "highwayCodeSafety": "[CY]Highway Code / Safety"
     },
     "dangerousFault": "Nam peryglus",
     "dangerousFaultsCardDescription": "Namau peryglus",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -362,7 +362,8 @@
       "controlsBalanceSlowControl": "Rheolaeth - Cydbwysedd / Rheolaeth araf",
       "positioningNormalRiding": "Lleoli ar y ffordd - Beicio arferol",
       "bends": "Troeon",
-      "clearanceOrObstructions" : "Clirio / Rhwystrau"
+      "clearanceOrObstructions" : "Clirio / Rhwystrau",
+      "highwayCodeSafety": "[CY]Highway Code/ Safety"
     },
     "dangerousFault": "Nam peryglus",
     "dangerousFaultsCardDescription": "Namau peryglus",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -363,7 +363,7 @@
       "bends": "Bends",
       "safetyQuestions": "Safety Questions",
       "clearanceOrObstructions" : "Clearance/obstructions",
-      "highwayCodeSafety": "Highway Code/ Safety"
+      "highwayCodeSafety": "Highway Code / Safety"
     },
     "dangerousFault": "Dangerous fault",
     "dangerousFaultsCardDescription": "dangerous faults",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -362,7 +362,8 @@
       "positioningNormalRiding": "Positioning - Normal riding",
       "bends": "Bends",
       "safetyQuestions": "Safety Questions",
-      "clearanceOrObstructions" : "Clearance/obstructions"
+      "clearanceOrObstructions" : "Clearance/obstructions",
+      "highwayCodeSafety": "Highway Code/ Safety"
     },
     "dangerousFault": "Dangerous fault",
     "dangerousFaultsCardDescription": "dangerous faults",

--- a/src/pages/view-test-result/cat-home-test/components/debrief-card/debrief-card.ts
+++ b/src/pages/view-test-result/cat-home-test/components/debrief-card/debrief-card.ts
@@ -7,8 +7,9 @@ import {
   ViewTestResultLabels,
   TestRequirementsLabels,
 } from '../../../components/data-row-with-list/data-list-with-row.model';
-// TODO - Cat HOME, change to the correct labels
-import { manoeuvreTypeLabels } from '../../../../../shared/constants/competencies/catbe-manoeuvres';
+import {
+  manoeuvreTypeLabelsCatHomeTest,
+} from '../../../../../shared/constants/competencies/cathometest-manoeuvres';
 import { FaultSummary } from '../../../../../shared/models/fault-marking.model';
 import { FaultSummaryProvider } from '../../../../../providers/fault-summary/fault-summary';
 import { FaultCountProvider } from '../../../../../providers/fault-count/fault-count';
@@ -72,7 +73,7 @@ export class DebriefCardComponent {
 
   public getManoeuvre(): string {
     const isReverseLeftSelected = get(this.data, 'manoeuvres.reverseLeft.selected', false);
-    return isReverseLeftSelected ? manoeuvreTypeLabels.reverseLeft : 'None' ;
+    return isReverseLeftSelected ? manoeuvreTypeLabelsCatHomeTest.reverseLeft : 'None' ;
   }
 
   public getEco(): DataRowListItem[] {

--- a/src/shared/constants/competencies/cathometest-manoeuvres.ts
+++ b/src/shared/constants/competencies/cathometest-manoeuvres.ts
@@ -1,0 +1,12 @@
+export enum manoeuvreTypeLabelsCatHomeTest {
+    reverseLeft = 'Reverse',
+  }
+
+interface ManoeuvreCompetencyLabel {
+  [key: string]: 'Control' | 'Observation';
+}
+
+export const manoeuvreCompetencyLabelsCatHomeTest: ManoeuvreCompetencyLabel = {
+  controlFault: 'Control',
+  observationFault: 'Observation',
+};


### PR DESCRIPTION
MES 5096
Address  TODO around manouevre labels
also found issue with debrief card competencies for HighwayCode Safety so added and added placeholder for welsh till translations appear.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

