### PR TITLE
MES-5174 / DF count calculation amendment on AMOD2 Saftety/Balance questions

### DIFF
--- a/src/providers/fault-count/cat-a-mod2/__tests__/fault-count.cat-a-mod2.spec.ts
+++ b/src/providers/fault-count/cat-a-mod2/__tests__/fault-count.cat-a-mod2.spec.ts
@@ -23,14 +23,14 @@ describe('FaultCountAM2Helper', () => {
       expect(temp).toEqual(output);
     });
 
-    it('0 driving faults, 2 failed safety questions', () => {
-      const output =  { drivingFaults: 0 };
+    it('1 driving faults, 2 failed safety questions', () => {
+      const output =  { drivingFaults: 1 };
       const temp = FaultCountAM2Helper.getSafetyAndBalanceFaultCountCatAM2(safetyAndBalanceMock2FaultsSafety);
       expect(temp).toEqual(output);
     });
 
-    it('0 driving faults, 1 failed safety and 1 failed balance question', () => {
-      const output =  { drivingFaults: 0 };
+    it('1 driving faults, 1 failed safety and 1 failed balance question', () => {
+      const output =  { drivingFaults: 1 };
       const temp = FaultCountAM2Helper.getSafetyAndBalanceFaultCountCatAM2(safetyAndBalanceMock2FaultsSafetyAndBalance);
       expect(temp).toEqual(output);
     });

--- a/src/providers/fault-count/cat-a-mod2/fault-count.cat-a-mod2.ts
+++ b/src/providers/fault-count/cat-a-mod2/fault-count.cat-a-mod2.ts
@@ -26,7 +26,7 @@ export class FaultCountAM2Helper {
     const totalIncorrectAnswerCount: number = numberOfIncorrectSafetyAnswers + numberOfIncorrectBalanceAnswers;
 
     return {
-      drivingFaults: (totalIncorrectAnswerCount >= 3) ? 1 : 0,
+      drivingFaults: (totalIncorrectAnswerCount >= 1) ? 1 : 0,
     };
   }
 


### PR DESCRIPTION
## Description

When only one of the Safety/balance questions are marked as 'Wrong Answer' on the wrtc page a single DF is now added, instead of it being 1 for all 3 incorrect, unit tests updated

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
