### PR TITLE
MES-5368 Introduce adi2 logic to end test link

### DIFF
--- a/src/components/common/end-test-link/__tests__/end-test-link.spec.ts
+++ b/src/components/common/end-test-link/__tests__/end-test-link.spec.ts
@@ -3,7 +3,15 @@ import { EndTestLinkComponent } from '../end-test-link';
 import { IonicModule, ModalController, NavController } from 'ionic-angular';
 import { ModalControllerMock, NavControllerMock } from 'ionic-mocks';
 import { AppModule } from '../../../../app/app.module';
-import { CAT_B, CAT_BE, CAT_C, CAT_D, CAT_A_MOD1, CAT_A_MOD2 } from '../../../../pages/page-names.constants';
+import {
+  CAT_B,
+  CAT_BE,
+  CAT_C,
+  CAT_D,
+  CAT_A_MOD1,
+  CAT_A_MOD2,
+  CAT_ADI_PART2,
+} from '../../../../pages/page-names.constants';
 import { configureTestSuite } from 'ng-bullet';
 
 describe('EndTestLinkComponent', () => {
@@ -121,6 +129,15 @@ describe('EndTestLinkComponent', () => {
           const { calls } = navController.push as jasmine.Spy;
           expect(calls.argsFor(0)[0]).toBe(CAT_A_MOD2.DEBRIEF_PAGE);
         });
+      });
+
+      it('should dismiss the termination confirmation dialog and navigate to CAT ADI2 debrief', () => {
+        component.category = 'ADI2';
+        component.terminateTestModal = jasmine.createSpyObj('terminateTestModal', ['dismiss']);
+        component.onTerminate();
+        expect(component.terminateTestModal.dismiss).toHaveBeenCalled();
+        const { calls } = navController.push as jasmine.Spy;
+        expect(calls.argsFor(0)[0]).toBe(CAT_ADI_PART2.DEBRIEF_PAGE);
       });
 
     });

--- a/src/components/common/end-test-link/end-test-link.ts
+++ b/src/components/common/end-test-link/end-test-link.ts
@@ -7,7 +7,7 @@ import {
   CAT_D,
   CAT_A_MOD1,
   CAT_A_MOD2,
-  CAT_HOME_TEST, CAT_CPC,
+  CAT_HOME_TEST, CAT_CPC, CAT_ADI_PART2,
 } from '../../../pages/page-names.constants';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
@@ -42,6 +42,9 @@ export class EndTestLinkComponent {
   onTerminate = () => {
     this.terminateTestModal.dismiss();
     switch (this.category) {
+      case TestCategory.ADI2:
+        this.navController.push(CAT_ADI_PART2.DEBRIEF_PAGE);
+        break;
       case TestCategory.B:
         this.navController.push(CAT_B.DEBRIEF_PAGE);
         break;


### PR DESCRIPTION
## Description
Fixes the inability to end the test prior to test report for adi2 tests
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
