### PR TITLE
MES-5374 Allow N/A to be selected for show me questions on office page ADI2

### DIFF
--- a/src/pages/office/cat-adi-part2/components/show-me-questions/__tests__/show-me-questions.spec.ts
+++ b/src/pages/office/cat-adi-part2/components/show-me-questions/__tests__/show-me-questions.spec.ts
@@ -37,6 +37,10 @@ describe('ShowMeQuestionsCatADI2Component', () => {
 
   describe('Class', () => {
     describe('isOptionDisabled', () => {
+      it('should return false if the question code is N/A', () => {
+        const result = component.isOptionDisabled({ code: 'N/A', description: '', shortName: '' });
+        expect(result).toEqual(false);
+      });
       it(`should return true if the question is in the list of questions to disable
           and not equal to the currently selected question`,
         () => {

--- a/src/pages/office/cat-adi-part2/components/show-me-questions/show-me-questions.ts
+++ b/src/pages/office/cat-adi-part2/components/show-me-questions/show-me-questions.ts
@@ -107,6 +107,9 @@ export class ShowMeQuestionsCatADI2Component implements OnChanges, OnInit {
   }
 
   isOptionDisabled(question: VehicleChecksQuestion): boolean {
+    if (question.code === 'N/A') {
+      return false;
+    }
     const doesQuestionExist: QuestionResult =
       this.questionsToDisable.find(
         questionToDisable => questionToDisable.code === question.code &&

--- a/src/shared/constants/show-me-questions/show-me-questions.cat-adi-part2.constants.ts
+++ b/src/shared/constants/show-me-questions/show-me-questions.cat-adi-part2.constants.ts
@@ -48,6 +48,11 @@ export const questions: VehicleChecksQuestion[] = [
     description: 'When it is safe to do so can you show me how you would operate the cruise control.',
     shortName: 'Cruise control',
   },
+  {
+    code: 'N/A',
+    description: 'Not applicable.',
+    shortName: 'Not applicable',
+  },
 ];
 /* tslint:enable:max-line-length */
 


### PR DESCRIPTION
## Description
Allows N/A to be selected in the show me questions on office page.
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="390" alt="Screenshot 2020-06-26 at 10 43 38" src="https://user-images.githubusercontent.com/28736958/85843963-e8b0c680-b799-11ea-95c8-6681bea3d96a.png">
