### PR TITLE
Mes 5057 sanity check home test journey

### DIFF
--- a/src/modules/tests/test-data/cat-home-test/__tests__/test-data.cat-home.selector.spec.ts
+++ b/src/modules/tests/test-data/cat-home-test/__tests__/test-data.cat-home.selector.spec.ts
@@ -2,6 +2,7 @@ import {
   CatHomeTestData,
   getManoeuvres,
   getVehicleChecks,
+  hasManoeuvreBeenCompletedCatHomeTest,
   hasVehicleChecksBeenCompletedCatHomeTest,
 } from '../test-data.cat-home.selector';
 import { CompetencyOutcome } from '../../../../../shared/models/competency-outcome';
@@ -57,6 +58,27 @@ describe('TestDataSelectors', () => {
     it('should retrieve the manoeuvres data when requested', () => {
       const result = getManoeuvres(state);
       expect(result).toEqual(state.manoeuvres);
+    });
+  });
+
+  describe('hasManoeuvreBeenCompleted', () => {
+    it('should return true when no manoeuvres are present', () => {
+      const state: CatHomeTestData = {};
+      expect(hasManoeuvreBeenCompletedCatHomeTest(state)).toEqual(undefined);
+    });
+    it('should return false when no manoeuvres have been completed', () => {
+      const state: CatHomeTestData = {
+        manoeuvres: {},
+      };
+      expect(hasManoeuvreBeenCompletedCatHomeTest(state)).toBeFalsy();
+    });
+    it('should return true when a manoeuvre has been completed', () => {
+      const state: CatHomeTestData = {
+        manoeuvres: {
+          reverseLeft: { selected: true },
+        },
+      };
+      expect(hasManoeuvreBeenCompletedCatHomeTest(state)).toEqual(true);
     });
   });
 

