### PR TITLE
MES-6594: Make only one normal stop mandatory for cat b, a mod 1 and adi2

### DIFF
--- a/src/pages/test-report/cat-a-mod2/test-report.cat-a-mod2.page.html
+++ b/src/pages/test-report/cat-a-mod2/test-report.cat-a-mod2.page.html
@@ -28,14 +28,8 @@
           <ion-col>
             <legal-requirement
               [legalRequirement]="legalRequirements.normalStart1"
+              [isFullWidthButton]="true"
               [ticked]="(pageState.testRequirements$ | async)[legalRequirements.normalStart1]"
-            >
-            </legal-requirement>
-          </ion-col>
-          <ion-col>
-            <legal-requirement
-              [legalRequirement]="legalRequirements.normalStart2"
-              [ticked]="(pageState.testRequirements$ | async)[legalRequirements.normalStart2]"
             >
             </legal-requirement>
           </ion-col>

--- a/src/pages/test-report/cat-adi-part2/test-report.cat-adi-part2.page.html
+++ b/src/pages/test-report/cat-adi-part2/test-report.cat-adi-part2.page.html
@@ -31,14 +31,8 @@
           <ion-col>
             <legal-requirement
               [legalRequirement]="legalRequirements.normalStart1"
+              [isFullWidthButton]="true"
               [ticked]="(pageState.testRequirements$ | async)[legalRequirements.normalStart1]"
-            >
-            </legal-requirement>
-          </ion-col>
-          <ion-col>
-            <legal-requirement
-              [legalRequirement]="legalRequirements.normalStart2"
-              [ticked]="(pageState.testRequirements$ | async)[legalRequirements.normalStart2]"
             >
             </legal-requirement>
           </ion-col>

--- a/src/pages/test-report/cat-b/test-report.cat-b.page.html
+++ b/src/pages/test-report/cat-b/test-report.cat-b.page.html
@@ -32,14 +32,8 @@
           <ion-col>
             <legal-requirement
               [legalRequirement]="legalRequirements.normalStart1"
+              [isFullWidthButton]="true"
               [ticked]="(pageState.testRequirements$ | async)[legalRequirements.normalStart1]"
-            >
-            </legal-requirement>
-          </ion-col>
-          <ion-col>
-            <legal-requirement
-              [legalRequirement]="legalRequirements.normalStart2"
-              [ticked]="(pageState.testRequirements$ | async)[legalRequirements.normalStart2]"
             >
             </legal-requirement>
           </ion-col>

