### PR TITLE
MES-5196 Office page failure when setting driving fault

### DIFF
--- a/src/pages/office/components/fault-comment-card/fault-comment-card.ts
+++ b/src/pages/office/components/fault-comment-card/fault-comment-card.ts
@@ -34,7 +34,7 @@ export class FaultCommentCardComponent {
   @Output()
   faultCommentsChange = new EventEmitter<FaultSummary>();
 
-  ngOnInit() {
+  ngOnChanges() {
     this.faultComments.forEach((value) => {
       const control = new FormControl(null);
       this.formGroup.addControl(


### PR DESCRIPTION
## Description

If first driving fault set on office page, page fails.
changed lifecycle event to pick up changes to page input

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
