### PR TITLE
MES-6128: Vehicle checks marking for delegated examiner (Cat B+E only)

### DIFF
--- a/src/modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.action.ts
+++ b/src/modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.action.ts
@@ -6,7 +6,11 @@ export const SHOW_ME_QUESTION_OUTCOME_CHANGED = '[VehicleChecksPage] [CatBE] Sho
 export const TELL_ME_QUESTION_SELECTED = '[VehicleChecksPage] [CatBE] Tell Me Question Selected';
 export const TELL_ME_QUESTION_OUTCOME_CHANGED = '[VehicleChecksPage] [CatBE] Tell Me Question Outcome Changed';
 export const ADD_SHOW_ME_TELL_ME_COMMENT = '[Vehicle Checks] [CatBE] Add Show me Tell me comment';
-export const VEHICLE_CHECKS_COMPLETED = '[Vehicle Checks] [CatD] Vehicle Checks Completed';
+export const VEHICLE_CHECKS_COMPLETED = '[Vehicle Checks] [CatBE] Vehicle Checks Completed';
+export const VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED =
+  '[Vehicle Checks] [CatBE] Vehicle Checks Driving Faults Number Changed';
+export const VEHICLE_CHECKS_SERIOUS_FAULTS_NUMBER_CHANGED =
+  '[Vehicle Checks] [CatBE] Vehicle Checks Serious Faults Number Changed';
 
 export class ShowMeQuestionSelected implements Action {
   readonly type = SHOW_ME_QUESTION_SELECTED;
@@ -36,6 +40,14 @@ export class VehicleChecksCompletedToggled implements Action {
   constructor(public toggled: boolean) { }
   readonly type = VEHICLE_CHECKS_COMPLETED;
 }
+export class VehicleChecksDrivingFaultsNumberChanged implements Action {
+  constructor() { }
+  readonly type = VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED;
+}
+export class VehicleChecksSeriousFaultsNumberChanged implements Action {
+  constructor() { }
+  readonly type = VEHICLE_CHECKS_SERIOUS_FAULTS_NUMBER_CHANGED;
+}
 
 export type Types =
   | VehicleChecksCompletedToggled
@@ -43,4 +55,6 @@ export type Types =
   | ShowMeQuestionOutcomeChanged
   | TellMeQuestionSelected
   | TellMeQuestionOutcomeChanged
-  | AddShowMeTellMeComment;
+  | AddShowMeTellMeComment
+  | VehicleChecksDrivingFaultsNumberChanged
+  | VehicleChecksSeriousFaultsNumberChanged;

--- a/src/modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.action.ts
+++ b/src/modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.action.ts
@@ -9,8 +9,6 @@ export const ADD_SHOW_ME_TELL_ME_COMMENT = '[Vehicle Checks] [CatBE] Add Show me
 export const VEHICLE_CHECKS_COMPLETED = '[Vehicle Checks] [CatBE] Vehicle Checks Completed';
 export const VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED =
   '[Vehicle Checks] [CatBE] Vehicle Checks Driving Faults Number Changed';
-export const VEHICLE_CHECKS_SERIOUS_FAULTS_NUMBER_CHANGED =
-  '[Vehicle Checks] [CatBE] Vehicle Checks Serious Faults Number Changed';
 
 export class ShowMeQuestionSelected implements Action {
   readonly type = SHOW_ME_QUESTION_SELECTED;
@@ -44,10 +42,6 @@ export class VehicleChecksDrivingFaultsNumberChanged implements Action {
   constructor(public payload: QuestionResult[]) { }
   readonly type = VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED;
 }
-export class VehicleChecksSeriousFaultsNumberChanged implements Action {
-  constructor(public payload: QuestionResult) { }
-  readonly type = VEHICLE_CHECKS_SERIOUS_FAULTS_NUMBER_CHANGED;
-}
 
 export type Types =
   | VehicleChecksCompletedToggled
@@ -56,5 +50,4 @@ export type Types =
   | TellMeQuestionSelected
   | TellMeQuestionOutcomeChanged
   | AddShowMeTellMeComment
-  | VehicleChecksDrivingFaultsNumberChanged
-  | VehicleChecksSeriousFaultsNumberChanged;
+  | VehicleChecksDrivingFaultsNumberChanged;

--- a/src/modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.action.ts
+++ b/src/modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.action.ts
@@ -41,11 +41,11 @@ export class VehicleChecksCompletedToggled implements Action {
   readonly type = VEHICLE_CHECKS_COMPLETED;
 }
 export class VehicleChecksDrivingFaultsNumberChanged implements Action {
-  constructor() { }
+  constructor(public payload: QuestionResult[]) { }
   readonly type = VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED;
 }
 export class VehicleChecksSeriousFaultsNumberChanged implements Action {
-  constructor() { }
+  constructor(public payload: QuestionResult) { }
   readonly type = VEHICLE_CHECKS_SERIOUS_FAULTS_NUMBER_CHANGED;
 }
 

--- a/src/modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.reducer.ts
+++ b/src/modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.reducer.ts
@@ -64,11 +64,6 @@ export function vehicleChecksCatBEReducer(
         ...state,
         showMeQuestions: [...action.payload],
       };
-    case vehicleChecksCatBeActionTypes.VEHICLE_CHECKS_SERIOUS_FAULTS_NUMBER_CHANGED:
-      return {
-        ...state,
-        tellMeQuestions: [action.payload],
-      };
     default:
       return state;
   }

--- a/src/modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.reducer.ts
+++ b/src/modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.reducer.ts
@@ -59,6 +59,16 @@ export function vehicleChecksCatBEReducer(
         ...state,
         vehicleChecksCompleted: action.toggled,
       };
+    case vehicleChecksCatBeActionTypes.VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED:
+      console.log(`state`, state);
+      return {
+        ...state,
+      };
+    case vehicleChecksCatBeActionTypes.VEHICLE_CHECKS_SERIOUS_FAULTS_NUMBER_CHANGED:
+      console.log(`state`, state);
+      return {
+        ...state,
+      };
     default:
       return state;
   }

