### PR TITLE
MES-6437: Loading completed tests on manual journal refresh

### DIFF
--- a/src/modules/journal/journal.actions.ts
+++ b/src/modules/journal/journal.actions.ts
@@ -83,6 +83,7 @@ export class UnloadJournal implements Action {
 
 export class LoadCompletedTests implements Action {
   readonly type = LOAD_COMPLETED_TESTS;
+  constructor(public callThrough: boolean = false) {}
 }
 
 export class LoadCompletedTestsSuccess implements Action {

--- a/src/modules/journal/journal.effects.ts
+++ b/src/modules/journal/journal.effects.ts
@@ -42,6 +42,7 @@ import { getExaminer } from '../tests/journal-data/common/examiner/examiner.redu
 import { getStaffNumber } from '../tests/journal-data/common/examiner/examiner.selector';
 import { hasStartedTests } from '../tests/tests.selector';
 import { getTests } from '../tests/tests.reducer';
+import { SearchResultTestSchema } from '@dvsa/mes-search-schema';
 
 @Injectable()
 export class JournalEffects {
@@ -210,8 +211,18 @@ export class JournalEffects {
       ),
     ),
 
-    filter(([action, staffNumber, hasStartedTests, completedTests]) =>
-      !hasStartedTests && completedTests && completedTests.length === 0),
+    filter((
+      [action, staffNumber, hasStartedTests, completedTests]:
+      [journalActions.LoadCompletedTests, string, boolean, SearchResultTestSchema[]],
+    ) => {
+
+      // The callThrough property is set to true when doing a manual journal refresh for example
+      if (action.callThrough) {
+        return true;
+      }
+
+      return !hasStartedTests && completedTests && completedTests.length === 0;
+    }),
 
     switchMap(([action, staffNumber]) => {
       const numberOfDaysToView = this.appConfig.getAppConfig().journal.numberOfDaysToView;

--- a/src/pages/journal/journal.ts
+++ b/src/pages/journal/journal.ts
@@ -291,11 +291,23 @@ export class JournalPage extends BasePageComponent implements OnInit {
 
   public pullRefreshJournal = (refresher: Refresher) => {
     this.loadJournalManually();
+    this.loadCompletedTestsWithCallThrough();
     this.pageRefresher = refresher;
   }
 
   public refreshJournal = () => {
     this.loadJournalManually();
+    this.loadCompletedTestsWithCallThrough();
+  }
+
+  private loadCompletedTestsWithCallThrough = () => {
+
+    // When manually refreshing the journal we want to check
+    // if any of the tests have already been submitted by another device
+    // So we must make the Load Completed Tests request
+    // And that's why we set the callThrough property to true
+    const callThrough = true;
+    this.store$.dispatch(new journalActions.LoadCompletedTests(callThrough));
   }
 
   async logout() {


### PR DESCRIPTION
## Description

When the journal is manually refreshed we want to load in all completed tests that is assigned to the logged in user, so that the tests statuses get updated.
Added a `callThrough` property for the LoadCompletedTests action so that we can skip the existing filtering.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [x] One review from each scrum team
- [x] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
