### PR TITLE
MES-5778: Navigating to office pages when ending a delegated test on WRTC

### DIFF
--- a/src/components/common/end-test-link/__tests__/end-test-link.spec.ts
+++ b/src/components/common/end-test-link/__tests__/end-test-link.spec.ts
@@ -11,6 +11,7 @@ import {
   CAT_A_MOD1,
   CAT_A_MOD2,
   CAT_ADI_PART2,
+  CAT_CPC,
 } from '../../../../pages/page-names.constants';
 import { configureTestSuite } from 'ng-bullet';
 
@@ -138,6 +139,58 @@ describe('EndTestLinkComponent', () => {
         expect(component.terminateTestModal.dismiss).toHaveBeenCalled();
         const { calls } = navController.push as jasmine.Spy;
         expect(calls.argsFor(0)[0]).toBe(CAT_ADI_PART2.DEBRIEF_PAGE);
+      });
+
+      describe('delegate tests navigate to Office page', () => {
+
+        beforeEach(() => {
+          component.isDelegated = true;
+        });
+
+        it('should dismiss the termination confirmation dialog and navigate to CAT BE Office Page', () => {
+          component.category = 'B+E';
+          component.terminateTestModal = jasmine.createSpyObj('terminateTestModal', ['dismiss']);
+          component.onTerminate();
+          expect(component.terminateTestModal.dismiss).toHaveBeenCalled();
+          const { calls } = navController.push as jasmine.Spy;
+          expect(calls.argsFor(0)[0]).toBe(CAT_BE.OFFICE_PAGE);
+        });
+
+        it('should dismiss the termination confirmation dialog and navigate to CAT C Office Page', () => {
+          component.category = 'C';
+          component.terminateTestModal = jasmine.createSpyObj('terminateTestModal', ['dismiss']);
+          component.onTerminate();
+          expect(component.terminateTestModal.dismiss).toHaveBeenCalled();
+          const { calls } = navController.push as jasmine.Spy;
+          expect(calls.argsFor(0)[0]).toBe(CAT_C.OFFICE_PAGE);
+        });
+
+        it('should dismiss the termination confirmation dialog and navigate to CAT (C)CPC Office Page', () => {
+          component.category = 'CCPC';
+          component.terminateTestModal = jasmine.createSpyObj('terminateTestModal', ['dismiss']);
+          component.onTerminate();
+          expect(component.terminateTestModal.dismiss).toHaveBeenCalled();
+          const { calls } = navController.push as jasmine.Spy;
+          expect(calls.argsFor(0)[0]).toBe(CAT_CPC.OFFICE_PAGE);
+        });
+
+        it('should dismiss the termination confirmation dialog and navigate to CAT (D)CPC Office Page', () => {
+          component.category = 'DCPC';
+          component.terminateTestModal = jasmine.createSpyObj('terminateTestModal', ['dismiss']);
+          component.onTerminate();
+          expect(component.terminateTestModal.dismiss).toHaveBeenCalled();
+          const { calls } = navController.push as jasmine.Spy;
+          expect(calls.argsFor(0)[0]).toBe(CAT_CPC.OFFICE_PAGE);
+        });
+
+        it('should dismiss the termination confirmation dialog and navigate to CAT D Office Page', () => {
+          component.category = 'D';
+          component.terminateTestModal = jasmine.createSpyObj('terminateTestModal', ['dismiss']);
+          component.onTerminate();
+          expect(component.terminateTestModal.dismiss).toHaveBeenCalled();
+          const { calls } = navController.push as jasmine.Spy;
+          expect(calls.argsFor(0)[0]).toBe(CAT_D.OFFICE_PAGE);
+        });
       });
 
     });

