### PR TITLE
MES-5244 / Office page home test dangerous faults not appearing

### DIFF
--- a/src/pages/office/cat-home-test/office.cat-home-test.page.ts
+++ b/src/pages/office/cat-home-test/office.cat-home-test.page.ts
@@ -370,6 +370,7 @@ export class OfficeCatHomeTestPage extends BasePageComponent {
         select(getEcoFaultText),
       ),
       dangerousFaults$: currentTest$.pipe(
+        select(getTestData),
         map(data => this.faultSummaryProvider.getDangerousFaultsList(data, this.testCategory)),
       ),
       seriousFaults$: currentTest$.pipe(


### PR DESCRIPTION
## Description
Add selector for getting dangerous faults on the office page in order for the assoicated text boxes to be displayed
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
