### PR TITLE
MES-7197: make only one normal stop mandatory for b+e, C, CE, C1, C1E and Home tests

### DIFF
--- a/src/pages/test-report/cat-be/test-report.cat-be.page.html
+++ b/src/pages/test-report/cat-be/test-report.cat-be.page.html
@@ -29,14 +29,7 @@
             <legal-requirement
               [legalRequirement]="legalRequirements.normalStart1"
               [ticked]="(pageState.testRequirements$ | async)[legalRequirements.normalStart1]"
-              [disabled]="(pageState.delegatedTest$| async)"
-            >
-            </legal-requirement>
-          </ion-col>
-          <ion-col>
-            <legal-requirement
-              [legalRequirement]="legalRequirements.normalStart2"
-              [ticked]="(pageState.testRequirements$ | async)[legalRequirements.normalStart2]"
+              [isFullWidthButton]="true"
               [disabled]="(pageState.delegatedTest$| async)"
             >
             </legal-requirement>

--- a/src/pages/test-report/cat-c/test-report.cat-c.page.html
+++ b/src/pages/test-report/cat-c/test-report.cat-c.page.html
@@ -29,14 +29,7 @@
             <legal-requirement
               [legalRequirement]="legalRequirements.normalStart1"
               [ticked]="(pageState.testRequirements$ | async)[legalRequirements.normalStart1]"
-              [disabled]="(pageState.delegatedTest$ | async)"
-            >
-            </legal-requirement>
-          </ion-col>
-          <ion-col>
-            <legal-requirement
-              [legalRequirement]="legalRequirements.normalStart2"
-              [ticked]="(pageState.testRequirements$ | async)[legalRequirements.normalStart2]"
+              [isFullWidthButton]="true"
               [disabled]="(pageState.delegatedTest$ | async)"
             >
             </legal-requirement>

--- a/src/pages/test-report/cat-home-test/test-report.cat-home-test.page.html
+++ b/src/pages/test-report/cat-home-test/test-report.cat-home-test.page.html
@@ -24,13 +24,7 @@
             <legal-requirement
               [legalRequirement]="legalRequirements.normalStart1"
               [ticked]="(pageState.testRequirements$ | async)[legalRequirements.normalStart1]"
-            >
-            </legal-requirement>
-          </ion-col>
-          <ion-col>
-            <legal-requirement
-              [legalRequirement]="legalRequirements.normalStart2"
-              [ticked]="(pageState.testRequirements$ | async)[legalRequirements.normalStart2]"
+              [isFullWidthButton]="true"
             >
             </legal-requirement>
           </ion-col>

--- a/src/pages/view-test-result/cat-be/components/debrief-card/__tests__/debrief-card.spec.ts
+++ b/src/pages/view-test-result/cat-be/components/debrief-card/__tests__/debrief-card.spec.ts
@@ -76,16 +76,14 @@ describe('DebriefCardComponent', () => {
             angledStartControlledStop: true,
             downhillStart: false,
             normalStart1: true,
-            normalStart2: false,
           },
         };
         component.data = data;
         fixture.detectChanges();
         const result: DataRowListItem[] = component.getTestRequirements();
 
-        expect(result.length).toEqual(6);
+        expect(result.length).toEqual(5);
         expect(result).toContain({ label: TestRequirementsLabels.normalStart1, checked: true });
-        expect(result).toContain({ label: TestRequirementsLabels.normalStart2, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.uphillStart, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.downhillStart, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.angledStartControlledStop, checked: true });

--- a/src/pages/view-test-result/cat-be/components/debrief-card/debrief-card.ts
+++ b/src/pages/view-test-result/cat-be/components/debrief-card/debrief-card.ts
@@ -35,10 +35,6 @@ export class DebriefCardComponent {
         checked: get(this.data, 'testRequirements.normalStart1', false) ,
       },
       {
-        label: TestRequirementsLabels.normalStart2,
-        checked: get(this.data, 'testRequirements.normalStart2', false),
-      },
-      {
         label: TestRequirementsLabels.uphillStart,
         checked: get(this.data, 'testRequirements.uphillStart', false),
       },

