### PR TITLE
additional check and manual refresh of expired tokens

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="uk.gov.dvsa.mobile-examiner-app" version="3.8.0.5" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="uk.gov.dvsa.mobile-examiner-app" version="3.8.0.6" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>DrivingExaminerService</name>
     <description>An application for DVSA driving examiners to conduct driving tests</description>
     <author email="mobexaminer@gmail.com">MES Team</author>

--- a/src/providers/authentication/authentication.ts
+++ b/src/providers/authentication/authentication.ts
@@ -104,8 +104,20 @@ export class AuthenticationProvider {
   async hasValidToken(): Promise<boolean> {
     // refresh token if required
     await this.ionicAuth.isAuthenticated();
-    const token: any = await this.ionicAuth.getIdToken();
+    await this.refreshTokenIfExpired();
+    const token = await this.ionicAuth.getIdToken();
     return token.exp && new Date(token.exp * 1000) > new Date();
+  }
+
+  async refreshTokenIfExpired(): Promise<void> {
+    const token = await this.ionicAuth.getIdToken();
+    if (this.isTokenExpired(token)) {
+      await this.ionicAuth.refreshSession();
+    }
+  }
+
+  isTokenExpired(token: any): boolean {
+    return token.exp && new Date(token.exp * 1000) < new Date();
   }
 
   public getAuthenticationToken = async (): Promise<string> => {


### PR DESCRIPTION
## Description
- Adds additional manual check and refresh of security tokens prior to determining if token is valid.
- Workaround for potential issue with Ionic Auth deleting token expiry date from localStorage, resulting in call to `isAuthenticated` returning `true`

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