--- a/src/pages/test-report/components/legal-requirement/legal-requirement.ts
+++ b/src/pages/test-report/components/legal-requirement/legal-requirement.ts
@@ -19,12 +19,18 @@ export class LegalRequirementComponent {
   ticked: boolean;
   @Input()
   disabled: boolean = false;
+  @Input()
+  isFullWidthButton: boolean = false;
 
   constructor(
     private store$: Store<StoreModel>,
   ) {}
 
-  getLabel = (): string => legalRequirementLabels[this.legalRequirement];
+  getLabel = (): string => {
+    return this.legalRequirement === LegalRequirements.normalStart1 &&
+    this.isFullWidthButton ?
+      'Normal Stop' : legalRequirementLabels[this.legalRequirement];
+  }
 
   toggleLegalRequirement = (): void => {
     this.store$.dispatch(new ToggleLegalRequirement(this.legalRequirement));

--- a/src/providers/test-report-validator/__mocks__/test-result.mock.ts
+++ b/src/providers/test-report-validator/__mocks__/test-result.mock.ts
@@ -468,7 +468,6 @@ export const validTestCatK: CatKUniqueTypes.TestData = {
 
 export const legalRequirementsAMod2 = [
   legalRequirementsLabels.normalStart1,
-  legalRequirementsLabels.normalStart2,
   legalRequirementsLabels.angledStart,
   legalRequirementsLabels.hillStart,
   legalRequirementsLabels.safetyAndBalanceQuestions,
@@ -477,7 +476,6 @@ export const legalRequirementsAMod2 = [
 
 export const legalRequirementsADIPart2 = [
   legalRequirementsLabels.normalStart1,
-  legalRequirementsLabels.normalStart2,
   legalRequirementsLabels.angledStart,
   legalRequirementsLabels.uphillStart,
   legalRequirementsLabels.downhillStart,
@@ -488,7 +486,6 @@ export const legalRequirementsADIPart2 = [
 
 export const legalRequirementsB = [
   legalRequirementsLabels.normalStart1,
-  legalRequirementsLabels.normalStart2,
   legalRequirementsLabels.angledStart,
   legalRequirementsLabels.hillStart,
   legalRequirementsLabels.manoeuvre,

--- a/src/providers/test-report-validator/test-report-validator.ts
+++ b/src/providers/test-report-validator/test-report-validator.ts
@@ -184,7 +184,6 @@ export class TestReportValidatorProvider {
 
   private validateLegalRequirementsCatAdiPart2(data: CatADI2UniqueTypes.TestData): boolean {
     const normalStart1: boolean = get(data, 'testRequirements.normalStart1', false);
-    const normalStart2: boolean = get(data, 'testRequirements.normalStart2', false);
     const angledStart: boolean = get(data, 'testRequirements.angledStart', false);
     const uphillStart: boolean = get(data, 'testRequirements.uphillStart', false);
     const downhillStart: boolean = get(data, 'testRequirements.downhillStart', false);
@@ -194,7 +193,6 @@ export class TestReportValidatorProvider {
 
     return (
       normalStart1 &&
-      normalStart2 &&
       angledStart &&
       uphillStart &&
       downhillStart &&
@@ -208,7 +206,6 @@ export class TestReportValidatorProvider {
     const result: legalRequirementsLabels[] = [];
 
     !get(data, 'testRequirements.normalStart1', false) && result.push(legalRequirementsLabels.normalStart1);
-    !get(data, 'testRequirements.normalStart2', false) && result.push(legalRequirementsLabels.normalStart2);
     !get(data, 'testRequirements.angledStart', false) && result.push(legalRequirementsLabels.angledStart);
     !get(data, 'testRequirements.uphillStart', false) && result.push(legalRequirementsLabels.uphillStart);
     !get(data, 'testRequirements.downhillStart', false) && result.push(legalRequirementsLabels.downhillStart);
@@ -221,21 +218,19 @@ export class TestReportValidatorProvider {
 
   private validateLegalRequirementsCatB(data: CatBUniqueTypes.TestData): boolean {
     const normalStart1: boolean = get(data, 'testRequirements.normalStart1', false);
-    const normalStart2: boolean = get(data, 'testRequirements.normalStart2', false);
     const angledStart: boolean = get(data, 'testRequirements.angledStart', false);
     const hillStart: boolean = get(data, 'testRequirements.hillStart', false);
     const manoeuvre: boolean = hasManoeuvreBeenCompletedCatB(data) || false;
     const vehicleChecks: boolean = hasVehicleChecksBeenCompletedCatB(data) || false;
     const eco: boolean = get(data, 'eco.completed', false);
 
-    return normalStart1 && normalStart2 && angledStart && hillStart && manoeuvre && vehicleChecks && eco;
+    return normalStart1 && angledStart && hillStart && manoeuvre && vehicleChecks && eco;
   }
 
   private getMissingLegalRequirementsCatB(data: CatBUniqueTypes.TestData): legalRequirementsLabels[] {
     const result: legalRequirementsLabels[] = [];
 
     !get(data, 'testRequirements.normalStart1', false) && result.push(legalRequirementsLabels.normalStart1);
-    !get(data, 'testRequirements.normalStart2', false) && result.push(legalRequirementsLabels.normalStart2);
     !get(data, 'testRequirements.angledStart', false) && result.push(legalRequirementsLabels.angledStart);
     !get(data, 'testRequirements.hillStart', false) && result.push(legalRequirementsLabels.hillStart);
     !hasManoeuvreBeenCompletedCatB(data) && result.push(legalRequirementsLabels.manoeuvre);
@@ -548,14 +543,13 @@ export class TestReportValidatorProvider {
 
   private validateLegalRequirementsCatEUAM2(data: CatAMod2TestData): boolean {
     const normalStart1: boolean = get(data, 'testRequirements.normalStart1', false);
-    const normalStart2: boolean = get(data, 'testRequirements.normalStart2', false);
     const angledStart: boolean = get(data, 'testRequirements.angledStart', false);
     const hillStart: boolean = get(data, 'testRequirements.hillStart', false);
     const safteyAndBalanceQuestions: boolean =
       haveSafetyAndBalanceQuestionsBeenCompleted(data.safetyAndBalanceQuestions);
     const eco: boolean = get(data, 'eco.completed', false);
 
-    return normalStart1 && normalStart2 && angledStart && hillStart && safteyAndBalanceQuestions && eco;
+    return normalStart1 && angledStart && hillStart && safteyAndBalanceQuestions && eco;
   }
 
   private getMissingLegalRequirementsCatD1E(
@@ -588,7 +582,6 @@ export class TestReportValidatorProvider {
     const result: legalRequirementsLabels[] = [];
 
     !get(data, 'testRequirements.normalStart1', false) && result.push(legalRequirementsLabels.normalStart1);
-    !get(data, 'testRequirements.normalStart2', false) && result.push(legalRequirementsLabels.normalStart2);
     !get(data, 'testRequirements.angledStart', false) && result.push(legalRequirementsLabels.angledStart);
     !get(data, 'testRequirements.hillStart', false) && result.push(legalRequirementsLabels.hillStart);
     !haveSafetyAndBalanceQuestionsBeenCompleted(data.safetyAndBalanceQuestions)


### PR DESCRIPTION
## Description
- Requires only one normal stop to be completed for Cat B, A Mod 2 and ADI2 test types

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/33055124/131463334-361a785d-5443-4840-8f6b-b770b21d7391.png)
![image](https://user-images.githubusercontent.com/33055124/131463401-b5d6339a-c674-4f73-b2e3-46332faf2dd4.png)
