### PR TITLE
Cherry Pick MES-5117 Fix UTC / BST bug

### DIFF
--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -294,8 +294,8 @@ export class TestOutcomeComponent implements OnInit {
   }
 
   shouldDisplayCheckStartModal(): boolean {
-    const retVal = new DateTime().compareDuration(this.slotDetail.start, Duration.MINUTE) > 5;
-    return retVal;
+    const minsUntilTest = new DateTime().compareDuration(this.slotDetail.start, Duration.MINUTE);
+    return minsUntilTest > 5;
   }
 
   isE2EPracticeMode(): boolean {

--- a/src/shared/helpers/date-time.ts
+++ b/src/shared/helpers/date-time.ts
@@ -7,7 +7,7 @@ export class DateTime {
     if (sourceDateTime === undefined) {
       this.moment = moment();
     } else if (typeof sourceDateTime === 'string') {
-      this.moment = moment(new Date(sourceDateTime));
+      this.moment = moment(sourceDateTime);
     } else if (sourceDateTime instanceof Date) {
       this.moment = moment(sourceDateTime);
     } else {


### PR DESCRIPTION
## Description
- Fixes issue with use of JS Date constructor assuming string input are UTC in Safari / iOS and local times in Chrome.
- Fix for live bug with start test early modal showing incorrect time and using incorrect calculation for when to show modal

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
