### PR TITLE
MES-5220 / New Fields for ADI2 Test Result search

### DIFF
--- a/src/pages/view-test-result/cat-adi-part2/__tests__/view-test-result.cat-adi-part2.page.spec.ts
+++ b/src/pages/view-test-result/cat-adi-part2/__tests__/view-test-result.cat-adi-part2.page.spec.ts
@@ -12,20 +12,22 @@ import {
   PlatformMock,
   LoadingControllerMock,
 } from 'ionic-mocks';
+import { configureTestSuite } from 'ng-bullet';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { MockComponent } from 'ng-mocks';
+import { By } from '@angular/platform-browser';
+
 import { AppModule } from '../../../../app/app.module';
 import { AuthenticationProvider } from '../../../../providers/authentication/authentication';
 import { AuthenticationProviderMock } from '../../../../providers/authentication/__mocks__/authentication.mock';
 import { SearchProvider } from '../../../../providers/search/search';
 import { SearchProviderMock } from '../../../../providers/search/__mocks__/search.mock';
-import { MockComponent } from 'ng-mocks';
 import { TestDetailsCardComponent } from '../../components/test-details-card/test-details-card';
 import { RekeyDetailsCardComponent } from '../../components/rekey-details-card/rekey-details';
 import { RekeyReasonCardComponent } from '../../components/rekey-reason-card/rekey-reason';
 import { ExaminerDetailsCardComponent } from '../../components/examiner-details-card/examiner-details';
-import { By } from '@angular/platform-browser';
 import { ExaminerDetailsModel } from '../../components/examiner-details-card/examiner-details-card.model';
 import { TestDetailsModel } from '../../components/test-details-card/test-details-card.model';
-import { VehicleDetailsCardComponent } from '../../components/vehicle-details-card/vehicle-details-card';
 import { categoryAdiPart2TestMock } from '../../../../shared/mocks/cat-adi-part2-test-result.mock';
 import { CompressionProvider } from '../../../../providers/compression/compression';
 import { CompressionProviderMock } from '../../../../providers/compression/__mocks__/compression.mock';
@@ -38,8 +40,8 @@ import { ErrorMessageComponent } from '../../../../components/common/error-messa
 import { ViewTestResultCatADIPart2Page } from '../view-test-result.cat-adi-part2.page';
 import { BusinessDetailsCardComponent } from '../../components/business-details-card/business-details-card';
 import { ContactDetailsCardComponent } from '../../components/contact-details-card/contact-details-card';
