### PR TITLE
MES-5845: Enforce serious dangerous faults code 4 and 5 (CAT B ONLY)

### DIFF
--- a/src/pages/non-pass-finalisation/cat-b/__tests__/non-pass-finalisation.cat-b.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-b/__tests__/non-pass-finalisation.cat-b.page.spec.ts
@@ -30,6 +30,11 @@ import { FinalisationHeaderComponent } from
     '../../../../components/test-finalisation/finalisation-header/finalisation-header';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
+import { ActivityCodes } from '../../../../shared/models/activity-codes';
+import { ActivityCodeDescription } from '../../../../pages/office/components/activity-code/activity-code.constants';
+import {
+  ActivityCodeFinalisationProvider,
+} from '../../../../providers/activity-code-finalisation/activity-code-finalisation';
 
 describe('NonPassFinalisationCatBPage', () => {
   let fixture: ComponentFixture<NonPassFinalisationCatBPage>;
@@ -55,6 +60,7 @@ describe('NonPassFinalisationCatBPage', () => {
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
         { provide: Platform, useFactory: () => PlatformMock.instance() },
         { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
+        ActivityCodeFinalisationProvider,
       ],
     });
   });
@@ -115,6 +121,14 @@ describe('NonPassFinalisationCatBPage', () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.B));
         component.slotId = '123';
+        component.activityCode = {
+          activityCode: ActivityCodes.FAIL,
+          description: ActivityCodeDescription.FAIL,
+        },
+        component.testData = {
+          dangerousFaults: {},
+          seriousFaults: {},
+        };
 
         // Act
         component.continue();
@@ -123,12 +137,70 @@ describe('NonPassFinalisationCatBPage', () => {
         expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
 
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', () => {
+        // Arrange
+        store$.dispatch(new testActions.StartTest(123, TestCategory.B));
+        spyOn(component, 'openTestDataValidationModal').and.callThrough();
+        spyOn(component.modalController, 'create').and.callThrough();
+
+        component.slotId = '123';
+        component.activityCode = {
+          activityCode: ActivityCodes.FAIL_CANDIDATE_STOPS_TEST,
+          description: ActivityCodeDescription.FAIL_CANDIDATE_STOPS_TEST,
+        },
+        component.testData = {
+          dangerousFaults: {},
+          seriousFaults: {},
+        };
+
+        // Act
+        component.continue();
+
+        // Assert
+        expect(component.openTestDataValidationModal).toHaveBeenCalled();
+        expect(component.modalController.create).toHaveBeenCalled();
+        expect(store$.dispatch).not.toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
+      });
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', () => {
+        // Arrange
+        store$.dispatch(new testActions.StartTest(123, TestCategory.B));
+        spyOn(component, 'openTestDataValidationModal').and.callThrough();
+        spyOn(component.modalController, 'create').and.callThrough();
+
+        component.slotId = '123';
+        component.activityCode = {
+          activityCode: ActivityCodes.FAIL_PUBLIC_SAFETY,
+          description: ActivityCodeDescription.FAIL_PUBLIC_SAFETY,
+        },
+        component.testData = {
+          dangerousFaults: {},
+          seriousFaults: {},
+        };
+
+        // Act
+        component.continue();
+
+        // Assert
+        expect(component.openTestDataValidationModal).toHaveBeenCalled();
+        expect(component.modalController.create).toHaveBeenCalled();
+        expect(store$.dispatch).not.toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
+      });
+
       it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
         component.form = new FormGroup({
           requiredControl1: new FormControl(null, [Validators.required]),
           requiredControl2: new FormControl(null, [Validators.required]),
           notRequiredControl: new FormControl(null),
         });
+
+        component.activityCode = {
+          activityCode: ActivityCodes.FAIL,
+          description: ActivityCodeDescription.FAIL,
+        },
+        component.testData = {
+          dangerousFaults: {},
+          seriousFaults: {},
+        };
 
         component.continue();
         tick();

