### PR TITLE
MES 5282 Terminate Screen Fix

### DIFF
--- a/src/pages/debrief/cat-cpc/__tests__/debrief.cat-cpc.page.spec.ts
+++ b/src/pages/debrief/cat-cpc/__tests__/debrief.cat-cpc.page.spec.ts
@@ -145,6 +145,23 @@ describe('DebriefCatCPCPage', () => {
         expect(navController.push).toHaveBeenCalledWith(CAT_CPC.POST_DEBRIEF_HOLDING_PAGE);
       });
     });
+    describe('isTerminated', () => {
+      it('should return true if the test outcome is terminated', () => {
+        component.outcome = 'Terminated';
+        const result = component.isTerminated();
+        expect(result).toEqual(true);
+      });
+      it('should return false if the test outcome is pass', () => {
+        component.outcome = 'Pass';
+        const result = component.isTerminated();
+        expect(result).toEqual(false);
+      });
+      it('should return false if the test outcome is fail', () => {
+        component.outcome = 'Fail';
+        const result = component.isTerminated();
+        expect(result).toEqual(false);
+      });
+    });
   });
 
   describe('DOM', () => {

--- a/src/pages/debrief/cat-cpc/debrief.cat-cpc.page.html
+++ b/src/pages/debrief/cat-cpc/debrief.cat-cpc.page.html
@@ -9,7 +9,8 @@
 </ion-header>
 
 <ion-content>
-  <debrief-cpc-card [overallScore]="pageState.overallScore$ | async"
+  <debrief-cpc-card *ngIf="!this.isTerminated()"
+    [overallScore]="pageState.overallScore$ | async"
                     [question1]="pageState.question1$ | async"
                     [question2]="pageState.question2$ | async"
                     [question3]="pageState.question3$ | async"

--- a/src/pages/debrief/cat-cpc/debrief.cat-cpc.page.ts
+++ b/src/pages/debrief/cat-cpc/debrief.cat-cpc.page.ts
@@ -29,8 +29,8 @@ import {
   getQuestion3, getQuestion4, getQuestion5, getTotalPercent,
 } from '../../../modules/tests/test-data/cat-cpc/test-data.cat-cpc.selector';
 import { getTestData } from '../../../modules/tests/test-data/cat-cpc/test-data.cat-cpc.reducer';
-import { TestOutcome } from '../../../shared/models/test-outcome';
 import { CAT_CPC } from '../../page-names.constants';
+import { TestOutcome } from '../../../shared/models/test-outcome';
 
 interface DebriefPageState {
   conductedLanguage$: Observable<string>;
@@ -133,6 +133,10 @@ export class DebriefCatCPCPage extends BasePageComponent {
       this.subscription.unsubscribe();
 
     }
+  }
+
+  isTerminated(): boolean {
+    return this.outcome !== TestOutcome.PASS && this.outcome !== TestOutcome.FAIL;
   }
 
   endDebrief(): void {

--- a/src/pages/debrief/cat-cpc/debrief.cat-cpc.page.ts
+++ b/src/pages/debrief/cat-cpc/debrief.cat-cpc.page.ts
@@ -30,6 +30,7 @@ import {
 } from '../../../modules/tests/test-data/cat-cpc/test-data.cat-cpc.selector';
 import { getTestData } from '../../../modules/tests/test-data/cat-cpc/test-data.cat-cpc.reducer';
 import { CAT_CPC } from '../../page-names.constants';
+import { TestOutcome as OutcomeType } from '../../../modules/tests/tests.constants';
 import { TestOutcome } from '../../../shared/models/test-outcome';
 
 interface DebriefPageState {
@@ -136,7 +137,7 @@ export class DebriefCatCPCPage extends BasePageComponent {
   }
 
   isTerminated(): boolean {
-    return this.outcome !== TestOutcome.PASS && this.outcome !== TestOutcome.FAIL;
+    return this.outcome === OutcomeType.Terminated;
   }
 
   endDebrief(): void {


### PR DESCRIPTION
## Description
Introduced logic to hide faults on debrief screen when test outcome is terminated
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="420" alt="Screenshot 2020-06-11 at 12 26 43" src="https://user-images.githubusercontent.com/28736958/84380165-d6059180-abde-11ea-9baa-cefaaa3f9f13.png">