--- a/src/modules/tests/test-data/cat-home-test/__tests__/test-data.cat-home.selector.spec.ts
+++ b/src/modules/tests/test-data/cat-home-test/__tests__/test-data.cat-home.selector.spec.ts
@@ -62,7 +62,7 @@ describe('TestDataSelectors', () => {
   });
 
   describe('hasManoeuvreBeenCompleted', () => {
-    it('should return true when no manoeuvres are present', () => {
+    it('should return undefined when manoeuvres are not present', () => {
       const state: CatHomeTestData = {};
       expect(hasManoeuvreBeenCompletedCatHomeTest(state)).toEqual(undefined);
     });

--- a/src/modules/tests/test-data/cat-home-test/test-data.cat-home.selector.ts
+++ b/src/modules/tests/test-data/cat-home-test/test-data.cat-home.selector.ts
@@ -32,6 +32,13 @@ export const getVehicleChecks = (
 
 export const getManoeuvres = (data: CatHomeTestData): CatHomeTestManoeuvres => get(data, 'manoeuvres');
 
+// TODO - We should pass a Manoeuvre object here instead of TestData
+export const hasManoeuvreBeenCompletedCatHomeTest = (data: CatHomeTestData): boolean => {
+  return (
+    get(data, 'manoeuvres.reverseLeft.selected', undefined) // default to undefined for CAT K
+  );
+};
+
 // TODO - We should really pass a Vehicle Checks object here and not Test Data
 // TODO - Also this has to go into a provider
 export const hasVehicleChecksBeenCompletedCatHomeTest = (data: CatHomeTestData): boolean => {

--- a/src/pages/non-pass-finalisation/cat-home/non-pass-finalisation.cat-home-test.page.ts
+++ b/src/pages/non-pass-finalisation/cat-home/non-pass-finalisation.cat-home-test.page.ts
@@ -39,8 +39,7 @@ import {
 import { FormGroup } from '@angular/forms';
 import { PersistTests } from '../../../modules/tests/tests.actions';
 import { OutcomeBehaviourMapProvider } from '../../../providers/outcome-behaviour-map/outcome-behaviour-map';
-// TODO - Cat HOME use correct behavior map
-import { behaviourMap } from '../../office/office-behaviour-map.cat-be';
+import { behaviourMap } from '../../office/office-behaviour-map.cat-home-test';
 import {
   DebriefWitnessed,
   DebriefUnwitnessed,

--- a/src/pages/pass-finalisation/cat-home-test/pass-finalisation.cat-home-test.page.ts
+++ b/src/pages/pass-finalisation/cat-home-test/pass-finalisation.cat-home-test.page.ts
@@ -18,8 +18,7 @@ import {
   isProvisionalLicenseProvided,
 } from '../../../modules/tests/pass-completion/pass-completion.selector';
 import { Observable, Subscription } from 'rxjs';
-// TODO - Cat HOME - Use correct selector
-import { getCandidate } from '../../../modules/tests/journal-data/cat-be/candidate/candidate.cat-be.reducer';
+import { getCandidate } from '../../../modules/tests/journal-data/cat-home/candidate/candidate.cat-home.reducer';
 import {
   getCandidateName, getCandidateDriverNumber, formatDriverNumber, getUntitledCandidateName,
 } from '../../../modules/tests/journal-data/common/candidate/candidate.selector';
@@ -43,8 +42,7 @@ import {
   DebriefUnwitnessed,
 } from '../../../modules/tests/test-summary/common/test-summary.actions';
 import { OutcomeBehaviourMapProvider } from '../../../providers/outcome-behaviour-map/outcome-behaviour-map';
-// TODO - Cat HOME , use correct behavior map
-import { behaviourMap } from '../../office/office-behaviour-map.cat-be';
+import { behaviourMap } from '../../office/office-behaviour-map.cat-home-test';
 import { ActivityCodes } from '../../../shared/models/activity-codes';
 import {
   CandidateChoseToProceedWithTestInWelsh,

--- a/src/pages/test-report/cat-a-mod2/components/safety-and-balance/__tests__/safety-and-balance.spec.ts
+++ b/src/pages/test-report/cat-a-mod2/components/safety-and-balance/__tests__/safety-and-balance.spec.ts
@@ -64,8 +64,7 @@ describe('SafetyAndBalanceComponent', () => {
     });
   });
 
-  // TODO(MES-4515): Reintroduce once fault count providers are completed
-  xdescribe('DOM', () => {
+  describe('DOM', () => {
     it('should pass the number of S&B riding faults to the driving faults component', () => {
       fixture.detectChanges();
       const drivingFaultsBadge = fixture.debugElement.query(By.css('.driving-faults'))

--- a/src/pages/test-report/cat-home-test/test-report.cat-home-test.page.ts
+++ b/src/pages/test-report/cat-home-test/test-report.cat-home-test.page.ts
@@ -42,8 +42,9 @@ import { getTestCategory } from '../../../modules/tests/category/category.reduce
 import { CategoryCode } from '@dvsa/mes-test-schema/categories/common';
 import { getCandidate } from '../../../modules/tests/journal-data/cat-home/candidate/candidate.cat-home.reducer';
 import { TestDataByCategoryProvider } from '../../../providers/test-data-by-category/test-data-by-category';
-// TODO Implement Home Test selector
-import { hasManoeuvreBeenCompletedCatC } from '../../../modules/tests/test-data/cat-c/test-data.cat-c.selector';
+import {
+  hasManoeuvreBeenCompletedCatHomeTest,
+} from '../../../modules/tests/test-data/cat-home-test/test-data.cat-home.selector';
 import {
   getTestRequirementsCatHome,
 } from '../../../modules/tests/test-data/cat-home-test/test-requirements/test-requirements.cat-home.reducer';
@@ -149,16 +150,16 @@ export class TestReportCatHomeTestPage extends BasePageComponent {
       ),
       manoeuvres$: currentTest$.pipe(
         withLatestFrom(category$),
-        map(([data , category])  => this.testDataByCategory.getTestDataByCategoryCode(category)(data)),
-        select(hasManoeuvreBeenCompletedCatC),
+        map(([data , category]) => this.testDataByCategory.getTestDataByCategoryCode(category)(data)),
+        select(hasManoeuvreBeenCompletedCatHomeTest),
       ),
       testData$: currentTest$.pipe(
         withLatestFrom(category$),
-        map(([data , category])  => this.testDataByCategory.getTestDataByCategoryCode(category)(data)),
+        map(([data , category]) => this.testDataByCategory.getTestDataByCategoryCode(category)(data)),
       ),
       testRequirements$: currentTest$.pipe(
         withLatestFrom(category$),
-        map(([data , category])  => this.testDataByCategory.getTestDataByCategoryCode(category)(data)),
+        map(([data , category]) => this.testDataByCategory.getTestDataByCategoryCode(category)(data)),
         select(getTestRequirementsCatHome),
       ),
       testCategory$: currentTest$.pipe(

--- a/src/pages/view-test-result/cat-home-test/__tests__/view-test-result.cat-home-test.page.spec.ts
+++ b/src/pages/view-test-result/cat-home-test/__tests__/view-test-result.cat-home-test.page.spec.ts
@@ -26,8 +26,7 @@ import { By } from '@angular/platform-browser';
 import { ExaminerDetailsModel } from '../../components/examiner-details-card/examiner-details-card.model';
 import { TestDetailsModel } from '../../components/test-details-card/test-details-card.model';
 import { VehicleDetailsCardComponent } from '../../components/vehicle-details-card/vehicle-details-card';
-// TODO - Cat HOME , use correct data mock
-import { categoryBETestResultMock } from '../../../../shared/mocks/cat-be-test-result.mock';
+import { categoryHomeTestResultMock } from '../../../../shared/mocks/cat-home-test-result.mock';
 import { CompressionProvider } from '../../../../providers/compression/compression';
 import { CompressionProviderMock } from '../../../../providers/compression/__mocks__/compression.mock';
 import { TestSummaryCardComponent } from '../../components/test-summary-card/test-summary-card';
@@ -109,13 +108,12 @@ describe('ViewTestResultCatHomeTestPage', () => {
     });
     describe('getTestDetails', () => {
       it('should correctly generate the data', () => {
-        // TODO - Cat Home , use correct mock
-        component.testResult = categoryBETestResultMock;
+        component.testResult = categoryHomeTestResultMock;
 
         const result: TestDetailsModel = component.getTestDetails();
 
         expect(result.applicationReference).toBe('12345672013');
-        expect(result.category).toBe('B+E');
+        expect(result.category).toBe('F');
         expect(result.date).toBe('Friday 5th July 2019');
         expect(result.time).toBe('09:00');
         expect(result.specialNeeds).toEqual(
@@ -134,8 +132,7 @@ describe('ViewTestResultCatHomeTestPage', () => {
     });
     describe('getExaminerDetails', () => {
       it('should correctly generate the data', () => {
-        // TODO - Cat Home , use correct mock
-        component.testResult = categoryBETestResultMock;
+        component.testResult = categoryHomeTestResultMock;
 
         const result: ExaminerDetailsModel = component.getExaminerDetails();
 
@@ -150,8 +147,7 @@ describe('ViewTestResultCatHomeTestPage', () => {
     });
     describe('getHeaderDetails', () => {
       it('should return the correct data', () => {
-        // TODO - Cat Home , use correct mock
-        component.testResult = categoryBETestResultMock;
+        component.testResult = categoryHomeTestResultMock;
         const result: ViewTestHeaderModel = component.getHeaderDetails();
 
         expect(result.activityCode).toBe('2');
@@ -229,8 +225,7 @@ describe('ViewTestResultCatHomeTestPage', () => {
     });
     it('should show the cards when the data is not loading and there is no error', () => {
       component.isLoading = false;
-      // TODO - Cat Home , use correct mock
-      component.testResult = categoryBETestResultMock;
+      component.testResult = categoryHomeTestResultMock;
 
       fixture.detectChanges();
 
@@ -262,8 +257,7 @@ describe('ViewTestResultCatHomeTestPage', () => {
   });
   it('should show rekey cards only when rekey is true', () => {
     component.isLoading = false;
-    // TODO - Cat Home , use correct mock
-    component.testResult = categoryBETestResultMock;
+    component.testResult = categoryHomeTestResultMock;
 
     fixture.detectChanges();
 

--- a/src/shared/mocks/cat-home-test-result.mock.ts
+++ b/src/shared/mocks/cat-home-test-result.mock.ts
@@ -1,0 +1,164 @@
+import { CatFUniqueTypes } from '@dvsa/mes-test-schema/categories/F';
+
+export const categoryHomeTestResultMock: CatFUniqueTypes.TestResult = {
+  version: '0.0.1',
+  category: 'F',
+  activityCode: '2',
+  rekey: true,
+  rekeyDate: '2019-08-05T09:00:00',
+  rekeyReason: {
+    ipadIssue: {
+      selected: true,
+      broken: false,
+      lost: true,
+      technicalFault: false,
+      stolen: false,
+    },
+    transfer: {
+      selected: false,
+    },
+    other: {
+      selected: true,
+      reason: 'I do not like the app',
+    },
+  },
+  changeMarker: false,
+  examinerBooked: 12345678,
+  examinerConducted: 12345678,
+  examinerKeyed: 12345678,
+  journalData: {
+    applicationReference: {
+      applicationId: 1234567,
+      bookingSequence: 20,
+      checkDigit: 13,
+    },
+    candidate: {
+      candidateName: {
+        title: 'Miss',
+        firstName: 'Florence',
+        lastName: 'Pearson',
+      },
+      driverNumber: 'PEARSL6767655777BN',
+      emailAddress: 'candidate@candidate.com',
+      dateOfBirth: '01-01-2020',
+      gender: 'F',
+      primaryTelephone: '1234567890',
+      mobileTelephone: '2345678901',
+      candidateAddress: {
+        addressLine1: '999 Letsby Avenue',
+        addressLine2: 'Someplace',
+        addressLine3: 'Sometown',
+        postcode: 'AB67 8CD',
+      },
+      businessName: 'Logistic and Distribution Training Limited',
+      businessAddress: {
+        addressLine1: '18 Bridge Street',
+        addressLine2: 'Horncastle',
+        addressLine3: 'Lincolnshire',
+        postcode: 'LN9 5JA',
+      },
+      businessTelephone: '07988 674 536',
+    },
+    examiner: {
+      individualId: 1,
+      staffNumber: '12345678',
+    },
+    testCentre: {
+      centreId: 1,
+      costCode: 'EXTC1',
+      centreName: 'Example Test Centre',
+    },
+    testSlotAttributes: {
+      slotId: 1,
+      start: '2019-07-05T09:00:00',
+      extendedTest: false,
+      specialNeeds: false,
+      specialNeedsArray: ['Candidate is heavily pregnant', 'Candidate whishes to be called a different name'],
+      entitlementCheck: true,
+      slotType: 'Double Slot Special Needs',
+      previousCancellation: ['Act of nature', 'DSA'],
+      welshTest: false,
+      examinerVisiting: false,
+      vehicleTypeCode: 'mock-vehicle-type-code',
+    },
+  },
+  communicationPreferences: {
+    communicationMethod: 'Email',
+    conductedLanguage: 'English',
+    updatedEmail: 'candidate@updated-candidate.com',
+  },
+  vehicleDetails: {
+    gearboxCategory: 'Manual',
+    registrationNumber: 'AB12 XYZ',
+  },
+  accompaniment: {
+    ADI: true,
+    interpreter: true,
+    other: false,
+    supervisor: false,
+  },
+  passCompletion: {
+    passCertificateNumber: 'A123456X',
+    provisionalLicenceProvided: true,
+  },
+  testSummary: {
+    D255: false,
+    candidateDescription: 'Candidate liked tall cute girls.',
+    debriefWitnessed: true,
+    weatherConditions: ['Bright / dry roads', 'Icy'],
+    additionalInformation: 'Had time for an extra coffee',
+  },
+  testData: {
+    dangerousFaults: {
+      ancillaryControls: true,
+      ancillaryControlsComments: 'Candidate did not stop and continued to drive eratically',
+    },
+    drivingFaults: {
+      awarenessPlanning: 2,
+      awarenessPlanningComments: 'Candidate nearly killed a dog',
+    },
+    eco: {
+      completed: true,
+      adviceGivenControl: true,
+      adviceGivenPlanning: false,
+    },
+    ETA: {
+      physical: false,
+      verbal: true,
+    },
+    manoeuvres: {
+      reverseLeft: {
+        selected: true,
+        controlFault: 'DF',
+        observationFault: 'S',
+        observationFaultComments: 'Candidate nearly hit a little old lady crossing the road',
+      },
+    },
+    seriousFaults: {
+      clearance: true,
+      clearanceComments: 'Candidate lost the right wing mirror',
+    },
+    testRequirements: {
+      angledStart: true,
+      uphillStartDesignatedStart: true,
+      normalStart1: true,
+      normalStart2: true,
+    },
+    vehicleChecks: {
+      showMeQuestions: [
+        {
+          code: 'H1',
+          description: 'Direction indicators',
+          outcome: 'P',
+        },
+      ],
+      tellMeQuestions: [
+        {
+          code: 'H16',
+          description: 'Mirrors secure',
+          outcome: 'P',
+        },
+      ],
+    },
+  },
+};


### PR DESCRIPTION
## Description
Fixes a host of instances where the code for other categories is being used. Also:
- Adds tests on the test report page
- Fixes excluded tests which were not passing
- Deals with using a common selector to check the status of manoeuvres even when not present for CAT K

**JIRA Story**
https://jira.dvsacloud.uk/browse/MES-5070

**JIRA tasks**
- https://jira.dvsacloud.uk/browse/MES-5090
- https://jira.dvsacloud.uk/browse/MES-5092
- https://jira.dvsacloud.uk/browse/MES-5093
- https://jira.dvsacloud.uk/browse/MES-5094
- https://jira.dvsacloud.uk/browse/MES-5095

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