-import { configureTestSuite } from 'ng-bullet';
-import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { VehicleDetailsCatADIPt2Component } from '../components/vehicle-details/vehicle-details';
+import { TestDetailsCardCatADI2Component } from '../components/test-details/test-details.cat-adi-part2';
 
 describe('ViewTestResultCatADIPart2Page', () => {
   let fixture: ComponentFixture<ViewTestResultCatADIPart2Page>;
@@ -54,13 +56,14 @@ describe('ViewTestResultCatADIPart2Page', () => {
         MockComponent(RekeyDetailsCardComponent),
         MockComponent(RekeyReasonCardComponent),
         MockComponent(ExaminerDetailsCardComponent),
-        MockComponent(VehicleDetailsCardComponent),
+        MockComponent(VehicleDetailsCatADIPt2Component),
         MockComponent(TestSummaryCardComponent),
         MockComponent(ViewTestHeaderComponent),
         MockComponent(DebriefCardComponent),
         MockComponent(ErrorMessageComponent),
         MockComponent(BusinessDetailsCardComponent),
         MockComponent(ContactDetailsCardComponent),
+        MockComponent(TestDetailsCardCatADI2Component),
       ],
       imports: [IonicModule, AppModule],
       providers: [
@@ -236,9 +239,6 @@ describe('ViewTestResultCatADIPart2Page', () => {
         fixture.debugElement.query(By.css('view-test-header')),
       ).not.toBeNull();
       expect(
-        fixture.debugElement.query(By.css('test-details-card')),
-      ).not.toBeNull();
-      expect(
         fixture.debugElement.query(By.css('rekey-details-card')),
       ).not.toBeNull();
       expect(
@@ -248,7 +248,10 @@ describe('ViewTestResultCatADIPart2Page', () => {
         fixture.debugElement.query(By.css('examiner-details-card')),
       ).not.toBeNull();
       expect(
-        fixture.debugElement.query(By.css('vehicle-details-card')),
+        fixture.debugElement.query(By.css('test-details-card-adi2')),
+      ).not.toBeNull();
+      expect(
+        fixture.debugElement.query(By.css('vehicle-details-cat-adi-pt2')),
       ).not.toBeNull();
       expect(fixture.debugElement.query(By.css('debrief-card'))).not.toBeNull();
       expect(

--- a/src/pages/view-test-result/cat-adi-part2/components/debrief-card/debrief-card.html
+++ b/src/pages/view-test-result/cat-adi-part2/components/debrief-card/debrief-card.html
@@ -6,6 +6,7 @@
     <ion-grid>
       <data-row-with-list [label]="'Test requirements'" [data]="getTestRequirements()"></data-row-with-list>
       <data-row [label]="'Manoeuvre'" [value]="getManoeuvre()"></data-row>
+      <data-row-with-list [label]="'Controlled stop'" [data]="getControlledStop()"></data-row-with-list>
       <data-row-with-list [label]="'ECO'" [data]="getEco()"></data-row-with-list>
       <faults-data-row
         [label]="'Fault descriptions'"

--- a/src/pages/view-test-result/cat-adi-part2/components/debrief-card/debrief-card.ts
+++ b/src/pages/view-test-result/cat-adi-part2/components/debrief-card/debrief-card.ts
@@ -126,4 +126,14 @@ export class DebriefCardComponent {
   public getTellMeQuestions(): QuestionResult[] {
     return get(this.data, 'vehicleChecks.tellMeQuestions', []);
   }
+
+  public getControlledStop = (): DataRowListItem[] => {
+    const controlledStop = get(this.data, 'controlledStop.selected', false);
+    return [
+      {
+        label: controlledStop ? ViewTestResultLabels.completed : ViewTestResultLabels.notCompleted,
+        checked: controlledStop,
+      },
+    ];
+  }
 }

--- a/src/pages/view-test-result/cat-adi-part2/components/test-details/__tests__/test-details.cat-adi-part2.spec.ts
+++ b/src/pages/view-test-result/cat-adi-part2/components/test-details/__tests__/test-details.cat-adi-part2.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { IonicModule, Config } from 'ionic-angular';
+import { ConfigMock } from 'ionic-mocks';
+import { MockComponent } from 'ng-mocks';
+import { configureTestSuite } from 'ng-bullet';
+import { DataRowComponent } from '../../../../../../components/common/data-row/data-row';
+import { DataRowCustomComponent } from '../../../../../../components/common/data-row-custom/data-row-custom';
+import { CandidateDetails, TestDetailsCardCatADI2Component } from '../test-details.cat-adi-part2';
+import { it } from '@angular/cli/lib/ast-tools/spec-utils';
+
+describe('TestDetailsCardCatADI2Component', () => {
+  let fixture: ComponentFixture<TestDetailsCardCatADI2Component>;
+  let component: TestDetailsCardCatADI2Component;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TestDetailsCardCatADI2Component,
+        MockComponent(DataRowComponent),
+        MockComponent(DataRowCustomComponent),
+      ],
+      imports: [
+        IonicModule,
+      ],
+      providers: [
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+      ],
+    });
+  });
+
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(TestDetailsCardCatADI2Component);
+    component = fixture.componentInstance;
+  }));
+
+  describe('Class', () => {
+    // Unit tests for the components TypeScript class
+    it('should create', () => {
+      expect(component).toBeDefined();
+    });
+
+    describe('specialNeedsIsPopulated', () => {
+      it('should return false for an empty array', () => {
+        const specialNeedsArray = [];
+        expect(component.specialNeedsIsPopulated(specialNeedsArray)).toBeFalsy();
+      });
+      it('should return false for an array that has None in it', () => {
+        const specialNeedsArray = ['None'];
+        expect(component.specialNeedsIsPopulated(specialNeedsArray)).toBeFalsy();
+      });
+      it('should return true for a populated array', () => {
+        const specialNeedsArray = ['special need 1', 'special need 2'];
+        expect(component.specialNeedsIsPopulated(specialNeedsArray)).toBeTruthy();
+      });
+    });
+    describe('showAttemptNumber', () => {
+      it('should return false when attemptNumber is undefined', () => {
+        expect(component.showAttemptNumber()).toEqual(false);
+      });
+      it('should return true when attemptNumber is not null', () => {
+        component.candidateDetails = { attemptNumber: 2 } as CandidateDetails;
+        expect(component.showAttemptNumber()).toEqual(true);
+      });
+    });
+    describe('showPrn', () => {
+      it('should return false when attemptNumber is undefined', () => {
+        expect(component.showPrn()).toEqual(false);
+      });
+      it('should return true when attemptNumber is not null', () => {
+        component.candidateDetails = { prn: 223434 } as CandidateDetails;
+        expect(component.showPrn()).toEqual(true);
+      });
+    });
+  });
+});