--- a/src/pages/view-test-result/cat-c/components/debrief-card/__tests__/debrief-card.spec.ts
+++ b/src/pages/view-test-result/cat-c/components/debrief-card/__tests__/debrief-card.spec.ts
@@ -80,7 +80,6 @@ describe('DebriefCardComponent', () => {
             angledStartControlledStop: true,
             downhillStart: false,
             normalStart1: true,
-            normalStart2: false,
           },
         };
         component.data = data;
@@ -88,9 +87,8 @@ describe('DebriefCardComponent', () => {
         fixture.detectChanges();
         const result: DataRowListItem[] = component.getTestRequirements();
 
-        expect(result.length).toEqual(5);
+        expect(result.length).toEqual(4);
         expect(result).toContain({ label: TestRequirementsLabels.normalStart1, checked: true });
-        expect(result).toContain({ label: TestRequirementsLabels.normalStart2, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.uphillStart, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.downhillStart, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.angledStartControlledStop, checked: true });
@@ -112,9 +110,8 @@ describe('DebriefCardComponent', () => {
         fixture.detectChanges();
         const result: DataRowListItem[] = component.getTestRequirements();
 
-        expect(result.length).toEqual(6);
+        expect(result.length).toEqual(5);
         expect(result).toContain({ label: TestRequirementsLabels.normalStart1, checked: true });
-        expect(result).toContain({ label: TestRequirementsLabels.normalStart2, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.uphillStart, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.downhillStart, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.angledStartControlledStop, checked: true });
@@ -134,9 +131,8 @@ describe('DebriefCardComponent', () => {
         fixture.detectChanges();
         const result: DataRowListItem[] = component.getTestRequirements();
 
-        expect(result.length).toEqual(5);
+        expect(result.length).toEqual(4);
         expect(result).toContain({ label: TestRequirementsLabels.normalStart1, checked: true });
-        expect(result).toContain({ label: TestRequirementsLabels.normalStart2, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.uphillStart, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.downhillStart, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.angledStartControlledStop, checked: true });
@@ -155,9 +151,8 @@ describe('DebriefCardComponent', () => {
         fixture.detectChanges();
         const result: DataRowListItem[] = component.getTestRequirements();
 
-        expect(result.length).toEqual(6);
+        expect(result.length).toEqual(5);
         expect(result).toContain({ label: TestRequirementsLabels.normalStart1, checked: true });
-        expect(result).toContain({ label: TestRequirementsLabels.normalStart2, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.uphillStart, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.downhillStart, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.angledStartControlledStop, checked: true });

--- a/src/pages/view-test-result/cat-c/components/debrief-card/debrief-card.ts
+++ b/src/pages/view-test-result/cat-c/components/debrief-card/debrief-card.ts
@@ -47,10 +47,6 @@ export class DebriefCardComponent {
         checked: get(this.data, 'testRequirements.normalStart1', false) ,
       },
       {
-        label: TestRequirementsLabels.normalStart2,
-        checked: get(this.data, 'testRequirements.normalStart2', false),
-      },
-      {
         label: TestRequirementsLabels.uphillStart,
         checked: get(this.data, 'testRequirements.uphillStart', false),
       },

--- a/src/pages/view-test-result/cat-home-test/components/debrief-card/__tests__/debrief-card.spec.ts
+++ b/src/pages/view-test-result/cat-home-test/components/debrief-card/__tests__/debrief-card.spec.ts
@@ -76,7 +76,6 @@ describe('DebriefCardComponent', () => {
         const data: HomeTestData = {
           testRequirements: {
             normalStart1: true,
-            normalStart2: false,
             angledStart: true,
             uphillStartDesignatedStart: false,
           },
@@ -86,9 +85,8 @@ describe('DebriefCardComponent', () => {
         fixture.detectChanges();
         const result: DataRowListItem[] = component.getTestRequirements();
 
-        expect(result.length).toEqual(6);
+        expect(result.length).toEqual(5);
         expect(result).toContain({ label: TestRequirementsLabels.normalStart1, checked: true });
-        expect(result).toContain({ label: TestRequirementsLabels.normalStart2, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.uphillStart, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.downhillStart, checked: false });
         expect(result).toContain({ label: TestRequirementsLabels.angledStartControlledStop, checked: true });

--- a/src/pages/view-test-result/cat-home-test/components/debrief-card/debrief-card.ts
+++ b/src/pages/view-test-result/cat-home-test/components/debrief-card/debrief-card.ts
@@ -50,10 +50,6 @@ export class DebriefCardComponent {
         checked: get(this.data, 'testRequirements.normalStart1', false),
       },
       {
-        label: TestRequirementsLabels.normalStart2,
-        checked: get(this.data, 'testRequirements.normalStart2', false),
-      },
-      {
         label: TestRequirementsLabels.angledStart,
         checked: get(this.data, 'testRequirements.angledStart', false),
       },

--- a/src/providers/test-report-validator/__mocks__/test-result.mock.ts
+++ b/src/providers/test-report-validator/__mocks__/test-result.mock.ts
@@ -429,7 +429,6 @@ export const validTestCatH: CatHUniqueTypes.TestData = {
   testRequirements: {
     angledStart: true,
     normalStart1: true,
-    normalStart2: true,
     uphillStartDesignatedStart: true,
   },
   eco: {
@@ -452,7 +451,6 @@ export const validTestCatK: CatKUniqueTypes.TestData = {
   testRequirements: {
     angledStart: true,
     normalStart1: true,
-    normalStart2: true,
     uphillStartDesignatedStart: true,
   },
   eco: {
@@ -592,7 +590,6 @@ export const legalRequirementsCatD1E = [
 
 export const legalRequirementsCatF = [
   legalRequirementsLabels.normalStart1,
-  legalRequirementsLabels.normalStart2,
   legalRequirementsLabels.angledStart,
   legalRequirementsLabels.uphillStartDesignatedStart,
   legalRequirementsLabels.manoeuvre,
@@ -603,7 +600,6 @@ export const legalRequirementsCatF = [
 
 export const legalRequirementsCatG = [
   legalRequirementsLabels.normalStart1,
-  legalRequirementsLabels.normalStart2,
   legalRequirementsLabels.angledStart,
   legalRequirementsLabels.uphillStartDesignatedStart,
   legalRequirementsLabels.manoeuvre,
@@ -614,7 +610,6 @@ export const legalRequirementsCatG = [
 
 export const legalRequirementsCatH = [
   legalRequirementsLabels.normalStart1,
-  legalRequirementsLabels.normalStart2,
   legalRequirementsLabels.angledStart,
   legalRequirementsLabels.uphillStartDesignatedStart,
   legalRequirementsLabels.manoeuvre,
@@ -625,7 +620,6 @@ export const legalRequirementsCatH = [
 
 export const legalRequirementsCatK = [
   legalRequirementsLabels.normalStart1,
-  legalRequirementsLabels.normalStart2,
   legalRequirementsLabels.angledStart,
   legalRequirementsLabels.uphillStartDesignatedStart,
   legalRequirementsLabels.highwayCodeSafety,

--- a/src/providers/test-report-validator/__mocks__/test-result.mock.ts
+++ b/src/providers/test-report-validator/__mocks__/test-result.mock.ts
@@ -128,7 +128,7 @@ export const validTestCatB: CatBUniqueTypes.TestData = {
 export const validTestCatBE: CatBEUniqueTypes.TestData = {
   testRequirements: {
     angledStartControlledStop: true,
-    normalStart2: true,
+    normalStart1: true,
     uphillStart: true,
   },
   manoeuvres: {
@@ -147,7 +147,7 @@ export const validTestCatBE: CatBEUniqueTypes.TestData = {
 export const validDelegatedTestCatBE: CatBEUniqueTypes.TestData = {
   testRequirements: {
     angledStartControlledStop: true,
-    normalStart2: false,
+    normalStart1: false,
     uphillStart: false,
   },
   manoeuvres: {
@@ -166,7 +166,7 @@ export const validDelegatedTestCatBE: CatBEUniqueTypes.TestData = {
 export const validTestCatC: CatCUniqueTypes.TestData = {
   testRequirements: {
     angledStartControlledStop: true,
-    normalStart2: true,
+    normalStart1: true,
     uphillStart: true,
   },
   manoeuvres: {
@@ -198,7 +198,7 @@ export const validDelegatedTestCatCAndC1: CatCUniqueTypes.TestData = {
 export const validTestCatC1: CatC1UniqueTypes.TestData = {
   testRequirements: {
     angledStartControlledStop: true,
-    normalStart2: true,
+    normalStart1: true,
     uphillStart: true,
   },
   manoeuvres: {
@@ -233,7 +233,7 @@ export const validDelegatedTestCatCEAndC1E: CatCEUniqueTypes.TestData | CatCEUni
 export const validTestCatCE: CatCEUniqueTypes.TestData = {
   testRequirements: {
     angledStartControlledStop: true,
-    normalStart2: true,
+    normalStart1: true,
     uphillStart: true,
   },
   manoeuvres: {
@@ -252,7 +252,7 @@ export const validTestCatCE: CatCEUniqueTypes.TestData = {
 export const validTestCatC1E: CatC1EUniqueTypes.TestData = {
   testRequirements: {
     angledStartControlledStop: true,
-    normalStart2: true,
+    normalStart1: true,
     uphillStart: true,
   },
   manoeuvres: {

--- a/src/providers/test-report-validator/test-report-validator.ts
+++ b/src/providers/test-report-validator/test-report-validator.ts
@@ -287,14 +287,13 @@ export class TestReportValidatorProvider {
     isDelegated: boolean,
     ): boolean {
     const normalStart1: boolean = get(data, 'testRequirements.normalStart1', false);
-    const normalStart2: boolean = get(data, 'testRequirements.normalStart2', false);
     const uphillStart: boolean = get(data, 'testRequirements.uphillStart', false);
     const angledStartControlledStop: boolean = get(data, 'testRequirements.angledStartControlledStop', false);
     const manoeuvre: boolean = hasManoeuvreBeenCompletedCatC(data) || false;
     const eco: boolean = get(data, 'eco.completed', false);
 
     return !isDelegated ? (
-      (normalStart1 || normalStart2) &&
+      normalStart1 &&
       uphillStart &&
       angledStartControlledStop &&
       manoeuvre &&
@@ -312,7 +311,7 @@ export class TestReportValidatorProvider {
     ): legalRequirementsLabels[] {
     const result: legalRequirementsLabels[] = [];
     if (!isDelegated) {
-      (!get(data, 'testRequirements.normalStart1', false) && !get(data, 'testRequirements.normalStart2', false))
+      (!get(data, 'testRequirements.normalStart1', false))
         && result.push(legalRequirementsLabels.normalStart1);
       !get(data, 'testRequirements.uphillStart', false) && result.push(legalRequirementsLabels.uphillStart);
     }
@@ -329,7 +328,6 @@ export class TestReportValidatorProvider {
     isDelegated: boolean,
     ): boolean {
     const normalStart1: boolean = get(data, 'testRequirements.normalStart1', false);
-    const normalStart2: boolean = get(data, 'testRequirements.normalStart2', false);
     const uphillStart: boolean = get(data, 'testRequirements.uphillStart', false);
     const angledStartControlledStop: boolean = get(data, 'testRequirements.angledStartControlledStop', false);
     const manoeuvre: boolean = hasManoeuvreBeenCompletedCatC(data) || false;
@@ -337,7 +335,7 @@ export class TestReportValidatorProvider {
     const uncoupleRecouple: boolean = get(data, 'uncoupleRecouple.selected', false);
 
     return !isDelegated ? (
-      (normalStart1 || normalStart2) &&
+      normalStart1 &&
       uphillStart &&
       angledStartControlledStop &&
       manoeuvre &&
@@ -358,7 +356,7 @@ export class TestReportValidatorProvider {
     const result: legalRequirementsLabels[] = [];
 
     if (!isDelegated) {
-      (!get(data, 'testRequirements.normalStart1', false) && !get(data, 'testRequirements.normalStart2', false))
+      (!get(data, 'testRequirements.normalStart1', false))
         && result.push(legalRequirementsLabels.normalStart1);
       !get(data, 'testRequirements.uphillStart', false) && result.push(legalRequirementsLabels.uphillStart);
     }

--- a/src/providers/test-report-validator/test-report-validator.ts
+++ b/src/providers/test-report-validator/test-report-validator.ts
@@ -242,7 +242,6 @@ export class TestReportValidatorProvider {
 
   private validateLegalRequirementsCatBE(data: CatBEUniqueTypes.TestData, isDelegated: boolean): boolean {
     const normalStart1: boolean = get(data, 'testRequirements.normalStart1', false);
-    const normalStart2: boolean = get(data, 'testRequirements.normalStart2', false);
     const uphillStart: boolean = get(data, 'testRequirements.uphillStart', false);
     const angledStartControlledStop: boolean = get(data, 'testRequirements.angledStartControlledStop', false);
     const manoeuvre: boolean = hasManoeuvreBeenCompletedCatBE(data) || false;
@@ -250,7 +249,7 @@ export class TestReportValidatorProvider {
     const uncoupleRecouple: boolean = get(data, 'uncoupleRecouple.selected', false);
 
     return !isDelegated ? (
-      (normalStart1 || normalStart2) &&
+      normalStart1 &&
       uphillStart &&
       angledStartControlledStop &&
       manoeuvre &&
@@ -269,7 +268,7 @@ export class TestReportValidatorProvider {
   ): legalRequirementsLabels[] {
     const result: legalRequirementsLabels[] = [];
     if (!isDelegated) {
-      !get(data, 'testRequirements.normalStart1', false) && !get(data, 'testRequirements.normalStart2', false)
+      !get(data, 'testRequirements.normalStart1', false)
         && result.push(legalRequirementsLabels.normalStart1);
       !get(data, 'testRequirements.uphillStart', false) && result.push(legalRequirementsLabels.uphillStart);
     }
@@ -591,7 +590,6 @@ export class TestReportValidatorProvider {
 
   private validateLegalRequirementsCatHomeTest(data: HomeTestData): boolean {
     const normalStart1: boolean = get(data, 'testRequirements.normalStart1', false);
-    const normalStart2: boolean = get(data, 'testRequirements.normalStart2', false);
     const angledStart: boolean = get(data, 'testRequirements.angledStart', false);
     const controlledStop: boolean = get(data, 'controlledStop.selected', false);
     const uphillStartDesignatedStart: boolean = get(data, 'testRequirements.uphillStartDesignatedStart', false);
@@ -600,7 +598,7 @@ export class TestReportValidatorProvider {
 
     const eco: boolean = get(data, 'eco.completed', false);
 
-    return normalStart1 && normalStart2 && angledStart &&
+    return normalStart1 && angledStart &&
       uphillStartDesignatedStart && hCodeSafetyQuestions && eco && controlledStop;
   }
 
@@ -608,7 +606,6 @@ export class TestReportValidatorProvider {
     const result: legalRequirementsLabels[] = [];
 
     !get(data, 'testRequirements.normalStart1', false) && result.push(legalRequirementsLabels.normalStart1);
-    !get(data, 'testRequirements.normalStart2', false) && result.push(legalRequirementsLabels.normalStart2);
     !get(data, 'testRequirements.angledStart', false) && result.push(legalRequirementsLabels.angledStart);
     !get(data, 'testRequirements.uphillStartDesignatedStart', false)
       && result.push(legalRequirementsLabels.uphillStartDesignatedStart);
@@ -629,7 +626,6 @@ export class TestReportValidatorProvider {
     const result: legalRequirementsLabels[] = [];
 
     !get(data, 'testRequirements.normalStart1', false) && result.push(legalRequirementsLabels.normalStart1);
-    !get(data, 'testRequirements.normalStart2', false) && result.push(legalRequirementsLabels.normalStart2);
     !get(data, 'testRequirements.angledStart', false) && result.push(legalRequirementsLabels.angledStart);
     !get(data, 'testRequirements.uphillStartDesignatedStart', false)
       && result.push(legalRequirementsLabels.uphillStartDesignatedStart);


### PR DESCRIPTION
## Description
- Reduces requirement for 2 normal stops for above cats

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
