### PR TITLE
MES-5204 / add new fields to WRTC for ADIPt2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -621,9 +621,9 @@
       "dev": true
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.24.8",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.24.8.tgz",
-      "integrity": "sha512-/XCyhNENLntIhB5N0Ob74DmUM8Hxcul5XnIA3QepeLcSqfDXKlXaE2qZiucXQi6iP1tbHqC0UIqOzMmA1a2BJQ==",
+      "version": "3.24.9",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.24.9.tgz",
+      "integrity": "sha512-DrC5v8yTwTPkTubeYkwD4nLNUdLB6f3OA3cYh5a1iZOHKTHdSX3q41ISwj5TmFxQLHFlV15Z2zJXVGU4mb5Kew==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@dvsa/mes-config-schema": "1.0.6",
     "@dvsa/mes-journal-schema": "1.2.0",
     "@dvsa/mes-search-schema": "1.1.1",
-    "@dvsa/mes-test-schema": "3.24.8",
+    "@dvsa/mes-test-schema": "3.24.9",
     "@hapi/joi": "^15.1.0",
     "@ionic-native-mocks/device": "^2.0.12",
     "@ionic-native-mocks/secure-storage": "^2.0.12",

--- a/src/modules/tests/tests.cat-adi-part2.reducer.ts
+++ b/src/modules/tests/tests.cat-adi-part2.reducer.ts
@@ -21,6 +21,9 @@ import { testDataCatADI2Reducer } from './test-data/cat-adi-part2/test-data.cat-
 import { vehicleDetailsCatADIPart2Reducer }
 from './vehicle-details/cat-adi-part2/vehicle-details.cat-adi-part2.reducer';
 import { nullReducer } from '../../shared/classes/null.reducer';
