### PR TITLE
MES-5219 ADI2 Vehicle Checks Mandatory Field Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -621,9 +621,9 @@
       "dev": true
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.24.9",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.24.9.tgz",
-      "integrity": "sha512-DrC5v8yTwTPkTubeYkwD4nLNUdLB6f3OA3cYh5a1iZOHKTHdSX3q41ISwj5TmFxQLHFlV15Z2zJXVGU4mb5Kew==",
+      "version": "3.24.10",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.24.10.tgz",
+      "integrity": "sha512-E8x07QMeJ+e635PhsxX2my1AOfUnVzM/C99PkTfMNFAF4jP47ALkGbAqHqRwgL4IUgu2DnrCSJjMZUT4i5x6KQ==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@dvsa/mes-config-schema": "1.0.6",
     "@dvsa/mes-journal-schema": "1.2.0",
     "@dvsa/mes-search-schema": "1.1.1",
-    "@dvsa/mes-test-schema": "3.24.9",
+    "@dvsa/mes-test-schema": "3.24.10",
     "@hapi/joi": "^15.1.0",
     "@ionic-native-mocks/device": "^2.0.12",
     "@ionic-native-mocks/secure-storage": "^2.0.12",

--- a/src/modules/tests/test-data/cat-adi-part2/_tests_/test-data.cat-adi-part2.selector.spec.ts
+++ b/src/modules/tests/test-data/cat-adi-part2/_tests_/test-data.cat-adi-part2.selector.spec.ts
@@ -327,6 +327,7 @@ describe('TestDataSelectors Cat ADI2', () => {
           ],
           vehicleChecksCompleted: false,
         };
+
         expect(hasVehicleChecksBeenCompletedCatADI2(state)).toEqual(false);
       });
       it('should return false with an empty array as its parameter', () => {
@@ -334,6 +335,19 @@ describe('TestDataSelectors Cat ADI2', () => {
           tellMeQuestions: [],
           vehicleChecksCompleted: true,
         };
+
+        expect(hasVehicleChecksBeenCompletedCatADI2(state)).toEqual(false);
+      });
+      it('should return false with an array under 2 items', () => {
+        const state: CatADI2UniqueTypes.VehicleChecks = {
+          tellMeQuestions: [
+            {
+              outcome: CompetencyOutcome.P,
+            },
+          ],
+          vehicleChecksCompleted: true,
+        };
+
         expect(hasVehicleChecksBeenCompletedCatADI2(state)).toEqual(false);
       });
     });

--- a/src/modules/tests/test-data/cat-adi-part2/_tests_/test-data.cat-adi-part2.selector.spec.ts
+++ b/src/modules/tests/test-data/cat-adi-part2/_tests_/test-data.cat-adi-part2.selector.spec.ts
@@ -169,7 +169,7 @@ describe('TestDataSelectors Cat ADI2', () => {
     });
   });
 
