### PR TITLE
MES-5884 remove physical desc on office page for delex tests

### DIFF
--- a/src/pages/office/cat-cpc/office.cat-cpc.page.html
+++ b/src/pages/office/cat-cpc/office.cat-cpc.page.html
@@ -70,7 +70,7 @@
             </debrief-witnessed>
 
             <candidate-description
-              *ngIf="!(isDelegated && isPass())"
+              *ngIf="!isDelegated"
               [display]="(pageState.displayCandidateDescription$ | async)"
               [formGroup]="form"
               [candidateDescription]="pageState.candidateDescription$ | async"


### PR DESCRIPTION
## Description

Removed the physical description text inputs for a failed/terminated test on Delegated Examiner CPC Office page.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

<img src="https://user-images.githubusercontent.com/17671699/95474171-ba3bad80-097c-11eb-999e-985e24cd035c.png" width="250"/>
<img src="https://user-images.githubusercontent.com/17671699/95474184-bc9e0780-097c-11eb-95cf-8f18a6362dab.png" width="250"/>