--- a/src/pages/view-test-result/cat-adi-part2/components/test-details/__tests__/test-details.cat-adi-part2.spec.ts
+++ b/src/pages/view-test-result/cat-adi-part2/components/test-details/__tests__/test-details.cat-adi-part2.spec.ts
@@ -3,10 +3,10 @@ import { IonicModule, Config } from 'ionic-angular';
 import { ConfigMock } from 'ionic-mocks';
 import { MockComponent } from 'ng-mocks';
 import { configureTestSuite } from 'ng-bullet';
+
 import { DataRowComponent } from '../../../../../../components/common/data-row/data-row';
 import { DataRowCustomComponent } from '../../../../../../components/common/data-row-custom/data-row-custom';
 import { CandidateDetails, TestDetailsCardCatADI2Component } from '../test-details.cat-adi-part2';
-import { it } from '@angular/cli/lib/ast-tools/spec-utils';
 
 describe('TestDetailsCardCatADI2Component', () => {
   let fixture: ComponentFixture<TestDetailsCardCatADI2Component>;
@@ -34,7 +34,6 @@ describe('TestDetailsCardCatADI2Component', () => {
   }));
 
   describe('Class', () => {
-    // Unit tests for the components TypeScript class
     it('should create', () => {
       expect(component).toBeDefined();
     });

--- a/src/pages/view-test-result/cat-adi-part2/components/test-details/test-details.cat-adi-part2.html
+++ b/src/pages/view-test-result/cat-adi-part2/components/test-details/test-details.cat-adi-part2.html
@@ -1,0 +1,44 @@
+<ion-card>
+    <ion-card-header>
+        <h4>Test details</h4>
+    </ion-card-header>
+    <ion-card-content>
+        <ion-grid>
+            <data-row [label]="'Date'" [value]="data.date"></data-row>
+            <data-row [label]="'Time'" [value]="data.time"></data-row>
+            <data-row [label]="'Application reference'" [value]="data.applicationReference"></data-row>
+            <data-row [label]="'Test category'" [value]="data.category"></data-row>
+            <data-row
+                    [label]="'Slot type'"
+                    [value]="data.slotType"
+                    [shouldShowIndicator]="data.slotType !== 'Standard Test'">
+            </data-row>
+            <data-row-custom [label]="'Special requirements'" [shouldShowIndicator]="specialNeedsIsPopulated(data.specialNeeds)">
+                <div *ngFor="let specialNeed of data.specialNeeds" class="mes-data">
+                    - {{specialNeed}}
+                </div>
+            </data-row-custom>
+            <data-row
+                    *ngIf="data.entitlementCheck"
+                    [label]="'Entitlement check'"
+                    [value]="'Entitlement check is required.'"
+                    [shouldShowIndicator]="true">
+            </data-row>
+            <data-row-custom [label]="'Additional information'">
+                <div class="mes-data" *ngIf="data.previousCancellations.length === 0">- None</div>
+                <div class="mes-data" *ngIf="data.previousCancellations.length > 0">- Previous cancellations</div>
+                <div *ngFor="let previousCancellation of data.previousCancellations" class="mes-data">
+                    - {{previousCancellation}}
+                </div>
+            </data-row-custom>
+            <data-row *ngIf="showPrn()"
+                      [label]="'Personal reference number'"
+                      [value]="candidateDetails.prn">
+            </data-row>
+            <data-row *ngIf="showAttemptNumber()"
+                      [label]="'Attempt number'"
+                      [value]="candidateDetails.attemptNumber">
+            </data-row>
+        </ion-grid>
+    </ion-card-content>
+</ion-card>

--- a/src/pages/view-test-result/cat-adi-part2/components/test-details/test-details.cat-adi-part2.ts
+++ b/src/pages/view-test-result/cat-adi-part2/components/test-details/test-details.cat-adi-part2.ts
@@ -1,0 +1,37 @@
+import { Component, Input } from '@angular/core';
+import { get } from 'lodash';
+
+import { TestDetailsModel } from '../../../components/test-details-card/test-details-card.model';
+
+export type CandidateDetails = { prn: number; attemptNumber: number; };
+
+@Component({
+  selector: 'test-details-card-adi2',
+  templateUrl: 'test-details.cat-adi-part2.html',
+})
+export class TestDetailsCardCatADI2Component {
+
+  @Input()
+  data: TestDetailsModel;
+
+  @Input()
+  candidateDetails: CandidateDetails;
+
+  constructor() {
+  }
+
+  specialNeedsIsPopulated(specialNeedsArray: string[]): boolean {
+    return specialNeedsArray.length > 0 && specialNeedsArray[0] !== 'None';
+  }
+
+  showAttemptNumber(): boolean {
+    return get(this.candidateDetails, 'attemptNumber', null) !== null ||
+      typeof get(this.candidateDetails, 'attemptNumber') !== 'undefined';
+  }
+
+  showPrn(): boolean {
+    return get(this.candidateDetails, 'prn', null) !== null ||
+      typeof get(this.candidateDetails, 'prn') !== 'undefined';
+  }
+
+}

--- a/src/pages/view-test-result/cat-adi-part2/components/vehicle-details/__tests__/vehicle-details.spec.ts
+++ b/src/pages/view-test-result/cat-adi-part2/components/vehicle-details/__tests__/vehicle-details.spec.ts
@@ -1,0 +1,88 @@
+import { CatADI2UniqueTypes } from '@dvsa/mes-test-schema/categories/ADI2';
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { IonicModule, Config } from 'ionic-angular';
+import { ConfigMock } from 'ionic-mocks';
+import { MockComponent } from 'ng-mocks';
+import { configureTestSuite } from 'ng-bullet';
+
+import { DataRowComponent } from '../../../../../../components/common/data-row/data-row';
+import { VehicleDetailsCatADIPt2Component } from '../vehicle-details';
+
+describe('VehicleDetailsCatADIPt2Component', () => {
+  let fixture: ComponentFixture<VehicleDetailsCatADIPt2Component>;
+  let component: VehicleDetailsCatADIPt2Component;
+
+  const data = { gearboxCategory: 'Manual', registrationNumber: 'ABC123' };
+  const trainerDetails = {
+    trainerRegistrationNumber: 123456,
+    trainingRecords: null,
+    orditTrainedCandidate: null,
+  };
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        VehicleDetailsCatADIPt2Component,
+        MockComponent(DataRowComponent),
+      ],
+      imports: [
+        IonicModule,
+      ],
+      providers: [
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+      ],
+    });
+  });
+
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(VehicleDetailsCatADIPt2Component);
+    component = fixture.componentInstance;
+  }));
+
+  describe('Class', () => {
+    describe('getTransmission', () => {
+      it('should return the value of the gearboxCategory', () => {
+        component.data = data as CatADI2UniqueTypes.VehicleDetails;
+        expect(component.getTransmission()).toEqual('Manual');
+      });
+    });
+    describe('getRegistrationNumber', () => {
+      it('should return the value of the registrationNumber', () => {
+        component.data = data as CatADI2UniqueTypes.VehicleDetails;
+        expect(component.getRegistrationNumber()).toEqual('ABC123');
+      });
+    });
+    describe('getTrainerPRN', () => {
+      it('should return the value of the trainerRegistrationNumber', () => {
+        component.trainerData = trainerDetails;
+        expect(component.getTrainerPRN()).toEqual(123456);
+      });
+    });
+    describe('getTrainingRecords', () => {
+      it('should return `No` as default when null or undefined', () => {
+        expect(component.getTrainingRecords()).toEqual('No');
+      });
+      it('should return `No` when trainingRecords is false', () => {
+        component.trainerData = { trainingRecords: false } as CatADI2UniqueTypes.TrainerDetails;
+        expect(component.getTrainingRecords()).toEqual('No');
+      });
+      it('should return `Yes` when trainingRecords is true', () => {
+        component.trainerData = { trainingRecords: true } as CatADI2UniqueTypes.TrainerDetails;
+        expect(component.getTrainingRecords()).toEqual('Yes');
+      });
+    });
+    describe('getOrdit', () => {
+      it('should return `No` as default when null or undefined', () => {
+        expect(component.getOrdit()).toEqual('No');
+      });
+      it('should return `No` when orditTrainedCandidate is false', () => {
+        component.trainerData = { orditTrainedCandidate: false } as CatADI2UniqueTypes.TrainerDetails;
+        expect(component.getOrdit()).toEqual('No');
+      });
+      it('should return `Yes` when orditTrainedCandidate is true', () => {
+        component.trainerData = { orditTrainedCandidate: true } as CatADI2UniqueTypes.TrainerDetails;
+        expect(component.getOrdit()).toEqual('Yes');
+      });
+    });
+  });
+});