--- a/src/components/common/end-test-link/end-test-link.ts
+++ b/src/components/common/end-test-link/end-test-link.ts
@@ -23,6 +23,9 @@ export class EndTestLinkComponent {
   @Input()
   shouldAuthenticate: boolean = true;
 
+  @Input()
+  isDelegated: boolean = false;
+
   constructor(
     public modalController: ModalController,
     public navController: NavController,
@@ -45,6 +48,12 @@ export class EndTestLinkComponent {
 
   onTerminate = () => {
     this.terminateTestModal.dismiss();
+
+    if (this.isDelegated) {
+      this.navigateToOfficePage();
+      return;
+    }
+
     switch (this.category) {
       case TestCategory.ADI2:
         this.navController.push(CAT_ADI_PART2.DEBRIEF_PAGE);
@@ -82,6 +91,24 @@ export class EndTestLinkComponent {
       case TestCategory.EUAM2:
       case TestCategory.EUAMM2:
         this.navController.push(CAT_A_MOD2.DEBRIEF_PAGE);
+        break;
+    }
+  }
+
+  navigateToOfficePage = () => {
+    switch (this.category) {
+      case TestCategory.BE:
+        this.navController.push(CAT_BE.OFFICE_PAGE);
+        break;
+      case TestCategory.C:
+        this.navController.push(CAT_C.OFFICE_PAGE);
+        break;
+      case TestCategory.CCPC:
+      case TestCategory.DCPC:
+        this.navController.push(CAT_CPC.OFFICE_PAGE);
+        break;
+      case TestCategory.D:
+        this.navController.push(CAT_D.OFFICE_PAGE);
         break;
     }
   }

--- a/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.html
+++ b/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.html
@@ -2,7 +2,7 @@
   <ion-navbar [hideBackButton]="!(pageState.delegatedTest$ | async)">
     <ion-title>{{pageState.candidateName$ | async}}</ion-title>
     <ion-buttons end>
-      <end-test-link [shouldAuthenticate]="false" category="B+E"></end-test-link>
+      <end-test-link [shouldAuthenticate]="false" category="B+E" [isDelegated]="isDelegated"></end-test-link>
     </ion-buttons>
   </ion-navbar>
 </ion-header>

--- a/src/pages/waiting-room-to-car/cat-c/waiting-room-to-car.cat-c.page.html
+++ b/src/pages/waiting-room-to-car/cat-c/waiting-room-to-car.cat-c.page.html
@@ -2,7 +2,7 @@
   <ion-navbar [hideBackButton]="!(pageState.delegatedTest$ | async)">
     <ion-title>{{pageState.candidateName$ | async}}</ion-title>
     <ion-buttons end>
-      <end-test-link [shouldAuthenticate]="false" category="C"></end-test-link>
+      <end-test-link [shouldAuthenticate]="false" category="C" [isDelegated]="isDelegated"></end-test-link>
     </ion-buttons>
   </ion-navbar>
 </ion-header>

--- a/src/pages/waiting-room-to-car/cat-cpc/waiting-room-to-car.cat-cpc.page.html
+++ b/src/pages/waiting-room-to-car/cat-cpc/waiting-room-to-car.cat-cpc.page.html
@@ -2,7 +2,7 @@
   <ion-navbar [hideBackButton]="!(pageState.delegatedTest$ | async)">
     <ion-title>{{pageState.candidateName$ | async}}</ion-title>
     <ion-buttons end>
-      <end-test-link [shouldAuthenticate]="false" [category]="testCategory"></end-test-link>
+      <end-test-link [shouldAuthenticate]="false" [category]="testCategory" [isDelegated]="isDelegated"></end-test-link>
     </ion-buttons>
   </ion-navbar>
 </ion-header>

--- a/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.html
+++ b/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.html
@@ -2,7 +2,7 @@
   <ion-navbar [hideBackButton]="!(pageState.delegatedTest$ | async)">
     <ion-title>{{pageState.candidateName$ | async}}</ion-title>
     <ion-buttons end>
-      <end-test-link [shouldAuthenticate]="false" category="D"></end-test-link>
+      <end-test-link [shouldAuthenticate]="false" category="D" [isDelegated]="isDelegated"></end-test-link>
     </ion-buttons>
   </ion-navbar>
 </ion-header>


### PR DESCRIPTION
## Description

When Terminating a delegated driving test rekey from the Waiting Room To Car page we want to navigate to the Office page directly.
That's what this PR makes happen

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
