### PR TITLE
MES-6437: Set isLoading to false when completed tests have loaded

### DIFF
--- a/src/modules/journal/__tests__/journal.reducer.spec.ts
+++ b/src/modules/journal/__tests__/journal.reducer.spec.ts
@@ -6,9 +6,12 @@ import {
   UnsetError,
   ClearChangedSlot,
   CandidateDetailsSeen,
+  LoadCompletedTestsSuccess,
 } from '../journal.actions';
 import { SlotItem } from '../../../providers/slot-selector/slot-item';
 import { ConnectionStatus } from '../../../providers/network-state/network-state';
+import { searchResultsMock } from '../../../providers/search/__mocks__/search-results.mock';
+import { JournalModel } from '../journal.model';
 
 describe('Journal Reducer', () => {
 
@@ -146,6 +149,22 @@ describe('Journal Reducer', () => {
 
       expect(result.slots[slotDate][0].hasSeenCandidateDetails).toEqual(true);
 
+    });
+  });
+
+  describe('[JournalEffect] Load Completed Tests Success', () => {
+    it('should save competed test details and also set loading state to false', () => {
+      const state: JournalModel = {
+        ...initialState,
+        isLoading: true,
+      };
+
+      const action = new LoadCompletedTestsSuccess(searchResultsMock);
+
+      const result = journalReducer(state, action);
+
+      expect(result.isLoading).toBe(false);
+      expect(result.completedTests).toEqual(searchResultsMock);
     });
   });
 });

--- a/src/modules/journal/journal.reducer.ts
+++ b/src/modules/journal/journal.reducer.ts
@@ -91,6 +91,7 @@ export function journalReducer(state = initialState, action: journalActions.Jour
     case journalActions.LOAD_COMPLETED_TESTS_SUCCESS:
       return {
         ...state,
+        isLoading: false,
         completedTests: action.payload,
       };
     default:


### PR DESCRIPTION
## Description

Setting the isLoading to false once the Completed Tests have been successfully loaded.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