--- a/src/pages/view-test-result/cat-adi-part2/components/vehicle-details/vehicle-details.html
+++ b/src/pages/view-test-result/cat-adi-part2/components/vehicle-details/vehicle-details.html
@@ -1,0 +1,38 @@
+<ion-card>
+    <ion-card-header>
+        <h4>Vehicle details</h4>
+    </ion-card-header>
+    <ion-card-content>
+        <ion-grid>
+
+            <data-row
+                    *ngIf="getTransmission()"
+                    [label]="'Transmission'"
+                    [value]="getTransmission()">
+            </data-row>
+
+            <data-row
+                    *ngIf="getRegistrationNumber()"
+                    [label]="'Vehicle registration number'"
+                    [value]="getRegistrationNumber()">
+            </data-row>
+
+            <data-row
+                    *ngIf="getTrainerPRN()"
+                    [label]="'Trainer PRN'"
+                    [value]="getTrainerPRN()">
+            </data-row>
+
+            <data-row
+                    [label]="'ORDIT'"
+                    [value]="getOrdit()">
+            </data-row>
+
+            <data-row
+                    [label]="'Training Records'"
+                    [value]="getTrainingRecords()">
+            </data-row>
+
+        </ion-grid>
+    </ion-card-content>
+</ion-card>

--- a/src/pages/view-test-result/cat-adi-part2/components/vehicle-details/vehicle-details.ts
+++ b/src/pages/view-test-result/cat-adi-part2/components/vehicle-details/vehicle-details.ts
@@ -1,0 +1,39 @@
+import { Component, Input } from '@angular/core';
+import { get } from 'lodash';
+import { CatADI2UniqueTypes } from '@dvsa/mes-test-schema/categories/ADI2';
+
+@Component({
+  selector: 'vehicle-details-cat-adi-pt2',
+  templateUrl: 'vehicle-details.html',
+})
+export class VehicleDetailsCatADIPt2Component {
+
+  @Input()
+  data: CatADI2UniqueTypes.VehicleDetails;
+
+  @Input()
+  trainerData: CatADI2UniqueTypes.TrainerDetails;
+
+  constructor() {}
+
+  public getTransmission(): string {
+    return get(this.data, 'gearboxCategory');
+  }
+
+  public getRegistrationNumber(): string {
+    return get(this.data, 'registrationNumber');
+  }
+
+  public getTrainerPRN(): number {
+    return get(this.trainerData, 'trainerRegistrationNumber', null);
+  }
+
+  public getOrdit(): string {
+    return get(this.trainerData, 'orditTrainedCandidate', false) ? 'Yes' : 'No';
+  }
+
+  public getTrainingRecords(): string {
+    return get(this.trainerData, 'trainingRecords', false) ? 'Yes' : 'No';
+  }
+
+}

