### PR TITLE
MES-5777: added logic to display DF comments when no S/D faults exist

### DIFF
--- a/src/pages/view-test-result/cat-a-mod2/components/debrief-card/debrief-card.html
+++ b/src/pages/view-test-result/cat-a-mod2/components/debrief-card/debrief-card.html
@@ -13,7 +13,8 @@
         [dangerousFaults]="getDangerousFaults()"
         [drivingFaultCount]="getDrivingFaultCount()"
         [isRider]=true
-        [testCategory]='testCategory'>
+        [testCategory]='testCategory'
+        [minDrivingFaultCount]='6'>
     </faults-data-row>
       <data-row [label]="'ETA'" [value]="getETA()"></data-row>
       <safety-and-balance-data-row

--- a/src/pages/view-test-result/components/faults-data-row/__tests__/faults-data-row.spec.ts
+++ b/src/pages/view-test-result/components/faults-data-row/__tests__/faults-data-row.spec.ts
@@ -18,42 +18,26 @@ describe('FaultsDataRowComponent', () => {
       comment: 'comment',
     };
 
-    it('should return false when drivingFaultCount is less than minDrivingFaultCount and a serious fault exist', () => {
+    it('should return false when drivingFaultCount is less than minDrivingFaultCount', () => {
       const component = new FaultsDataRowComponent();
 
       component.drivingFaultCount = 5;
       component.minDrivingFaultCount = 6;
-      component.dangerousFaults = [];
-      component.seriousFaults = [faultSummary];
 
       const result = component.showFaultComment(faultSummary);
 
       expect(result).toBe(false);
     });
 
-    it('should return false when drivingFaultCount is equal to minDrivingFaultCount and a serious fault exist', () => {
+    it('should return false when drivingFaultCount is equal to minDrivingFaultCount', () => {
       const component = new FaultsDataRowComponent();
 
       component.drivingFaultCount = 6;
       component.minDrivingFaultCount = 6;
-      component.dangerousFaults = [];
-      component.seriousFaults = [faultSummary];
 
       const result = component.showFaultComment(faultSummary);
 
       expect(result).toBe(false);
-    });
-
-    it('should return true when drivingFault comments present and no serious/dangerous fault exist', () => {
-      const component = new FaultsDataRowComponent();
-
-      component.drivingFaultCount = 6;
-      component.dangerousFaults = [];
-      component.seriousFaults = [];
-
-      const result = component.showFaultComment(faultSummary);
-
-      expect(result).toBe(true);
     });
 
     it('should return false when there are no comments', () => {

--- a/src/pages/view-test-result/components/faults-data-row/__tests__/faults-data-row.spec.ts
+++ b/src/pages/view-test-result/components/faults-data-row/__tests__/faults-data-row.spec.ts
@@ -18,26 +18,42 @@ describe('FaultsDataRowComponent', () => {
       comment: 'comment',
     };
 
-    it('should return false when drivingFaultCount is less than minDrivingFaultCount', () => {
+    it('should return false when drivingFaultCount is less than minDrivingFaultCount and a serious fault exist', () => {
       const component = new FaultsDataRowComponent();
 
       component.drivingFaultCount = 5;
       component.minDrivingFaultCount = 6;
+      component.dangerousFaults = [];
+      component.seriousFaults = [faultSummary];
 
       const result = component.showFaultComment(faultSummary);
 
       expect(result).toBe(false);
     });
 
-    it('should return false when drivingFaultCount is equal to minDrivingFaultCount', () => {
+    it('should return false when drivingFaultCount is equal to minDrivingFaultCount and a serious fault exist', () => {
       const component = new FaultsDataRowComponent();
 
       component.drivingFaultCount = 6;
       component.minDrivingFaultCount = 6;
+      component.dangerousFaults = [];
+      component.seriousFaults = [faultSummary];
 
       const result = component.showFaultComment(faultSummary);
 
       expect(result).toBe(false);
+    });
+
+    it('should return true when drivingFault comments present and no serious/dangerous fault exist', () => {
+      const component = new FaultsDataRowComponent();
+
+      component.drivingFaultCount = 6;
+      component.dangerousFaults = [];
+      component.seriousFaults = [];
+
+      const result = component.showFaultComment(faultSummary);
+
+      expect(result).toBe(true);
     });
 
     it('should return false when there are no comments', () => {

--- a/src/pages/view-test-result/components/faults-data-row/faults-data-row.ts
+++ b/src/pages/view-test-result/components/faults-data-row/faults-data-row.ts
@@ -46,9 +46,7 @@ export class FaultsDataRowComponent {
    * @param drivingFault
    */
   showFaultComment = (drivingFault: FaultSummary): boolean =>
-    (this.drivingFaultCount > this.minDrivingFaultCount && drivingFault.comment !== undefined) ||
-    (this.drivingFaultCount > 0 && drivingFault.comment !== undefined
-      && this.seriousFaults.length === 0 && this.dangerousFaults.length === 0)
+    this.drivingFaultCount > this.minDrivingFaultCount && drivingFault.comment !== undefined
 
   public getDriverType(isRider: boolean): string {
     return isRider ? 'riding' : 'driving';

--- a/src/pages/view-test-result/components/faults-data-row/faults-data-row.ts
+++ b/src/pages/view-test-result/components/faults-data-row/faults-data-row.ts
@@ -40,12 +40,15 @@ export class FaultsDataRowComponent {
     this.seriousFaults.length === 0 &&
     this.dangerousFaults.length === 0
 
+  /**
+   * Display driving faults comments if driving faults exceed the minimum specified faults and comments exist
+   * OR fault comments exist when no serious/dangerous faults exist
+   * @param drivingFault
+   */
   showFaultComment = (drivingFault: FaultSummary): boolean =>
-    this.drivingFaultCount > this.minDrivingFaultCount &&
-    drivingFault.comment !== undefined
-
-  constructor() {
-  }
+    (this.drivingFaultCount > this.minDrivingFaultCount && drivingFault.comment !== undefined) ||
+    (this.drivingFaultCount > 0 && drivingFault.comment !== undefined
+      && this.seriousFaults.length === 0 && this.dangerousFaults.length === 0)
 
   public getDriverType(isRider: boolean): string {
     return isRider ? 'riding' : 'driving';


### PR DESCRIPTION
## Description

Added logic to display DF comments when no S/D faults exist
https://jira.dvsacloud.uk/browse/MES-5777
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
