### PR TITLE
MES-5270 Home Tests Make Controlled Stop Mandatory

### DIFF
--- a/src/providers/test-report-validator/__mocks__/test-result.mock.ts
+++ b/src/providers/test-report-validator/__mocks__/test-result.mock.ts
@@ -306,6 +306,9 @@ export const validTestCatF: CatFUniqueTypes.TestData = {
       selected: true,
     },
   },
+  controlledStop: {
+    selected: true,
+  },
 };
 
 export const validTestCatG: CatGUniqueTypes.TestData = {
@@ -325,6 +328,9 @@ export const validTestCatG: CatGUniqueTypes.TestData = {
     reverseLeft: {
       selected: true,
     },
+  },
+  controlledStop: {
+    selected: true,
   },
 };
 
@@ -346,6 +352,9 @@ export const validTestCatH: CatHUniqueTypes.TestData = {
       selected: true,
     },
   },
+  controlledStop: {
+    selected: true,
+  },
 };
 
 export const validTestCatK: CatKUniqueTypes.TestData = {
@@ -359,6 +368,9 @@ export const validTestCatK: CatKUniqueTypes.TestData = {
     completed: true,
   },
   highwayCodeSafety: {
+    selected: true,
+  },
+  controlledStop: {
     selected: true,
   },
 };
@@ -465,6 +477,7 @@ export const legalRequirementsCatF = [
   legalRequirementsLabels.manoeuvre,
   legalRequirementsLabels.highwayCodeSafety,
   legalRequirementsLabels.eco,
+  legalRequirementsLabels.controlledStop,
 ];
 
 export const legalRequirementsCatG = [
@@ -475,6 +488,7 @@ export const legalRequirementsCatG = [
   legalRequirementsLabels.manoeuvre,
   legalRequirementsLabels.highwayCodeSafety,
   legalRequirementsLabels.eco,
+  legalRequirementsLabels.controlledStop,
 ];
 
 export const legalRequirementsCatH = [
@@ -485,6 +499,7 @@ export const legalRequirementsCatH = [
   legalRequirementsLabels.manoeuvre,
   legalRequirementsLabels.highwayCodeSafety,
   legalRequirementsLabels.eco,
+  legalRequirementsLabels.controlledStop,
 ];
 
 export const legalRequirementsCatK = [
@@ -494,4 +509,5 @@ export const legalRequirementsCatK = [
   legalRequirementsLabels.uphillStartDesignatedStart,
   legalRequirementsLabels.highwayCodeSafety,
   legalRequirementsLabels.eco,
+  legalRequirementsLabels.controlledStop,
 ];

--- a/src/providers/test-report-validator/test-report-validator.ts
+++ b/src/providers/test-report-validator/test-report-validator.ts
@@ -531,13 +531,15 @@ export class TestReportValidatorProvider {
     const normalStart1: boolean = get(data, 'testRequirements.normalStart1', false);
     const normalStart2: boolean = get(data, 'testRequirements.normalStart2', false);
     const angledStart: boolean = get(data, 'testRequirements.angledStart', false);
+    const controlledStop: boolean = get(data, 'controlledStop.selected', false);
     const uphillStartDesignatedStart: boolean = get(data, 'testRequirements.uphillStartDesignatedStart', false);
 
-    const hCodeSafteyQuestions: boolean = get(data, 'highwayCodeSafety.selected', false);
+    const hCodeSafetyQuestions: boolean = get(data, 'highwayCodeSafety.selected', false);
 
     const eco: boolean = get(data, 'eco.completed', false);
 
-    return normalStart1 && normalStart2 && angledStart && uphillStartDesignatedStart && hCodeSafteyQuestions && eco;
+    return normalStart1 && normalStart2 && angledStart &&
+      uphillStartDesignatedStart && hCodeSafetyQuestions && eco && controlledStop;
   }
 
   private getMissingLegalRequirementsCatHomeTest(data: HomeTestData): legalRequirementsLabels[] {
@@ -555,6 +557,8 @@ export class TestReportValidatorProvider {
     !get(data, 'highwayCodeSafety.selected', false) && result.push(legalRequirementsLabels.highwayCodeSafety);
 
     !get(data, 'eco.completed', false) && result.push(legalRequirementsLabels.eco);
+
+    !get(data, 'controlledStop.selected', false) && result.push(legalRequirementsLabels.controlledStop);
 
     return result;
   }

--- a/src/providers/test-report-validator/test-report-validator.ts
+++ b/src/providers/test-report-validator/test-report-validator.ts
@@ -21,7 +21,7 @@ import {
   hasVehicleChecksBeenCompletedCatB,
 } from '../../modules/tests/test-data/cat-b/test-data.cat-b.selector';
 import { haveSafetyAndBalanceQuestionsBeenCompleted }
-  from '../../modules/tests/test-data/cat-a-mod2/test-data.cat-a-mod2.selector';
+ from '../../modules/tests/test-data/cat-a-mod2/test-data.cat-a-mod2.selector';
 import { hasManoeuvreBeenCompletedCatBE } from '../../modules/tests/test-data/cat-be/test-data.cat-be.selector';
 import { hasManoeuvreBeenCompletedCatC } from '../../modules/tests/test-data/cat-c/test-data.cat-c.selector';
 import { legalRequirementsLabels } from '../../shared/constants/legal-requirements/legal-requirements.constants';
@@ -575,6 +575,7 @@ export class TestReportValidatorProvider {
     !get(data, 'highwayCodeSafety.selected', false) && result.push(legalRequirementsLabels.highwayCodeSafety);
 
     !get(data, 'eco.completed', false) && result.push(legalRequirementsLabels.eco);
+    !get(data, 'controlledStop.selected', false) && result.push(legalRequirementsLabels.controlledStop);
 
     return result;
   }

--- a/src/shared/constants/legal-requirements/legal-requirements.constants.ts
+++ b/src/shared/constants/legal-requirements/legal-requirements.constants.ts
@@ -3,6 +3,7 @@ export enum legalRequirementsLabels {
   normalStart2 = 'NS (normal start)',
   angledStart = 'AS (angled start)',
   angledStartControlledStop = 'AS/CS (angled start/ controlled stop)',
+  controlledStop = 'Controlled Stop',
   uphillStart = 'UH (uphill start)',
   downhillStart = 'DH (downhill start)',
   hillStart = 'HS / DS (hill or designated start)',


### PR DESCRIPTION
## Description
Introduces logic which makes Controlled Stop a mandatory field on the test report page for Home tests.
## Checklist
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="185" alt="Screenshot 2020-05-27 at 11 38 36af3b6f06d7174cb7e42b6c14905a6b78cb0d590e3b1c07b002b9df395768a4e8" src="https://user-images.githubusercontent.com/28736958/83015250-0dd5dc00-a018-11ea-8eb2-cef85c12450a.png">