+import {
+    trainerDetailsCatADIPart2Reducer,
+} from './trainer-details/cat-adi-part2/trainer-details.cat-adi-part2.reducer';
 
 export function testsCatADIPart2Reducer(
   action: Action, state: CatADI2UniqueTypes.TestResult): Required<CatADI2UniqueTypes.TestResult> {
@@ -34,6 +37,7 @@ export function testsCatADIPart2Reducer(
       accompaniment: accompanimentReducer,
       vehicleDetails: vehicleDetailsCatADIPart2Reducer,
       testData: testDataCatADI2Reducer,
+      trainerDetails: trainerDetailsCatADIPart2Reducer,
       passCompletion: nullReducer,
       postTestDeclarations: postTestDeclarationsReducer,
       testSummary: testSummaryReducer,

--- a/src/modules/tests/trainer-details/cat-adi-part2/__tests__/trainer-details.cat-adi-part2.spec.ts
+++ b/src/modules/tests/trainer-details/cat-adi-part2/__tests__/trainer-details.cat-adi-part2.spec.ts
@@ -1,0 +1,30 @@
+import { CatADI2UniqueTypes } from '@dvsa/mes-test-schema/categories/ADI2';
+import {
+  getOrditTrained,
+  getTrainerRegistrationNumber,
+  getTrainingRecords,
+} from '../trainer-details.cat-adi-part2.selector';
+
+describe('Trainer details Cat ADI PT2 selectors', () => {
+  const state: CatADI2UniqueTypes.TrainerDetails = {
+    orditTrainedCandidate: false,
+    trainerRegistrationNumber: 23456,
+    trainingRecords: true,
+  };
+
+  describe('getOrditTrained', () => {
+    it('should retrieve the ordit trained from the trainer details', () => {
+      expect(getOrditTrained(state)).toBe(false);
+    });
+  });
+  describe('getTrainerRegistrationNumber', () => {
+    it('should retrieve the trainer registration number', () => {
+      expect(getTrainerRegistrationNumber(state)).toBe(23456);
+    });
+  });
+  describe('getTrainingRecords', () => {
+    it('should retrieve the training recorded', () => {
+      expect(getTrainingRecords(state)).toBe(true);
+    });
+  });
+});

--- a/src/modules/tests/trainer-details/cat-adi-part2/trainer-details.cat-adi-part2.actions.ts
+++ b/src/modules/tests/trainer-details/cat-adi-part2/trainer-details.cat-adi-part2.actions.ts
@@ -1,0 +1,25 @@
+import { Action } from '@ngrx/store';
+
+export const ORDIT_CHANGED = '[WRTC] [CatADIPart2] Ordit Trained changed';
+export const TRAINING_RECORDS_CHANGED = '[WRTC] [CatADIPart2] Training Records changed';
+export const TRAINER_REGISTRATION_NUMBER_CHANGED = '[WRTC] Trainer registration number changed';
+
+export class OrditTrainedChanged implements Action {
+  readonly type = ORDIT_CHANGED;
+  constructor(public orditChanged: boolean) { }
+}
+
+export class TrainingRecordsChanged implements Action {
+  readonly type = TRAINING_RECORDS_CHANGED;
+  constructor(public trainingRecordChanged: boolean) { }
+}
+
+export class TrainerRegistrationNumberChanged implements Action {
+  readonly type = TRAINER_REGISTRATION_NUMBER_CHANGED;
+  constructor(public trainerRegistrationNumber: number) {}
+}
+
+export type Types =
+  OrditTrainedChanged |
+  TrainingRecordsChanged |
+  TrainerRegistrationNumberChanged;

--- a/src/modules/tests/trainer-details/cat-adi-part2/trainer-details.cat-adi-part2.reducer.ts
+++ b/src/modules/tests/trainer-details/cat-adi-part2/trainer-details.cat-adi-part2.reducer.ts
@@ -1,0 +1,36 @@
+import * as trainerDetailActions from './trainer-details.cat-adi-part2.actions';
+import { CatADI2UniqueTypes } from '@dvsa/mes-test-schema/categories/ADI2';
+import { createFeatureSelector } from '@ngrx/store';
+
+const initialState: CatADI2UniqueTypes.TrainerDetails = {
+  orditTrainedCandidate: null,
+  trainingRecords: null,
+  trainerRegistrationNumber: null,
+};
+
+export const trainerDetailsCatADIPart2Reducer = (
+  state: CatADI2UniqueTypes.TrainerDetails = initialState,
+  action: trainerDetailActions.Types,
+): CatADI2UniqueTypes.TrainerDetails => {
+  switch (action.type) {
+    case trainerDetailActions.ORDIT_CHANGED:
+      return {
+        ...state,
+        orditTrainedCandidate: action.orditChanged,
+      };
+    case trainerDetailActions.TRAINING_RECORDS_CHANGED:
+      return {
+        ...state,
+        trainingRecords: action.trainingRecordChanged,
+      };
+    case trainerDetailActions.TRAINER_REGISTRATION_NUMBER_CHANGED:
+      return {
+        ...state,
+        trainerRegistrationNumber: action.trainerRegistrationNumber,
+      };
+    default:
+      return state;
+  }
+};
+
+export const getTrainerDetails = createFeatureSelector<CatADI2UniqueTypes.TrainerDetails>('trainerDetails');

--- a/src/modules/tests/trainer-details/cat-adi-part2/trainer-details.cat-adi-part2.selector.ts
+++ b/src/modules/tests/trainer-details/cat-adi-part2/trainer-details.cat-adi-part2.selector.ts
@@ -1,0 +1,10 @@
+import { CatADI2UniqueTypes } from '@dvsa/mes-test-schema/categories/ADI2';
+
+export const getOrditTrained = (
+  trainerDetails: CatADI2UniqueTypes.TrainerDetails) => trainerDetails.orditTrainedCandidate;
+
+export const getTrainingRecords = (
+  trainerDetails: CatADI2UniqueTypes.TrainerDetails) => trainerDetails.trainingRecords;
+
+export const getTrainerRegistrationNumber = (
+  trainerDetails: CatADI2UniqueTypes.TrainerDetails) => trainerDetails.trainerRegistrationNumber;

--- a/src/pages/waiting-room-to-car/cat-adi-part2/__tests__/waiting-room-to-car.cat-adi-part2.page.spec.ts
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/__tests__/waiting-room-to-car.cat-adi-part2.page.spec.ts
@@ -1,6 +1,11 @@
 import { ComponentFixture, async, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { IonicModule, NavController, NavParams, Config, Platform } from 'ionic-angular';
 import { NavControllerMock, NavParamsMock, ConfigMock, PlatformMock } from 'ionic-mocks';
+import { StoreModule, Store } from '@ngrx/store';
+import { By } from '@angular/platform-browser';
+import { MockComponent } from 'ng-mocks';
+import { of } from 'rxjs';
+import { configureTestSuite } from 'ng-bullet';
 
 import { AppModule } from '../../../../app/app.module';
 import { WaitingRoomToCarCatADIPart2Page } from '../waiting-room-to-car.cat-adi-part2.page';
@@ -8,14 +13,10 @@ import { AuthenticationProvider } from '../../../../providers/authentication/aut
 import { AuthenticationProviderMock } from '../../../../providers/authentication/__mocks__/authentication.mock';
 import { DateTimeProvider } from '../../../../providers/date-time/date-time';
 import { DateTimeProviderMock } from '../../../../providers/date-time/__mocks__/date-time.mock';
-import { StoreModule, Store } from '@ngrx/store';
 import { StoreModel } from '../../../../shared/models/store.model';
-import { By } from '@angular/platform-browser';
-import { MockComponent } from 'ng-mocks';
 import {
   EyesightFailureConfirmationComponent,
 } from '../../components/eyesight-failure-confirmation/eyesight-failure-confirmation';
-import { of } from 'rxjs';
 import { QuestionProvider } from '../../../../providers/question/question';
 import { QuestionProviderMock } from '../../../../providers/question/__mocks__/question.mock';
 import { EndTestLinkComponent } from '../../../../components/common/end-test-link/end-test-link';
@@ -30,11 +31,15 @@ import { WaitingRoomToCarValidationError } from '../../waiting-room-to-car.actio
 import { EyesightTestReset } from '../../../../modules/tests/test-data/common/eyesight-test/eyesight-test.actions';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { TransmissionComponent } from '../../../../components/common/transmission/transmission';
-import { configureTestSuite } from 'ng-bullet';
 import {
   AccompanimentCardCatADIPart2Component,
 } from '../components/accompaniment-card/accompaniment-card.cat-adi-part2';
 import { VehicleChecksCatADIPart2Component } from '../components/vehicle-checks/vehicle-checks.cat-adi-part2';
+import { OrditTrainerCatAdiPart2Component } from '../components/ordit-trainer/ordit-trainer.cat-adi-part2';
+import { TrainingRecordsCatAdiPart2Component } from '../components/training-records/training-records.cat-adi-part2';
+import {
+  TrainerRegistrationNumberCatAdiPart2Component,
+} from '../components/trainer-registration-number/trainer-registration-number.cat-adi-part2';
 
 describe('WaitingRoomToCarCatADIPart2Page', () => {
   let fixture: ComponentFixture<WaitingRoomToCarCatADIPart2Page>;
@@ -55,6 +60,9 @@ describe('WaitingRoomToCarCatADIPart2Page', () => {
         MockComponent(AccompanimentCardCatADIPart2Component),
         MockComponent(AccompanimentComponent),
         MockComponent(VehicleChecksCatADIPart2Component),
+        MockComponent(OrditTrainerCatAdiPart2Component),
+        MockComponent(TrainingRecordsCatAdiPart2Component),
+        MockComponent(TrainerRegistrationNumberCatAdiPart2Component),
       ],
       imports: [
         IonicModule,
@@ -68,14 +76,19 @@ describe('WaitingRoomToCarCatADIPart2Page', () => {
             startedTests: {
               123: {
                 vehicleDetails: {},
+                trainerDetails: {
+                  orditTrainedCandidate: null,
+                  trainingRecords: null,
+                  trainerRegistrationNumber: null,
+                },
                 accompaniment: {},
                 testData: {
                   vehicleChecks: {
-                    tellMeQuestion: {
+                    tellMeQuestion: [{
                       code: 'T1',
                       description: 'desc',
                       outcome: CompetencyOutcome.P,
-                    },
+                    }],
                   },
                   seriousFaults: [],
                   eyesightTest: {},
@@ -155,8 +168,6 @@ describe('WaitingRoomToCarCatADIPart2Page', () => {
   });
   describe('onSubmit', () => {
     it('should dispatch the appropriate WaitingRoomToCarValidationError actions', fakeAsync(() => {
-      fixture.detectChanges();
-
       component.form = new FormGroup({
         requiredControl1: new FormControl(null, [Validators.required]),
         requiredControl2: new FormControl(null, [Validators.required]),

--- a/src/pages/waiting-room-to-car/cat-adi-part2/components/ordit-trainer/ordit-trainer.cat-adi-part2.html
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/components/ordit-trainer/ordit-trainer.cat-adi-part2.html
@@ -1,0 +1,42 @@
+<ion-row class="mes-validated-row mes-row-separator" id="ordit-trainer-card" [formGroup]="formGroup">
+    <div class="validation-bar" [class.ng-invalid]="invalid"></div>
+    <ion-col class="component-label" col-32 align-self-center>
+        <label>Did the candidate receive training from an ORDIT trainer?</label>
+    </ion-col>
+    <ion-col align-self-center padding-left>
+        <ion-row class="spacing-row"></ion-row>
+        <ion-row>
+            <ion-col col-48>
+                <input type="radio"
+                       formControlName="orditTrainedCtrl"
+                       name="orditTrainedCtrl"
+                       id="ordit-trained-yes"
+                       class="gds-radio-button"
+                       [checked]="orditTrainedRadioChecked === true"
+                       [class.ng-invalid]="invalid"
+                       (change)="orditTrainingOutcomeChanged($event.target.value)"
+                       value="Y">
+                <label for="ordit-trained-yes" class="radio-label">Yes</label>
+            </ion-col>
+            <ion-col col-48>
+                <input type="radio"
+                       formControlName="orditTrainedCtrl"
+                       name="orditTrainedCtrl"
+                       id="ordit-trained-no"
+                       class="gds-radio-button"
+                       [checked]="orditTrainedRadioChecked === false"
+                       [class.ng-invalid]="invalid"
+                       (change)="orditTrainingOutcomeChanged($event.target.value)"
+                       value="N">
+                <label for="ordit-trained-no" class="radio-label">No</label>
+            </ion-col>
+        </ion-row>
+        <ion-row class="validation-message-row" align-items-center>
+            <div class="validation-text"
+                 [class.ng-invalid]="invalid"
+                 id="waiting-room-to-car-ordit-trained-validation-text">
+                Select the ORDIT trainer outcome
+            </div>
+        </ion-row>
+    </ion-col>
+</ion-row>

--- a/src/pages/waiting-room-to-car/cat-adi-part2/components/ordit-trainer/ordit-trainer.cat-adi-part2.ts
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/components/ordit-trainer/ordit-trainer.cat-adi-part2.ts
@@ -1,0 +1,44 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+enum OrditTrained {
+  YES = 'Y',
+  NO = 'N',
+}
+
+@Component({
+  selector: 'ordit-trainer-cat-adi-part2',
+  templateUrl: 'ordit-trainer.cat-adi-part2.html',
+})
+export class OrditTrainerCatAdiPart2Component {
+
+  @Input()
+  orditTrainedRadioChecked: boolean;
+
+  @Input()
+  formGroup: FormGroup;
+
+  formControl: FormControl;
+
+  @Output()
+  orditTrainedOutcomeChange = new EventEmitter<boolean>();
+
+  ngOnChanges(): void {
+    if (!this.formControl) {
+      this.formControl = new FormControl('', [Validators.required]);
+      this.formGroup.addControl('orditTrainedCtrl', this.formControl);
+    }
+    this.formControl.patchValue(this.orditTrainedRadioChecked);
+  }
+
+  get invalid(): boolean {
+    return !this.formControl.valid && this.formControl.dirty;
+  }
+
+  orditTrainingOutcomeChanged(orditTrained: string): void {
+    if (this.formControl.valid) {
+      this.orditTrainedOutcomeChange.emit(orditTrained === OrditTrained.YES);
+    }
+  }
+
+}

--- a/src/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/__tests__/trainer-registration-number.cat-adi-part2.spec.ts
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/__tests__/trainer-registration-number.cat-adi-part2.spec.ts
@@ -1,0 +1,66 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup } from '@angular/forms';
+import { IonicModule } from 'ionic-angular';
+import { configureTestSuite } from 'ng-bullet';
+
+import { TrainerRegistrationNumberCatAdiPart2Component } from '../trainer-registration-number.cat-adi-part2';
+import {
+  mockBlankTrainerRegNumber,
+  mockInvalidTrainerRegNumber, mockLeadingZeroTrainerRegNumber,
+  mockOnlyZeroTrainerRegNumber,
+  mockValidTrainerRegNumber,
+} from './trainer-registration-number.mock';
+
+describe('TrainerRegistrationNumberCatAdiPart2Component', () => {
+  let fixture: ComponentFixture<TrainerRegistrationNumberCatAdiPart2Component>;
+  let component: TrainerRegistrationNumberCatAdiPart2Component;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TrainerRegistrationNumberCatAdiPart2Component,
+      ],
+      imports: [
+        IonicModule,
+      ],
+    });
+  });
+
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(TrainerRegistrationNumberCatAdiPart2Component);
+    component = fixture.componentInstance;
+    component.formGroup = new FormGroup({});
+    component.formControl = new FormControl(null);
+  }));
+
+  describe('vehicleRegistrationChanged', () => {
+    beforeEach(() => {
+      spyOn(component.trainerRegistrationChange, 'emit');
+    });
+
+    it('should recognise a valid numeric string and emit the value as a number', () => {
+      component.trainerRegistrationChanged(mockValidTrainerRegNumber);
+      expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(1234567);
+    });
+
+    it('should remove non-numeric characters and emit the value as number', () => {
+      component.trainerRegistrationChanged(mockInvalidTrainerRegNumber);
+      expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(12457);
+    });
+
+    it('should remove preceding zeros and emit rest of valid result', () => {
+      component.trainerRegistrationChanged(mockLeadingZeroTrainerRegNumber);
+      expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(4567);
+    });
+
+    it('should remove preceding zeros and emit undefined as empty', () => {
+      component.trainerRegistrationChanged(mockOnlyZeroTrainerRegNumber);
+      expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should emit undefined as the value can`t be cast to a number', () => {
+      component.trainerRegistrationChanged(mockBlankTrainerRegNumber);
+      expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(undefined);
+    });
+  });
+});

--- a/src/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/__tests__/trainer-registration-number.mock.ts
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/__tests__/trainer-registration-number.mock.ts
@@ -1,0 +1,29 @@
+export const mockValidTrainerRegNumber = {
+  target: {
+    value: '1234567',
+  },
+};
+
+export const mockInvalidTrainerRegNumber = {
+  target: {
+    value: '12£45H7',
+  },
+};
+
+export const mockLeadingZeroTrainerRegNumber = {
+  target: {
+    value: '04567',
+  },
+};
+
+export const mockOnlyZeroTrainerRegNumber = {
+  target: {
+    value: '0',
+  },
+};
+
+export const mockBlankTrainerRegNumber = {
+  target: {
+    value: '',
+  },
+};

--- a/src/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.html
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.html
@@ -1,0 +1,23 @@
+<ion-row class="mes-component-row mes-row-separator" id="trainer-registration-card" [formGroup]="formGroup">
+    <div class="validation-bar" [class.ng-invalid]="invalid"></div>
+    <ion-col class="component-label" col-32 align-self-center>
+        <label>Trainer PRN (optional)</label>
+    </ion-col>
+    <ion-col align-self-center padding-left>
+        <ion-row class="spacing-row"></ion-row>
+        <ion-row>
+            <ion-col col-32>
+                <input type="text"
+                       id="trainer-registration"
+                       formControlName="trainerRegistration"
+                       [maxLength]="trainerRegistrationNumberValidator.maxLength"
+                       (input)="trainerRegistrationChanged($event)">
+            </ion-col>
+        </ion-row>
+        <ion-row class="validation-message-row" align-items-center>
+            <div class="validation-text" [class.ng-invalid]="invalid" id="wrtc-trainer-reg-validation-text">
+                Enter the trainer registration (max 7 digits)
+            </div>
+        </ion-row>
+    </ion-col>
+</ion-row>

--- a/src/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.ts
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.ts
@@ -1,0 +1,49 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { FormGroup, FormControl } from '@angular/forms';
+import {
+  FieldValidators,
+  getTrainerRegistrationNumberValidator,
+  leadingZero,
+  nonNumericValues,
+} from '../../../../../shared/constants/field-validators/field-validators';
+
+@Component({
+  selector: 'trainer-registration-number-cat-adi-part2',
+  templateUrl: 'trainer-registration-number.cat-adi-part2.html',
+})
+export class TrainerRegistrationNumberCatAdiPart2Component implements OnChanges {
+
+  @Input()
+  trainerRegistration: number;
+
+  @Input()
+  formGroup: FormGroup;
+
+  @Output()
+  trainerRegistrationChange = new EventEmitter<number>();
+
+  formControl: FormControl;
+
+  readonly trainerRegistrationNumberValidator: FieldValidators = getTrainerRegistrationNumberValidator();
+
+  ngOnChanges(): void {
+    if (!this.formControl) {
+      this.formControl = new FormControl(null);
+      this.formGroup.addControl('trainerRegistration', this.formControl);
+    }
+    this.formControl.patchValue(this.trainerRegistration);
+  }
+
+  trainerRegistrationChanged(event: any): void {
+    if (!this.trainerRegistrationNumberValidator.pattern.test(event.target.value)) {
+      event.target.value = event.target.value
+        .replace(leadingZero, '')
+        .replace(nonNumericValues, '');
+    }
+    this.trainerRegistrationChange.emit(Number(event.target.value) || undefined);
+  }
+
+  get invalid(): boolean {
+    return !this.formControl.valid && this.formControl.dirty;
+  }
+}

--- a/src/pages/waiting-room-to-car/cat-adi-part2/components/training-records/training-records.cat-adi-part2.html
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/components/training-records/training-records.cat-adi-part2.html
@@ -1,0 +1,42 @@
+<ion-row class="mes-validated-row mes-row-separator" id="training-record-card" [formGroup]="formGroup">
+    <div class="validation-bar" [class.ng-invalid]="invalid"></div>
+    <ion-col class="component-label" col-32 align-self-center>
+        <label>Training records</label>
+    </ion-col>
+    <ion-col align-self-center padding-left>
+        <ion-row class="spacing-row"></ion-row>
+        <ion-row>
+            <ion-col col-48>
+                <input type="radio"
+                       formControlName="trainingRecordCtrl"
+                       name="trainingRecordCtrl"
+                       id="training-record-yes"
+                       class="gds-radio-button"
+                       [checked]="trainingRecordRadioChecked === true"
+                       [class.ng-invalid]="invalid"
+                       (change)="trainingRecordOutcomeChanged($event.target.value)"
+                       value="Y">
+                <label for="training-record-yes" class="radio-label">Yes</label>
+            </ion-col>
+            <ion-col col-48>
+                <input type="radio"
+                       formControlName="trainingRecordCtrl"
+                       name="trainingRecordCtrl"
+                       id="training-record-no"
+                       class="gds-radio-button"
+                       [checked]="!trainingRecordRadioChecked === false"
+                       [class.ng-invalid]="invalid"
+                       (change)="trainingRecordOutcomeChanged($event.target.value)"
+                       value="N">
+                <label for="training-record-no" class="radio-label">No</label>
+            </ion-col>
+        </ion-row>
+        <ion-row class="validation-message-row" align-items-center>
+            <div class="validation-text"
+                 [class.ng-invalid]="invalid"
+                 id="waiting-room-to-car-training-records-validation-text">
+                Select the training records outcome
+            </div>
+        </ion-row>
+    </ion-col>
+</ion-row>

--- a/src/pages/waiting-room-to-car/cat-adi-part2/components/training-records/training-records.cat-adi-part2.html
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/components/training-records/training-records.cat-adi-part2.html
@@ -24,7 +24,7 @@
                        name="trainingRecordCtrl"
                        id="training-record-no"
                        class="gds-radio-button"
-                       [checked]="!trainingRecordRadioChecked === false"
+                       [checked]="trainingRecordRadioChecked === false"
                        [class.ng-invalid]="invalid"
                        (change)="trainingRecordOutcomeChanged($event.target.value)"
                        value="N">

--- a/src/pages/waiting-room-to-car/cat-adi-part2/components/training-records/training-records.cat-adi-part2.ts
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/components/training-records/training-records.cat-adi-part2.ts
@@ -1,0 +1,44 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+enum TrainingRecorded {
+  YES = 'Y',
+  NO = 'N',
+}
+
+@Component({
+  selector: 'training-records-cat-adi-part2',
+  templateUrl: 'training-records.cat-adi-part2.html',
+})
+export class TrainingRecordsCatAdiPart2Component {
+
+  @Input()
+  trainingRecordRadioChecked: boolean;
+
+  @Input()
+  formGroup: FormGroup;
+
+  formControl: FormControl;
+
+  @Output()
+  trainingRecordOutcomeChange = new EventEmitter<boolean>();
+
+  ngOnChanges(): void {
+    if (!this.formControl) {
+      this.formControl = new FormControl('', [Validators.required]);
+      this.formGroup.addControl('trainingRecordCtrl', this.formControl);
+    }
+    this.formControl.patchValue(this.trainingRecordRadioChecked);
+  }
+
+  get invalid(): boolean {
+    return !this.formControl.valid && this.formControl.dirty;
+  }
+
+  trainingRecordOutcomeChanged(trainingRecorded: string): void {
+    if (this.formControl.valid) {
+      this.trainingRecordOutcomeChange.emit(trainingRecorded === TrainingRecorded.YES);
+    }
+  }
+
+}

--- a/src/pages/waiting-room-to-car/cat-adi-part2/components/waiting-room-to-car.cat-adi-part2.components.module.ts
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/components/waiting-room-to-car.cat-adi-part2.components.module.ts
@@ -7,11 +7,19 @@ import { ComponentsModule } from '../../../../components/common/common-component
 import { AccompanimentCardCatADIPart2Component }
   from './accompaniment-card/accompaniment-card.cat-adi-part2';
 import { WaitingRoomToCarComponentsModule } from '../../components/waiting-room-to-car.components.module';
+import { TrainingRecordsCatAdiPart2Component } from './training-records/training-records.cat-adi-part2';
+import { OrditTrainerCatAdiPart2Component } from './ordit-trainer/ordit-trainer.cat-adi-part2';
+import {
+  TrainerRegistrationNumberCatAdiPart2Component,
+} from './trainer-registration-number/trainer-registration-number.cat-adi-part2';
 
 @NgModule({
   declarations: [
     VehicleChecksCatADIPart2Component,
     AccompanimentCardCatADIPart2Component,
+    TrainingRecordsCatAdiPart2Component,
+    OrditTrainerCatAdiPart2Component,
+    TrainerRegistrationNumberCatAdiPart2Component,
   ],
   imports: [
     CommonModule,
@@ -23,6 +31,9 @@ import { WaitingRoomToCarComponentsModule } from '../../components/waiting-room-
   exports: [
     VehicleChecksCatADIPart2Component,
     AccompanimentCardCatADIPart2Component,
+    TrainingRecordsCatAdiPart2Component,
+    OrditTrainerCatAdiPart2Component,
+    TrainerRegistrationNumberCatAdiPart2Component,
   ],
 })
 export class WaitingRoomToCarCatADIPart2ComponentsModule { }

--- a/src/pages/waiting-room-to-car/cat-adi-part2/waiting-room-to-car.cat-adi-part2.page.html
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/waiting-room-to-car.cat-adi-part2.page.html
@@ -58,6 +58,24 @@
               (schoolVehicleDetailsChange)="schoolCarToggled()"
               (dualVehicleDetailsChange)="dualControlsToggled()"
             ></vehicle-details-card>
+
+            <ordit-trainer-cat-adi-part2
+                    [formGroup]="form"
+                    [orditTrainedRadioChecked]="pageState?.orditTrained$ | async"
+                    (orditTrainedOutcomeChange)="orditTrainedOutcomeChanged($event)">
+            </ordit-trainer-cat-adi-part2>
+
+            <trainer-registration-number-cat-adi-part2
+                    [formGroup]="form"
+                    [trainerRegistration]="pageState.trainerRegistrationNumber$ | async"
+                    (trainerRegistrationChange)="trainerRegistrationNumberChanged($event)">
+            </trainer-registration-number-cat-adi-part2>
+
+            <training-records-cat-adi-part2
+                    [formGroup]="form"
+                    [trainingRecordRadioChecked]="pageState.trainingRecords$ | async"
+                    (trainingRecordOutcomeChange)="trainingRecordOutcomeChanged($event)">
+            </training-records-cat-adi-part2>
           </ion-col>
         </ion-row>
 

--- a/src/pages/waiting-room-to-car/cat-adi-part2/waiting-room-to-car.cat-adi-part2.page.ts
+++ b/src/pages/waiting-room-to-car/cat-adi-part2/waiting-room-to-car.cat-adi-part2.page.ts
@@ -64,6 +64,19 @@ import { VehicleChecksQuestion } from '../../../providers/question/vehicle-check
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { BasePageComponent } from '../../../shared/classes/base-page';
 import { CatADI2UniqueTypes } from '@dvsa/mes-test-schema/categories/ADI2';
+import {
+  OrditTrainedChanged,
+  TrainerRegistrationNumberChanged,
+  TrainingRecordsChanged,
+} from '../../../modules/tests/trainer-details/cat-adi-part2/trainer-details.cat-adi-part2.actions';
+import {
+  getTrainerDetails,
+} from '../../../modules/tests/trainer-details/cat-adi-part2/trainer-details.cat-adi-part2.reducer';
+import {
+  getOrditTrained,
+  getTrainerRegistrationNumber,
+  getTrainingRecords,
+} from '../../../modules/tests/trainer-details/cat-adi-part2/trainer-details.cat-adi-part2.selector';
 
 interface WaitingRoomToCarPageState {
   candidateName$: Observable<string>;
@@ -81,6 +94,9 @@ interface WaitingRoomToCarPageState {
   gearboxManualRadioChecked$: Observable<boolean>;
   vehicleChecksScore$: Observable<VehicleChecksScore>;
   vehicleChecks$: Observable<CatADI2UniqueTypes.VehicleChecks>;
+  orditTrained$: Observable<boolean>;
+  trainingRecords$: Observable<boolean>;
+  trainerRegistrationNumber$: Observable<number>;
 }
 
 @IonicPage()
@@ -188,6 +204,18 @@ export class WaitingRoomToCarCatADIPart2Page extends BasePageComponent {
         select(getTestData),
         select(getVehicleChecksCatADIPart2),
       ),
+      orditTrained$: currentTest$.pipe(
+        select(getTrainerDetails),
+        select(getOrditTrained),
+      ),
+      trainingRecords$: currentTest$.pipe(
+        select(getTrainerDetails),
+        select(getTrainingRecords),
+      ),
+      trainerRegistrationNumber$: currentTest$.pipe(
+        select(getTrainerDetails),
+        select(getTrainerRegistrationNumber),
+      ),
     };
   }
 
@@ -278,6 +306,18 @@ export class WaitingRoomToCarCatADIPart2Page extends BasePageComponent {
   eyesightTestResultChanged(passed: boolean): void {
     const action = passed ? new EyesightTestPassed() : new EyesightTestFailed();
     this.store$.dispatch(action);
+  }
+
+  trainingRecordOutcomeChanged(hasRecords: boolean): void {
+    this.store$.dispatch(new TrainingRecordsChanged(hasRecords));
+  }
+
+  orditTrainedOutcomeChanged(wasOrditTrained: boolean): void {
+    this.store$.dispatch(new OrditTrainedChanged(wasOrditTrained));
+  }
+
+  trainerRegistrationNumberChanged(instructorRegistration: number): void {
+    this.store$.dispatch(new TrainerRegistrationNumberChanged(instructorRegistration));
   }
 
   getDebriefPage() {

--- a/src/shared/constants/field-validators/field-validators.ts
+++ b/src/shared/constants/field-validators/field-validators.ts
@@ -29,6 +29,13 @@ export const getInstructorRegistrationNumberValidator = (): FieldValidators => {
   };
 };
 
+export const getTrainerRegistrationNumberValidator = (): FieldValidators => {
+  return {
+    pattern: /^[1-9][0-9]{0,6}$/g,
+    maxLength: '7',
+  };
+};
+
 export const getSpeedCheckValidator = (): FieldValidators => {
   return {
     pattern: /^[1-9][0-9]{0,2}$/g,


### PR DESCRIPTION
## Description
Add Ordit Trainer, Training records and Trainer reg number fields to WRTC screen for ADI part 2
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="418" alt="Screenshot 2020-05-07 at 11 24 04" src="https://user-images.githubusercontent.com/33056264/81283990-6cc9b600-9055-11ea-8c9b-b5b4bcfe82b6.png">
<img width="417" alt="Screenshot 2020-05-07 at 11 24 33" src="https://user-images.githubusercontent.com/33056264/81283994-6fc4a680-9055-11ea-8b7b-a622e96f8967.png">
