### PR TITLE
MES 6791 adjust TR for Cat A Mod 2

### DIFF
--- a/src/theme/sass-partials/_buttons.scss
+++ b/src/theme/sass-partials/_buttons.scss
@@ -162,7 +162,7 @@
 
   margin: 0em;
 
-  height: 4vh;
+  height: 3.9vh;
 
 
   display: flex;


### PR DESCRIPTION
## Description
- Shaves a small amount of competency button heigh to ensure Cat A Mod2 TR does not spill off screen and cause scroll

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/33055124/121531813-ac03cc80-c9f6-11eb-8453-2097bb982c31.png)
