### PR TITLE
MES-6376: Enable activity code 4 or 5 termination with driving faults

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -54,6 +54,7 @@ import {
 } from '../providers/bike-category-detail/bike-category-detail';
 import { CPCQuestionProvider } from '../providers/cpc-questions/cpc-questions';
 import { SearchProvider } from '../providers/search/search';
+import { TestResultProvider } from '../providers/test-result/test-result';
 
 export function createTranslateLoader(http: HttpClient) {
   return new TranslateHttpLoader(http, 'assets/i18n/', '.json');
@@ -160,6 +161,7 @@ if (!window['devToolsExtension'] && !window['__REDUX_DEVTOOLS_EXTENSION__']
     BikeCategoryDetailProvider,
     CPCQuestionProvider,
     SearchProvider,
+    TestResultProvider,
   ],
 })
 export class AppModule { }

--- a/src/modules/journal/journal.effects.ts
+++ b/src/modules/journal/journal.effects.ts
@@ -210,7 +210,8 @@ export class JournalEffects {
       ),
     ),
 
-    filter(([action, staffNumber, hasStartedTests, completedTests]) => !hasStartedTests && completedTests.length === 0),
+    filter(([action, staffNumber, hasStartedTests, completedTests]) =>
+      !hasStartedTests && completedTests && completedTests.length === 0),
 
     switchMap(([action, staffNumber]) => {
       const numberOfDaysToView = this.appConfig.getAppConfig().journal.numberOfDaysToView;

--- a/src/pages/non-pass-finalisation/cat-a-mod1/__tests__/non-pass-finalisation.cat-a-mod1.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-a-mod1/__tests__/non-pass-finalisation.cat-a-mod1.page.spec.ts
@@ -114,7 +114,7 @@ describe('NonPassFinalisationCatAMod1Page', () => {
       });
     });
     describe('OnContinue', () => {
-      it('should dispatch a change test state to WriteUp action', () => {
+      it('should dispatch a change test state to WriteUp action', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.EUA1M1));
         component.slotId = '123';
@@ -128,13 +128,14 @@ describe('NonPassFinalisationCatAMod1Page', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
 
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.EUA1M1));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -151,14 +152,15 @@ describe('NonPassFinalisationCatAMod1Page', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();
         expect(component.modalController.create).toHaveBeenCalled();
         expect(store$.dispatch).not.toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.EUA1M1));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -175,7 +177,7 @@ describe('NonPassFinalisationCatAMod1Page', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();

--- a/src/pages/non-pass-finalisation/cat-a-mod1/__tests__/non-pass-finalisation.cat-a-mod1.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-a-mod1/__tests__/non-pass-finalisation.cat-a-mod1.page.spec.ts
@@ -149,6 +149,9 @@ describe('NonPassFinalisationCatAMod1Page', () => {
         component.testData = {
           dangerousFaults: {},
           seriousFaults: {},
+          emergencyStop: {
+            outcome: null,
+          },
         };
 
         // Act
@@ -174,6 +177,9 @@ describe('NonPassFinalisationCatAMod1Page', () => {
         component.testData = {
           dangerousFaults: {},
           seriousFaults: {},
+          emergencyStop: {
+            outcome: null,
+          },
         };
 
         // Act

--- a/src/pages/non-pass-finalisation/cat-a-mod1/non-pass-finalisation.cat-a-mod1.page.ts
+++ b/src/pages/non-pass-finalisation/cat-a-mod1/non-pass-finalisation.cat-a-mod1.page.ts
@@ -231,10 +231,10 @@ export class NonPassFinalisationCatAMod1Page extends BasePageComponent implement
     );
   }
 
-  continue() {
+  async continue() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
-      const testDataIsInvalid = this.activityCodeFinalisationProvider
+      const testDataIsInvalid = await this.activityCodeFinalisationProvider
         .catAMod1TestDataIsInvalid(this.activityCode.activityCode, this.testData);
 
       if (testDataIsInvalid) {

--- a/src/pages/non-pass-finalisation/cat-a-mod2/__tests__/non-pass-finalisation.cat-a.mod2.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-a-mod2/__tests__/non-pass-finalisation.cat-a.mod2.page.spec.ts
@@ -114,7 +114,7 @@ describe('NonPassFinalisationCatAMod2Page', () => {
       });
     });
     describe('OnContinue', () => {
-      it('should dispatch a change test state to WriteUp action', () => {
+      it('should dispatch a change test state to WriteUp action', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.EUA1M2));
         component.slotId = '123';
@@ -128,13 +128,14 @@ describe('NonPassFinalisationCatAMod2Page', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
 
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.EUA1M2));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -151,14 +152,15 @@ describe('NonPassFinalisationCatAMod2Page', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();
         expect(component.modalController.create).toHaveBeenCalled();
         expect(store$.dispatch).not.toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.EUA1M2));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -175,7 +177,7 @@ describe('NonPassFinalisationCatAMod2Page', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();

--- a/src/pages/non-pass-finalisation/cat-a-mod2/non-pass-finalisation.cat-a-mod2.page.ts
+++ b/src/pages/non-pass-finalisation/cat-a-mod2/non-pass-finalisation.cat-a-mod2.page.ts
@@ -229,10 +229,10 @@ export class NonPassFinalisationCatAMod2Page extends BasePageComponent implement
     );
   }
 
-  continue() {
+  async continue() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
-      const testDataIsInvalid = this.activityCodeFinalisationProvider
+      const testDataIsInvalid = await this.activityCodeFinalisationProvider
         .catAMod2TestDataIsInvalid(this.activityCode.activityCode, this.testData);
 
       if (testDataIsInvalid) {

--- a/src/pages/non-pass-finalisation/cat-adi-part2/__tests__/non-pass-finalisation.cat-adi-part2.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-adi-part2/__tests__/non-pass-finalisation.cat-adi-part2.page.spec.ts
@@ -134,7 +134,7 @@ describe('NonPassFinalisationCatADIPart2Page', () => {
         expect(navController$.removeView).toHaveBeenCalledWith({ id: 'DebriefCatADIPart2Page' });
       }));
 
-      it('should dispatch a change test state to WriteUp action', () => {
+      it('should dispatch a change test state to WriteUp action', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.ADI2));
         component.slotId = '123';
@@ -148,13 +148,14 @@ describe('NonPassFinalisationCatADIPart2Page', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
 
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.ADI2));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -171,14 +172,15 @@ describe('NonPassFinalisationCatADIPart2Page', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();
         expect(component.modalController.create).toHaveBeenCalled();
         expect(store$.dispatch).not.toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.ADI2));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -195,7 +197,7 @@ describe('NonPassFinalisationCatADIPart2Page', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();

--- a/src/pages/non-pass-finalisation/cat-adi-part2/non-pass-finalisation.cat-adi-part2.page.ts
+++ b/src/pages/non-pass-finalisation/cat-adi-part2/non-pass-finalisation.cat-adi-part2.page.ts
@@ -218,10 +218,10 @@ export class NonPassFinalisationCatADIPart2Page extends BasePageComponent implem
     );
   }
 
-  continue() {
+  async continue() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
-      const testDataIsInvalid = this.activityCodeFinalisationProvider
+      const testDataIsInvalid = await this.activityCodeFinalisationProvider
         .catADIPart2TestDataIsInvalid(this.activityCode.activityCode, this.testData);
 
       if (testDataIsInvalid) {

--- a/src/pages/non-pass-finalisation/cat-b/__tests__/non-pass-finalisation.cat-b.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-b/__tests__/non-pass-finalisation.cat-b.page.spec.ts
@@ -117,7 +117,7 @@ describe('NonPassFinalisationCatBPage', () => {
       });
     });
     describe('OnContinue', () => {
-      it('should dispatch a change test state to WriteUp action', () => {
+      it('should dispatch a change test state to WriteUp action', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.B));
         component.slotId = '123';
@@ -131,13 +131,14 @@ describe('NonPassFinalisationCatBPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
 
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.B));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -154,14 +155,16 @@ describe('NonPassFinalisationCatBPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();
         expect(component.modalController.create).toHaveBeenCalled();
         expect(store$.dispatch).not.toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', () => {
+
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.B));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -178,7 +181,7 @@ describe('NonPassFinalisationCatBPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();

--- a/src/pages/non-pass-finalisation/cat-b/non-pass-finalisation.cat-b.page.ts
+++ b/src/pages/non-pass-finalisation/cat-b/non-pass-finalisation.cat-b.page.ts
@@ -228,10 +228,10 @@ export class NonPassFinalisationCatBPage extends PracticeableBasePageComponent {
     );
   }
 
-  continue() {
+  async continue() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
-      const testDataIsInvalid = this.activityCodeFinalisationProvider
+      const testDataIsInvalid = await this.activityCodeFinalisationProvider
         .catBTestDataIsInvalid(this.activityCode.activityCode, this.testData);
 
       if (testDataIsInvalid) {

--- a/src/pages/non-pass-finalisation/cat-be/__tests__/non-pass-finalisation.cat-be.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-be/__tests__/non-pass-finalisation.cat-be.page.spec.ts
@@ -117,7 +117,7 @@ describe('NonPassFinalisationCatBEPage', () => {
       });
     });
     describe('OnContinue', () => {
-      it('should dispatch a change test state to WriteUp action', () => {
+      it('should dispatch a change test state to WriteUp action', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.BE));
         component.slotId = '123';
@@ -131,13 +131,14 @@ describe('NonPassFinalisationCatBEPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
 
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.BE));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -154,14 +155,15 @@ describe('NonPassFinalisationCatBEPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();
         expect(component.modalController.create).toHaveBeenCalled();
         expect(store$.dispatch).not.toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.BE));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -178,7 +180,7 @@ describe('NonPassFinalisationCatBEPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();

--- a/src/pages/non-pass-finalisation/cat-be/non-pass-finalisation.cat-be.page.ts
+++ b/src/pages/non-pass-finalisation/cat-be/non-pass-finalisation.cat-be.page.ts
@@ -230,10 +230,10 @@ export class NonPassFinalisationCatBEPage extends BasePageComponent implements O
     );
   }
 
-  continue() {
+  async continue() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
-      const testDataIsInvalid = this.activityCodeFinalisationProvider
+      const testDataIsInvalid = await this.activityCodeFinalisationProvider
         .catBETestDataIsInvalid(this.activityCode.activityCode, this.testData);
 
       if (testDataIsInvalid) {

--- a/src/pages/non-pass-finalisation/cat-c/__tests__/non-pass-finalisation.cat-c.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-c/__tests__/non-pass-finalisation.cat-c.page.spec.ts
@@ -127,7 +127,7 @@ describe('NonPassFinalisationCatCPage', () => {
       });
     });
     describe('OnContinue', () => {
-      it('should dispatch a change test state to WriteUp action', () => {
+      it('should dispatch a change test state to WriteUp action', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.C));
         component.slotId = '123';
@@ -141,13 +141,14 @@ describe('NonPassFinalisationCatCPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
 
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.C));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -164,14 +165,15 @@ describe('NonPassFinalisationCatCPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();
         expect(component.modalController.create).toHaveBeenCalled();
         expect(store$.dispatch).not.toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.C));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -188,7 +190,7 @@ describe('NonPassFinalisationCatCPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();

--- a/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.ts
+++ b/src/pages/non-pass-finalisation/cat-c/non-pass-finalisation.cat-c.page.ts
@@ -260,10 +260,10 @@ export class NonPassFinalisationCatCPage extends BasePageComponent implements On
     );
   }
 
-  continue() {
+  async continue() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
-      const testDataIsInvalid = this.activityCodeFinalisationProvider
+      const testDataIsInvalid = await this.activityCodeFinalisationProvider
         .catCTestDataIsInvalid(this.activityCode.activityCode, this.testData);
 
       if (testDataIsInvalid) {

--- a/src/pages/non-pass-finalisation/cat-cpc/__tests__/non-pass-finalisation.cat-cpc.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-cpc/__tests__/non-pass-finalisation.cat-cpc.page.spec.ts
@@ -97,7 +97,7 @@ describe('NonPassFinalisationCatCPCPage', () => {
       });
     });
     describe('OnContinue', () => {
-      it('should dispatch a change test state to WriteUp action', () => {
+      it('should dispatch a change test state to WriteUp action', async () => {
         store$.dispatch(new testActions.StartTest(123, TestCategory.C));
         component.slotId = '123';
         component.continue();

--- a/src/pages/non-pass-finalisation/cat-cpc/non-pass-finalisation.cat-cpc.page.ts
+++ b/src/pages/non-pass-finalisation/cat-cpc/non-pass-finalisation.cat-cpc.page.ts
@@ -150,7 +150,7 @@ export class NonPassFinalisationCatCPCPage extends BasePageComponent implements 
     this.store$.dispatch(new NonPassFinalisationViewDidEnter());
   }
 
-  continue() {
+  async continue() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
       this.store$.dispatch(new SetTestStatusWriteUp(this.slotId));

--- a/src/pages/non-pass-finalisation/cat-d/__tests__/non-pass-finalisation.cat-d.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-d/__tests__/non-pass-finalisation.cat-d.page.spec.ts
@@ -127,7 +127,7 @@ describe('NonPassFinalisationCatDPage', () => {
       });
     });
     describe('OnContinue', () => {
-      it('should dispatch a change test state to WriteUp action', () => {
+      it('should dispatch a change test state to WriteUp action', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.D));
         component.slotId = '123';
@@ -141,13 +141,14 @@ describe('NonPassFinalisationCatDPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
 
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.D));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -164,14 +165,15 @@ describe('NonPassFinalisationCatDPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();
         expect(component.modalController.create).toHaveBeenCalled();
         expect(store$.dispatch).not.toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.D));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -188,7 +190,7 @@ describe('NonPassFinalisationCatDPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();

--- a/src/pages/non-pass-finalisation/cat-d/non-pass-finalisation.cat-d.page.ts
+++ b/src/pages/non-pass-finalisation/cat-d/non-pass-finalisation.cat-d.page.ts
@@ -260,10 +260,10 @@ export class NonPassFinalisationCatDPage extends BasePageComponent implements On
     );
   }
 
-  continue() {
+  async continue() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
-      const testDataIsInvalid = this.activityCodeFinalisationProvider
+      const testDataIsInvalid = await this.activityCodeFinalisationProvider
         .catDTestDataIsInvalid(this.activityCode.activityCode, this.testData);
 
       if (testDataIsInvalid) {

--- a/src/pages/non-pass-finalisation/cat-home/__tests__/non-pass-finalisation.cat-home-test.page.spec.ts
+++ b/src/pages/non-pass-finalisation/cat-home/__tests__/non-pass-finalisation.cat-home-test.page.spec.ts
@@ -114,7 +114,7 @@ describe('NonPassFinalisationCatHomeTestPage', () => {
       });
     });
     describe('OnContinue', () => {
-      it('should dispatch a change test state to WriteUp action', () => {
+      it('should dispatch a change test state to WriteUp action', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.K));
         component.slotId = '123';
@@ -128,13 +128,14 @@ describe('NonPassFinalisationCatHomeTestPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(store$.dispatch).toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
 
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 5 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.K));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -151,14 +152,15 @@ describe('NonPassFinalisationCatHomeTestPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();
         expect(component.modalController.create).toHaveBeenCalled();
         expect(store$.dispatch).not.toHaveBeenCalledWith(new SetTestStatusWriteUp('123'));
       });
-      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', () => {
+      // tslint:disable-next-line:max-line-length
+      it('should create the TestFinalisationInvalidTestDataModal when activityCode is 4 and no S/D faults', async () => {
         // Arrange
         store$.dispatch(new testActions.StartTest(123, TestCategory.K));
         spyOn(component, 'openTestDataValidationModal').and.callThrough();
@@ -175,7 +177,7 @@ describe('NonPassFinalisationCatHomeTestPage', () => {
         };
 
         // Act
-        component.continue();
+        await component.continue();
 
         // Assert
         expect(component.openTestDataValidationModal).toHaveBeenCalled();

--- a/src/pages/non-pass-finalisation/cat-home/non-pass-finalisation.cat-home-test.page.ts
+++ b/src/pages/non-pass-finalisation/cat-home/non-pass-finalisation.cat-home-test.page.ts
@@ -224,10 +224,10 @@ export class NonPassFinalisationCatHomeTestPage extends BasePageComponent implem
     this.navController.push(CAT_HOME_TEST.TEST_REPORT_PAGE);
   }
 
-  continue() {
+  async continue() {
     Object.keys(this.form.controls).forEach(controlName => this.form.controls[controlName].markAsDirty());
     if (this.form.valid) {
-      const testDataIsInvalid = this.activityCodeFinalisationProvider
+      const testDataIsInvalid = await this.activityCodeFinalisationProvider
         .catHomeTestDataIsInvalid(this.activityCode.activityCode, this.testData);
 
       if (testDataIsInvalid) {

--- a/src/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
+++ b/src/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
@@ -8,7 +8,7 @@ import { TestResultProvider } from '../../test-result/test-result';
 import { ActivityCodeFinalisationProvider } from '../activity-code-finalisation';
 // import { TestResultProviderMock } from '../../test-result/__mocks__/test-result.mock';
 
-fdescribe('Activity code finalisation Provider', () => {
+describe('Activity code finalisation Provider', () => {
 
   let testResultProvider: TestResultProvider;
   let activityCodeFinalisationProvider: ActivityCodeFinalisationProvider;

--- a/src/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
+++ b/src/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
@@ -6,7 +6,6 @@ import { ActivityCodes } from '../../../shared/models/activity-codes';
 import { FaultCountProvider } from '../../fault-count/fault-count';
 import { TestResultProvider } from '../../test-result/test-result';
 import { ActivityCodeFinalisationProvider } from '../activity-code-finalisation';
-// import { TestResultProviderMock } from '../../test-result/__mocks__/test-result.mock';
 
 describe('Activity code finalisation Provider', () => {
 
@@ -16,7 +15,6 @@ describe('Activity code finalisation Provider', () => {
   configureTestSuite(() => {
     TestBed.configureTestingModule({
       providers: [
-        // { provide: TestResultProvider, useClass: TestResultProviderMock },
         TestResultProvider,
         FaultCountProvider,
         ActivityCodeFinalisationProvider,
@@ -66,6 +64,42 @@ describe('Activity code finalisation Provider', () => {
       activityCodeFinalisationProvider.catHomeTestDataIsInvalid(ActivityCodes.FAIL_PUBLIC_SAFETY, {});
       expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.F, {});
     });
+  });
+
+  it('should return false when activity code is not 4/5 for Home', () => {
+    const result = activityCodeFinalisationProvider.catHomeTestDataIsInvalid(ActivityCodes.BAD_LIGHT, {});
+    expect(result).toBe(false);
+  });
+  it('should return false when activity code is not 4/5 for B', () => {
+    const result = activityCodeFinalisationProvider.catBTestDataIsInvalid(ActivityCodes.ACCIDENT, {});
+    expect(result).toBe(false);
+  });
+  it('should return false when activity code is not 4/5 for BE', () => {
+    const result = activityCodeFinalisationProvider.catBETestDataIsInvalid(ActivityCodes.CANDIDATE_LATE, {});
+    expect(result).toBe(false);
+  });
+  it('should return false when activity code is not 4/5 for C', () => {
+    const result = activityCodeFinalisationProvider.catCTestDataIsInvalid(ActivityCodes.EXAMINER_ILL_PRE_TEST, {});
+    expect(result).toBe(false);
+  });
+  it('should return false when activity code is not 4/5 for D', () => {
+    const result = activityCodeFinalisationProvider.catDTestDataIsInvalid(ActivityCodes.CANDIDATE_PREGNANT, {});
+    expect(result).toBe(false);
+  });
+  it('should return false when activity code is not 4/5 for AMod1', () => {
+    // tslint:disable-next-line:max-line-length
+    const result = activityCodeFinalisationProvider.catAMod1TestDataIsInvalid(ActivityCodes.CANDIDATE_REFUSED_TO_SIGN_RESIDENCY_DECLARATION, {});
+    expect(result).toBe(false);
+  });
+  it('should return false when activity code is not 4/5 for AMod2', () => {
+    // tslint:disable-next-line:max-line-length
+    const result = activityCodeFinalisationProvider.catAMod2TestDataIsInvalid(ActivityCodes.ILLEGAL_ACTIVITY_FROM_CANDIDATE, {});
+    expect(result).toBe(false);
+  });
+  it('should return false when activity code is not 4/5 for ADI2', () => {
+    // tslint:disable-next-line:max-line-length
+    const result = activityCodeFinalisationProvider.catADIPart2TestDataIsInvalid(ActivityCodes.BAD_LIGHT, {});
+    expect(result).toBe(false);
   });
 
 });

--- a/src/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
+++ b/src/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+
+import { configureTestSuite } from 'ng-bullet';
+import { ActivityCodes } from '../../../shared/models/activity-codes';
+import { FaultCountProvider } from '../../fault-count/fault-count';
+import { TestResultProvider } from '../../test-result/test-result';
+import { ActivityCodeFinalisationProvider } from '../activity-code-finalisation';
+// import { TestResultProviderMock } from '../../test-result/__mocks__/test-result.mock';
+
+fdescribe('Activity code finalisation Provider', () => {
+
+  let testResultProvider: TestResultProvider;
+  let activityCodeFinalisationProvider: ActivityCodeFinalisationProvider;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        // { provide: TestResultProvider, useClass: TestResultProviderMock },
+        TestResultProvider,
+        FaultCountProvider,
+        ActivityCodeFinalisationProvider,
+      ],
+    });
+  });
+
+  beforeEach(() => {
+    testResultProvider = TestBed.get(TestResultProvider);
+    activityCodeFinalisationProvider = TestBed.get(ActivityCodeFinalisationProvider);
+    spyOn(testResultProvider, 'calculateTestResult');
+  });
+
+  describe('Check if test data for different categories are invalid', () => {
+
+    it('should call testResultProvider with the correct category for B', () => {
+      activityCodeFinalisationProvider.catBTestDataIsInvalid(ActivityCodes.FAIL_PUBLIC_SAFETY, {});
+      expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.B, {});
+    });
+
+    it('should call testResultProvider with the correct category for C', () => {
+      activityCodeFinalisationProvider.catCTestDataIsInvalid(ActivityCodes.FAIL_CANDIDATE_STOPS_TEST, {});
+      expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.C, {});
+    });
+
+    it('should call testResultProvider with the correct category for AM1', () => {
+      activityCodeFinalisationProvider.catAMod1TestDataIsInvalid(ActivityCodes.FAIL_PUBLIC_SAFETY, {});
+      expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.EUAM1, {});
+    });
+
+    it('should call testResultProvider with the correct category for AM2', () => {
+      activityCodeFinalisationProvider.catAMod2TestDataIsInvalid(ActivityCodes.FAIL_PUBLIC_SAFETY, {});
+      expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.EUAM2, {});
+    });
+
+    it('should call testResultProvider with the correct category for ADI2', () => {
+      activityCodeFinalisationProvider.catADIPart2TestDataIsInvalid(ActivityCodes.FAIL_CANDIDATE_STOPS_TEST, {});
+      expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.ADI2, {});
+    });
+
+    it('should call testResultProvider with the correct category for BE', () => {
+      activityCodeFinalisationProvider.catBETestDataIsInvalid(ActivityCodes.FAIL_PUBLIC_SAFETY, {});
+      expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.BE, {});
+    });
+
+    it('should call testResultProvider with the correct category for Home', () => {
+      activityCodeFinalisationProvider.catHomeTestDataIsInvalid(ActivityCodes.FAIL_PUBLIC_SAFETY, {});
+      expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.F, {});
+    });
+  });
+
+});

--- a/src/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
+++ b/src/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
@@ -66,39 +66,40 @@ describe('Activity code finalisation Provider', () => {
     });
   });
 
-  it('should return false when activity code is not 4/5 for Home', () => {
-    const result = activityCodeFinalisationProvider.catHomeTestDataIsInvalid(ActivityCodes.BAD_LIGHT, {});
+  it('should return false when activity code is not 4/5 for Home', async () => {
+    const result = await activityCodeFinalisationProvider.catHomeTestDataIsInvalid(ActivityCodes.BAD_LIGHT, {});
     expect(result).toBe(false);
   });
-  it('should return false when activity code is not 4/5 for B', () => {
-    const result = activityCodeFinalisationProvider.catBTestDataIsInvalid(ActivityCodes.ACCIDENT, {});
+  it('should return false when activity code is not 4/5 for B', async () => {
+    const result = await activityCodeFinalisationProvider.catBTestDataIsInvalid(ActivityCodes.ACCIDENT, {});
     expect(result).toBe(false);
   });
-  it('should return false when activity code is not 4/5 for BE', () => {
-    const result = activityCodeFinalisationProvider.catBETestDataIsInvalid(ActivityCodes.CANDIDATE_LATE, {});
+  it('should return false when activity code is not 4/5 for BE', async () => {
+    const result = await activityCodeFinalisationProvider.catBETestDataIsInvalid(ActivityCodes.CANDIDATE_LATE, {});
     expect(result).toBe(false);
   });
-  it('should return false when activity code is not 4/5 for C', () => {
-    const result = activityCodeFinalisationProvider.catCTestDataIsInvalid(ActivityCodes.EXAMINER_ILL_PRE_TEST, {});
-    expect(result).toBe(false);
-  });
-  it('should return false when activity code is not 4/5 for D', () => {
-    const result = activityCodeFinalisationProvider.catDTestDataIsInvalid(ActivityCodes.CANDIDATE_PREGNANT, {});
-    expect(result).toBe(false);
-  });
-  it('should return false when activity code is not 4/5 for AMod1', () => {
+  it('should return false when activity code is not 4/5 for C', async () => {
     // tslint:disable-next-line:max-line-length
-    const result = activityCodeFinalisationProvider.catAMod1TestDataIsInvalid(ActivityCodes.CANDIDATE_REFUSED_TO_SIGN_RESIDENCY_DECLARATION, {});
+    const result = await activityCodeFinalisationProvider.catCTestDataIsInvalid(ActivityCodes.EXAMINER_ILL_PRE_TEST, {});
     expect(result).toBe(false);
   });
-  it('should return false when activity code is not 4/5 for AMod2', () => {
-    // tslint:disable-next-line:max-line-length
-    const result = activityCodeFinalisationProvider.catAMod2TestDataIsInvalid(ActivityCodes.ILLEGAL_ACTIVITY_FROM_CANDIDATE, {});
+  it('should return false when activity code is not 4/5 for D', async () => {
+    const result = await activityCodeFinalisationProvider.catDTestDataIsInvalid(ActivityCodes.CANDIDATE_PREGNANT, {});
     expect(result).toBe(false);
   });
-  it('should return false when activity code is not 4/5 for ADI2', () => {
+  it('should return false when activity code is not 4/5 for AMod1', async () => {
     // tslint:disable-next-line:max-line-length
-    const result = activityCodeFinalisationProvider.catADIPart2TestDataIsInvalid(ActivityCodes.BAD_LIGHT, {});
+    const result = await activityCodeFinalisationProvider.catAMod1TestDataIsInvalid(ActivityCodes.CANDIDATE_REFUSED_TO_SIGN_RESIDENCY_DECLARATION, {});
+    expect(result).toBe(false);
+  });
+  it('should return false when activity code is not 4/5 for AMod2', async () => {
+    // tslint:disable-next-line:max-line-length
+    const result = await activityCodeFinalisationProvider.catAMod2TestDataIsInvalid(ActivityCodes.ILLEGAL_ACTIVITY_FROM_CANDIDATE, {});
+    expect(result).toBe(false);
+  });
+  it('should return false when activity code is not 4/5 for ADI2', async () => {
+    // tslint:disable-next-line:max-line-length
+    const result = await activityCodeFinalisationProvider.catADIPart2TestDataIsInvalid(ActivityCodes.BAD_LIGHT, {});
     expect(result).toBe(false);
   });
 

--- a/src/providers/activity-code-finalisation/activity-code-finalisation.ts
+++ b/src/providers/activity-code-finalisation/activity-code-finalisation.ts
@@ -21,7 +21,7 @@ export class ActivityCodeFinalisationProvider {
     }
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.EUA1M1, testData).toPromise()
+      this.testResultProvider.calculateTestResult(TestCategory.EUAM1, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
@@ -31,7 +31,7 @@ export class ActivityCodeFinalisationProvider {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+      this.testResultProvider.calculateTestResult(TestCategory.EUAM2, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
@@ -43,7 +43,7 @@ export class ActivityCodeFinalisationProvider {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+      this.testResultProvider.calculateTestResult(TestCategory.ADI2, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
@@ -63,7 +63,7 @@ export class ActivityCodeFinalisationProvider {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+      this.testResultProvider.calculateTestResult(TestCategory.BE, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
@@ -73,7 +73,7 @@ export class ActivityCodeFinalisationProvider {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+      this.testResultProvider.calculateTestResult(TestCategory.C, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
@@ -83,7 +83,7 @@ export class ActivityCodeFinalisationProvider {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+      this.testResultProvider.calculateTestResult(TestCategory.D, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
@@ -93,7 +93,7 @@ export class ActivityCodeFinalisationProvider {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+      this.testResultProvider.calculateTestResult(TestCategory.F, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;

--- a/src/providers/activity-code-finalisation/activity-code-finalisation.ts
+++ b/src/providers/activity-code-finalisation/activity-code-finalisation.ts
@@ -7,90 +7,96 @@ import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
 import { ActivityCodes } from '../../shared/models/activity-codes';
 import { CatCTestData, CatDTestData, CatHomeTestData } from '../../shared/unions/test-schema-unions';
-import { FaultCountAM1Helper } from '../fault-count/cat-a-mod1/fault-count.cat-a-mod1';
-import { FaultCountAM2Helper } from '../fault-count/cat-a-mod2/fault-count.cat-a-mod2';
-import { FaultCountADIPart2Helper } from '../fault-count/cat-adi-part2/fault-count.cat-adi-part2';
-import { FaultCountBHelper } from '../fault-count/cat-b/fault-count.cat-b';
-import { FaultCountBEHelper } from '../fault-count/cat-be/fault-count.cat-be';
-import { FaultCountCHelper } from '../fault-count/cat-c/fault-count.cat-c';
-import { FaultCountDHelper } from '../fault-count/cat-d/fault-count.cat-d';
-import { FaultCountHomeTestHelper } from '../fault-count/cat-home-test/fault-count.cat-home-test';
+import { TestResultProvider } from '../test-result/test-result';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 @Injectable()
 export class ActivityCodeFinalisationProvider {
 
-  catAMod1TestDataIsInvalid(activityCode: ActivityCode, testData: CatAMod1TestData): boolean {
+  constructor(private testResultProvider: TestResultProvider) {}
+
+  async catAMod1TestDataIsInvalid(activityCode: ActivityCode, testData: CatAMod1TestData): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) {
       return false;
     }
 
-    const numberOfSeriousFaults = FaultCountAM1Helper.getSeriousFaultSumCountCatAM1(testData);
-    const numberOfDangerousFaults = FaultCountAM1Helper.getDangerousFaultSumCountCatAM1(testData);
+    const isPass = await (
+      this.testResultProvider.calculateTestResult(TestCategory.EUA1M1, testData).toPromise()
+    ) === ActivityCodes.PASS;
 
-    return numberOfSeriousFaults === 0 && numberOfDangerousFaults === 0;
+    return isPass;
   }
 
-  catAMod2TestDataIsInvalid(activityCode: ActivityCode, testData: CatAMod2TestData): boolean {
+  async catAMod2TestDataIsInvalid(activityCode: ActivityCode, testData: CatAMod2TestData): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
-    const numberOfSeriousFaults = FaultCountAM2Helper.getSeriousFaultSumCountCatAM2(testData);
-    const numberOfDangerousFaults = FaultCountAM2Helper.getDangerousFaultSumCountCatAM2(testData);
+    const isPass = await (
+      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+    ) === ActivityCodes.PASS;
 
-    return numberOfSeriousFaults === 0 && numberOfDangerousFaults === 0;
+    return isPass;
   }
 
-  catADIPart2TestDataIsInvalid(activityCode: ActivityCode, testData: CatADI2UniqueTypes.TestData): boolean {
+  async catADIPart2TestDataIsInvalid(
+    activityCode: ActivityCode, testData: CatADI2UniqueTypes.TestData,
+  ): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
-    const numberOfSeriousFaults = FaultCountADIPart2Helper.getSeriousFaultSumCountCatADIPart2(testData);
-    const numberOfDangerousFaults = FaultCountADIPart2Helper.getDangerousFaultSumCountCatADIPart2(testData);
+    const isPass = await (
+      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+    ) === ActivityCodes.PASS;
 
-    return numberOfSeriousFaults === 0 && numberOfDangerousFaults === 0;
+    return isPass;
   }
 
-  catBTestDataIsInvalid(activityCode: ActivityCode, testData: CatBUniqueTypes.TestData): boolean {
+  async catBTestDataIsInvalid(activityCode: ActivityCode, testData: CatBUniqueTypes.TestData): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
-    const numberOfSeriousFaults = FaultCountBHelper.getSeriousFaultSumCountCatB(testData);
-    const numberOfDangerousFaults = FaultCountBHelper.getDangerousFaultSumCountCatB(testData);
+    const isPass = await (
+      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+    ) === ActivityCodes.PASS;
 
-    return numberOfSeriousFaults === 0 && numberOfDangerousFaults === 0;
+    return isPass;
   }
 
-  catBETestDataIsInvalid(activityCode: ActivityCode, testData: CatBEUniqueTypes.TestData): boolean {
+  async catBETestDataIsInvalid(activityCode: ActivityCode, testData: CatBEUniqueTypes.TestData): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
-    const numberOfSeriousFaults = FaultCountBEHelper.getSeriousFaultSumCountCatBE(testData);
-    const numberOfDangerousFaults = FaultCountBEHelper.getDangerousFaultSumCountCatBE(testData);
+    const isPass = await (
+      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+    ) === ActivityCodes.PASS;
 
-    return numberOfSeriousFaults === 0 && numberOfDangerousFaults === 0;
+    return isPass;
   }
 
-  catCTestDataIsInvalid(activityCode: ActivityCode, testData: CatCTestData): boolean {
+  async catCTestDataIsInvalid(activityCode: ActivityCode, testData: CatCTestData): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
-    const numberOfSeriousFaults = FaultCountCHelper.getSeriousFaultSumCountCatC(testData);
-    const numberOfDangerousFaults = FaultCountCHelper.getDangerousFaultSumCountCatC(testData);
+    const isPass = await (
+      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+    ) === ActivityCodes.PASS;
 
-    return numberOfSeriousFaults === 0 && numberOfDangerousFaults === 0;
+    return isPass;
   }
 
-  catDTestDataIsInvalid(activityCode: ActivityCode, testData: CatDTestData): boolean {
+  async catDTestDataIsInvalid(activityCode: ActivityCode, testData: CatDTestData): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
-    const numberOfSeriousFaults = FaultCountDHelper.getSeriousFaultSumCountCatD(testData);
-    const numberOfDangerousFaults = FaultCountDHelper.getDangerousFaultSumCountCatD(testData);
+    const isPass = await (
+      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+    ) === ActivityCodes.PASS;
 
-    return numberOfSeriousFaults === 0 && numberOfDangerousFaults === 0;
+    return isPass;
   }
 
-  catHomeTestDataIsInvalid(activityCode: ActivityCode, testData: CatHomeTestData): boolean {
+  async catHomeTestDataIsInvalid(activityCode: ActivityCode, testData: CatHomeTestData): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
-    const numberOfSeriousFaults = FaultCountHomeTestHelper.getSeriousFaultSumCountHomeTest(testData);
-    const numberOfDangerousFaults = FaultCountHomeTestHelper.getDangerousFaultSumCountHomeTest(testData);
+    const isPass = await (
+      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+    ) === ActivityCodes.PASS;
 
-    return numberOfSeriousFaults === 0 && numberOfDangerousFaults === 0;
+    return isPass;
   }
 
   private activityCodeIs4or5(activityCode: ActivityCode): boolean {


### PR DESCRIPTION
## Description

- Updates the `ActivityCodeFinalisationProvider` to use the `TestResultProvider` instead of the fault count helpers.
- Adds unit tests

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
