### PR TITLE
MES-5845: [Bug fix] Includes activityCode on initialisation of non-pass-finalisation-page

### DIFF
--- a/src/pages/non-pass-finalisation/cat-a-mod1/non-pass-finalisation.cat-a-mod1.page.ts
+++ b/src/pages/non-pass-finalisation/cat-a-mod1/non-pass-finalisation.cat-a-mod1.page.ts
@@ -176,12 +176,15 @@ export class NonPassFinalisationCatAMod1Page extends BasePageComponent implement
       ),
     };
 
-    const { testData$, slotId$ } = this.pageState;
+    const { testData$, slotId$, activityCode$ } = this.pageState;
 
     this.subscription = merge(
       slotId$.pipe(map(slotId => this.slotId = slotId)),
       testData$.pipe(
         map(testData => this.testData = testData),
+      ),
+      activityCode$.pipe(
+        map(activityCode => this.activityCode = activityCode),
       ),
     ).subscribe();
   }

--- a/src/pages/non-pass-finalisation/cat-a-mod2/non-pass-finalisation.cat-a-mod2.page.ts
+++ b/src/pages/non-pass-finalisation/cat-a-mod2/non-pass-finalisation.cat-a-mod2.page.ts
@@ -174,12 +174,15 @@ export class NonPassFinalisationCatAMod2Page extends BasePageComponent implement
       ),
     };
 
-    const { testData$, slotId$ } = this.pageState;
+    const { testData$, slotId$, activityCode$ } = this.pageState;
 
     this.subscription = merge(
       slotId$.pipe(map(slotId => this.slotId = slotId)),
       testData$.pipe(
         map(testData => this.testData = testData),
+      ),
+      activityCode$.pipe(
+        map(activityCode => this.activityCode = activityCode),
       ),
     ).subscribe();
   }

--- a/src/pages/non-pass-finalisation/cat-adi-part2/non-pass-finalisation.cat-adi-part2.page.ts
+++ b/src/pages/non-pass-finalisation/cat-adi-part2/non-pass-finalisation.cat-adi-part2.page.ts
@@ -163,12 +163,15 @@ export class NonPassFinalisationCatADIPart2Page extends BasePageComponent implem
       ),
     };
 
-    const { testData$, slotId$ } = this.pageState;
+    const { testData$, slotId$, activityCode$ } = this.pageState;
 
     this.subscription = merge(
       slotId$.pipe(map(slotId => this.slotId = slotId)),
       testData$.pipe(
         map(testData => this.testData = testData),
+      ),
+      activityCode$.pipe(
+        map(activityCode => this.activityCode = activityCode),
       ),
     ).subscribe();
   }

--- a/src/pages/non-pass-finalisation/cat-b/non-pass-finalisation.cat-b.page.ts
+++ b/src/pages/non-pass-finalisation/cat-b/non-pass-finalisation.cat-b.page.ts
@@ -174,12 +174,15 @@ export class NonPassFinalisationCatBPage extends PracticeableBasePageComponent {
       ),
     };
 
-    const { testData$, slotId$ } = this.pageState;
+    const { testData$, slotId$, activityCode$ } = this.pageState;
 
     this.subscription = merge(
       slotId$.pipe(map(slotId => this.slotId = slotId)),
       testData$.pipe(
         map(testData => this.testData = testData),
+      ),
+      activityCode$.pipe(
+        map(activityCode => this.activityCode = activityCode),
       ),
     ).subscribe();
   }

--- a/src/pages/non-pass-finalisation/cat-be/non-pass-finalisation.cat-be.page.ts
+++ b/src/pages/non-pass-finalisation/cat-be/non-pass-finalisation.cat-be.page.ts
@@ -176,12 +176,15 @@ export class NonPassFinalisationCatBEPage extends BasePageComponent implements O
       ),
     };
 
-    const { testData$, slotId$ } = this.pageState;
+    const { testData$, slotId$, activityCode$ } = this.pageState;
 
     this.subscription = merge(
       slotId$.pipe(map(slotId => this.slotId = slotId)),
       testData$.pipe(
         map(testData => this.testData = testData),
+      ),
+      activityCode$.pipe(
+        map(activityCode => this.activityCode = activityCode),
       ),
     ).subscribe();
   }

--- a/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.ts
+++ b/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.ts
@@ -205,12 +205,15 @@ export class NonPassFinalisationCatCPage extends BasePageComponent implements On
       ),
     };
 
-    const { testData$, slotId$ } = this.pageState;
+    const { testData$, slotId$, activityCode$ } = this.pageState;
 
     this.subscription = merge(
       slotId$.pipe(map(slotId => this.slotId = slotId)),
       testData$.pipe(
         map(testData => this.testData = testData),
+      ),
+      activityCode$.pipe(
+        map(activityCode => this.activityCode = activityCode),
       ),
     ).subscribe();
   }

--- a/src/pages/non-pass-finalisation/cat-d/non-pass-finalisation.cat-d.page.ts
+++ b/src/pages/non-pass-finalisation/cat-d/non-pass-finalisation.cat-d.page.ts
@@ -205,12 +205,15 @@ export class NonPassFinalisationCatDPage extends BasePageComponent implements On
       ),
     };
 
-    const { testData$, slotId$ } = this.pageState;
+    const { testData$, slotId$, activityCode$ } = this.pageState;
 
     this.subscription = merge(
       slotId$.pipe(map(slotId => this.slotId = slotId)),
       testData$.pipe(
         map(testData => this.testData = testData),
+      ),
+      activityCode$.pipe(
+        map(activityCode => this.activityCode = activityCode),
       ),
     ).subscribe();
   }

--- a/src/pages/non-pass-finalisation/cat-home/non-pass-finalisation.cat-home-test.page.ts
+++ b/src/pages/non-pass-finalisation/cat-home/non-pass-finalisation.cat-home-test.page.ts
@@ -174,12 +174,15 @@ export class NonPassFinalisationCatHomeTestPage extends BasePageComponent implem
       ),
     };
 
-    const { testData$, slotId$ } = this.pageState;
+    const { testData$, slotId$, activityCode$ } = this.pageState;
 
     this.subscription = merge(
       slotId$.pipe(map(slotId => this.slotId = slotId)),
       testData$.pipe(
         map(testData => this.testData = testData),
+      ),
+      activityCode$.pipe(
+        map(activityCode => this.activityCode = activityCode),
       ),
     ).subscribe();
   }


### PR DESCRIPTION
## Description
Includes the `activityCode` prop on the non-pass-finalisation-page to fix a bug where standard fails were causing a runtime error due to the activityCode being un-initialised.

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