--- a/src/modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.reducer.ts
+++ b/src/modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.reducer.ts
@@ -60,14 +60,14 @@ export function vehicleChecksCatBEReducer(
         vehicleChecksCompleted: action.toggled,
       };
     case vehicleChecksCatBeActionTypes.VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED:
-      console.log(`state`, state);
       return {
         ...state,
+        showMeQuestions: [...action.payload],
       };
     case vehicleChecksCatBeActionTypes.VEHICLE_CHECKS_SERIOUS_FAULTS_NUMBER_CHANGED:
-      console.log(`state`, state);
       return {
         ...state,
+        tellMeQuestions: [action.payload],
       };
     default:
       return state;

--- a/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.html
+++ b/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.html
@@ -46,7 +46,6 @@
                     [vehicleChecksCompleted]="pageState.vehicleChecksCompleted$ | async"
                     (vehicleChecksCompletedOutcomeChange)="vehicleChecksCompletedOutcomeChanged($event)"
                     (vehicleChecksDrivingFaultsNumberChange)="vehicleChecksDrivingFaultsNumberChanged($event)"
-                    (vehicleChecksSeriousFaultsNumberChange)="vehicleChecksSeriousFaultsNumberChanged($event)"
             ></vehicle-checks-completed>
 
             <accompaniment-card [formGroup]="form" [instructorAccompaniment]="pageState.instructorAccompaniment$ | async"

--- a/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.html
+++ b/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.html
@@ -45,6 +45,8 @@
                     [formGroup]="form"
                     [vehicleChecksCompleted]="pageState.vehicleChecksCompleted$ | async"
                     (vehicleChecksCompletedOutcomeChange)="vehicleChecksCompletedOutcomeChanged($event)"
+                    (vehicleChecksDrivingFaultsNumberChange)="vehicleChecksDrivingFaultsNumberChanged($event)"
+                    (vehicleChecksSeriousFaultsNumberChange)="vehicleChecksSeriousFaultsNumberChanged($event)"
             ></vehicle-checks-completed>
 
             <accompaniment-card [formGroup]="form" [instructorAccompaniment]="pageState.instructorAccompaniment$ | async"

--- a/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
+++ b/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
@@ -88,7 +88,7 @@ import {
   SetDeclarationStatus,
 } from '../../../modules/tests/pre-test-declarations/common/pre-test-declarations.actions';
 import {
-  VehicleChecksCompletedToggled,
+  VehicleChecksCompletedToggled, VehicleChecksDrivingFaultsNumberChanged, VehicleChecksSeriousFaultsNumberChanged,
 } from '../../../modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.action';
 import { getNextPageDebriefOffice } from '../../../shared/constants/getNextPageDebriefOffice.constants';
 
