### PR TITLE
mes-5784: upload delEx tests to test results database

### DIFF
--- a/src/modules/tests/tests.analytics.effects.ts
+++ b/src/modules/tests/tests.analytics.effects.ts
@@ -66,8 +66,8 @@ export class TestsAnalyticsEffects {
         formatApplicationReference(journalDataOfTest.applicationReference),
       );
       this.analytics.addCustomDimension(
-        AnalyticsDimensionIndices.CANDIDATE_ID, journalDataOfTest.candidate.candidateId.toString());
-
+        AnalyticsDimensionIndices.CANDIDATE_ID,
+        journalDataOfTest.candidate.candidateId ? journalDataOfTest.candidate.candidateId.toString() : null);
       return of(new AnalyticRecorded());
     }),
   );

--- a/src/modules/tests/tests.effects.ts
+++ b/src/modules/tests/tests.effects.ts
@@ -174,7 +174,7 @@ export class TestsEffects {
         };
         slot = getDelegatedBookedTestSlot(delegatedRekeySearch);
 
-        // TODO remove this temporary hard keyed test centre when real data is available
+        // TODO MES-5790: remove this temporary hard keyed test centre when real data is available
         slot = {
           ...slot, testCentre: {
             centreId: 11111,

--- a/src/modules/tests/tests.effects.ts
+++ b/src/modules/tests/tests.effects.ts
@@ -173,6 +173,16 @@ export class TestsEffects {
           staffNumber: employeeId,
         };
         slot = getDelegatedBookedTestSlot(delegatedRekeySearch);
+
+        // TODO remove this temporary hard keyed test centre when real data is available
+        slot = {
+          ...slot, testCentre: {
+            centreId: 11111,
+            centreName: 'Temp Test Centre',
+            costCode: 'EXAM1',
+          },
+          vehicleTypeCode: 'X',
+        };
       } else if (isRekeySearch) {
         examinerBooked = getStaffNumber(rekeySearch);
         examiner = {

--- a/src/pages/delegated-rekey-search/delegated-rekey-search.effects.ts
+++ b/src/pages/delegated-rekey-search/delegated-rekey-search.effects.ts
@@ -49,6 +49,7 @@ export class DelegatedRekeySearchEffects {
                         checkDigit: response.testSlot.booking.application.checkDigit,
                         testCategory: response.testSlot.booking.application.testCategory,
                         welshTest: false,
+                        extendedTest: false,
                       },
                       candidate: {
                         candidateName: {


### PR DESCRIPTION
## Description

Added default for extended tests, temp data for test centre details and fixed issue with analytics when candidate id isnt available.

https://jira.dvsacloud.uk/browse/MES-5784

## Checklist

- [x] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

![image](https://user-images.githubusercontent.com/48550267/94425672-39163680-0184-11eb-9296-35548113bb5a.png)
![image](https://user-images.githubusercontent.com/48550267/94425692-40d5db00-0184-11eb-8feb-efe0fd79365c.png)

