### PR TITLE
MES-5795: Prefixing delegated test analytics events with DelExRk -

### DIFF
--- a/src/modules/tests/__tests__/tests.selector.spec.ts
+++ b/src/modules/tests/__tests__/tests.selector.spec.ts
@@ -10,6 +10,7 @@ import {
   getIncompleteTests,
   getIncompleteTestsCount,
   getOldestIncompleteTest,
+  isDelegatedTest,
 } from '../tests.selector';
 import { JournalModel } from '../../../modules/journal/journal.model';
 import { AppInfoModel } from '../../app-info/app-info.model';
@@ -504,4 +505,124 @@ describe('testsSelector', () => {
     });
   });
 
+  describe('isDelegatedTest', () => {
+    const testsState: TestsModel = {
+      currentTest: { slotId: '12345' },
+      startedTests: {
+        12345: {
+          version: '0.0.1',
+          category: 'B',
+          activityCode: ActivityCodes.PASS,
+          journalData: {
+            testSlotAttributes: {
+              welshTest: false,
+              slotId: 3002,
+              start: '2019-08-30T10:14:00',
+              vehicleTypeCode: 'C',
+              extendedTest: false,
+              specialNeeds: false,
+            },
+            examiner: {
+              staffNumber: '',
+            },
+            testCentre: {
+              centreId: 1,
+              costCode: '',
+            },
+            candidate: {},
+            applicationReference: {
+              applicationId: 999,
+              bookingSequence: 3,
+              checkDigit: 5,
+            },
+          },
+          rekey: false,
+          changeMarker: false,
+          examinerBooked: 1,
+          examinerConducted: 1,
+          examinerKeyed: 1,
+        },
+      },
+      testStatus: {},
+    };
+
+    it('should return false when no delegated tests possible for the category', () => {
+      const localTestsState: TestsModel = {
+        ...testsState,
+        startedTests: {
+          ...testsState.startedTests,
+          12345: {
+            ...testsState.startedTests['12345'],
+            category: 'B',
+          },
+        },
+      };
+      const result = isDelegatedTest(localTestsState);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when test has valid category but delegatedTest flag is not set', () => {
+      const localTestsState: TestsModel = {
+        ...testsState,
+        startedTests: {
+          ...testsState.startedTests,
+          12345: {
+            ...testsState.startedTests['12345'],
+            category: 'B+E',
+            delegatedTest: undefined,
+          },
+        },
+      };
+      const result = isDelegatedTest(localTestsState);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when test has valid category but delegatedTest flag is set to false', () => {
+      const localTestsState: TestsModel = {
+        ...testsState,
+        startedTests: {
+          ...testsState.startedTests,
+          12345: {
+            ...testsState.startedTests['12345'],
+            category: 'B+E',
+            delegatedTest: false,
+          },
+        },
+      };
+      const result = isDelegatedTest(localTestsState);
+      expect(result).toBe(false);
+    });
+
+    it('should return true when test has valid common category and delegatedTest flag is set to true', () => {
+      const localTestsState: TestsModel = {
+        ...testsState,
+        startedTests: {
+          ...testsState.startedTests,
+          12345: {
+            ...testsState.startedTests['12345'],
+            category: 'B+E',
+            delegatedTest: true,
+          },
+        },
+      };
+      const result = isDelegatedTest(localTestsState);
+      expect(result).toBe(true);
+    });
+
+    it('should return true when test has valid CPC category and delegatedTest flag is set to true', () => {
+      const localTestsState: TestsModel = {
+        ...testsState,
+        startedTests: {
+          ...testsState.startedTests,
+          12345: {
+            ...testsState.startedTests['12345'],
+            category: 'CCPC',
+            delegatedTest: true,
+          },
+        },
+      };
+      const result = isDelegatedTest(localTestsState);
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/src/modules/tests/tests.selector.ts
+++ b/src/modules/tests/tests.selector.ts
@@ -12,6 +12,8 @@ import { TestOutcome } from './tests.constants';
 import { ActivityCodes } from '../../shared/models/activity-codes';
 import { DateTime } from '../../shared/helpers/date-time';
 import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { TestResultCatCPCSchema } from '@dvsa/mes-test-schema/categories/CPC';
 
 export const getCurrentTestSlotId = (tests: TestsModel): string => tests.currentTest.slotId;
 
@@ -83,6 +85,29 @@ export const isTestReportPracticeTest = (tests: TestsModel): boolean =>
 
 export const isEndToEndPracticeTest = (tests: TestsModel) : boolean =>
   startsWith(tests.currentTest.slotId, end2endPracticeSlotId);
+
+export const isDelegatedTest = (tests: TestsModel): boolean => {
+  const test = getCurrentTest(tests);
+
+  if (test.category === TestCategory.BE
+    || test.category === TestCategory.C
+    || test.category === TestCategory.CE
+    || test.category === TestCategory.C1
+    || test.category === TestCategory.C1E
+    || test.category === TestCategory.D
+    || test.category === TestCategory.DE
+    || test.category === TestCategory.D1
+    || test.category === TestCategory.D1E) {
+    return (test as TestResultCommonSchema).delegatedTest || false;
+  }
+
+  if (test.category === TestCategory.CCPC
+    || test.category === TestCategory.DCPC) {
+    return (test as TestResultCatCPCSchema).delegatedTest || false;
+  }
+
+  return false;
+};
 
 export const getAllTestStatuses = (test: TestsModel): { [slotId: string]: TestStatus; } => {
   return test.testStatus;

--- a/src/providers/analytics/analytics.model.ts
+++ b/src/providers/analytics/analytics.model.ts
@@ -63,6 +63,7 @@ export enum AnalyticsEventCategories {
   WAITING_ROOM = 'waiting room',
   WAITING_ROOM_TO_CAR = 'waiting room to car',
   OFFICE = 'office',
+  DELEGATED_TEST = 'DelExRk',
 }
 
 export enum AnalyticsEvents {

--- a/src/shared/helpers/__tests__/format-analytics-text.spec.ts
+++ b/src/shared/helpers/__tests__/format-analytics-text.spec.ts
@@ -57,4 +57,49 @@ describe('formatAnalyticsText', () => {
     expect(result).toBe(eventString);
   });
 
+  it('should prefix delegated tests with the correct text', () => {
+    const state = { ...initialState };
+    const action = new testsActions.StartTest(slotId, TestCategory.BE, false, true);
+    const tests = testsReducer(state, action);
+
+    const localTests: TestsModel = {
+      ...tests,
+      startedTests: {
+        ...tests.startedTests,
+        [slotId]: {
+          ...tests.startedTests[slotId],
+          category: 'B+E',
+          delegatedTest: true,
+        },
+      },
+    };
+
+    const result = formatAnalyticsText(eventString, localTests);
+
+    expect(result).toBe(`${AnalyticsEventCategories.DELEGATED_TEST} - ${eventString}`);
+  });
+
+  it('should prefix delegated tests with the DelExRk even though test is rekey', () => {
+    const state = { ...initialState };
+    const action = new testsActions.StartTest(slotId, TestCategory.BE, true, true);
+    const tests = testsReducer(state, action);
+
+    const localTests: TestsModel = {
+      ...tests,
+      startedTests: {
+        ...tests.startedTests,
+        [slotId]: {
+          ...tests.startedTests[slotId],
+          category: 'B+E',
+          delegatedTest: true,
+          rekey: true,
+        },
+      },
+    };
+
+    const result = formatAnalyticsText(eventString, localTests);
+
+    expect(result).toBe(`${AnalyticsEventCategories.DELEGATED_TEST} - ${eventString}`);
+  });
+
 });

--- a/src/shared/helpers/format-analytics-text.ts
+++ b/src/shared/helpers/format-analytics-text.ts
@@ -1,5 +1,10 @@
 import { TestsModel } from '../../modules/tests/tests.model';
-import { isEndToEndPracticeTest, isTestReportPracticeTest, getCurrentTest } from '../../modules/tests/tests.selector';
+import {
+  isEndToEndPracticeTest,
+  isTestReportPracticeTest,
+  getCurrentTest,
+  isDelegatedTest,
+} from '../../modules/tests/tests.selector';
 import { AnalyticsEventCategories } from '../../providers/analytics/analytics.model';
 
 export function formatAnalyticsText(eventText: string, tests: TestsModel): string {
@@ -8,6 +13,9 @@ export function formatAnalyticsText(eventText: string, tests: TestsModel): strin
   }
   if (isTestReportPracticeTest(tests)) {
     return `${AnalyticsEventCategories.PRACTICE_TEST} - ${eventText}`;
+  }
+  if (isDelegatedTest(tests)) {
+    return `${AnalyticsEventCategories.DELEGATED_TEST} - ${eventText}`;
   }
   if (getCurrentTest(tests).rekey) {
     return `${AnalyticsEventCategories.REKEY} - ${eventText}`;


### PR DESCRIPTION
## Description

Making sure that all analytics events for delegated tests are prefixed with `DelExRk -`

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
