### PR TITLE
MES-5509 ensure 0 values are displayed in mod 1 search result for speed reqs card

### DIFF
--- a/src/pages/view-test-result/cat-a-mod1/components/speed-card/speed-card.html
+++ b/src/pages/view-test-result/cat-a-mod1/components/speed-card/speed-card.html
@@ -5,12 +5,12 @@
         <label>Emergency Stop</label>
       </ion-col>
       <ion-col col-20 no-padding>
-        <div *ngIf=emergencyStop.firstAttempt>
+        <div *ngIf="(emergencyStop.firstAttempt || emergencyStop.firstAttempt === 0)">
           1st: {{emergencyStop.firstAttempt}}km/h
         </div>
       </ion-col>
       <ion-col col-20 no-padding>
-        <div *ngIf=emergencyStop.secondAttempt>
+        <div *ngIf="(emergencyStop.secondAttempt || emergencyStop.secondAttempt === 0)">
           2nd: {{emergencyStop.secondAttempt}}km/h
         </div>
       </ion-col>
@@ -37,12 +37,12 @@
         <label>Avoidance</label>
       </ion-col>
       <ion-col col-20 no-padding>
-        <div *ngIf=avoidance.firstAttempt>
+        <div *ngIf="(avoidance.firstAttempt || avoidance.firstAttempt === 0)">
           1st: {{avoidance.firstAttempt}}km/h
         </div>
       </ion-col>
       <ion-col col-20 no-padding>
-        <div *ngIf=avoidance.secondAttempt>
+        <div *ngIf="(avoidance.secondAttempt || avoidance.secondAttempt === 0)">
           2nd: {{avoidance.secondAttempt}}km/h
         </div>
       </ion-col>


### PR DESCRIPTION
## Description
- Fixes bug identified with Mod 1 Search results where 0 values are not displayed (this is due to Angular ngIf treating 0 values as falsy)

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![Screenshot 2020-08-03 at 16 14 54](https://user-images.githubusercontent.com/33055124/89200581-24645a80-d5a8-11ea-86db-35a17dd02a19.png)
![image](https://user-images.githubusercontent.com/33055124/89200547-17e00200-d5a8-11ea-81dd-a2c1c4e9252d.png)
