### PR TITLE
mes-5843 expire tokens on app launch

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="uk.gov.dvsa.mobile-examiner-app" version="3.8.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="uk.gov.dvsa.mobile-examiner-app" version="3.8.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>DrivingExaminerService</name>
     <description>An application for DVSA driving examiners to conduct driving tests</description>
     <author email="mobexaminer@gmail.com">MES Team</author>

--- a/src/pages/login/__tests__/login.spec.ts
+++ b/src/pages/login/__tests__/login.spec.ts
@@ -256,6 +256,7 @@ describe('LoginPage', () => {
       component.initialiseAppConfig = jasmine.createSpy('component.initialiseAppConfig');
       component.initialiseAuthentication = jasmine.createSpy('component.initialiseAuthentication');
       component.authenticationProvider.login = jasmine.createSpy('authenticationProvider.login');
+      component.authenticationProvider.expireTokens = jasmine.createSpy('authenticationProvider.expireTokens ');
       component.appConfigProvider.loadRemoteConfig = jasmine.createSpy('appConfigProvider.loadRemoteConfig');
       component.analytics.initialiseAnalytics = jasmine.createSpy('analytics.initialiseAnalytics');
       component.validateDeviceType = jasmine.createSpy('component.validateDeviceType');
@@ -269,6 +270,7 @@ describe('LoginPage', () => {
       // Shouldn't be called
       expect(component.initialiseAppConfig).not.toHaveBeenCalled();
       expect(component.initialiseAuthentication).not.toHaveBeenCalled();
+      expect(component.authenticationProvider.expireTokens).not.toHaveBeenCalled();
       expect(component.authenticationProvider.login).not.toHaveBeenCalled();
       expect(component.initialisePersistentStorage).not.toHaveBeenCalled();
       expect(component.appConfigProvider.loadRemoteConfig).not.toHaveBeenCalled();
@@ -286,6 +288,7 @@ describe('LoginPage', () => {
       expect(component.platform.ready).toHaveBeenCalled();
       // Shouldn't be called
       expect(component.initialiseAuthentication).not.toHaveBeenCalled();
+      expect(component.authenticationProvider.expireTokens).not.toHaveBeenCalled();
       expect(component.authenticationProvider.login).not.toHaveBeenCalled();
       expect(component.initialisePersistentStorage).not.toHaveBeenCalled();
       expect(component.appConfigProvider.loadRemoteConfig).not.toHaveBeenCalled();
@@ -304,6 +307,7 @@ describe('LoginPage', () => {
       expect(component.platform.ready).toHaveBeenCalled();
       expect(component.initialiseAppConfig).toHaveBeenCalled();
       expect(component.initialisePersistentStorage).toHaveBeenCalled();
+      expect(component.authenticationProvider.expireTokens).toHaveBeenCalled();
       // Shouldn't be called
       expect(component.appConfigProvider.loadRemoteConfig).not.toHaveBeenCalled();
       expect(component.analytics.initialiseAnalytics).not.toHaveBeenCalled();
@@ -321,6 +325,7 @@ describe('LoginPage', () => {
       expect(component.initialiseAppConfig).toHaveBeenCalled();
       expect(component.initialisePersistentStorage).toHaveBeenCalled();
       // Shouldn't be called
+      expect(component.authenticationProvider.expireTokens).not.toHaveBeenCalled();
       expect(component.appConfigProvider.loadRemoteConfig).not.toHaveBeenCalled();
       expect(component.analytics.initialiseAnalytics).not.toHaveBeenCalled();
       expect(component.validateDeviceType).not.toHaveBeenCalled();
@@ -336,6 +341,7 @@ describe('LoginPage', () => {
       expect(component.platform.ready).toHaveBeenCalled();
       expect(component.initialiseAppConfig).toHaveBeenCalled();
       expect(component.initialisePersistentStorage).toHaveBeenCalled();
+      expect(component.authenticationProvider.expireTokens).toHaveBeenCalled();
       expect(component.appConfigProvider.loadRemoteConfig).toHaveBeenCalled();
       // Shouldn't be called
       expect(component.analytics.initialiseAnalytics).not.toHaveBeenCalled();

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -97,6 +97,8 @@ export class LoginPage extends BasePageComponent {
 
       await this.initialisePersistentStorage();
 
+      await this.authenticationProvider.expireTokens();
+
       const isAuthenticated = await this.authenticationProvider.isAuthenticated();
 
       if (!isAuthenticated) {

--- a/src/providers/authentication/__mocks__/authentication.mock.ts
+++ b/src/providers/authentication/__mocks__/authentication.mock.ts
@@ -22,4 +22,7 @@ export class AuthenticationProviderMock {
   logoutEnabled = jasmine.createSpy('logoutEnabled').and.returnValue(true);
 
   setEmployeeId = jasmine.createSpy('setEmployeeId').and.returnValue(Promise.resolve());
+
+  expireTokens = jasmine.createSpy('expireTokens').and.returnValue(Promise.resolve());
+
 }

--- a/src/providers/authentication/__tests__/authentication.spec.ts
+++ b/src/providers/authentication/__tests__/authentication.spec.ts
@@ -165,5 +165,12 @@ describe('Authentication', () => {
         expect(logoutEnabled).toEqual(true);
       });
     });
+    describe('expireTokens', () => {
+      it('should call through to ionic auth expire() method', async() => {
+        spyOn(authenticationProvider.ionicAuth, 'expire').and.returnValue(Promise.resolve());
+        await authenticationProvider.expireTokens();
+        expect(authenticationProvider.ionicAuth.expire).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/providers/authentication/authentication.ts
+++ b/src/providers/authentication/authentication.ts
@@ -50,6 +50,10 @@ export class AuthenticationProvider {
     };
   }
 
+  public async expireTokens(): Promise<void> {
+    await this.ionicAuth.expire();
+  }
+
   private async getToken(tokenName: Token): Promise<string | null> {
     try {
       return JSON.parse(await this.dataStoreProvider.getItem(tokenName));


### PR DESCRIPTION
## Description
- Forces token renewal on app launch by calling Ionic Auth `expire()` method.
- Resolves issue with Ionic Auth being unable to determine if token expired when deleting and reinstalling app

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
