### PR TITLE
MES-7040 - Fix transmission display for failed tests

### DIFF
--- a/src/components/common/transmission-display/__test__/transmission-display.spec.ts
+++ b/src/components/common/transmission-display/__test__/transmission-display.spec.ts
@@ -1,8 +1,15 @@
-import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { configureTestSuite } from 'ng-bullet';
 import { TransmissionDisplayComponent } from '../transmission-display';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { IonicModule } from 'ionic-angular';
+
+enum GearBox {
+  AUTOMATIC_NOT_SUBMITTED = 'Automatic - An automatic licence issued',
+  AUTOMATIC_SUBMITTED = 'Automatic',
+  MANUAL = 'Manual',
+  CODE78 = 'Automatic - No code 78 - A manual licence issued',
+}
 
 describe('TransmissionDisplayComponent', () => {
   let fixture: ComponentFixture<TransmissionDisplayComponent>;
@@ -26,25 +33,49 @@ describe('TransmissionDisplayComponent', () => {
 
   describe('getTransmissionText', () => {
     it('should return appropriate string if Manual', () => {
-      expect(component.getTransmissionText('Manual', false, TestCategory.B)).toEqual('Manual');
+      component.transmission = 'Manual';
+      component.code78 = false;
+      component.category = TestCategory.B;
+      expect(component.getTransmissionText()).toEqual(GearBox.MANUAL);
     });
     it('should return appropriate string if Automatic', () => {
-      expect(component.getTransmissionText('Automatic', false, TestCategory.B))
-        .toEqual('Automatic - An automatic licence issued');
+      component.transmission = 'Automatic';
+      component.code78 = false;
+      component.category = TestCategory.B;
+      expect(component.getTransmissionText())
+        .toEqual(GearBox.AUTOMATIC_NOT_SUBMITTED);
     });
     it('should return appropriate string if Manual and no code78', () => {
-      expect(component.getTransmissionText('Manual', false, TestCategory.C)).toEqual('Manual');
+      component.transmission = 'Manual';
+      component.code78 = false;
+      component.category = TestCategory.C;
+      expect(component.getTransmissionText()).toEqual(GearBox.MANUAL);
     });
     it('should return appropriate string if Manual and code78', () => {
-      expect(component.getTransmissionText('Manual', true, TestCategory.C)).toEqual('Manual');
+      component.transmission = 'Manual';
+      component.code78 = true;
+      component.category = TestCategory.C;
+      expect(component.getTransmissionText()).toEqual(GearBox.MANUAL);
     });
     it('should return appropriate string if Automatic and code78', () => {
-      expect(component.getTransmissionText('Automatic', true, TestCategory.C))
-        .toEqual('Automatic - An automatic licence issued');
+      component.transmission = 'Automatic';
+      component.code78 = true;
+      component.category = TestCategory.C;
+      expect(component.getTransmissionText())
+        .toEqual(GearBox.AUTOMATIC_NOT_SUBMITTED);
     });
     it('should return appropriate string if Automatic no code78', () => {
-      expect(component.getTransmissionText('Automatic', false, TestCategory.C))
-        .toEqual('Automatic - No code 78 - A manual licence issued');
+      component.transmission = 'Automatic';
+      component.code78 = false;
+      component.category = TestCategory.C;
+      expect(component.getTransmissionText())
+        .toEqual(GearBox.CODE78);
+    });
+    it('should return appropriate string if Automatic anf Fail (missing code 78)', () => {
+      component.transmission = 'Automatic';
+      component.category = TestCategory.C;
+      expect(component.getTransmissionText())
+        .toEqual(GearBox.AUTOMATIC_NOT_SUBMITTED);
     });
   });
 });

--- a/src/components/common/transmission-display/transmission-display.html
+++ b/src/components/common/transmission-display/transmission-display.html
@@ -3,6 +3,6 @@
     <label>Transmission</label>
   </ion-col>
   <ion-col col-56>
-    <span class="mes-data">{{getTransmissionText(transmission, code78, category)}}</span>
+    <span class="mes-data">{{getTransmissionText()}}</span>
   </ion-col>
 </ion-row>

--- a/src/components/common/transmission-display/transmission-display.ts
+++ b/src/components/common/transmission-display/transmission-display.ts
@@ -3,7 +3,8 @@ import { GearboxCategory } from '@dvsa/mes-test-schema/categories/common';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 enum GearBox {
-  AUTOMATIC = 'Automatic - An automatic licence issued',
+  AUTOMATIC_NOT_SUBMITTED = 'Automatic - An automatic licence issued',
+  AUTOMATIC_SUBMITTED = 'Automatic',
   MANUAL = 'Manual',
   CODE78 = 'Automatic - No code 78 - A manual licence issued',
 }
@@ -23,18 +24,27 @@ export class TransmissionDisplayComponent {
   @Input()
   category: TestCategory;
 
+  @Input()
+  isTestSubmitted: boolean = false;
+
   constructor() {
   }
 
-  getTransmissionText(gearbox: GearboxCategory, code78: boolean, category: TestCategory): GearBox {
-    switch (category) {
-      case TestCategory.C:
-      case TestCategory.CE:
-      case TestCategory.D:
-      case TestCategory.DE:
-        return gearbox === GearBox.MANUAL ? GearBox.MANUAL : !code78 ? GearBox.CODE78 : GearBox.AUTOMATIC;
-      default:
-        return gearbox === GearBox.MANUAL ? GearBox.MANUAL : GearBox.AUTOMATIC;
+  getTransmissionText(): GearBox {
+    const code78Categories: TestCategory[] = [TestCategory.C, TestCategory.CE, TestCategory.D, TestCategory.DE];
+    if (this.transmission === GearBox.MANUAL) {
+      return GearBox.MANUAL;
     }
+    if (
+      code78Categories.includes(this.category) &&
+      this.transmission !== GearBox.MANUAL &&
+      !this.code78 &&
+      typeof this.code78 !== 'undefined'
+    ) {
+      return GearBox.CODE78;
+    }
+    return this.transmission === 'Automatic' && this.isTestSubmitted ?
+      GearBox.AUTOMATIC_SUBMITTED :
+      GearBox.AUTOMATIC_NOT_SUBMITTED;
   }
 }

--- a/src/pages/confirm-test-details/confirm-test-details.page.html
+++ b/src/pages/confirm-test-details/confirm-test-details.page.html
@@ -51,7 +51,8 @@
           *ngIf="isPassed(pageState.testOutcomeText$ | async)"
           [category]="category"
           [transmission]="pageState.transmission$ | async"
-          [code78]="pageState.code78$ | async">
+          [code78]="pageState.code78$ | async"
+          [isTestSubmitted]="false">
         </transmission-display>
         <!-- D255 -->
         <data-row

--- a/src/pages/view-test-result/components/vehicle-details-card/vehicle-details-card.html
+++ b/src/pages/view-test-result/components/vehicle-details-card/vehicle-details-card.html
@@ -8,7 +8,8 @@
         *ngIf="getTransmission()"
         [category]="category"
         [transmission]="data.gearboxCategory"
-        [code78]="passCompletion?.code78Present">
+        [code78]="passCompletion?.code78Present"
+        [isTestSubmitted]="true">
       </transmission-display>
       <data-row
         [label]="'Vehicle registration number'"


### PR DESCRIPTION
## Description
- Resolves bug with 'licence issued' displaying for failed tests when performing test result searches

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