--- a/src/pages/view-test-result/cat-adi-part2/components/view-test-result.cat-adi-part2.components.module.ts
+++ b/src/pages/view-test-result/cat-adi-part2/components/view-test-result.cat-adi-part2.components.module.ts
@@ -5,10 +5,14 @@ import { DebriefCardComponent } from './debrief-card/debrief-card';
 import { ComponentsModule } from '../../../../components/common/common-components.module';
 import { ViewTestResultComponentsModule }
 from '../../components/view-test-result.components.module';
+import { VehicleDetailsCatADIPt2Component } from './vehicle-details/vehicle-details';
+import { TestDetailsCardCatADI2Component } from './test-details/test-details.cat-adi-part2';
 
 @NgModule({
   declarations: [
     DebriefCardComponent,
+    VehicleDetailsCatADIPt2Component,
+    TestDetailsCardCatADI2Component,
   ],
   imports: [
     CommonModule,
@@ -18,6 +22,8 @@ from '../../components/view-test-result.components.module';
   ],
   exports: [
     DebriefCardComponent,
+    VehicleDetailsCatADIPt2Component,
+    TestDetailsCardCatADI2Component,
   ],
 })
 export class ViewTestResultCatADIPart2ComponentsModule {}

--- a/src/pages/view-test-result/cat-adi-part2/view-test-result.cat-adi-part2.page.html
+++ b/src/pages/view-test-result/cat-adi-part2/view-test-result.cat-adi-part2.page.html
@@ -14,7 +14,10 @@
   </error-message>
   <div *ngIf="!isLoading && !showErrorMessage">
     <view-test-header [data]="getHeaderDetails()"></view-test-header>
