### PR TITLE
MES-5538 - Introduce delegated functionality for bypassing long press on manoeuvre competency

### DIFF
--- a/src/pages/test-report/components/manoeuvre-competency/manoeuvre-competency.html
+++ b/src/pages/test-report/components/manoeuvre-competency/manoeuvre-competency.html
@@ -1,5 +1,5 @@
 <div class="manoeuvre-competency-button"
-  (tap)="addOrRemoveFault()"
+  (tap)="addOrRemoveFault(this.isDelegated)"
   (press)="addOrRemoveFault(true)"
   (touchstart)="onTouchStart()"
   (touchend)="onTouchEnd()"

--- a/src/pages/test-report/components/manoeuvre-competency/manoeuvre-competency.ts
+++ b/src/pages/test-report/components/manoeuvre-competency/manoeuvre-competency.ts
@@ -21,12 +21,15 @@ import { map } from 'rxjs/operators';
 import { ManoeuvreOutcome } from '@dvsa/mes-test-schema/categories/common';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { ToggleSeriousFaultMode, ToggleDangerousFaultMode, ToggleRemoveFaultMode } from '../../test-report.actions';
+import { getDelegatedTestIndicator } from '../../../../modules/tests/delegated-test/delegated-test.reducer';
+import { isDelegatedTest } from '../../../../modules/tests/delegated-test/delegated-test.selector';
 
 interface ManoeuvreCompetencyComponentState {
   isRemoveFaultMode$: Observable<boolean>;
   isSeriousMode$: Observable<boolean>;
   isDangerousMode$: Observable<boolean>;
   manoeuvreCompetencyOutcome$: Observable<ManoeuvreOutcome | null>;
+  delegatedTest$: Observable<boolean>;
 }
 
 @Component({
@@ -56,6 +59,7 @@ export class ManoeuvreCompetencyComponent implements OnInit, OnDestroy {
   isRemoveFaultMode: boolean = false;
   isSeriousMode: boolean = false;
   isDangerousMode: boolean = false;
+  isDelegated: boolean = false;
   manoeuvreCompetencyOutcome: ManoeuvreOutcome | null;
 
   constructor(
@@ -91,6 +95,10 @@ export class ManoeuvreCompetencyComponent implements OnInit, OnDestroy {
           return null;
         }),
       ),
+      delegatedTest$: currentTest$.pipe(
+        select(getDelegatedTestIndicator),
+        select(isDelegatedTest),
+      ),
     };
 
     const {
@@ -98,12 +106,14 @@ export class ManoeuvreCompetencyComponent implements OnInit, OnDestroy {
       isSeriousMode$,
       isDangerousMode$,
       manoeuvreCompetencyOutcome$,
+      delegatedTest$,
     } = this.componentState;
 
     const merged$ = merge(
       isRemoveFaultMode$.pipe(map(toggle => this.isRemoveFaultMode = toggle)),
       isSeriousMode$.pipe(map(toggle => this.isSeriousMode = toggle)),
       isDangerousMode$.pipe(map(toggle => this.isDangerousMode = toggle)),
+      delegatedTest$.pipe(map(toggle => this.isDelegated = toggle)),
       manoeuvreCompetencyOutcome$.pipe(map(outcome => this.manoeuvreCompetencyOutcome = outcome)),
     );
 


### PR DESCRIPTION
## Description
Introduces logic to allow for delegated examiners to skip the long press restraint for adding faults inside of the manoeuvre competencies.
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