--- a/src/pages/non-pass-finalisation/cat-b/non-pass-finalisation.cat-b.page.module.ts
+++ b/src/pages/non-pass-finalisation/cat-b/non-pass-finalisation.cat-b.page.module.ts
@@ -6,6 +6,9 @@ import { TestFinalisationComponentsModule } from
 '../../../components/test-finalisation/test-finalisation-component.module';
 import { NonPassFinalisationCatBPage } from './non-pass-finalisation.cat-b.page';
 import { NonPassFinalisationAnalyticsEffects } from '../non-pass-finalisation.analytics.effects';
+import {
+  ActivityCodeFinalisationProvider,
+} from '../../../providers/activity-code-finalisation/activity-code-finalisation';
 
 @NgModule({
   declarations: [
@@ -17,5 +20,6 @@ import { NonPassFinalisationAnalyticsEffects } from '../non-pass-finalisation.an
     ComponentsModule,
     TestFinalisationComponentsModule,
   ],
+  providers: [ActivityCodeFinalisationProvider],
 })
 export class NonPassFinalisationCatBPageModule { }

--- a/src/pages/non-pass-finalisation/cat-b/non-pass-finalisation.cat-b.page.ts
+++ b/src/pages/non-pass-finalisation/cat-b/non-pass-finalisation.cat-b.page.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
-import { IonicPage, NavController, Platform } from 'ionic-angular';
+import { IonicPage, Modal, ModalController, NavController, Platform } from 'ionic-angular';
 import { PracticeableBasePageComponent } from '../../../shared/classes/practiceable-base-page';
 import { AuthenticationProvider } from '../../../providers/authentication/authentication';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '../../../shared/models/store.model';
 import { CAT_B } from '../../page-names.constants';