-  fdescribe('hasManoeuvreBeenCompleted', () => {
+  describe('hasManoeuvreBeenCompleted', () => {
     it('should return false when no manoeuvres have been completed', () => {
       const state: CatADI2UniqueTypes.Manoeuvres[] = [{
       }];
@@ -239,7 +239,7 @@ describe('TestDataSelectors Cat ADI2', () => {
     });
 
     describe('hasVehicleChecksBeenCompleted', () => {
-      it('should return true if vehicle checks have been completed with a pass', () => {
+      it('should return true if vehicle checks have been completed with a pass & button has been selected', () => {
         const state: CatADI2UniqueTypes.VehicleChecks = {
           tellMeQuestions: [
             {
@@ -252,11 +252,12 @@ describe('TestDataSelectors Cat ADI2', () => {
               outcome: CompetencyOutcome.P,
             },
           ],
+          vehicleChecksCompleted: true,
         };
 
         expect(hasVehicleChecksBeenCompletedCatADI2(state)).toEqual(true);
       });
-      it('should return true if vehicle checks have been completed with a driving fault', () => {
+      it('should return true if vehicle checks have been completed with driving faults', () => {
         const state: CatADI2UniqueTypes.VehicleChecks = {
           tellMeQuestions: [
             {
@@ -269,6 +270,7 @@ describe('TestDataSelectors Cat ADI2', () => {
               outcome: CompetencyOutcome.DF,
             },
           ],
+          vehicleChecksCompleted: true,
         };
 
         expect(hasVehicleChecksBeenCompletedCatADI2(state)).toEqual(true);
@@ -286,6 +288,7 @@ describe('TestDataSelectors Cat ADI2', () => {
               outcome: CompetencyOutcome.S,
             },
           ],
+          vehicleChecksCompleted: true,
         };
 
         expect(hasVehicleChecksBeenCompletedCatADI2(state)).toEqual(true);
@@ -303,9 +306,35 @@ describe('TestDataSelectors Cat ADI2', () => {
               outcome: CompetencyOutcome.D,
             },
           ],
+          vehicleChecksCompleted: true,
         };
 
         expect(hasVehicleChecksBeenCompletedCatADI2(state)).toEqual(true);
+      });
+      it('should return false if vehicleChecksCompleted is false', () => {
+        const state: CatADI2UniqueTypes.VehicleChecks = {
+
+          tellMeQuestions: [
+            {
+              outcome: CompetencyOutcome.P,
+            },
+            {
+              outcome: CompetencyOutcome.P,
+            },
+            {
+              outcome: CompetencyOutcome.P,
+            },
+          ],
+          vehicleChecksCompleted: false,
+        };
+        expect(hasVehicleChecksBeenCompletedCatADI2(state)).toEqual(false);
+      });
+      it('should return false with an empty array as its parameter', () => {
+        const state: CatADI2UniqueTypes.VehicleChecks = {
+          tellMeQuestions: [],
+          vehicleChecksCompleted: true,
+        };
+        expect(hasVehicleChecksBeenCompletedCatADI2(state)).toEqual(false);
       });
     });
   });

--- a/src/modules/tests/test-data/cat-adi-part2/_tests_/test-data.cat-adi-part2.selector.spec.ts
+++ b/src/modules/tests/test-data/cat-adi-part2/_tests_/test-data.cat-adi-part2.selector.spec.ts
@@ -7,14 +7,13 @@ import {
 } from '../../common/test-data.selector';
 import {
   getDrivingFaultCount,
-  // TODO - ADI2: Update with manoeuvres
-  // getManoeuvres,
-  // hasManoeuvreBeenCompletedCatBE,
   areTellMeQuestionsSelected,
   areTellMeQuestionsCorrect,
   hasVehicleChecksBeenCompletedCatADI2,
   hasEyesightTestGotSeriousFault,
   hasEyesightTestBeenCompleted,
+  getManoeuvresADI2,
+  hasManoeuvreBeenCompletedCatADIPart2,
 } from '../test-data.cat-adi-part2.selector';
 import { Competencies } from '../../test-data.constants';
 import { CompetencyOutcome } from '../../../../../shared/models/competency-outcome';
@@ -163,30 +162,35 @@ describe('TestDataSelectors Cat ADI2', () => {
     });
   });
 
-  // TODO - ADI2: Manoeuvres yet to be compeleted
-  // describe('getManoeuvres', () => {
-  //   it('should retrive the manoeuvres data when requested', () => {
-  //     const result = getManoeuvres(state);
-  //     expect(result).toEqual(state.manoeuvres);
-  //   });
-  // });
+  describe('getManoeuvres', () => {
+    it('should retrieve the manoeuvres data when requested', () => {
+      const result = getManoeuvresADI2(state);
+      expect(result).toEqual(state.manoeuvres);
+    });
+  });
 
-  // describe('hasManoeuvreBeenCompleted', () => {
-  //   it('should return false when no manoeuvres have been completed', () => {
-  //     const state: CatBEUniqueTypes.TestData = {
-  //       manoeuvres: {},
-  //     };
-  //     expect(hasManoeuvreBeenCompletedCatBE(state)).toBeFalsy();
-  //   });
-  //   it('should return true when a manoeuvre has been completed', () => {
-  //     const state: CatBEUniqueTypes.TestData = {
-  //       manoeuvres: {
-  //         reverseLeft: { selected: true },
-  //       },
-  //     };
-  //     expect(hasManoeuvreBeenCompletedCatBE(state)).toEqual(true);
-  //   });
-  // });
+  fdescribe('hasManoeuvreBeenCompleted', () => {
+    it('should return false when no manoeuvres have been completed', () => {
+      const state: CatADI2UniqueTypes.Manoeuvres[] = [{
+      }];
+      expect(hasManoeuvreBeenCompletedCatADIPart2(state)).toBeFalsy();
+    });
+    it('should return true when 2 manoeuvres have been completed', () => {
+      const state: CatADI2UniqueTypes.Manoeuvres[] = [
+        {
+          reverseRight: {
+            selected: true,
+          },
+        },
+        {
+          reverseParkRoad: {
+            selected: true,
+          },
+        },
+      ];
+      expect(hasManoeuvreBeenCompletedCatADIPart2(state)).toEqual(true);
+    });
+  });
 
   describe('vehicle checks selector', () => {
     describe('areTellMeQuestionsSelected', () => {

--- a/src/modules/tests/test-data/cat-adi-part2/_tests_/test-data.cat-adi-part2.selector.spec.ts
+++ b/src/modules/tests/test-data/cat-adi-part2/_tests_/test-data.cat-adi-part2.selector.spec.ts
@@ -173,7 +173,7 @@ describe('TestDataSelectors Cat ADI2', () => {
     it('should return false when no manoeuvres have been completed', () => {
       const state: CatADI2UniqueTypes.Manoeuvres[] = [{
       }];
-      expect(hasManoeuvreBeenCompletedCatADIPart2(state)).toBeFalsy();
+      expect(hasManoeuvreBeenCompletedCatADIPart2(state)).toEqual(false);
     });
     it('should return true when 2 manoeuvres have been completed', () => {
       const state: CatADI2UniqueTypes.Manoeuvres[] = [
@@ -189,6 +189,16 @@ describe('TestDataSelectors Cat ADI2', () => {
         },
       ];
       expect(hasManoeuvreBeenCompletedCatADIPart2(state)).toEqual(true);
+    });
+    it('should return false with only 1 manoeuvre completed', () => {
+      const state: CatADI2UniqueTypes.Manoeuvres[] = [
+        {
+          reverseRight: {
+            selected: true,
+          },
+        },
+      ];
+      expect(hasManoeuvreBeenCompletedCatADIPart2(state)).toEqual(false);
     });
   });
 

--- a/src/modules/tests/test-data/cat-adi-part2/test-data.cat-adi-part2.selector.ts
+++ b/src/modules/tests/test-data/cat-adi-part2/test-data.cat-adi-part2.selector.ts
@@ -70,7 +70,8 @@ export const hasVehicleChecksBeenCompletedCatADI2 = (vehicleChecks: CatADI2Uniqu
 
   if (
     !(vehicleChecks && vehicleChecks.tellMeQuestions instanceof Array) ||
-    vehicleChecks.tellMeQuestions.length !== NUMBER_OF_TELL_ME_QUESTIONS
+    vehicleChecks.tellMeQuestions.length !== NUMBER_OF_TELL_ME_QUESTIONS ||
+    !vehicleChecks.vehicleChecksCompleted
   ) {
     return false;
   }

--- a/src/modules/tests/test-data/cat-adi-part2/test-data.cat-adi-part2.selector.ts
+++ b/src/modules/tests/test-data/cat-adi-part2/test-data.cat-adi-part2.selector.ts
@@ -15,7 +15,7 @@ export const getManoeuvresADI2 = (data: CatADI2UniqueTypes.TestData) : CatADI2Un
   data.manoeuvres;
 
 export const hasManoeuvreBeenCompletedCatADIPart2 = (manoeuvres: CatADI2UniqueTypes.Manoeuvres[]) => {
-  if (manoeuvres.length < 2) return false;
+  if (!manoeuvres || manoeuvres.length < 2) return false;
 
   return manoeuvres.every((manoeuvre) => {
     return (

--- a/src/modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.action.ts
+++ b/src/modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.action.ts
@@ -12,20 +12,15 @@ export const VEHICLE_CHECKS_REMOVE_SERIOUS_FAULT = '[Vehicle Checks] [CatADI2] V
 export const VEHICLE_CHECKS_ADD_DANGEROUS_FAULT = '[Vehicle Checks] [CatADI2] Vehicle Checks Add Dangerous Fault';
 export const VEHICLE_CHECKS_REMOVE_DANGEROUS_FAULT = '[Vehicle Checks] [CatADI2] Vehicle Checks Remove Dangerous Fault';
 export const ADD_SHOW_ME_TELL_ME_COMMENT = '[Vehicle Checks] [CatADI2] Add Show Me / Tell Me comment';
-export const VEHICLE_CHECKS_COMPLETED_SELECTED = '[Vehicle Checks] [CatADI2] Vehicle Checks Completed Selected';
-export const VEHICLE_CHECKS_COMPLETED_DESELECTED = '[Vehicle Checks] [CatADI2] Vehicle Checks Completed Deselected';
+export const VEHICLE_CHECKS_TOGGLE = '[Vehicle Checks] [CatADI2] Vehicle Checks Completed Toggled';
 
 export class ShowMeQuestionSelected implements Action {
   readonly type = SHOW_ME_QUESTION_SELECTED;
   constructor(public showMeQuestion: QuestionResult, public index: number) {}
 }
 
-export class VehicleChecksCompletedSelected implements Action {
-  readonly type = VEHICLE_CHECKS_COMPLETED_SELECTED;
-}
-
-export class VehicleChecksCompletedDeselected implements Action {
-  readonly type = VEHICLE_CHECKS_COMPLETED_DESELECTED;
+export class VehicleChecksCompletedToggle implements Action {
+  readonly type = VEHICLE_CHECKS_TOGGLE;
 }
 
 export class ShowMeQuestionOutcomeChanged implements Action {
@@ -85,5 +80,4 @@ export type Types =
   | VehicleChecksAddDangerousFault
   | VehicleChecksRemoveSeriousFault
   | VehicleChecksRemoveDangerousFault
-  | VehicleChecksCompletedDeselected
-  | VehicleChecksCompletedSelected;
+  | VehicleChecksCompletedToggle;

--- a/src/modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.action.ts
+++ b/src/modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.action.ts
@@ -12,10 +12,20 @@ export const VEHICLE_CHECKS_REMOVE_SERIOUS_FAULT = '[Vehicle Checks] [CatADI2] V
 export const VEHICLE_CHECKS_ADD_DANGEROUS_FAULT = '[Vehicle Checks] [CatADI2] Vehicle Checks Add Dangerous Fault';
 export const VEHICLE_CHECKS_REMOVE_DANGEROUS_FAULT = '[Vehicle Checks] [CatADI2] Vehicle Checks Remove Dangerous Fault';
 export const ADD_SHOW_ME_TELL_ME_COMMENT = '[Vehicle Checks] [CatADI2] Add Show Me / Tell Me comment';
+export const VEHICLE_CHECKS_COMPLETED_SELECTED = '[Vehicle Checks] [CatADI2] Vehicle Checks Completed Selected';
+export const VEHICLE_CHECKS_COMPLETED_DESELECTED = '[Vehicle Checks] [CatADI2] Vehicle Checks Completed Deselected';
 
 export class ShowMeQuestionSelected implements Action {
   readonly type = SHOW_ME_QUESTION_SELECTED;
   constructor(public showMeQuestion: QuestionResult, public index: number) {}
+}
+
+export class VehicleChecksCompletedSelected implements Action {
+  readonly type = VEHICLE_CHECKS_COMPLETED_SELECTED;
+}
+
+export class VehicleChecksCompletedDeselected implements Action {
+  readonly type = VEHICLE_CHECKS_COMPLETED_DESELECTED;
 }
 
 export class ShowMeQuestionOutcomeChanged implements Action {

--- a/src/modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.action.ts
+++ b/src/modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.action.ts
@@ -84,4 +84,6 @@ export type Types =
   | VehicleChecksAddSeriousFault
   | VehicleChecksAddDangerousFault
   | VehicleChecksRemoveSeriousFault
-  | VehicleChecksRemoveDangerousFault;
+  | VehicleChecksRemoveDangerousFault
+  | VehicleChecksCompletedDeselected
+  | VehicleChecksCompletedSelected;

--- a/src/modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.reducer.ts
+++ b/src/modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.reducer.ts
@@ -22,6 +22,7 @@ export const initialState: CatADI2UniqueTypes.VehicleChecks = {
   ],
   seriousFault: false,
   dangerousFault: false,
+  vehicleChecksCompleted: false,
 };
 
 export function vehicleChecksCatADI2Reducer(

--- a/src/modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.reducer.ts
+++ b/src/modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.reducer.ts
@@ -101,6 +101,16 @@ export function vehicleChecksCatADI2Reducer(
         ...state,
         dangerousFault: false,
       };
+    case vehicleChecksCatADI2ActionTypes.VEHICLE_CHECKS_COMPLETED_DESELECTED:
+      return {
+        ...state,
+        vehicleChecksCompleted: false,
+      };
+    case vehicleChecksCatADI2ActionTypes.VEHICLE_CHECKS_COMPLETED_SELECTED:
+      return {
+        ...state,
+        vehicleChecksCompleted: true,
+      };
     default:
       return state;
   }

--- a/src/modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.reducer.ts
+++ b/src/modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.reducer.ts
@@ -102,15 +102,10 @@ export function vehicleChecksCatADI2Reducer(
         ...state,
         dangerousFault: false,
       };
-    case vehicleChecksCatADI2ActionTypes.VEHICLE_CHECKS_COMPLETED_DESELECTED:
+    case vehicleChecksCatADI2ActionTypes.VEHICLE_CHECKS_TOGGLE:
       return {
         ...state,
-        vehicleChecksCompleted: false,
-      };
-    case vehicleChecksCatADI2ActionTypes.VEHICLE_CHECKS_COMPLETED_SELECTED:
-      return {
-        ...state,
-        vehicleChecksCompleted: true,
+        vehicleChecksCompleted: !state.vehicleChecksCompleted,
       };
     default:
       return state;

--- a/src/pages/test-report/cat-adi-part2/components/vehicle-check/vehicle-check.html
+++ b/src/pages/test-report/cat-adi-part2/components/vehicle-check/vehicle-check.html
@@ -9,7 +9,7 @@
       }"
     >
       <span class='tickwrapper'>
-        <tick-indicator [ticked]="selectedShowMeQuestion"></tick-indicator>
+        <tick-indicator [ticked]="vehicleChecksCompleted"></tick-indicator>
       </span>
     </competency-button>
   </ion-col>

--- a/src/pages/test-report/cat-adi-part2/components/vehicle-check/vehicle-check.ts
+++ b/src/pages/test-report/cat-adi-part2/components/vehicle-check/vehicle-check.ts
@@ -15,7 +15,7 @@ import {
   VehicleChecksRemoveSeriousFault,
   VehicleChecksRemoveDangerousFault,
   ShowMeQuestionAddDrivingFault,
-  ShowMeQuestionRemoveDrivingFault,
+  ShowMeQuestionRemoveDrivingFault, VehicleChecksCompletedDeselected, VehicleChecksCompletedSelected,
 } from '../../../../../modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.action';
 import { ToggleSeriousFaultMode, ToggleDangerousFaultMode, ToggleRemoveFaultMode } from '../../../test-report.actions';
 import { getTestReportState } from '../../../test-report.reducer';
@@ -112,10 +112,12 @@ export class VehicleCheckComponent implements OnInit, OnDestroy {
     }
 
     if (this.selectedShowMeQuestion) {
+      this.store$.dispatch(new VehicleChecksCompletedDeselected());
       this.selectedShowMeQuestion = false;
       return;
     }
 
+    this.store$.dispatch(new VehicleChecksCompletedSelected());
     this.selectedShowMeQuestion = true;
   }
 

--- a/src/pages/test-report/cat-adi-part2/components/vehicle-check/vehicle-check.ts
+++ b/src/pages/test-report/cat-adi-part2/components/vehicle-check/vehicle-check.ts
@@ -4,7 +4,7 @@ import { StoreModel } from '../../../../../shared/models/store.model';
 import { getTests } from '../../../../../modules/tests/tests.reducer';
 import { getCurrentTest } from '../../../../../modules/tests/tests.selector';
 import { getTestData } from '../../../../../modules/tests/test-data/cat-adi-part2/test-data.cat-adi-part2.reducer';
-import { getVehicleChecksCatADIPart2 }
+import { getVehicleChecksCatADIPart2, hasVehicleChecksBeenCompletedCatADI2 }
   from '../../../../../modules/tests/test-data/cat-adi-part2/test-data.cat-adi-part2.selector';
 import { CatADI2UniqueTypes } from '@dvsa/mes-test-schema/categories/ADI2';
 import { CompetencyOutcome } from '../../../../../shared/models/competency-outcome';
@@ -35,6 +35,7 @@ export class VehicleCheckComponent implements OnInit, OnDestroy {
   tellMeQuestionFaultCount: number;
 
   vehicleChecks: CatADI2UniqueTypes.VehicleChecks;
+  vehicleChecksCompleted: boolean = false;
 
   isRemoveFaultMode: boolean = false;
   isSeriousMode: boolean = false;
@@ -73,6 +74,10 @@ export class VehicleCheckComponent implements OnInit, OnDestroy {
       select(isRemoveFaultMode),
     );
 
+    const vehicleChecksCompleted$ = merge(vehicleChecks$.pipe(
+      select(hasVehicleChecksBeenCompletedCatADI2),
+    ));
+
     this.subscription = merge(
       vehicleChecks$.pipe(map((vehicleChecks: CatADI2UniqueTypes.VehicleChecks) => {
         this.vehicleChecks = vehicleChecks;
@@ -85,6 +90,7 @@ export class VehicleCheckComponent implements OnInit, OnDestroy {
           { showMeQuestions: vehicleChecks.showMeQuestions },
         ).drivingFaults;
       })),
+      vehicleChecksCompleted$.pipe(map(toggle => this.vehicleChecksCompleted = toggle)),
       isSeriousMode$.pipe(map(toggle => this.isSeriousMode = toggle)),
       isDangerousMode$.pipe(map(toggle => this.isDangerousMode = toggle)),
       isRemoveFaultMode$.pipe(map(toggle => this.isRemoveFaultMode = toggle)),

--- a/src/pages/test-report/cat-adi-part2/components/vehicle-check/vehicle-check.ts
+++ b/src/pages/test-report/cat-adi-part2/components/vehicle-check/vehicle-check.ts
@@ -15,7 +15,7 @@ import {
   VehicleChecksRemoveSeriousFault,
   VehicleChecksRemoveDangerousFault,
   ShowMeQuestionAddDrivingFault,
-  ShowMeQuestionRemoveDrivingFault, VehicleChecksCompletedDeselected, VehicleChecksCompletedSelected,
+  ShowMeQuestionRemoveDrivingFault, VehicleChecksCompletedToggle,
 } from '../../../../../modules/tests/test-data/cat-adi-part2/vehicle-checks/vehicle-checks.cat-adi-part2.action';
 import { ToggleSeriousFaultMode, ToggleDangerousFaultMode, ToggleRemoveFaultMode } from '../../../test-report.actions';
 import { getTestReportState } from '../../../test-report.reducer';
@@ -118,12 +118,12 @@ export class VehicleCheckComponent implements OnInit, OnDestroy {
     }
 
     if (this.selectedShowMeQuestion) {
-      this.store$.dispatch(new VehicleChecksCompletedDeselected());
+      this.store$.dispatch(new VehicleChecksCompletedToggle());
       this.selectedShowMeQuestion = false;
       return;
     }
 
-    this.store$.dispatch(new VehicleChecksCompletedSelected());
+    this.store$.dispatch(new VehicleChecksCompletedToggle());
     this.selectedShowMeQuestion = true;
   }
 

--- a/src/pages/test-report/cat-adi-part2/components/vehicle-check/vehicle-check.ts
+++ b/src/pages/test-report/cat-adi-part2/components/vehicle-check/vehicle-check.ts
@@ -117,14 +117,8 @@ export class VehicleCheckComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (this.selectedShowMeQuestion) {
-      this.store$.dispatch(new VehicleChecksCompletedToggle());
-      this.selectedShowMeQuestion = false;
-      return;
-    }
-
     this.store$.dispatch(new VehicleChecksCompletedToggle());
-    this.selectedShowMeQuestion = true;
+    this.selectedShowMeQuestion = !this.selectedShowMeQuestion;
   }
 
   canButtonRipple = () => {

--- a/src/providers/test-report-validator/__mocks__/test-result.mock.ts
+++ b/src/providers/test-report-validator/__mocks__/test-result.mock.ts
@@ -15,6 +15,7 @@ import { CatFUniqueTypes } from '@dvsa/mes-test-schema/categories/F';
 import { CatGUniqueTypes } from '@dvsa/mes-test-schema/categories/G';
 import { CatHUniqueTypes } from '@dvsa/mes-test-schema/categories/H';
 import { CatKUniqueTypes } from '@dvsa/mes-test-schema/categories/K';
+import { CatADI2UniqueTypes } from '@dvsa/mes-test-schema/categories/ADI2';
 
 export const validTestCatAMod2: CatAMod2TestData = {
   testRequirements: {
@@ -44,6 +45,56 @@ export const validTestCatAMod2: CatAMod2TestData = {
       },
     ],
   },
+  eco: {
+    completed: true,
+  },
+};
+
+export const validTestCatADIPart2: CatADI2UniqueTypes.TestData = {
+  testRequirements: {
+    angledStart: true,
+    downhillStart: true,
+    uphillStart: true,
+    normalStart1: true,
+    normalStart2: true,
+  },
+  vehicleChecks: {
+    showMeQuestions: [
+      {
+        outcome: CompetencyOutcome.P,
+      },
+      {
+        outcome: CompetencyOutcome.P,
+      },
+      {
+        outcome: CompetencyOutcome.P,
+      },
+    ],
+    tellMeQuestions: [
+      {
+        outcome: CompetencyOutcome.P,
+      },
+      {
+        outcome: CompetencyOutcome.P,
+      },
+      {
+        outcome: CompetencyOutcome.P,
+      },
+    ],
+    vehicleChecksCompleted: true,
+  },
+  manoeuvres: [
+    {
+      reverseRight: {
+        selected: true,
+      },
+    },
+    {
+      reverseParkCarpark: {
+        selected: true,
+      },
+    },
+  ],
   eco: {
     completed: true,
   },
@@ -318,6 +369,17 @@ export const legalRequirementsAMod2 = [
   legalRequirementsLabels.angledStart,
   legalRequirementsLabels.hillStart,
   legalRequirementsLabels.safetyAndBalanceQuestions,
+  legalRequirementsLabels.eco,
+];
+
+export const legalRequirementsADIPart2 = [
+  legalRequirementsLabels.normalStart1,
+  legalRequirementsLabels.normalStart2,
+  legalRequirementsLabels.angledStart,
+  legalRequirementsLabels.uphillStart,
+  legalRequirementsLabels.downhillStart,
+  legalRequirementsLabels.manoeuvre,
+  legalRequirementsLabels.vehicleChecks,
   legalRequirementsLabels.eco,
 ];
 

--- a/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
+++ b/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
@@ -26,6 +26,7 @@ describe('TestReportValidator', () => {
     { category: TestCategory.G, validTest: mocks.validTestCatG, legalReqs: mocks.legalRequirementsCatG },
     { category: TestCategory.H, validTest: mocks.validTestCatH, legalReqs: mocks.legalRequirementsCatH },
     { category: TestCategory.K, validTest: mocks.validTestCatK, legalReqs: mocks.legalRequirementsCatK },
+    { category: TestCategory.ADI2, validTest: mocks.validTestCatADIPart2, legalReqs: mocks.legalRequirementsADIPart2 },
   ];
 
   let testReportValidatorProvider: TestReportValidatorProvider;
@@ -56,7 +57,7 @@ describe('TestReportValidator', () => {
     });
 
   });
-  describe('getMissingLegalRequirements', () => {
+  fdescribe('getMissingLegalRequirements', () => {
     categories.forEach((cat) => {
       it(`should return an empty array if the legal requirements are met for a Cat ${cat.category} test`, () => {
         const result = testReportValidatorProvider.getMissingLegalRequirements(cat.validTest, cat.category);

--- a/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
+++ b/src/providers/test-report-validator/__tests__/test-report-validator.spec.ts
@@ -57,7 +57,7 @@ describe('TestReportValidator', () => {
     });
 
   });
-  fdescribe('getMissingLegalRequirements', () => {
+  describe('getMissingLegalRequirements', () => {
     categories.forEach((cat) => {
       it(`should return an empty array if the legal requirements are met for a Cat ${cat.category} test`, () => {
         const result = testReportValidatorProvider.getMissingLegalRequirements(cat.validTest, cat.category);


### PR DESCRIPTION
## Description
Adds functionality and unit tests for making the vehicle checks a mandatory field within the Test Report page for ADI 2 tests.
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="416" alt="Screenshot 2020-05-13 at 09 22 41" src="https://user-images.githubusercontent.com/28736958/81789035-54491800-94fb-11ea-82dc-ac40ff0f1b7b.png">
