### PR TITLE
MES-6128: Vehicle checks marking for delegated examiner for remaining categories

### DIFF
--- a/src/modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.action.ts
+++ b/src/modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.action.ts
@@ -9,6 +9,8 @@ export const TELL_ME_QUESTION_SELECTED = '[VehicleChecksPage] [CatC] Tell Me Que
 export const TELL_ME_QUESTION_OUTCOME_CHANGED = '[VehicleChecksPage] [CatC] Tell Me Question Outcome Changed';
 export const ADD_SHOW_ME_TELL_ME_COMMENT = '[Vehicle Checks] [CatC] Add Show me Tell me comment';
 export const VEHICLE_CHECKS_COMPLETED = '[Vehicle Checks] [CatC] Vehicle Checks Completed';
+export const VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED =
+  '[Vehicle Checks] [CatC] Vehicle Checks Driving Faults Number Changed';
 
 export class InitializeVehicleChecks implements Action {
   constructor(public category: TestCategory) { }
@@ -44,6 +46,11 @@ export class VehicleChecksCompletedToggled implements Action {
   readonly type = VEHICLE_CHECKS_COMPLETED;
 }
 
+export class VehicleChecksDrivingFaultsNumberChanged implements Action {
+  constructor(public payload: QuestionResult[]) { }
+  readonly type = VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED;
+}
+
 export type Types =
   | InitializeVehicleChecks
   | ShowMeQuestionSelected
@@ -51,4 +58,5 @@ export type Types =
   | TellMeQuestionSelected
   | TellMeQuestionOutcomeChanged
   | AddShowMeTellMeComment
-  | VehicleChecksCompletedToggled;
+  | VehicleChecksCompletedToggled
+  | VehicleChecksDrivingFaultsNumberChanged;

--- a/src/modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.reducer.ts
+++ b/src/modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.reducer.ts
@@ -67,6 +67,11 @@ export function vehicleChecksCatCReducer(
         ...state,
         vehicleChecksCompleted: action.toggled,
       };
+    case vehicleChecksCatCActionTypes.VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED:
+      return {
+        ...state,
+        showMeQuestions: [...action.payload],
+      };
     default:
       return state;
   }

--- a/src/modules/tests/test-data/cat-d/vehicle-checks/vehicle-checks.cat-d.action.ts
+++ b/src/modules/tests/test-data/cat-d/vehicle-checks/vehicle-checks.cat-d.action.ts
@@ -9,6 +9,8 @@ export const TELL_ME_QUESTION_SELECTED = '[VehicleChecksPage] [CatD] Tell Me Que
 export const TELL_ME_QUESTION_OUTCOME_CHANGED = '[VehicleChecksPage] [CatD] Tell Me Question Outcome Changed';
 export const ADD_SHOW_ME_TELL_ME_COMMENT = '[Vehicle Checks] [CatD] Add Show me Tell me comment';
 export const VEHICLE_CHECKS_COMPLETED = '[Vehicle Checks] [CatD] Vehicle Checks Completed';
+export const VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED =
+  '[Vehicle Checks] [CatD] Vehicle Checks Driving Faults Number Changed';
 
 export class InitializeVehicleChecks implements Action {
   constructor(public category: TestCategory) { }
@@ -44,6 +46,11 @@ export class VehicleChecksCompletedToggled implements Action {
   readonly type = VEHICLE_CHECKS_COMPLETED;
 }
 
+export class VehicleChecksDrivingFaultsNumberChanged implements Action {
+  constructor(public payload: QuestionResult[]) { }
+  readonly type = VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED;
+}
+
 export type Types =
   | VehicleChecksCompletedToggled
   | InitializeVehicleChecks
@@ -51,4 +58,5 @@ export type Types =
   | ShowMeQuestionOutcomeChanged
   | TellMeQuestionSelected
   | TellMeQuestionOutcomeChanged
-  | AddShowMeTellMeComment;
+  | AddShowMeTellMeComment
+  | VehicleChecksDrivingFaultsNumberChanged;

--- a/src/modules/tests/test-data/cat-d/vehicle-checks/vehicle-checks.cat-d.reducer.ts
+++ b/src/modules/tests/test-data/cat-d/vehicle-checks/vehicle-checks.cat-d.reducer.ts
@@ -67,6 +67,11 @@ export function vehicleChecksCatDReducer(
         ...state,
         vehicleChecksCompleted: action.toggled,
       };
+    case vehicleChecksCatDActionTypes.VEHICLE_CHECKS_DRIVING_FAULTS_NUMBER_CHANGED:
+      return {
+        ...state,
+        showMeQuestions: [...action.payload],
+      };
     default:
       return state;
   }

