### PR TITLE
MES-6953 narrow click target of practice mode exit button

### DIFF
--- a/src/components/common/practice-mode-banner/practice-mode-banner.html
+++ b/src/components/common/practice-mode-banner/practice-mode-banner.html
@@ -1,9 +1,19 @@
-<div class="practice-mode-top-banner" (click)="exitPracticeMode()">
-  <span class="exit-text">
-    <ion-icon name="play"></ion-icon>
-    EXIT
-  </span>
-  <span class="title">
-    You're in practice mode
-  </span>
+<div class="practice-mode-top-banner">
+  <ion-grid class="practice-mode-row">
+    <ion-row no-padding>
+      <ion-col no-padding>
+        <div class="exit-text" (click)="exitPracticeMode()">
+          <ion-icon name="play"></ion-icon>
+          EXIT
+        </div>
+      </ion-col>
+      <ion-col no-padding>
+        <div class="title">
+          You're in practice mode
+        </div>
+      </ion-col>
+      <ion-col no-padding>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
 </div>

--- a/src/components/common/practice-mode-banner/practice-mode-banner.scss
+++ b/src/components/common/practice-mode-banner/practice-mode-banner.scss
@@ -1,4 +1,8 @@
 practice-mode-banner {
+  .practice-mode-row {
+    height: 24px;
+    padding: 0;
+  }
   .practice-mode-top-banner {
     height: 24px;
     background: map-get($colors, secondary-button);


### PR DESCRIPTION
## Description
- Narrows target click area to exit practice mode to the button only, rather than entire banner.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/33055124/122017865-4333a000-cdba-11eb-8908-43dc8ce8003f.png)
