### PR TITLE
MES-6835: new AC for confirmation screen for code78

### DIFF
--- a/src/pages/confirm-test-details/__test__/confirm-test-details.page.spec.ts
+++ b/src/pages/confirm-test-details/__test__/confirm-test-details.page.spec.ts
@@ -19,6 +19,7 @@ import { ActivityCodeModel } from '../../office/components/activity-code/activit
 import * as pageConstants from '../../page-names.constants';
 import { SetTestStatusWriteUp } from '../../../modules/tests/test-status/test-status.actions';
 import { PersistTests } from '../../../modules/tests/tests.actions';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 describe('ConfirmTestDetailsPage', () => {
   let fixture: ComponentFixture<ConfirmTestDetailsPage>;
@@ -148,10 +149,31 @@ describe('ConfirmTestDetailsPage', () => {
 
   describe('getTransmissionText', () => {
     it('should return appropriate string if Manual', () => {
-      expect(component.getTransmissionText('Manual')).toEqual('Manual');
+      component.category = TestCategory.B;
+      expect(component.getTransmissionText('Manual', false)).toEqual('Manual');
     });
     it('should return appropriate string if Automatic', () => {
-      expect(component.getTransmissionText('Automatic')).toEqual('Automatic - An automatic licence will be issued');
+      component.category = TestCategory.B;
+      expect(component.getTransmissionText('Automatic', false))
+        .toEqual('Automatic - An automatic licence will be issued');
+    });
+    it('should return appropriate string if Manual and no code78', () => {
+      component.category = TestCategory.C;
+      expect(component.getTransmissionText('Manual', false)).toEqual('Manual');
+    });
+    it('should return appropriate string if Manual and code78', () => {
+      component.category = TestCategory.C;
+      expect(component.getTransmissionText('Manual', true)).toEqual('Manual');
+    });
+    it('should return appropriate string if Automatic and code78', () => {
+      component.category = TestCategory.C;
+      expect(component.getTransmissionText('Automatic', true))
+        .toEqual('Automatic - An automatic licence will be issued');
+    });
+    it('should return appropriate string if Automatic no code78', () => {
+      component.category = TestCategory.C;
+      expect(component.getTransmissionText('Automatic', false))
+        .toEqual('Automatic - No code 78 - A manual licence will be issued');
     });
   });
 

--- a/src/pages/confirm-test-details/confirm-test-details.page.html
+++ b/src/pages/confirm-test-details/confirm-test-details.page.html
@@ -50,7 +50,7 @@
         <data-row
           *ngIf="isPassed(pageState.testOutcomeText$ | async)"
           [label]="'Transmission'"
-          [value]="getTransmissionText(pageState.transmission$ | async)">
+          [value]="getTransmissionText(pageState.transmission$ | async, pageState.code78$ | async)">
         </data-row>
         <!-- D255 -->
         <data-row

--- a/src/pages/confirm-test-details/confirm-test-details.page.ts
+++ b/src/pages/confirm-test-details/confirm-test-details.page.ts
@@ -41,6 +41,7 @@ import { includes } from 'lodash';
 import { ConfirmTestDetailsViewDidEnter } from './confirm-test-details.actions';
 import { SetTestStatusWriteUp } from '../../modules/tests/test-status/test-status.actions';
 import { PersistTests } from '../../modules/tests/tests.actions';
+import { getCode78 } from '../../modules/tests/pass-completion/cat-d/pass-completion.cat-d.selector';
 
 interface ConfirmTestDetailsPageState {
   candidateUntitledName$: Observable<string>;
@@ -51,6 +52,7 @@ interface ConfirmTestDetailsPageState {
   testCategory$: Observable<TestCategory>;
   provisionalLicense$?: Observable<boolean>;
   transmission$: Observable<GearboxCategory>;
+  code78$: Observable<boolean>;
   d255$: Observable<boolean>;
   slotId$: Observable<string>;
 }
@@ -63,6 +65,7 @@ enum LicenceReceivedText {
 enum GearBox {
   AUTOMATIC = 'Automatic - An automatic licence will be issued',
   MANUAL = 'Manual',
+  CODE78 = 'Automatic - No code 78 - A manual licence will be issued',
 }
 
 enum D255 {
@@ -169,6 +172,10 @@ export class ConfirmTestDetailsPage extends PracticeableBasePageComponent {
           select(vehicleDetails.vehicleDetails),
           select(getGearboxCategory),
         ),
+        code78$: currentTest$.pipe(
+          select(getPassCompletion),
+          select(getCode78),
+        ),
         d255$: currentTest$.pipe(
           select(getTestSummary),
           select(getD255),
@@ -211,8 +218,16 @@ export class ConfirmTestDetailsPage extends PracticeableBasePageComponent {
     return received ? LicenceReceivedText.TRUE : LicenceReceivedText.FALSE;
   }
 
-  getTransmissionText(gearbox: GearboxCategory): GearBox {
-    return gearbox === GearBox.MANUAL ? GearBox.MANUAL : GearBox.AUTOMATIC;
+  getTransmissionText(gearbox: GearboxCategory, code78:boolean): GearBox {
+    switch (this.category) {
+      case TestCategory.C:
+      case TestCategory.CE:
+      case TestCategory.D:
+      case TestCategory.DE:
+        return gearbox === GearBox.MANUAL ? GearBox.MANUAL : !code78 ? GearBox.CODE78 : GearBox.AUTOMATIC;
+      default:
+        return gearbox === GearBox.MANUAL ? GearBox.MANUAL : GearBox.AUTOMATIC;
+    }
   }
 
   getD255Text(d255: boolean): D255 {


### PR DESCRIPTION
## Description

new AC for confirmation screen for code78

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![Screenshot 2021-04-21 at 11 14 30](https://user-images.githubusercontent.com/48550267/115538080-6bf45900-a293-11eb-8cd0-c3da97765d50.png)
![Screenshot 2021-04-21 at 11 14 50](https://user-images.githubusercontent.com/48550267/115538083-6c8cef80-a293-11eb-9a2a-dbf0ccfa9856.png)
![Screenshot 2021-04-21 at 11 15 11](https://user-images.githubusercontent.com/48550267/115538084-6c8cef80-a293-11eb-8f5c-310227d3c547.png)
![Screenshot 2021-04-21 at 11 29 10](https://user-images.githubusercontent.com/48550267/115540086-9e06ba80-a295-11eb-8685-fc9111a3c17b.png)
![Screenshot 2021-04-21 at 11 29 22](https://user-images.githubusercontent.com/48550267/115540092-9e9f5100-a295-11eb-8fb2-8c7aa44ceb71.png)
![Screenshot 2021-04-21 at 11 30 42](https://user-images.githubusercontent.com/48550267/115540093-9f37e780-a295-11eb-9eaa-742b46c20698.png)
![Screenshot 2021-04-21 at 11 30 54](https://user-images.githubusercontent.com/48550267/115540094-9f37e780-a295-11eb-99a4-93de26616dab.png)