--- a/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.html
+++ b/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.html
@@ -43,6 +43,7 @@
             <vehicle-checks-completed
                     *ngIf="pageState.delegatedTest$ | async"
                     [formGroup]="form"
+                    [testCategory]="testCategory"
                     [vehicleChecksCompleted]="pageState.vehicleChecksCompleted$ | async"
                     (vehicleChecksCompletedOutcomeChange)="vehicleChecksCompletedOutcomeChanged($event)"
                     (vehicleChecksDrivingFaultsNumberChange)="vehicleChecksDrivingFaultsNumberChanged($event)"

--- a/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
+++ b/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
@@ -310,11 +310,9 @@ export class WaitingRoomToCarCatBEPage extends BasePageComponent {
   }
 
   vehicleChecksDrivingFaultsNumberChanged(number: number) {
-    if (number > 0) {
-      this.store$.dispatch(new VehicleChecksDrivingFaultsNumberChanged(
-        this.generateDelegatedQuestionResults(number, CompetencyOutcome.DF),
-      ));
-    }
+    this.store$.dispatch(new VehicleChecksDrivingFaultsNumberChanged(
+      this.generateDelegatedQuestionResults(number, CompetencyOutcome.DF),
+    ));
   }
 
   candidateDeclarationOutcomeChanged(declaration: boolean) {

--- a/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
+++ b/src/pages/waiting-room-to-car/cat-be/waiting-room-to-car.cat-be.page.ts
@@ -124,6 +124,7 @@ interface WaitingRoomToCarPageState {
 export class WaitingRoomToCarCatBEPage extends BasePageComponent {
   pageState: WaitingRoomToCarPageState;
   form: FormGroup;
+  testCategory = TestCategory.BE;
 
   @ViewChild(VehicleChecksCatBEComponent)
   vehicleChecks: VehicleChecksCatBEComponent;

--- a/src/pages/waiting-room-to-car/cat-c/waiting-room-to-car.cat-c.page.html
+++ b/src/pages/waiting-room-to-car/cat-c/waiting-room-to-car.cat-c.page.html
@@ -36,6 +36,7 @@
             <vehicle-checks-completed
             *ngIf="pageState.delegatedTest$ | async"
             [formGroup]="form"
+            [testCategory]="testCategory"
             [vehicleChecksCompleted]="pageState.vehicleChecksCompleted$ | async"
             (vehicleChecksCompletedOutcomeChange)="vehicleChecksCompletedOutcomeChanged($event)"
             (vehicleChecksDrivingFaultsNumberChange)="vehicleChecksDrivingFaultsNumberChanged($event)"

--- a/src/pages/waiting-room-to-car/cat-c/waiting-room-to-car.cat-c.page.html
+++ b/src/pages/waiting-room-to-car/cat-c/waiting-room-to-car.cat-c.page.html
@@ -38,6 +38,7 @@
             [formGroup]="form"
             [vehicleChecksCompleted]="pageState.vehicleChecksCompleted$ | async"
             (vehicleChecksCompletedOutcomeChange)="vehicleChecksCompletedOutcomeChanged($event)"
+            (vehicleChecksDrivingFaultsNumberChange)="vehicleChecksDrivingFaultsNumberChanged($event)"
             ></vehicle-checks-completed>
 
             <accompaniment-card [formGroup]="form" [instructorAccompaniment]="pageState.instructorAccompaniment$ | async"

--- a/src/pages/waiting-room-to-car/cat-c/waiting-room-to-car.cat-c.page.ts
+++ b/src/pages/waiting-room-to-car/cat-c/waiting-room-to-car.cat-c.page.ts
@@ -242,11 +242,9 @@ export class WaitingRoomToCarCatCPage extends BasePageComponent {
   createDelegatedQuestionResult = (outcome: CompetencyOutcome) => ({ outcome, code: 'DELEGATED EXAMINER' });
 
   vehicleChecksDrivingFaultsNumberChanged(number: number) {
-    if (number > 0) {
-      this.store$.dispatch(new VehicleChecksDrivingFaultsNumberChanged(
-        this.generateDelegatedQuestionResults(number, CompetencyOutcome.DF),
-      ));
-    }
+    this.store$.dispatch(new VehicleChecksDrivingFaultsNumberChanged(
+      this.generateDelegatedQuestionResults(number, CompetencyOutcome.DF),
+    ));
   }
 
   setupSubscription() {

--- a/src/pages/waiting-room-to-car/cat-c/waiting-room-to-car.cat-c.page.ts
+++ b/src/pages/waiting-room-to-car/cat-c/waiting-room-to-car.cat-c.page.ts
@@ -46,11 +46,12 @@ import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
 import { VehicleChecksCatCComponent } from './components/vehicle-checks/vehicle-checks.cat-c';
 import { getTestCategory } from '../../../modules/tests/category/category.reducer';
 
-import { CategoryCode } from '@dvsa/mes-test-schema/categories/common';
+import { CategoryCode, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
 import { getDelegatedTestIndicator } from '../../../modules/tests/delegated-test/delegated-test.reducer';
 import { isDelegatedTest } from '../../../modules/tests/delegated-test/delegated-test.selector';
 import {
   VehicleChecksCompletedToggled,
+  VehicleChecksDrivingFaultsNumberChanged,
 } from '../../../modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.action';
 import {
   getPreTestDeclarations,
@@ -64,6 +65,7 @@ import {
   CandidateDeclarationSigned,
   SetDeclarationStatus,
 } from '../../../modules/tests/pre-test-declarations/common/pre-test-declarations.actions';
+import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 
 interface WaitingRoomToCarPageState {
   candidateName$: Observable<string>;
@@ -229,6 +231,22 @@ export class WaitingRoomToCarCatCPage extends BasePageComponent {
 
   closeVehicleChecksModal = () => {
     this.store$.dispatch(new waitingRoomToCarActions.WaitingRoomToCarViewDidEnter());
+  }
+
+  generateDelegatedQuestionResults(number: number, outcome: CompetencyOutcome): QuestionResult[] {
+    return Array(number).fill(null).map(() => {
+      return this.createDelegatedQuestionResult(outcome);
+    });
+  }
+
+  createDelegatedQuestionResult = (outcome: CompetencyOutcome) => ({ outcome, code: 'DELEGATED EXAMINER' });
+
+  vehicleChecksDrivingFaultsNumberChanged(number: number) {
+    if (number > 0) {
+      this.store$.dispatch(new VehicleChecksDrivingFaultsNumberChanged(
+        this.generateDelegatedQuestionResults(number, CompetencyOutcome.DF),
+      ));
+    }
   }
 
   setupSubscription() {

--- a/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.html
+++ b/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.html
@@ -28,6 +28,7 @@
             <vehicle-checks-cat-d
                     *ngIf="!(pageState.delegatedTest$ | async)"
                     [formGroup]="form"
+                    [testCategory]="testCategory"
                     [vehicleChecksScore]="pageState.vehicleChecksScore$ | async"
                     [safetyQuestionsScore]="pageState.safetyQuestionsScore$ | async"
                     [vehicleChecks]="pageState.vehicleChecks$ | async"

--- a/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.html
+++ b/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.html
@@ -28,7 +28,6 @@
             <vehicle-checks-cat-d
                     *ngIf="!(pageState.delegatedTest$ | async)"
                     [formGroup]="form"
-                    [testCategory]="testCategory"
                     [vehicleChecksScore]="pageState.vehicleChecksScore$ | async"
                     [safetyQuestionsScore]="pageState.safetyQuestionsScore$ | async"
                     [vehicleChecks]="pageState.vehicleChecks$ | async"
@@ -39,6 +38,7 @@
             <vehicle-checks-completed
                     *ngIf="pageState.delegatedTest$ | async"
                     [formGroup]="form"
+                    [testCategory]="testCategory"
                     [vehicleChecksCompleted]="pageState.vehicleChecksCompleted$ | async"
                     (vehicleChecksCompletedOutcomeChange)="vehicleChecksCompletedOutcomeChanged($event)"
                     (vehicleChecksDrivingFaultsNumberChange)="vehicleChecksDrivingFaultsNumberChanged($event)"

--- a/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.html
+++ b/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.html
@@ -40,6 +40,7 @@
                     [formGroup]="form"
                     [vehicleChecksCompleted]="pageState.vehicleChecksCompleted$ | async"
                     (vehicleChecksCompletedOutcomeChange)="vehicleChecksCompletedOutcomeChanged($event)"
+                    (vehicleChecksDrivingFaultsNumberChange)="vehicleChecksDrivingFaultsNumberChanged($event)"
             ></vehicle-checks-completed>
 
             <accompaniment-card [formGroup]="form" [instructorAccompaniment]="pageState.instructorAccompaniment$ | async"

--- a/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.ts
+++ b/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.ts
@@ -55,7 +55,7 @@ import { getTestCategory } from '../../../modules/tests/category/category.reduce
 
 import { CategoryCode, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
 import { getDelegatedTestIndicator } from '../../../modules/tests/delegated-test/delegated-test.reducer';
-import { isDelegatedTest } from '../../../modules/tests/delegated-test/delegated-test.selector';
+// import { isDelegatedTest } from '../../../modules/tests/delegated-test/delegated-test.selector';
 import {
   getVehicleChecksCompleted,
 } from '../../../modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.selector';
@@ -191,7 +191,8 @@ export class WaitingRoomToCarCatDPage extends BasePageComponent {
       ),
       delegatedTest$: currentTest$.pipe(
         select(getDelegatedTestIndicator),
-        select(isDelegatedTest),
+        // select(isDelegatedTest),
+        select(() => true),
       ),
       vehicleChecksCompleted$: currentTest$.pipe(
         select(getTestData),

--- a/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.ts
+++ b/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.ts
@@ -262,11 +262,9 @@ export class WaitingRoomToCarCatDPage extends BasePageComponent {
   }
 
   vehicleChecksDrivingFaultsNumberChanged(number: number) {
-    if (number > 0) {
-      this.store$.dispatch(new VehicleChecksDrivingFaultsNumberChanged(
-        this.generateDelegatedQuestionResults(number, CompetencyOutcome.DF),
-      ));
-    }
+    this.store$.dispatch(new VehicleChecksDrivingFaultsNumberChanged(
+      this.generateDelegatedQuestionResults(number, CompetencyOutcome.DF),
+    ));
   }
 
   createDelegatedQuestionResult = (outcome: CompetencyOutcome) => ({ outcome, code: 'DELEGATED EXAMINER' });

--- a/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.ts
+++ b/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.ts
@@ -53,7 +53,7 @@ import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
 import { VehicleChecksCatDComponent } from './components/vehicle-checks/vehicle-checks.cat-d';
 import { getTestCategory } from '../../../modules/tests/category/category.reducer';
 
-import { CategoryCode } from '@dvsa/mes-test-schema/categories/common';
+import { CategoryCode, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
 import { getDelegatedTestIndicator } from '../../../modules/tests/delegated-test/delegated-test.reducer';
 import { isDelegatedTest } from '../../../modules/tests/delegated-test/delegated-test.selector';
 import {
@@ -68,12 +68,13 @@ import {
   getResidencyDeclarationStatus,
 } from '../../../modules/tests/pre-test-declarations/common/pre-test-declarations.selector';
 import {
-  VehicleChecksCompletedToggled,
+  VehicleChecksCompletedToggled, VehicleChecksDrivingFaultsNumberChanged,
 } from '../../../modules/tests/test-data/cat-d/vehicle-checks/vehicle-checks.cat-d.action';
 import {
   CandidateDeclarationSigned,
   SetDeclarationStatus,
 } from '../../../modules/tests/pre-test-declarations/common/pre-test-declarations.actions';
+import { CompetencyOutcome } from '../../../shared/models/competency-outcome';
 
 interface WaitingRoomToCarPageState {
   candidateName$: Observable<string>;
@@ -253,6 +254,22 @@ export class WaitingRoomToCarCatDPage extends BasePageComponent {
   vehicleChecksCompletedOutcomeChanged(toggled: boolean) {
     this.store$.dispatch(new VehicleChecksCompletedToggled(toggled));
   }
+
+  generateDelegatedQuestionResults(number: number, outcome: CompetencyOutcome): QuestionResult[] {
+    return Array(number).fill(null).map(() => {
+      return this.createDelegatedQuestionResult(outcome);
+    });
+  }
+
+  vehicleChecksDrivingFaultsNumberChanged(number: number) {
+    if (number > 0) {
+      this.store$.dispatch(new VehicleChecksDrivingFaultsNumberChanged(
+        this.generateDelegatedQuestionResults(number, CompetencyOutcome.DF),
+      ));
+    }
+  }
+
+  createDelegatedQuestionResult = (outcome: CompetencyOutcome) => ({ outcome, code: 'DELEGATED EXAMINER' });
 
   candidateDeclarationOutcomeChanged(declaration: boolean) {
     this.store$.dispatch(new SetDeclarationStatus(declaration));

--- a/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.ts
+++ b/src/pages/waiting-room-to-car/cat-d/waiting-room-to-car.cat-d.page.ts
@@ -55,7 +55,7 @@ import { getTestCategory } from '../../../modules/tests/category/category.reduce
 
 import { CategoryCode, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
 import { getDelegatedTestIndicator } from '../../../modules/tests/delegated-test/delegated-test.reducer';
-// import { isDelegatedTest } from '../../../modules/tests/delegated-test/delegated-test.selector';
+import { isDelegatedTest } from '../../../modules/tests/delegated-test/delegated-test.selector';
 import {
   getVehicleChecksCompleted,
 } from '../../../modules/tests/test-data/cat-c/vehicle-checks/vehicle-checks.cat-c.selector';
@@ -191,8 +191,7 @@ export class WaitingRoomToCarCatDPage extends BasePageComponent {
       ),
       delegatedTest$: currentTest$.pipe(
         select(getDelegatedTestIndicator),
-        // select(isDelegatedTest),
-        select(() => true),
+        select(isDelegatedTest),
       ),
       vehicleChecksCompleted$: currentTest$.pipe(
         select(getTestData),

--- a/src/pages/waiting-room-to-car/components/vehicle-checks-completed/__tests__/vehicle-checks-completed.spec.ts
+++ b/src/pages/waiting-room-to-car/components/vehicle-checks-completed/__tests__/vehicle-checks-completed.spec.ts
@@ -6,6 +6,7 @@ import { configureTestSuite } from 'ng-bullet';
 
 import { AppModule } from '../../../../../app/app.module';
 import { VehicleChecksToggleComponent } from '../vehicle-checks-completed';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 describe('VehicleChecksToggleComponent', () => {
   let fixture: ComponentFixture<VehicleChecksToggleComponent>;
@@ -32,6 +33,7 @@ describe('VehicleChecksToggleComponent', () => {
   describe('DOM', () => {
     it('should call VehicleChecksToggleResultChanged with Completed when selected', () => {
       spyOn(component, 'vehicleChecksToggleResultChanged');
+      component.testCategory = TestCategory.BE;
       component.ngOnChanges();
       const vehicleChecksCompletedRadio =
         fixture.debugElement.query(By.css('#vehicle-checks-toggle-completed'));
@@ -42,6 +44,7 @@ describe('VehicleChecksToggleComponent', () => {
     });
     it('should call VehicleChecksToggleResultChanged with Not completed when not selected', () => {
       spyOn(component, 'vehicleChecksToggleResultChanged');
+      component.testCategory = TestCategory.BE;
       component.ngOnChanges();
       const vehicleChecksCompletedRadio =
         fixture.debugElement.query(By.css('#vehicle-checks-toggle-non-completed'));

--- a/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.ts
+++ b/src/pages/waiting-room-to-car/components/vehicle-checks-completed/vehicle-checks-completed.ts
@@ -1,11 +1,7 @@
 import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
-import {
-  NUMBER_OF_SHOW_ME_QUESTIONS,
-} from '../../../../shared/constants/show-me-questions/show-me-questions.cat-be.constants';
-import {
-  NUMBER_OF_TELL_ME_QUESTIONS,
-} from '../../../../shared/constants/tell-me-questions/tell-me-questions.cat-be.constants';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { vehicleChecksQuestionsByCategory } from '../../../../shared/helpers/vehicle-checks-questions-by-category';
 
 enum VehicleChecksCompletedResult {
   COMPLETED = 'Completed',
@@ -24,6 +20,9 @@ export class VehicleChecksToggleComponent implements OnChanges {
   vehicleChecksCompleted: boolean;
 
   @Input()
+  testCategory: TestCategory;
+
+  @Input()
   formGroup: FormGroup;
 
   @Output()
@@ -32,10 +31,13 @@ export class VehicleChecksToggleComponent implements OnChanges {
   @Output()
   vehicleChecksDrivingFaultsNumberChange = new EventEmitter<number>();
 
-  drivingFaultsNumberOptions: number[] = Array(
-    NUMBER_OF_SHOW_ME_QUESTIONS +
-    NUMBER_OF_TELL_ME_QUESTIONS + 1,
-  ).fill(null).map((v, i) => i);
+  drivingFaultsNumberOptions: number[];
+
+  ngOnInit(): void {
+    this.drivingFaultsNumberOptions = Array(
+      vehicleChecksQuestionsByCategory(this.testCategory) + 1,
+    ).fill(null).map((v, i) => i);
+  }
 
   ngOnChanges(): void {
     if (!this.formControl) {

--- a/src/shared/helpers/vehicle-checks-questions-by-category.ts
+++ b/src/shared/helpers/vehicle-checks-questions-by-category.ts
@@ -1,0 +1,39 @@
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import {
+  NUMBER_OF_SHOW_ME_QUESTIONS,
+} from '../constants/show-me-questions/show-me-questions.cat-be.constants';
+import {
+  NUMBER_OF_TELL_ME_QUESTIONS,
+} from '../constants/tell-me-questions/tell-me-questions.cat-be.constants';
+import {
+  NUMBER_OF_TELL_ME_QUESTIONS as NUMBER_OF_TELL_ME_QUESTIONS_NON_TRAILER,
+} from '../constants/tell-me-questions/tell-me-questions.vocational.constants';
+
+import {
+  NUMBER_OF_SHOW_ME_QUESTIONS as NUMBER_OF_SHOW_ME_QUESTIONS_NON_TRAILER,
+} from '../constants/show-me-questions/show-me-questions.vocational.constants';
+
+import {
+  NUMBER_OF_TELL_ME_QUESTIONS as NUMBER_OF_TELL_ME_QUESTIONS_TRAILER,
+} from '../constants/tell-me-questions/tell-me-questions.vocational-trailer.constants';
+
+import {
+  NUMBER_OF_SHOW_ME_QUESTIONS as NUMBER_OF_SHOW_ME_QUESTIONS_TRAILER,
+} from '../constants/show-me-questions/show-me-questions.vocational-trailer.constants';
+
+export const vehicleChecksQuestionsByCategory = (category: TestCategory): number => {
+  switch (category) {
+    case TestCategory.BE:
+      return NUMBER_OF_SHOW_ME_QUESTIONS + NUMBER_OF_TELL_ME_QUESTIONS;
+    case TestCategory.C:
+    case TestCategory.C1:
+    case TestCategory.D:
+    case TestCategory.D1:
+      return NUMBER_OF_SHOW_ME_QUESTIONS_NON_TRAILER + NUMBER_OF_TELL_ME_QUESTIONS_NON_TRAILER;
+    case TestCategory.CE:
+    case TestCategory.C1E:
+    case TestCategory.DE:
+    case TestCategory.D1E:
+      return NUMBER_OF_SHOW_ME_QUESTIONS_TRAILER + NUMBER_OF_TELL_ME_QUESTIONS_TRAILER;
+  }
+};


### PR DESCRIPTION
## Description
Implements #1835 for the remaining categories: C, C1, CE, C1E, D, D1, DE, D1E

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
