### PR TITLE
MES-6602 Add licence-provided-warning-banner component to pass finalisation pages

### DIFF
--- a/src/pages/pass-finalisation/cat-a-mod2/_tests_/pass-finalisation.cat-a-mod2.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-a-mod2/_tests_/pass-finalisation.cat-a-mod2.page.spec.ts
@@ -40,6 +40,8 @@ import { Subscription } from 'rxjs';
 import { configureTestSuite } from 'ng-bullet';
 import { PopulateTestCategory } from '../../../../modules/tests/category/category.actions';
 import { BikeCategoryTypeComponent } from '../../../../components/common/bike-category-type/bike-category-type';
+import { LicenceProvidedWarningBannerComponent } from
+    '../../components/licence-provided-warning-banner/licence-provided-warning-banner';
 
 describe('PassFinalisationCatAMod2Page', () => {
   let fixture: ComponentFixture<PassFinalisationCatAMod2Page>;
@@ -59,6 +61,7 @@ describe('PassFinalisationCatAMod2Page', () => {
         MockComponent(LanguagePreferencesComponent),
         MockComponent(WarningBannerComponent),
         MockComponent(BikeCategoryTypeComponent),
+        MockComponent(LicenceProvidedWarningBannerComponent),
       ],
       imports: [IonicModule, AppModule],
       providers: [

--- a/src/pages/pass-finalisation/cat-a-mod2/pass-finalisation.cat-a-mod2.page.html
+++ b/src/pages/pass-finalisation/cat-a-mod2/pass-finalisation.cat-a-mod2.page.html
@@ -37,6 +37,8 @@
           (licenseNotReceived)="provisionalLicenseNotReceived()">
         </license-provided>
 
+        <licence-provided-warning-banner [licenceProvided]="pageState.provisionalLicense$ | async"></licence-provided-warning-banner>
+
         <transmission
           [formGroup]="form"
           (transmissionChange)="transmissionChanged($event)">

--- a/src/pages/pass-finalisation/cat-b/_tests_/pass-finalisation.cat-b.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-b/_tests_/pass-finalisation.cat-b.page.spec.ts
@@ -39,6 +39,8 @@ import { PASS_CERTIFICATE_NUMBER_CTRL }
   from '../../components/pass-certificate-number/pass-certificate-number.constants';
 import { configureTestSuite } from 'ng-bullet';
 import { Subscription } from 'rxjs';
+import { LicenceProvidedWarningBannerComponent } from
+    '../../components/licence-provided-warning-banner/licence-provided-warning-banner';
 
 describe('PassFinalisationCatBPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatBPage>;
@@ -58,6 +60,7 @@ describe('PassFinalisationCatBPage', () => {
         MockComponent(FinalisationHeaderComponent),
         MockComponent(LanguagePreferencesComponent),
         MockComponent(WarningBannerComponent),
+        MockComponent(LicenceProvidedWarningBannerComponent),
       ],
       imports: [IonicModule, AppModule],
       providers: [

--- a/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.html
+++ b/src/pages/pass-finalisation/cat-b/pass-finalisation.cat-b.page.html
@@ -31,6 +31,8 @@
           (licenseNotReceived)="provisionalLicenseNotReceived()">
         </license-provided>
 
+        <licence-provided-warning-banner [licenceProvided]="pageState.provisionalLicense$ | async"></licence-provided-warning-banner>
+
         <transmission [formGroup]="form" (transmissionChange)="transmissionChanged($event)"></transmission>
 
         <warning-banner *ngIf="displayTransmissionBanner()" warningText="An automatic licence will be issued.">

--- a/src/pages/pass-finalisation/cat-be/_tests_/pass-finalisation.cat-be.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-be/_tests_/pass-finalisation.cat-be.page.spec.ts
@@ -38,6 +38,8 @@ import { PASS_CERTIFICATE_NUMBER_CTRL }
   from '../../components/pass-certificate-number/pass-certificate-number.constants';
 import { Subscription } from 'rxjs';
 import { configureTestSuite } from 'ng-bullet';
+import { LicenceProvidedWarningBannerComponent } from
+    '../../components/licence-provided-warning-banner/licence-provided-warning-banner';
 
 describe('PassFinalisationCatBEPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatBEPage>;
@@ -56,6 +58,7 @@ describe('PassFinalisationCatBEPage', () => {
         MockComponent(FinalisationHeaderComponent),
         MockComponent(LanguagePreferencesComponent),
         MockComponent(WarningBannerComponent),
+        MockComponent(LicenceProvidedWarningBannerComponent),
       ],
       imports: [IonicModule, AppModule],
       providers: [

--- a/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.html
+++ b/src/pages/pass-finalisation/cat-be/pass-finalisation.cat-be.page.html
@@ -30,6 +30,8 @@
           (licenseNotReceived)="provisionalLicenseNotReceived()">
         </license-provided>
 
+        <licence-provided-warning-banner [licenceProvided]="pageState.provisionalLicense$ | async"></licence-provided-warning-banner>
+
         <transmission
           [formGroup]="form"
           [transmission]="pageState.transmission$ | async"

--- a/src/pages/pass-finalisation/cat-c/_tests_/pass-finalisation.cat-c.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-c/_tests_/pass-finalisation.cat-c.page.spec.ts
@@ -40,6 +40,8 @@ import { Code78Component } from '../../components/code-78/code-78';
 import { TransmissionType } from '../../../../shared/models/transmission-type';
 import { configureTestSuite } from 'ng-bullet';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { LicenceProvidedWarningBannerComponent } from
+    '../../components/licence-provided-warning-banner/licence-provided-warning-banner';
 
 describe('PassFinalisationCatCPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatCPage>;
@@ -196,6 +198,7 @@ describe('PassFinalisationCatCPage', () => {
         MockComponent(LanguagePreferencesComponent),
         MockComponent(WarningBannerComponent),
         MockComponent(Code78Component),
+        MockComponent(LicenceProvidedWarningBannerComponent),
       ],
       imports: [IonicModule, AppModule],
       providers: [

--- a/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.html
+++ b/src/pages/pass-finalisation/cat-c/pass-finalisation.cat-c.page.html
@@ -29,6 +29,8 @@
           (licenseNotReceived)="provisionalLicenseNotReceived()">
         </license-provided>
 
+        <licence-provided-warning-banner [licenceProvided]="pageState.provisionalLicense$ | async"></licence-provided-warning-banner>
+
         <warning-banner *ngIf="shouldShowCandidateDoesntNeedLicenseBanner()" warningText="{{askCandidateLicenseMessage}}">
         </warning-banner>
 

--- a/src/pages/pass-finalisation/cat-d/_tests_/pass-finalisation.cat-d.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-d/_tests_/pass-finalisation.cat-d.page.spec.ts
@@ -40,6 +40,8 @@ import { Code78Component } from '../../components/code-78/code-78';
 import { TransmissionType } from '../../../../shared/models/transmission-type';
 import { configureTestSuite } from 'ng-bullet';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { LicenceProvidedWarningBannerComponent } from
+    '../../components/licence-provided-warning-banner/licence-provided-warning-banner';
 
 describe('PassFinalisationCatDPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatDPage>;
@@ -196,6 +198,7 @@ describe('PassFinalisationCatDPage', () => {
         MockComponent(LanguagePreferencesComponent),
         MockComponent(WarningBannerComponent),
         MockComponent(Code78Component),
+        MockComponent(LicenceProvidedWarningBannerComponent),
       ],
       imports: [IonicModule, AppModule],
       providers: [

--- a/src/pages/pass-finalisation/cat-d/pass-finalisation.cat-d.page.html
+++ b/src/pages/pass-finalisation/cat-d/pass-finalisation.cat-d.page.html
@@ -29,6 +29,8 @@
           (licenseNotReceived)="provisionalLicenseNotReceived()">
         </license-provided>
 
+        <licence-provided-warning-banner [licenceProvided]="pageState.provisionalLicense$ | async"></licence-provided-warning-banner>
+
         <warning-banner *ngIf="shouldShowCandidateDoesntNeedLicenseBanner()" warningText="{{askCandidateLicenseMessage}}">
         </warning-banner>
 

--- a/src/pages/pass-finalisation/cat-home-test/_tests_/pass-finalisation.cat-home-test.page.spec.ts
+++ b/src/pages/pass-finalisation/cat-home-test/_tests_/pass-finalisation.cat-home-test.page.spec.ts
@@ -36,6 +36,8 @@ import { PASS_CERTIFICATE_NUMBER_CTRL }
   from '../../components/pass-certificate-number/pass-certificate-number.constants';
 import { Subscription } from 'rxjs';
 import { configureTestSuite } from 'ng-bullet';
+import { LicenceProvidedWarningBannerComponent } from
+    '../../components/licence-provided-warning-banner/licence-provided-warning-banner';
 
 describe('PassFinalisationCatHomeTestPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatHomeTestPage>;
@@ -53,6 +55,7 @@ describe('PassFinalisationCatHomeTestPage', () => {
         MockComponent(FinalisationHeaderComponent),
         MockComponent(LanguagePreferencesComponent),
         MockComponent(WarningBannerComponent),
+        MockComponent(LicenceProvidedWarningBannerComponent),
       ],
       imports: [IonicModule, AppModule],
       providers: [

--- a/src/pages/pass-finalisation/cat-home-test/pass-finalisation.cat-home-test.page.html
+++ b/src/pages/pass-finalisation/cat-home-test/pass-finalisation.cat-home-test.page.html
@@ -30,6 +30,8 @@
           (licenseNotReceived)="provisionalLicenseNotReceived()">
         </license-provided>
 
+        <licence-provided-warning-banner [licenceProvided]="pageState.provisionalLicense$ | async"></licence-provided-warning-banner>
+
         <pass-certificate-number
           [form]="form"
           [passCertificateNumberInput]="pageState.passCertificateNumber$ | async"

--- a/src/pages/pass-finalisation/components/licence-provided-warning-banner/__tests__/licence-provided-warning-banner.spec.ts
+++ b/src/pages/pass-finalisation/components/licence-provided-warning-banner/__tests__/licence-provided-warning-banner.spec.ts
@@ -1,0 +1,46 @@
+import { LicenceProvidedWarningBannerComponent } from '../licence-provided-warning-banner';
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { IonicModule } from 'ionic-angular';
+import { configureTestSuite } from 'ng-bullet';
+import { By } from '@angular/platform-browser';
+import { WarningBannerComponent } from '../../../../../components/common/warning-banner/warning-banner';
+
+describe('LicenceProvidedWarningBannerComponent', () => {
+  let fixture: ComponentFixture<LicenceProvidedWarningBannerComponent>;
+  let component: LicenceProvidedWarningBannerComponent;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        LicenceProvidedWarningBannerComponent,
+        WarningBannerComponent,
+      ],
+      imports: [
+        IonicModule,
+      ],
+      providers: [
+        LicenceProvidedWarningBannerComponent,
+      ],
+    });
+  });
+
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(LicenceProvidedWarningBannerComponent);
+    component = fixture.componentInstance;
+  }));
+
+  describe('DOM', () => {
+    it('should display correct message when licence provided', () => {
+      component.licenceProvided = true;
+      fixture.detectChanges();
+      const rendered = fixture.debugElement.query(By.css('span#warning_text')).nativeElement.innerHTML;
+      expect(rendered).toBe(component.yesText);
+    });
+    it('should display correct message when licence NOT provided', () => {
+      component.licenceProvided = false;
+      fixture.detectChanges();
+      const rendered = fixture.debugElement.query(By.css('span#warning_text')).nativeElement.innerHTML;
+      expect(rendered).toBe(component.noText);
+    });
+  });
+});

--- a/src/pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner.html
+++ b/src/pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner.html
@@ -1,0 +1,2 @@
+<warning-banner *ngIf="licenceProvided === true || licenceProvided === false" [warningText]="licenceProvided ? yesText : noText">
+</warning-banner>

--- a/src/pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner.ts
+++ b/src/pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner.ts
@@ -1,0 +1,19 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'licence-provided-warning-banner',
+  templateUrl: 'licence-provided-warning-banner.html',
+})
+
+export class LicenceProvidedWarningBannerComponent {
+  @Input()
+  licenceProvided: boolean;
+
+  yesText: string = 'Please retain the candidate\'s licence';
+  noText: string = 'Please ensure the licence is kept by the candidate';
+
+  constructor() {
+
+  }
+
+}

--- a/src/pages/pass-finalisation/components/pass-finalisation-components.module.ts
+++ b/src/pages/pass-finalisation/components/pass-finalisation-components.module.ts
@@ -6,12 +6,15 @@ import { IonicModule } from 'ionic-angular';
 import { ComponentsModule } from '../../../components/common/common-components.module';
 import { DirectivesModule } from '../../../directives/directives.module';
 import { Code78Component } from './code-78/code-78';
+import { LicenceProvidedWarningBannerComponent } from
+    './licence-provided-warning-banner/licence-provided-warning-banner';
 
 @NgModule({
   declarations: [
     LicenseProvidedComponent,
     PassCertificateNumberComponent,
     Code78Component,
+    LicenceProvidedWarningBannerComponent,
   ],
   imports: [
     CommonModule,
@@ -23,6 +26,7 @@ import { Code78Component } from './code-78/code-78';
     LicenseProvidedComponent,
     PassCertificateNumberComponent,
     Code78Component,
+    LicenceProvidedWarningBannerComponent,
   ],
 })
 export class PassFinalisationComponentsModule { }


### PR DESCRIPTION
## Description
- Adds licence received warning banner to pass finalisation pages for multiple cats. [MES-6602](https://jira.dvsacloud.uk/browse/MES-6602)

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

![image](https://user-images.githubusercontent.com/33055124/110142128-c0b83f00-7dcd-11eb-90f5-e589ecda5ec6.png)
![image](https://user-images.githubusercontent.com/33055124/110142152-c9107a00-7dcd-11eb-846a-e1064ad5405f.png)