@@ -222,6 +222,7 @@ export class WaitingRoomToCarCatBEPage extends BasePageComponent {
       delegatedTest$: currentTest$.pipe(
         select(getDelegatedTestIndicator),
         select(isDelegatedTest),
+        // select(() => true),
       ),
       vehicleChecksCompleted$: currentTest$.pipe(
         select(getTestData),
@@ -303,6 +304,14 @@ export class WaitingRoomToCarCatBEPage extends BasePageComponent {
 
   vehicleChecksCompletedOutcomeChanged(toggled: boolean) {
     this.store$.dispatch(new VehicleChecksCompletedToggled(toggled));
+  }
+
+  vehicleChecksDrivingFaultsNumberChanged() {
+    this.store$.dispatch(new VehicleChecksDrivingFaultsNumberChanged());
+  }
+
+  vehicleChecksSeriousFaultsNumberChanged() {
+    this.store$.dispatch(new VehicleChecksSeriousFaultsNumberChanged());
   }
 
   candidateDeclarationOutcomeChanged(declaration: boolean) {

--- a/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
+++ b/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
@@ -309,17 +309,18 @@ export class WaitingRoomToCarCatBEPage extends BasePageComponent {
   }
 
   vehicleChecksDrivingFaultsNumberChanged(number: number) {
-    this.store$.dispatch(new VehicleChecksDrivingFaultsNumberChanged(
-      this.generateDelegatedQuestionResults(number, CompetencyOutcome.DF),
-    ));
+    if (number > 0) {
+      this.store$.dispatch(new VehicleChecksDrivingFaultsNumberChanged(
+        this.generateDelegatedQuestionResults(number, CompetencyOutcome.DF),
+      ));
+    }
   }
 
   vehicleChecksSeriousFaultsNumberChanged(number: number) {
-    let payload: QuestionResult = {};
     if (number > 0) {
-      payload = this.createDelegatedQuestionResult(CompetencyOutcome.S);
+      const payload = this.createDelegatedQuestionResult(CompetencyOutcome.S);
+      this.store$.dispatch(new VehicleChecksSeriousFaultsNumberChanged(payload));
     }
-    this.store$.dispatch(new VehicleChecksSeriousFaultsNumberChanged(payload));
   }
 
   candidateDeclarationOutcomeChanged(declaration: boolean) {

--- a/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
+++ b/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
@@ -82,13 +82,13 @@ import {
   getResidencyDeclarationStatus,
 } from '../../../modules/tests/pre-test-declarations/common/pre-test-declarations.selector';
 import { getDelegatedTestIndicator } from '../../../modules/tests/delegated-test/delegated-test.reducer';
-import { isDelegatedTest } from '../../../modules/tests/delegated-test/delegated-test.selector';
+// import { isDelegatedTest } from '../../../modules/tests/delegated-test/delegated-test.selector';
 import {
   CandidateDeclarationSigned,
   SetDeclarationStatus,
 } from '../../../modules/tests/pre-test-declarations/common/pre-test-declarations.actions';
 import {
-  VehicleChecksCompletedToggled, VehicleChecksDrivingFaultsNumberChanged, VehicleChecksSeriousFaultsNumberChanged,
+  VehicleChecksCompletedToggled, VehicleChecksDrivingFaultsNumberChanged,
 } from '../../../modules/tests/test-data/cat-be/vehicle-checks/vehicle-checks.cat-be.action';
 import { getNextPageDebriefOffice } from '../../../shared/constants/getNextPageDebriefOffice.constants';
 import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
@@ -222,7 +222,8 @@ export class WaitingRoomToCarCatBEPage extends BasePageComponent {
       ),
       delegatedTest$: currentTest$.pipe(
         select(getDelegatedTestIndicator),
-        select(isDelegatedTest),
+        select(() => true),
+        // select(isDelegatedTest),
       ),
       vehicleChecksCompleted$: currentTest$.pipe(
         select(getTestData),
@@ -316,13 +317,6 @@ export class WaitingRoomToCarCatBEPage extends BasePageComponent {
     }
   }
 
-  vehicleChecksSeriousFaultsNumberChanged(number: number) {
-    if (number > 0) {
-      const payload = this.createDelegatedQuestionResult(CompetencyOutcome.S);
-      this.store$.dispatch(new VehicleChecksSeriousFaultsNumberChanged(payload));
-    }
-  }
-
   candidateDeclarationOutcomeChanged(declaration: boolean) {
     this.store$.dispatch(new SetDeclarationStatus(declaration));
     this.store$.dispatch(new CandidateDeclarationSigned());
@@ -391,7 +385,7 @@ export class WaitingRoomToCarCatBEPage extends BasePageComponent {
     this.store$.dispatch(new VehicleChecksCompletedToggled(toggled));
   }
 
-  createDelegatedQuestionResult = (outcome: CompetencyOutcome) => ({ outcome, code: 'delegated' });
+  createDelegatedQuestionResult = (outcome: CompetencyOutcome) => ({ outcome, code: 'DELEGATED EXAMINER' });
 
   nextPage() {
     return getNextPageDebriefOffice(CAT_BE, this.isDelegated);

--- a/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
+++ b/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
@@ -82,7 +82,7 @@ import {
   getResidencyDeclarationStatus,
 } from '../../../modules/tests/pre-test-declarations/common/pre-test-declarations.selector';
 import { getDelegatedTestIndicator } from '../../../modules/tests/delegated-test/delegated-test.reducer';
-// import { isDelegatedTest } from '../../../modules/tests/delegated-test/delegated-test.selector';
+import { isDelegatedTest } from '../../../modules/tests/delegated-test/delegated-test.selector';
 import {
   CandidateDeclarationSigned,
   SetDeclarationStatus,
@@ -222,8 +222,7 @@ export class WaitingRoomToCarCatBEPage extends BasePageComponent {
       ),
       delegatedTest$: currentTest$.pipe(
         select(getDelegatedTestIndicator),
-        select(() => true),
-        // select(isDelegatedTest),
+        select(isDelegatedTest),
       ),
       vehicleChecksCompleted$: currentTest$.pipe(
         select(getTestData),

--- a/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.html
+++ b/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.html
@@ -47,7 +47,6 @@
                             cancelText="Cancel"
                             [formControlName]="'vehicleChecksDrivingFaultsNumber'"
                             (ionChange)="vehicleChecksDrivingFaultsNumberChanged($event)"
-                            [disabled]="!vehicleChecksCompleted"
                             [selectOptions]="{cssClass:'mes-select vehicle-checks-question-select', enableBackdropDismiss:false}"
                 >
                     <ion-option *ngFor="let number of drivingFaultsNumberOptions" [value]="number">
@@ -63,7 +62,6 @@
                             cancelText="Cancel"
                             [formControlName]="'vehicleChecksSeriousFaultsNumber'"
                             (ionChange)="vehicleChecksSeriousFaultsNumberChanged($event)"
-                            [disabled]="!vehicleChecksCompleted"
                             [selectOptions]="{cssClass:'mes-select vehicle-checks-question-select', enableBackdropDismiss:false}"
                 >
                     <ion-option *ngFor="let number of seriousFaultsNumberOptions" [value]="number">

--- a/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.html
+++ b/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.html
@@ -54,21 +54,6 @@
                     </ion-option>
                 </ion-select>
             </ion-col>
-            <ion-col col-48>
-                <ion-select id="vehicle-checks-serious-fault-selector"
-                            class="vehicle-checks-fault-selector"
-                            placeholder="Serious faults" 
-                            okText="Submit"
-                            cancelText="Cancel"
-                            [formControlName]="'vehicleChecksSeriousFaultsNumber'"
-                            (ionChange)="vehicleChecksSeriousFaultsNumberChanged($event)"
-                            [selectOptions]="{cssClass:'mes-select vehicle-checks-question-select', enableBackdropDismiss:false}"
-                >
-                    <ion-option *ngFor="let number of seriousFaultsNumberOptions" [value]="number">
-                        {{number}}
-                    </ion-option>
-                </ion-select>
-            </ion-col>
         </ion-row>
     </ion-col>
 </ion-row>

--- a/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.html
+++ b/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.html
@@ -38,5 +38,39 @@
                 Select the vehicle checks completed outcome
             </div>
         </ion-row>
+        <ion-row class="spacing-row">
+            <ion-col col-36>
+                <ion-select id="vehicle-checks-driving-fault-selector"
+                            class="vehicle-checks-driving-fault-selector"
+                            placeholder="Driving faults" 
+                            okText="Submit"
+                            cancelText="Cancel"
+                            [formControlName]="'vehicleChecksDrivingFaultsNumber'"
+                            (ionChange)="vehicleChecksDrivingFaultsNumberChanged($event)"
+                            [disabled]="!vehicleChecksCompleted"
+                            [selectOptions]="{cssClass:'mes-select vehicle-checks-question-select', enableBackdropDismiss:false}"
+                >
+                    <ion-option *ngFor="let number of drivingFaultsNumberOptions" [value]="number">
+                        {{number}}
+                    </ion-option>
+                </ion-select>
+            </ion-col>
+            <ion-col col-36>
+                <ion-select id="vehicle-checks-serious-fault-selector"
+                            class="vehicle-checks-serious-fault-selector"
+                            placeholder="Serious faults" 
+                            okText="Submit"
+                            cancelText="Cancel"
+                            [formControlName]="'vehicleChecksSeriousFaultsNumber'"
+                            (ionChange)="vehicleChecksSeriousFaultsNumberChanged($event)"
+                            [disabled]="!vehicleChecksCompleted"
+                            [selectOptions]="{cssClass:'mes-select vehicle-checks-question-select', enableBackdropDismiss:false}"
+                >
+                    <ion-option *ngFor="let number of seriousFaultsNumberOptions" [value]="number">
+                        {{number}}
+                    </ion-option>
+                </ion-select>
+            </ion-col>
+        </ion-row>
     </ion-col>
 </ion-row>

--- a/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.html
+++ b/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.html
@@ -38,10 +38,10 @@
                 Select the vehicle checks completed outcome
             </div>
         </ion-row>
-        <ion-row class="spacing-row">
-            <ion-col col-36>
+        <ion-row class="spacing-row" margin-bottom>
+            <ion-col col-48>
                 <ion-select id="vehicle-checks-driving-fault-selector"
-                            class="vehicle-checks-driving-fault-selector"
+                            class="vehicle-checks-fault-selector"
                             placeholder="Driving faults" 
                             okText="Submit"
                             cancelText="Cancel"
@@ -55,9 +55,9 @@
                     </ion-option>
                 </ion-select>
             </ion-col>
-            <ion-col col-36>
+            <ion-col col-48>
                 <ion-select id="vehicle-checks-serious-fault-selector"
-                            class="vehicle-checks-serious-fault-selector"
+                            class="vehicle-checks-fault-selector"
                             placeholder="Serious faults" 
                             okText="Submit"
                             cancelText="Cancel"

--- a/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.scss
+++ b/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.scss
@@ -1,0 +1,5 @@
+vehicle-checks-completed {
+  .vehicle-checks-fault-selector {
+    width: 75%;
+  }
+}

--- a/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.scss
+++ b/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.scss
@@ -1,5 +1,0 @@
-vehicle-checks-completed {
-  .vehicle-checks-fault-selector {
-    width: 75%;
-  }
-}

--- a/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.ts
+++ b/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.ts
@@ -1,5 +1,11 @@
 import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
+import {
+  NUMBER_OF_SHOW_ME_QUESTIONS,
+} from '../../../../shared/constants/show-me-questions/show-me-questions.cat-be.constants';
+import {
+  NUMBER_OF_TELL_ME_QUESTIONS,
+} from '../../../../shared/constants/tell-me-questions/tell-me-questions.cat-be.constants';
 
 enum VehicleChecksCompletedResult {
   COMPLETED = 'Completed',
@@ -23,10 +29,25 @@ export class VehicleChecksToggleComponent implements OnChanges {
   @Output()
   vehicleChecksCompletedOutcomeChange = new EventEmitter<boolean>();
 
+  @Output()
+  vehicleChecksDrivingFaultsNumberChange = new EventEmitter<boolean>();
+
+  @Output()
+  vehicleChecksSeriousFaultsNumberChange = new EventEmitter<boolean>();
+
+  drivingFaultsNumberOptions: number[] = Array(
+    NUMBER_OF_SHOW_ME_QUESTIONS +
+    NUMBER_OF_TELL_ME_QUESTIONS + 1,
+  ).fill(null).map((v, i) => i);
+
+  seriousFaultsNumberOptions = [0, 1];
+
   ngOnChanges(): void {
     if (!this.formControl) {
       this.formControl = new FormControl('', [Validators.required]);
       this.formGroup.addControl('vehicleChecksToggleCtrl', this.formControl);
+      this.formGroup.addControl('vehicleChecksDrivingFaultsNumber', this.formControl);
+      this.formGroup.addControl('vehicleChecksSeriousFaultsNumber', this.formControl);
     }
     this.formControl.patchValue(this.vehicleChecksCompleted);
   }
@@ -34,6 +55,16 @@ export class VehicleChecksToggleComponent implements OnChanges {
     if (this.formControl.valid) {
       this.vehicleChecksCompletedOutcomeChange.emit(result === VehicleChecksCompletedResult.COMPLETED);
     }
+  }
+
+  vehicleChecksDrivingFaultsNumberChanged() {
+    console.log('vehicleChecksDrivingFaultsNumberChanged');
+    this.vehicleChecksDrivingFaultsNumberChange.emit();
+  }
+
+  vehicleChecksSeriousFaultsNumberChanged() {
+    console.log('vehicleChecksSeriousFaultsNumberChanged');
+    this.vehicleChecksSeriousFaultsNumberChange.emit();
   }
 
   get invalid(): boolean {

--- a/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.ts
+++ b/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.ts
@@ -30,10 +30,10 @@ export class VehicleChecksToggleComponent implements OnChanges {
   vehicleChecksCompletedOutcomeChange = new EventEmitter<boolean>();
 
   @Output()
-  vehicleChecksDrivingFaultsNumberChange = new EventEmitter<boolean>();
+  vehicleChecksDrivingFaultsNumberChange = new EventEmitter<number>();
 
   @Output()
-  vehicleChecksSeriousFaultsNumberChange = new EventEmitter<boolean>();
+  vehicleChecksSeriousFaultsNumberChange = new EventEmitter<number>();
 
   drivingFaultsNumberOptions: number[] = Array(
     NUMBER_OF_SHOW_ME_QUESTIONS +
@@ -57,14 +57,12 @@ export class VehicleChecksToggleComponent implements OnChanges {
     }
   }
 
-  vehicleChecksDrivingFaultsNumberChanged() {
-    console.log('vehicleChecksDrivingFaultsNumberChanged');
-    this.vehicleChecksDrivingFaultsNumberChange.emit();
+  vehicleChecksDrivingFaultsNumberChanged(number: number) {
+    this.vehicleChecksDrivingFaultsNumberChange.emit(number);
   }
 
-  vehicleChecksSeriousFaultsNumberChanged() {
-    console.log('vehicleChecksSeriousFaultsNumberChanged');
-    this.vehicleChecksSeriousFaultsNumberChange.emit();
+  vehicleChecksSeriousFaultsNumberChanged(number: number) {
+    this.vehicleChecksSeriousFaultsNumberChange.emit(number);
   }
 
   get invalid(): boolean {

--- a/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.ts
+++ b/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.ts
@@ -32,15 +32,10 @@ export class VehicleChecksToggleComponent implements OnChanges {
   @Output()
   vehicleChecksDrivingFaultsNumberChange = new EventEmitter<number>();
 
-  @Output()
-  vehicleChecksSeriousFaultsNumberChange = new EventEmitter<number>();
-
   drivingFaultsNumberOptions: number[] = Array(
     NUMBER_OF_SHOW_ME_QUESTIONS +
     NUMBER_OF_TELL_ME_QUESTIONS + 1,
   ).fill(null).map((v, i) => i);
-
-  seriousFaultsNumberOptions = [0, 1];
 
   ngOnChanges(): void {
     if (!this.formControl) {
@@ -59,10 +54,6 @@ export class VehicleChecksToggleComponent implements OnChanges {
 
   vehicleChecksDrivingFaultsNumberChanged(number: number) {
     this.vehicleChecksDrivingFaultsNumberChange.emit(number);
-  }
-
-  vehicleChecksSeriousFaultsNumberChanged(number: number) {
-    this.vehicleChecksSeriousFaultsNumberChange.emit(number);
   }
 
   get invalid(): boolean {


### PR DESCRIPTION
## Description
- Creates a new dropdown for recording the number of driving faults on the WRTC page
- Adds a new action and a reducer switch case to enable adding multiple driving faults to vehicle checks at once
- Saves the driving fault value to the existing vehicle checks slice of state
- Ensures that the existing logic for vehicle checks of **5 DF = 4 DF + 1 Serious Fault** is retained
- Tested in the development environment
- Remaining categories to be delivered in separate PR

## Checklist

- [x] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

**Default**
![image](https://user-images.githubusercontent.com/33695049/98831404-72082300-2433-11eb-9d63-5c9c7c22ad04.png)

**Dropdown**
![image](https://user-images.githubusercontent.com/33695049/98831436-7cc2b800-2433-11eb-9150-489be001d599.png)