-    <test-details-card [data]="getTestDetails()"></test-details-card>
+    <test-details-card-adi2
+            [data]="getTestDetails()"
+            [candidateDetails]="getCandidateDetails()"
+    ></test-details-card-adi2>
     <contact-details-card
       [candidateData]="testResult.journalData.candidate"
       [communicationPreferencesData]="testResult.communicationPreferences">
@@ -25,7 +28,10 @@
       <rekey-reason-card [data]='testResult.rekeyReason'></rekey-reason-card>
     </div>
     <examiner-details-card [data]='getExaminerDetails()'></examiner-details-card>
-    <vehicle-details-card [data]='testResult.vehicleDetails'></vehicle-details-card>
+    <vehicle-details-cat-adi-pt2
+            [data]='testResult.vehicleDetails'
+            [trainerData]="getTrainerData()">
+    </vehicle-details-cat-adi-pt2>
     <debrief-card [data]='testResult.testData'></debrief-card>
     <test-summary-card
       [accompaniment]='testResult.accompaniment'

--- a/src/pages/view-test-result/cat-adi-part2/view-test-result.cat-adi-part2.page.ts
+++ b/src/pages/view-test-result/cat-adi-part2/view-test-result.cat-adi-part2.page.ts
@@ -119,6 +119,27 @@ export class ViewTestResultCatADIPart2Page extends BasePageComponent implements 
     }
   }
 
+  getTrainerData(): CatADI2UniqueTypes.TrainerDetails {
+    if (!this.testResult) {
+      return null;
+    }
+    return {
+      orditTrainedCandidate: get(this.testResult, 'trainerDetails.orditTrainedCandidate'),
+      trainingRecords: get(this.testResult, 'trainerDetails.trainingRecords'),
+      trainerRegistrationNumber: get(this.testResult, 'trainerDetails.trainerRegistrationNumber'),
+    };
+  }
+
+  getCandidateDetails(): { prn: number; attemptNumber: number; } {
+    if (!this.testResult) {
+      return null;
+    }
+    return {
+      prn: get(this.testResult, 'journalData.candidate.prn'),
+      attemptNumber: get(this.testResult, 'journalData.candidate.previousADITests'),
+    };
+  }
+
   getTestDetails(): TestDetailsModel {
     if (!this.testResult) {
       return null;

--- a/src/pages/view-test-result/components/vehicle-details-card/vehicle-details-card.ts
+++ b/src/pages/view-test-result/components/vehicle-details-card/vehicle-details-card.ts
@@ -41,7 +41,6 @@ export class VehicleDetailsCardComponent {
       case TestCategory.G:
       case TestCategory.H:
       case TestCategory.K:
-      case TestCategory.ADI2:
         return true;
       default:
         return false;

--- a/src/shared/mocks/cat-adi-part2-test-result.mock.ts
+++ b/src/shared/mocks/cat-adi-part2-test-result.mock.ts
@@ -93,6 +93,11 @@ export const categoryAdiPart2TestMock: CatADI2UniqueTypes.TestResult = {
     dualControls: true,
     schoolCar: false,
   },
+  trainerDetails: {
+    orditTrainedCandidate: true,
+    trainingRecords: true,
+    trainerRegistrationNumber: 2433244,
+  },
   accompaniment: {
     ADI: true,
     interpreter: true,


### PR DESCRIPTION
## Description
Added ability for user to see the new fields captured on the WRTC screen (ORDIT, Training Records and Trainer reg number) and also brought through new values from the journals, the attempt number and PRN
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![1227 Tue 12 May](https://user-images.githubusercontent.com/33056264/81781650-62456b80-94f0-11ea-9a1b-46f979ec25d6.png)
![1227 Tue 12 May](https://user-images.githubusercontent.com/33056264/81781661-670a1f80-94f0-11ea-948d-84d23fa57a12.png)
![1227 Tue 12 May](https://user-images.githubusercontent.com/33056264/81781668-6b363d00-94f0-11ea-80de-465f59836270.png)