-import { Observable } from 'rxjs';
+import { merge, Observable, Subscription } from 'rxjs';
 import { getTests } from '../../../modules/tests/tests.reducer';
 import {
   getCurrentTest,
@@ -53,6 +53,11 @@ import {
 } from '../../../modules/tests/communication-preferences/communication-preferences.actions';
 import { SetTestStatusWriteUp } from '../../../modules/tests/test-status/test-status.actions';
 import { SetActivityCode } from '../../../modules/tests/activity-code/activity-code.actions';
+import { getTestData } from '../../../modules/tests/test-data/cat-b/test-data.reducer';
+import { TestData } from '@dvsa/mes-test-schema/categories/common';
+import {
+  ActivityCodeFinalisationProvider,
+} from '../../../providers/activity-code-finalisation/activity-code-finalisation';
 
 interface NonPassFinalisationPageState {
   candidateName$: Observable<string>;
@@ -66,6 +71,8 @@ interface NonPassFinalisationPageState {
   displayD255$: Observable<boolean>;
   d255$: Observable<boolean>;
   isWelshTest$: Observable<boolean>;
+  testData$: Observable<TestData>;
+  slotId$: Observable<string>;
 }
 
 @IonicPage()
@@ -79,6 +86,10 @@ export class NonPassFinalisationCatBPage extends PracticeableBasePageComponent {
   form: FormGroup;
   activityCodeOptions: ActivityCodeModel[];
   slotId: string;
+  testData: TestData;
+  activityCode: ActivityCodeModel;
+  subscription: Subscription;
+  invalidTestDataModal: Modal;
 
   constructor(
     store$: Store<StoreModel>,
@@ -86,6 +97,8 @@ export class NonPassFinalisationCatBPage extends PracticeableBasePageComponent {
     public platform: Platform,
     public authenticationProvider: AuthenticationProvider,
     private outcomeBehaviourProvider: OutcomeBehaviourMapProvider,
+    public modalController: ModalController,
+    public activityCodeFinalisationProvider: ActivityCodeFinalisationProvider,
   ) {
     super(platform, navController, authenticationProvider, store$);
     this.form = new FormGroup({});
@@ -94,16 +107,16 @@ export class NonPassFinalisationCatBPage extends PracticeableBasePageComponent {
   }
 
   ngOnInit() {
-    this.store$.pipe(
-      select(getTests),
-      map(tests => tests.currentTest.slotId),
-    ).subscribe(slotId => this.slotId = slotId);
 
     const currentTest$ = this.store$.pipe(
       select(getTests),
       select(getCurrentTest),
     );
     this.pageState = {
+      slotId$: this.store$.pipe(
+        select(getTests),
+        map(tests => tests.currentTest.slotId),
+      ),
       candidateName$: currentTest$.pipe(
         select(getJournalData),
         select(getCandidate),
@@ -156,16 +169,55 @@ export class NonPassFinalisationCatBPage extends PracticeableBasePageComponent {
         select(getTestSlotAttributes),
         select(isWelshTest),
       ),
+      testData$: currentTest$.pipe(
+        select(getTestData),
+      ),
     };
+
+    const { testData$, slotId$ } = this.pageState;
+
+    this.subscription = merge(
+      slotId$.pipe(map(slotId => this.slotId = slotId)),
+      testData$.pipe(
+        map(testData => this.testData = testData),
+      ),
+    ).subscribe();
   }
 
   ionViewDidEnter(): void {
     this.store$.dispatch(new NonPassFinalisationViewDidEnter());
   }
 
+  ionViewDidLeave(): void {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+  }
+
+  openTestDataValidationModal() {
+    this.invalidTestDataModal = this.modalController.create('TestFinalisationInvalidTestDataModal', {
+      onCancel: this.onCancel,
+      onReturnToTestReport: this.onReturnToTestReport,
+    }, { cssClass: 'mes-modal-alert text-zoom-regular' });
+    this.invalidTestDataModal.present();
+  }
+
+  onCancel = () => {
+    this.invalidTestDataModal.dismiss();
+  }
+
+  onReturnToTestReport = () => {
+    this.invalidTestDataModal.dismiss();
+    this.navController.push(CAT_B.TEST_REPORT_PAGE);
+  }
+
   continue() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
+      if (this.activityCodeFinalisationProvider.testDataIsInvalid(this.activityCode.activityCode, this.testData)) {
+        this.openTestDataValidationModal();
+        return;
+      }
       this.store$.dispatch(new SetTestStatusWriteUp(this.slotId));
       this.store$.dispatch(new PersistTests());
       this.navController.push(CAT_B.BACK_TO_OFFICE_PAGE);
@@ -179,6 +231,7 @@ export class NonPassFinalisationCatBPage extends PracticeableBasePageComponent {
   }
 
   activityCodeChanged(activityCodeModel: ActivityCodeModel) {
+    this.activityCode = activityCodeModel;
     this.store$.dispatch(new SetActivityCode(activityCodeModel.activityCode));
   }
 

--- a/src/pages/test-report/components/test-finalisation-invalid-test-data-modal/test-finalisation-invalid-test-data-modal.html
+++ b/src/pages/test-report/components/test-finalisation-invalid-test-data-modal/test-finalisation-invalid-test-data-modal.html
@@ -1,0 +1,15 @@
+<ion-card class="modal-alert">
+  <ion-row justify-content-center>
+    <ion-col>
+      <h3 class="modal-alert-header">You must add at least 1 Serious or Dangerous fault in order to submit a code 4 or 5 result</h3>
+    </ion-col>
+  </ion-row>
+  <ion-row>
+    <ion-col no-padding class="column-border-top">
+      <button ion-button clear class="return-button" (click)="onCancel()">Change termination code</button>
+    </ion-col>
+    <ion-col no-padding class="column-border-top">
+      <button ion-button clear class="terminate-button" (click)="onReturnToTestReport()">Return to test report</button>
+    </ion-col>
+  </ion-row>
+</ion-card>

--- a/src/pages/test-report/components/test-finalisation-invalid-test-data-modal/test-finalisation-invalid-test-data-modal.module.ts
+++ b/src/pages/test-report/components/test-finalisation-invalid-test-data-modal/test-finalisation-invalid-test-data-modal.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { TestFinalisationInvalidTestDataModal } from './test-finalisation-invalid-test-data-modal';
+
+@NgModule({
+  declarations: [
+    TestFinalisationInvalidTestDataModal,
+  ],
+  imports: [
+    IonicPageModule.forChild(TestFinalisationInvalidTestDataModal),
+  ],
+  exports: [
+    TestFinalisationInvalidTestDataModal,
+  ],
+})
+export class TestFinalisationInvalidTestDataModalModule { }

--- a/src/pages/test-report/components/test-finalisation-invalid-test-data-modal/test-finalisation-invalid-test-data-modal.scss
+++ b/src/pages/test-report/components/test-finalisation-invalid-test-data-modal/test-finalisation-invalid-test-data-modal.scss
@@ -1,0 +1,27 @@
+test-finalisation-invalid-test-data-modal {
+  @extend .modal-alert-wrapper;
+
+  .modal-alert {
+    width: 400px;
+  }
+
+  .modal-alert-header {
+    margin: 20px 0 20px 0;
+  }
+
+  .mes-primary-button {
+    margin-top: 60px;
+    margin-bottom: 60px;
+    width: 100%;
+    height: 56px;
+  }
+
+  .terminate-button {
+    color: map-get($colors-gds, gds-red);
+  }
+
+  .return-button {
+    color: map-get($colors-gds, gds-black);
+  }
+
+}

--- a/src/pages/test-report/components/test-finalisation-invalid-test-data-modal/test-finalisation-invalid-test-data-modal.ts
+++ b/src/pages/test-report/components/test-finalisation-invalid-test-data-modal/test-finalisation-invalid-test-data-modal.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { IonicPage, NavParams } from 'ionic-angular';
+
+@IonicPage()
+@Component({
+  selector: 'test-finalisation-invalid-test-data-modal',
+  templateUrl: 'test-finalisation-invalid-test-data-modal.html',
+})
+export class TestFinalisationInvalidTestDataModal {
+
+  onCancel: Function;
+  onReturnToTestReport: Function;
+
+  constructor(
+    private navParams: NavParams,
+  ) {
+    this.onCancel = this.navParams.get('onCancel');
+    this.onReturnToTestReport = this.navParams.get('onReturnToTestReport');
+  }
+
+}

--- a/src/pages/test-report/components/test-report-components.module.ts
+++ b/src/pages/test-report/components/test-report-components.module.ts
@@ -24,6 +24,9 @@ import { ControlledStopComponent } from './controlled-stop/controlled-stop';
 import {
   SpecialLegalRequirementModalModule,
 } from './special-legal-requirement-modal/special-legal-requirement-modal.module';
+import {
+  TestFinalisationInvalidTestDataModalModule,
+} from './test-finalisation-invalid-test-data-modal/test-finalisation-invalid-test-data-modal.module';
 
 @NgModule({
   declarations: [
@@ -51,6 +54,7 @@ import {
     LegalRequirementsModalModule,
     SpecialLegalRequirementModalModule,
     EtaInvalidModalModule,
+    TestFinalisationInvalidTestDataModalModule,
   ],
   exports:[
     EtaComponent,

--- a/src/providers/activity-code-finalisation/activity-code-finalisation.ts
+++ b/src/providers/activity-code-finalisation/activity-code-finalisation.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { isEmpty } from 'lodash';
+
+import { ActivityCodes } from '../../shared/models/activity-codes';
+
+@Injectable()
+export class ActivityCodeFinalisationProvider {
+
+  testDataIsInvalid(activityCode, testData): boolean {
+    const { dangerousFaults, seriousFaults } = testData;
+    const activityCodeIs4or5 =
+      (activityCode === ActivityCodes.FAIL_PUBLIC_SAFETY) ||
+      (activityCode === ActivityCodes.FAIL_CANDIDATE_STOPS_TEST);
+    const hasSeriousOrDangerousFaults =
+      !isEmpty(dangerousFaults) ||
+      !isEmpty(seriousFaults);
+
+    return activityCodeIs4or5 && !hasSeriousOrDangerousFaults;
+  }
+
+}


### PR DESCRIPTION
## Description
- Creates a `ActivityCodeFinalisationProvider` to handle the logic for displaying the new modal
- Creates a `TestFinalisationInvalidTestDataModal` page
- Remaining categories to follow in a separate PR

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/33695049/97733970-6f6f0a80-1ad0-11eb-8b6c-7a47acb28a81.png)
