### PR TITLE
MES-5436: Use real delegated rekey search

### DIFF
--- a/src/pages/delegated-rekey-search/__tests__/delegated-rekey-search.effects.spec.ts
+++ b/src/pages/delegated-rekey-search/__tests__/delegated-rekey-search.effects.spec.ts
@@ -1,5 +1,5 @@
 import { DelegatedRekeySearchEffects } from '../delegated-rekey-search.effects';
-import { defer, ReplaySubject } from 'rxjs';
+import { defer, of, ReplaySubject } from 'rxjs';
 import { async, TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 import { delegatedSearchReducer } from '../delegated-rekey-search.reducer';
@@ -12,6 +12,12 @@ import { SearchProvider } from '../../../providers/search/search';
 import { HttpStatusCodes } from '../../../shared/models/http-status-codes';
 import { SearchProviderMock } from '../../../providers/search/__mocks__/search.mock';
 import { DelegatedRekeySearchErrorMessages } from '../delegated-rekey-search-error-model';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { UrlProvider } from '../../../providers/url/url';
+import { UrlProviderMock } from '../../../providers/url/__mocks__/url.mock';
+import { AppConfigProvider } from '../../../providers/app-config/app-config';
+import { AppConfigProviderMock } from '../../../providers/app-config/__mocks__/app-config.mock';
+import { mockGetDelegatedBooking } from '../../../providers/delegated-rekey-search/mock-data/delegated-mock-data';
 
 describe('Delegated Rekey Search Effects', () => {
 
@@ -33,6 +39,7 @@ describe('Delegated Rekey Search Effects', () => {
   configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [
+        HttpClientTestingModule,
         StoreModule.forRoot({
           delegatedRekeySearch: delegatedSearchReducer,
         }),
@@ -42,7 +49,9 @@ describe('Delegated Rekey Search Effects', () => {
         provideMockActions(() => actions$),
         Store,
         DelegatedRekeySearchProvider,
+        { provide: UrlProvider, useClass: UrlProviderMock },
         { provide: SearchProvider, useClass: SearchProviderMock },
+        { provide: AppConfigProvider, useClass: AppConfigProviderMock },
       ],
     });
   });
@@ -56,7 +65,8 @@ describe('Delegated Rekey Search Effects', () => {
 
   it('should dispatch the SearchBookedTestSuccess action when searched with success', (done) => {
 
-    spyOn(delegatedRekeySearchProvider, 'getDelegatedExaminerBookingByAppRef').and.callThrough();
+    spyOn(delegatedRekeySearchProvider, 'getDelegatedExaminerBookingByAppRef')
+      .and.returnValue(of(mockGetDelegatedBooking()));
     spyOn(searchProvider, 'getTestResult')
       .and.returnValue(asyncError(getTestResultHttpErrorResponse(HttpStatusCodes.BAD_REQUEST)));
     actions$.next(new delegatedRekeySearchActions.SearchBookedDelegatedTest('12345678910'));
@@ -91,7 +101,8 @@ describe('Delegated Rekey Search Effects', () => {
   it('should call getDelegatedExaminerBookingByAppRef on the test search provider', (done) => {
     spyOn(searchProvider, 'getTestResult')
       .and.returnValue(asyncError(getTestResultHttpErrorResponse(HttpStatusCodes.BAD_REQUEST)));
-    spyOn(delegatedRekeySearchProvider, 'getDelegatedExaminerBookingByAppRef').and.callThrough();
+    spyOn(delegatedRekeySearchProvider, 'getDelegatedExaminerBookingByAppRef')
+      .and.returnValue(of(mockGetDelegatedBooking()));
 
     actions$.next(new delegatedRekeySearchActions.SearchBookedDelegatedTest(appRef));
 
@@ -104,7 +115,8 @@ describe('Delegated Rekey Search Effects', () => {
 
   it('should not call getBooking if getTestResult succeeds', (done) => {
 
-    spyOn(delegatedRekeySearchProvider, 'getDelegatedExaminerBookingByAppRef').and.callThrough();
+    spyOn(delegatedRekeySearchProvider, 'getDelegatedExaminerBookingByAppRef')
+      .and.returnValue(of(mockGetDelegatedBooking()));
 
     const expectedFailureAction = new delegatedRekeySearchActions.SearchBookedDelegatedTestFailure({
       message: DelegatedRekeySearchErrorMessages.BookingAlreadyCompleted,

--- a/src/pages/delegated-rekey-search/delegated-rekey-search-error-model.ts
+++ b/src/pages/delegated-rekey-search/delegated-rekey-search-error-model.ts
@@ -4,4 +4,5 @@ export interface DelegatedRekeySearchError {
 
 export enum DelegatedRekeySearchErrorMessages {
   BookingAlreadyCompleted = 'BookingAlreadyCompleted',
+  MappingToTestSlotError = 'Error mapping delegated examiner search response to test slot',
 }

--- a/src/pages/delegated-rekey-search/delegated-rekey-search.effects.ts
+++ b/src/pages/delegated-rekey-search/delegated-rekey-search.effects.ts
@@ -37,10 +37,6 @@ export class DelegatedRekeySearchEffects {
         catchError((err: HttpErrorResponse): Observable<DelegatedRekeySearchActionTypes> => {
           if (err.status === HttpStatusCodes.BAD_REQUEST) {
             return this.delegatedRekeySearchProvider.getDelegatedExaminerBookingByAppRef(action.appRef).pipe(
-              // @TODO - MES-5436 - map real response once available
-              map((response: HttpResponse<any>) => {
-                return response.body;
-              }),
               map((testSlot: any) => new SearchBookedDelegatedTestSuccess(testSlot)),
               catchError((err: any) => {
                 return of(new SearchBookedDelegatedTestFailure(err));

--- a/src/pages/delegated-rekey-search/delegated-rekey-search.effects.ts
+++ b/src/pages/delegated-rekey-search/delegated-rekey-search.effects.ts
@@ -44,7 +44,7 @@ export class DelegatedRekeySearchEffects {
                   delegatedExaminerTestSlot = {
                     booking: {
                       application: {
-                        applicationId: response.testSlot.application.applicationId,
+                        applicationId: response.testSlot.booking.application.applicationId,
                         bookingSequence: response.testSlot.booking.application.bookingSequence,
                         checkDigit: response.testSlot.booking.application.checkDigit,
                         testCategory: response.testSlot.booking.application.testCategory,

--- a/src/pages/delegated-rekey-search/delegated-rekey-search.effects.ts
+++ b/src/pages/delegated-rekey-search/delegated-rekey-search.effects.ts
@@ -79,6 +79,7 @@ export class DelegatedRekeySearchEffects {
           }
           return of(new SearchBookedDelegatedTestFailure(err));
         }),
+        catchError(err => of(new SearchBookedDelegatedTestFailure(err))),
       );
     }),
   );

--- a/src/pages/delegated-rekey-search/delegated-rekey-search.effects.ts
+++ b/src/pages/delegated-rekey-search/delegated-rekey-search.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Effect, Actions, ofType } from '@ngrx/effects';
 import { DelegatedRekeySearchProvider } from '../../providers/delegated-rekey-search/delegated-rekey-search';
-import { switchMap, map, catchError } from 'rxjs/operators';
+import { switchMap, catchError } from 'rxjs/operators';
 import { Observable, of } from 'rxjs';
 import {
   SEARCH_BOOKED_DELEGATED_TEST,
@@ -13,6 +13,7 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { HttpStatusCodes } from '../../shared/models/http-status-codes';
 import { SearchProvider } from '../../providers/search/search';
 import { DelegatedRekeySearchErrorMessages } from './delegated-rekey-search-error-model';
+import { DelegatedExaminerTestSlot } from 'src/providers/delegated-rekey-search/mock-data/delegated-mock-data';
 
 @Injectable()
 export class DelegatedRekeySearchEffects {
@@ -37,9 +38,42 @@ export class DelegatedRekeySearchEffects {
         catchError((err: HttpErrorResponse): Observable<DelegatedRekeySearchActionTypes> => {
           if (err.status === HttpStatusCodes.BAD_REQUEST) {
             return this.delegatedRekeySearchProvider.getDelegatedExaminerBookingByAppRef(action.appRef).pipe(
-              map((testSlot: any) => new SearchBookedDelegatedTestSuccess(testSlot)),
-              catchError((err: any) => {
-                return of(new SearchBookedDelegatedTestFailure(err));
+              switchMap((response: any): Observable<any> => {
+                let delegatedExaminerTestSlot: DelegatedExaminerTestSlot;
+                try {
+                  delegatedExaminerTestSlot = {
+                    booking: {
+                      application: {
+                        applicationId: response.testSlot.application.applicationId,
+                        bookingSequence: response.testSlot.booking.application.bookingSequence,
+                        checkDigit: response.testSlot.booking.application.checkDigit,
+                        testCategory: response.testSlot.booking.application.testCategory,
+                        welshTest: false,
+                      },
+                      candidate: {
+                        candidateName: {
+                          firstName: response.testSlot.booking.candidate.candidateName.firstName,
+                          lastName: response.testSlot.booking.candidate.candidateName.lastName,
+                        },
+                        driverNumber: response.testSlot.booking.candidate.driverNumber,
+                        dateOfBirth: response.testSlot.booking.candidate.dateOfBirth,
+                      },
+                    },
+                    slotDetail: {
+                      slotId: response.testSlot.slotDetail.slotId,
+                      start: response.testSlot.slotDetail.start,
+                    },
+                    vehicleTypeCode: response.testSlot.vehicleTypeCode,
+                    examinerId: response.examinerId,
+                  };
+                  return of(new SearchBookedDelegatedTestSuccess(delegatedExaminerTestSlot));
+                } catch (err) {
+                  return of(
+                    new SearchBookedDelegatedTestFailure({
+                      message: DelegatedRekeySearchErrorMessages.MappingToTestSlotError,
+                    }),
+                  );
+                }
               }),
             );
           }

--- a/src/providers/app-config/app-config.ts
+++ b/src/providers/app-config/app-config.ts
@@ -238,6 +238,7 @@ export class AppConfigProvider {
       journal: {
         journalUrl: data.journal.journalUrl,
         searchBookingUrl: data.journal.searchBookingUrl,
+        delegatedExaminerSearchBookingUrl: data.journal.delegatedExaminerSearchBookingUrl,
         autoRefreshInterval: data.journal.autoRefreshInterval || 15000,
         numberOfDaysToView: data.journal.numberOfDaysToView,
         daysToCacheJournalData: data.journal.daysToCacheJournalData,

--- a/src/providers/delegated-rekey-search/delegated-rekey-search.ts
+++ b/src/providers/delegated-rekey-search/delegated-rekey-search.ts
@@ -1,24 +1,59 @@
-import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { timeout } from 'rxjs/operators';
-
-import { AppConfigProvider } from '../app-config/app-config';
-import { UrlProvider } from '../url/url';
+import { Observable, of, throwError } from 'rxjs';
+import { getDelegatedBooking } from './mock-data/delegated-mock-data';
+import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 @Injectable()
 export class DelegatedRekeySearchProvider {
 
-  constructor(
-    private http: HttpClient,
-    private urlProvider: UrlProvider,
-    private appConfig: AppConfigProvider,
-  ) { }
+  applicationReferences = [
+    { referenceNumber: '12345678910', testCategory: TestCategory.BE, isWelshTest: false, slotId: 1234567 },
+    { referenceNumber: '12345678911', testCategory: TestCategory.BE, isWelshTest: true, slotId: 1234568 },
+    { referenceNumber: '12345678912', testCategory: TestCategory.C, isWelshTest: false, slotId: 1234569 },
+    { referenceNumber: '12345678913', testCategory: TestCategory.C, isWelshTest: true, slotId: 1234570 },
+    { referenceNumber: '12345678914', testCategory: TestCategory.C1, isWelshTest: false, slotId: 1234571 },
+    { referenceNumber: '12345678915', testCategory: TestCategory.C1, isWelshTest: true, slotId: 1234572 },
+    { referenceNumber: '12345678916', testCategory: TestCategory.C1E, isWelshTest: false, slotId: 1234573 },
+    { referenceNumber: '12345678917', testCategory: TestCategory.C1E, isWelshTest: true, slotId: 1234574 },
+    { referenceNumber: '12345678918', testCategory: TestCategory.CE, isWelshTest: false, slotId: 1234575 },
+    { referenceNumber: '12345678919', testCategory: TestCategory.CE, isWelshTest: true, slotId: 1234576 },
+    { referenceNumber: '12345678920', testCategory: TestCategory.D, isWelshTest: false, slotId: 1234577 },
+    { referenceNumber: '12345678921', testCategory: TestCategory.D, isWelshTest: true, slotId: 1234578 },
+    { referenceNumber: '12345678922', testCategory: TestCategory.D1, isWelshTest: false, slotId: 1234579 },
+    { referenceNumber: '12345678923', testCategory: TestCategory.D1, isWelshTest: true, slotId: 1234580 },
+    { referenceNumber: '12345678924', testCategory: TestCategory.DE, isWelshTest: false, slotId: 1234581 },
+    { referenceNumber: '12345678925', testCategory: TestCategory.DE, isWelshTest: true, slotId: 1234582 },
+    { referenceNumber: '12345678926', testCategory: TestCategory.D1E, isWelshTest: false, slotId: 1234583 },
+    { referenceNumber: '12345678927', testCategory: TestCategory.D1E, isWelshTest: true, slotId: 1234584 },
+    { referenceNumber: '12345678928', testCategory: TestCategory.CCPC, isWelshTest: false, slotId: 1234585 },
+    { referenceNumber: '12345678929', testCategory: TestCategory.CCPC, isWelshTest: true, slotId: 1234586 },
+    { referenceNumber: '12345678930', testCategory: TestCategory.DCPC, isWelshTest: false, slotId: 1234587 },
+    { referenceNumber: '12345678931', testCategory: TestCategory.DCPC, isWelshTest: true, slotId: 1234588 },
+  ];
+  constructor() {
+  }
 
   getDelegatedExaminerBookingByAppRef(applicationReference: string): Observable<Object> {
-    return this.http.get(
-      this.urlProvider.getDelegatedExaminerSearchBookingUrl(applicationReference),
-    ).pipe(timeout(this.appConfig.getAppConfig().requestTimeout));
+    // @TODO - MES-5436 mock responses added. Implementation needed once delegated end point is available
+    const foundReference = this.applicationReferences.find((ref) => {
+      return applicationReference === ref.referenceNumber;
+    });
+    if (foundReference) {
+      return of(new HttpResponse({
+        status: 200,
+        body: getDelegatedBooking(foundReference.testCategory, foundReference.isWelshTest, foundReference.slotId),
+      }));
+    }
+    if (applicationReference === '12345678950') {
+      return throwError(new HttpErrorResponse({
+        error: 'Internal server error',
+        status: 500,
+      }));
+    }
+    return of(new HttpResponse({
+      status: 204,
+    }));
   }
 
 }

--- a/src/providers/delegated-rekey-search/delegated-rekey-search.ts
+++ b/src/providers/delegated-rekey-search/delegated-rekey-search.ts
@@ -1,59 +1,24 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, of, throwError } from 'rxjs';
-import { getDelegatedBooking } from './mock-data/delegated-mock-data';
-import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
-import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { Observable } from 'rxjs';
+import { timeout } from 'rxjs/operators';
+
+import { AppConfigProvider } from '../app-config/app-config';
+import { UrlProvider } from '../url/url';
 
 @Injectable()
 export class DelegatedRekeySearchProvider {
 
-  applicationReferences = [
-    { referenceNumber: '12345678910', testCategory: TestCategory.BE, isWelshTest: false, slotId: 1234567 },
-    { referenceNumber: '12345678911', testCategory: TestCategory.BE, isWelshTest: true, slotId: 1234568 },
-    { referenceNumber: '12345678912', testCategory: TestCategory.C, isWelshTest: false, slotId: 1234569 },
-    { referenceNumber: '12345678913', testCategory: TestCategory.C, isWelshTest: true, slotId: 1234570 },
-    { referenceNumber: '12345678914', testCategory: TestCategory.C1, isWelshTest: false, slotId: 1234571 },
-    { referenceNumber: '12345678915', testCategory: TestCategory.C1, isWelshTest: true, slotId: 1234572 },
-    { referenceNumber: '12345678916', testCategory: TestCategory.C1E, isWelshTest: false, slotId: 1234573 },
-    { referenceNumber: '12345678917', testCategory: TestCategory.C1E, isWelshTest: true, slotId: 1234574 },
-    { referenceNumber: '12345678918', testCategory: TestCategory.CE, isWelshTest: false, slotId: 1234575 },
-    { referenceNumber: '12345678919', testCategory: TestCategory.CE, isWelshTest: true, slotId: 1234576 },
-    { referenceNumber: '12345678920', testCategory: TestCategory.D, isWelshTest: false, slotId: 1234577 },
-    { referenceNumber: '12345678921', testCategory: TestCategory.D, isWelshTest: true, slotId: 1234578 },
-    { referenceNumber: '12345678922', testCategory: TestCategory.D1, isWelshTest: false, slotId: 1234579 },
-    { referenceNumber: '12345678923', testCategory: TestCategory.D1, isWelshTest: true, slotId: 1234580 },
-    { referenceNumber: '12345678924', testCategory: TestCategory.DE, isWelshTest: false, slotId: 1234581 },
-    { referenceNumber: '12345678925', testCategory: TestCategory.DE, isWelshTest: true, slotId: 1234582 },
-    { referenceNumber: '12345678926', testCategory: TestCategory.D1E, isWelshTest: false, slotId: 1234583 },
-    { referenceNumber: '12345678927', testCategory: TestCategory.D1E, isWelshTest: true, slotId: 1234584 },
-    { referenceNumber: '12345678928', testCategory: TestCategory.CCPC, isWelshTest: false, slotId: 1234585 },
-    { referenceNumber: '12345678929', testCategory: TestCategory.CCPC, isWelshTest: true, slotId: 1234586 },
-    { referenceNumber: '12345678930', testCategory: TestCategory.DCPC, isWelshTest: false, slotId: 1234587 },
-    { referenceNumber: '12345678931', testCategory: TestCategory.DCPC, isWelshTest: true, slotId: 1234588 },
-  ];
-  constructor() {
-  }
+  constructor(
+    private http: HttpClient,
+    private urlProvider: UrlProvider,
+    private appConfig: AppConfigProvider,
+  ) { }
 
   getDelegatedExaminerBookingByAppRef(applicationReference: string): Observable<Object> {
-    // @TODO - MES-5436 mock responses added. Implementation needed once delegated end point is available
-    const foundReference = this.applicationReferences.find((ref) => {
-      return applicationReference === ref.referenceNumber;
-    });
-    if (foundReference) {
-      return of(new HttpResponse({
-        status: 200,
-        body: getDelegatedBooking(foundReference.testCategory, foundReference.isWelshTest, foundReference.slotId),
-      }));
-    }
-    if (applicationReference === '12345678950') {
-      return throwError(new HttpErrorResponse({
-        error: 'Internal server error',
-        status: 500,
-      }));
-    }
-    return of(new HttpResponse({
-      status: 204,
-    }));
+    return this.http.get(
+      this.urlProvider.getDelegatedExaminerSearchBookingUrl(applicationReference),
+    ).pipe(timeout(this.appConfig.getAppConfig().requestTimeout));
   }
 
 }

--- a/src/providers/delegated-rekey-search/mock-data/delegated-mock-data.ts
+++ b/src/providers/delegated-rekey-search/mock-data/delegated-mock-data.ts
@@ -6,34 +6,36 @@ export interface DelegatedExaminerTestSlot extends TestSlot {
   examinerId: number;
 }
 
-export function getDelegatedBooking(
-  category: TestCategory,
-  isWelshTest: boolean,
-  slotNumber: number,
-): DelegatedExaminerTestSlot {
+export function mockGetDelegatedBooking(
+  category: TestCategory = TestCategory.B,
+  isWelshTest: boolean = false,
+  slotNumber: number = 1,
+): any {
   return {
-    booking: {
-      application: {
-        applicationId: 22123411,
-        bookingSequence: 3,
-        checkDigit: 1,
-        testCategory: category,
-        welshTest: isWelshTest,
-      },
-      candidate: {
-        candidateName: {
-          firstName: 'A Delegated',
-          lastName: 'Candidate',
-        },
-        driverNumber: 'DAVID015220A99HC',
-        dateOfBirth: '1980-01-01',
-      },
-    },
-    slotDetail: {
-      slotId: slotNumber,
-      start: '2020-07-15T08:10:00',
-    },
-    vehicleTypeCode: category,
     examinerId: 4583912,
+    testSlot: {
+      slotDetail: {
+        slotId: '35294119',
+        start: '2020-09-17T08:00:00',
+      },
+      vehicleTypeCode: 'V4',
+      vehicleSlotTypeCode: '122',
+      booking: {
+        candidate: {
+          driverNumber: 'RED99808065W97NM',
+          dateOfBirth: '1985-08-06',
+          candidateName: {
+            firstName: 'Dele',
+            lastName: 'Gated-Exam',
+          },
+        },
+        application: {
+          applicationId: '24306741',
+          bookingSequence: 1,
+          checkDigit: 0,
+          testCategory: 'CCPC',
+        },
+      },
+    },
   };
 }

--- a/src/providers/url/url.ts
+++ b/src/providers/url/url.ts
@@ -28,7 +28,9 @@ export class UrlProvider {
 
   getDelegatedExaminerSearchBookingUrl(applicationReference: string): string {
     const urlTemplate = this.appConfigProvider.getAppConfig().journal.delegatedExaminerSearchBookingUrl;
-    return urlTemplate.replace('{staffNumber}', isNil(applicationReference) ? '00000000' : applicationReference);
+    return urlTemplate.replace(
+      '{applicationReference}', isNil(applicationReference) ? '00000000' : applicationReference,
+    );
   }
 
   getRekeySearchUrl(staffNumber: string): string {


### PR DESCRIPTION
## Description

- Removes mock for delegated examiner search
- Maps the server response to the correct shape needed to render the test slot
- Updates unit tests

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
