### PR TITLE
Mes-7301: add rekey to manoeuvres categories

### DIFF
--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -241,6 +241,16 @@ export class TestOutcomeComponent implements OnInit {
       case TestCategory.F:
         this.navController.push(CAT_HOME_TEST.WAITING_ROOM_PAGE);
         break;
+      case TestCategory.C1EM:
+      case TestCategory.C1M:
+      case TestCategory.CEM:
+      case TestCategory.CM:
+      case TestCategory.D1EM:
+      case TestCategory.D1M:
+      case TestCategory.DEM:
+      case TestCategory.DM:
+        this.navController.push(MANOEUVRES_PAGE);
+        break;
     }
   }
 

--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -20,7 +20,7 @@ import {
   CAT_ADI_PART2,
   CAT_HOME_TEST,
   CAT_CPC,
-  MANOEUVRES_PAGE,
+  CAT_MANOEUVRERS,
 } from '../../../pages/page-names.constants';
 import { ModalEvent } from '../../../pages/journal/journal-rekey-modal/journal-rekey-modal.constants';
 import {
@@ -249,7 +249,7 @@ export class TestOutcomeComponent implements OnInit {
       case TestCategory.D1M:
       case TestCategory.DEM:
       case TestCategory.DM:
-        this.navController.push(MANOEUVRES_PAGE);
+        this.navController.push(CAT_MANOEUVRERS.MANOEUVRES_PAGE);
         break;
     }
   }
@@ -432,7 +432,7 @@ export class TestOutcomeComponent implements OnInit {
       case TestCategory.D1M:
       case TestCategory.DEM:
       case TestCategory.DM:
-        return MANOEUVRES_PAGE;
+        return CAT_MANOEUVRERS.MANOEUVRES_PAGE;
     }
   }
 

--- a/src/pages/manoeuvres/__tests__/manoeuvres.spec.ts
+++ b/src/pages/manoeuvres/__tests__/manoeuvres.spec.ts
@@ -35,7 +35,7 @@ import {
   ManoeuvresViewPageSubmission,
 } from '../manoeuvres.actions';
 import { SendCurrentTest } from '../../../modules/tests/tests.actions';
-import { JOURNAL_PAGE } from '../../page-names.constants';
+import { CAT_MANOEUVRERS, JOURNAL_PAGE } from '../../page-names.constants';
 
 describe('ManoeuvresPage', () => {
   let fixture: ComponentFixture<ManoeuvresPage>;
@@ -228,6 +228,7 @@ describe('ManoeuvresPage', () => {
         component.passCode = '1';
       });
       it('should dispatch the complete test action and pop to journal', async () => {
+        component.isRekey = false;
         component.activityCodeSelected = { activityCode: '1' } as ActivityCodeModel;
         await component.onTestDetailsConfirm();
         expect(store$.dispatch).toHaveBeenCalledWith(new ManoeuvresViewPageSubmission());
@@ -236,6 +237,7 @@ describe('ManoeuvresPage', () => {
         expect(navController.popTo).toHaveBeenCalled();
       });
       it('should remove previously selected value if changed from pass and pop to journal', async () => {
+        component.isRekey = false;
         component.activityCodeSelected = { activityCode: '2' } as ActivityCodeModel;
         await component.onTestDetailsConfirm();
         expect(store$.dispatch).toHaveBeenCalledWith(new ManoeuvresViewPageSubmission());
@@ -244,6 +246,15 @@ describe('ManoeuvresPage', () => {
         expect(store$.dispatch).toHaveBeenCalledWith(new SendCurrentTest());
         expect(navController.getViews).toHaveBeenCalled();
         expect(navController.popTo).toHaveBeenCalled();
+      });
+      it('should not submit results if rekey and should nav to rekey-reason screen', async () => {
+        component.isRekey = true;
+        component.activityCodeSelected = { activityCode: '2' } as ActivityCodeModel;
+        await component.onTestDetailsConfirm();
+        expect(store$.dispatch).toHaveBeenCalledWith(new PassCertificateNumberChanged(null));
+        expect(store$.dispatch).toHaveBeenCalledWith(new ClearGearboxCategory());
+        expect(store$.dispatch).not.toHaveBeenCalledWith(new SendCurrentTest());
+        expect(navController.push).toHaveBeenCalledWith(CAT_MANOEUVRERS.REKEY_REASON_PAGE);
       });
     });
   });

--- a/src/pages/manoeuvres/manoeuvres.html
+++ b/src/pages/manoeuvres/manoeuvres.html
@@ -31,9 +31,12 @@
                     <ion-col col-80 no-padding class="decrease-spacing">
                         <div>
                             <ul>
-                                <li *ngFor="let exercise of exercises; index as i;">
-                                    <p id="exercise-text-{{i}}">{{exercise}}</p>
+                                <li>
+                                    <p id="exercise-text-manoeuvre">Manoeuvre</p>
                                 </li>
+                              <li *ngIf="displayUncouple">
+                                <p id="exercise-text-uncouple">Uncouple/Recouple</p>
+                              </li>
                             </ul>
                         </div>
                     </ion-col>

--- a/src/pages/manoeuvres/manoeuvres.ts
+++ b/src/pages/manoeuvres/manoeuvres.ts
@@ -79,7 +79,7 @@ export class ManoeuvresPage implements OnInit {
   public activityCodeSelected: ActivityCodeModel;
   private testOutcome: string;
   private candidateName: string;
-  private isRekey: boolean;
+  isRekey: boolean;
   candidateButton = (): void => {};
 
   constructor(

--- a/src/pages/manoeuvres/manoeuvres.ts
+++ b/src/pages/manoeuvres/manoeuvres.ts
@@ -45,6 +45,8 @@ import {
   ManoeuvresViewPageSubmission,
 } from './manoeuvres.actions';
 import { SendCurrentTest } from '../../modules/tests/tests.actions';
+import { getRekeyIndicator } from '../../modules/tests/rekey/rekey.reducer';
+import { isRekey } from '../../modules/tests/rekey/rekey.selector';
 
 interface ManoeuvresPageState {
   candidateName$: Observable<string>;
@@ -55,6 +57,7 @@ interface ManoeuvresPageState {
   testCategory$: Observable<TestCategory>;
   testOutcomeText$: Observable<string>;
   activityCode$: Observable<ActivityCodeModel>;
+  isRekey$: Observable<boolean>;
 }
 
 @IonicPage()
@@ -76,6 +79,7 @@ export class ManoeuvresPage implements OnInit {
   public activityCodeSelected: ActivityCodeModel;
   private testOutcome: string;
   private candidateName: string;
+  private isRekey: boolean;
   candidateButton = (): void => {};
 
   constructor(
@@ -94,6 +98,10 @@ export class ManoeuvresPage implements OnInit {
     );
 
     this.pageState = {
+      isRekey$: currentTest$.pipe(
+        select(getRekeyIndicator),
+        select(isRekey),
+      ),
       candidateName$: currentTest$.pipe(
         select(getJournalData),
         select(getCandidate),
@@ -131,7 +139,7 @@ export class ManoeuvresPage implements OnInit {
       ),
     };
 
-    const { activityCode$, testCategory$, testOutcomeText$, candidateUntitledName$ } = this.pageState;
+    const { isRekey$, activityCode$, testCategory$, testOutcomeText$, candidateUntitledName$ } = this.pageState;
 
     this.merged$ = merge(
       testCategory$.pipe(
@@ -144,6 +152,7 @@ export class ManoeuvresPage implements OnInit {
       candidateUntitledName$.pipe(tap(value => this.candidateName = value)),
       activityCode$.pipe(tap(value => this.activityCodeSelected = value)),
     );
+    isRekey$.pipe(tap(value => this.isRekey = value));
   }
 
   ionViewDidEnter(): void {
@@ -188,6 +197,7 @@ export class ManoeuvresPage implements OnInit {
   }
 
   async onSubmit(): Promise<void> {
+    console.log('rekey', this.isRekey);
     if (this.isFormValid()) {
       await this.showCompleteModal();
     }

--- a/src/pages/page-names.constants.ts
+++ b/src/pages/page-names.constants.ts
@@ -181,6 +181,7 @@ export const CAT_CPC: BasePageNames = {
 };
 
 export const CAT_MANOEUVRERS: BasePageNames = {
+  MANOEUVRES_PAGE,
   REKEY_UPLOAD_OUTCOME_PAGE,
   REKEY_REASON_PAGE: 'RekeyReasonCatManoeuvresPage',
 };
@@ -191,6 +192,7 @@ type BasePageNames = {
 
 export type PageNameKeys =
   'REKEY_UPLOAD_OUTCOME_PAGE' |
+  'MANOEUVRES_PAGE' |
   'BACK_TO_OFFICE_PAGE' |
   'COMMUNICATION_PAGE' |
   'DEBRIEF_PAGE' |

--- a/src/pages/page-names.constants.ts
+++ b/src/pages/page-names.constants.ts
@@ -180,6 +180,11 @@ export const CAT_CPC: BasePageNames = {
   POST_DEBRIEF_HOLDING_PAGE: 'PostDebriefHoldingCatCPCPage',
 };
 
+export const CAT_MANOEUVRERS: BasePageNames = {
+  REKEY_UPLOAD_OUTCOME_PAGE,
+  REKEY_REASON_PAGE: 'RekeyReasonCatManoeuvresPage',
+};
+
 type BasePageNames = {
   [key in PageNameKeys]?: string;
 };

--- a/src/pages/rekey-reason/cat-manoeuvres/__tests__/rekey-reason.cat-manoeuvres.page.spec.ts
+++ b/src/pages/rekey-reason/cat-manoeuvres/__tests__/rekey-reason.cat-manoeuvres.page.spec.ts
@@ -1,0 +1,248 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { IonicModule, NavController, Platform, Config, LoadingController, ModalController } from 'ionic-angular';
+import { NavControllerMock, PlatformMock, ConfigMock, LoadingControllerMock, ModalControllerMock } from 'ionic-mocks';
+import { RekeyReasonCatManoeuvresPage } from '../rekey-reason.cat-manoeuvres.page';
+import { AuthenticationProvider } from '../../../../providers/authentication/authentication';
+import { AuthenticationProviderMock } from '../../../../providers/authentication/__mocks__/authentication.mock';
+import { Store, StoreModule } from '@ngrx/store';
+import { AppModule } from '../../../../app/app.module';
+import { RekeyReasonModel } from '../../rekey-reason.model';
+import { getUploadStatus } from '../../rekey-reason.selector';
+import {
+  SendCurrentTest,
+  SendCurrentTestSuccess,
+  SendCurrentTestFailure,
+} from '../../../../modules/tests/tests.actions';
+import { rekeyReasonReducer } from '../../rekey-reason.reducer';
+import { AppInfoModel } from '../../../../modules/app-info/app-info.model';
+import {
+  IpadIssueSelected,
+  OtherSelected,
+  OtherReasonUpdated,
+  TransferSelected,
+  IpadIssueLostSelected,
+} from '../../../../modules/tests/rekey-reason/rekey-reason.actions';
+import { By } from '@angular/platform-browser';
+import { SetExaminerConducted } from '../../../../modules/tests/examiner-conducted/examiner-conducted.actions';
+import { MockComponent } from 'ng-mocks';
+import { FindUserProvider } from '../../../../providers/find-user/find-user';
+import { FindUserProviderMock } from '../../../../providers/find-user/__mocks__/find-user.mock';
+import { IpadIssueComponent } from '../../components/ipad-issue/ipad-issue';
+import { TransferComponent } from '../../components/transfer/transfer';
+import { OtherReasonComponent } from '../../components/other-reason/other-reason';
+import { NavigationStateProvider } from '../../../../providers/navigation-state/navigation-state';
+import { NavigationStateProviderMock } from '../../../../providers/navigation-state/__mocks__/navigation-state.mock';
+import { configureTestSuite } from 'ng-bullet';
+import { CAT_MANOEUVRERS } from '../../../page-names.constants';
+
+describe('RekeyReasonCatManoeuvresPage', () => {
+  let fixture: ComponentFixture<RekeyReasonCatManoeuvresPage>;
+  let component: RekeyReasonCatManoeuvresPage;
+  let loadingController: LoadingController;
+  let navContoller: NavController;
+  let modalController: ModalController;
+  let store$: Store<AppInfoModel>;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        RekeyReasonCatManoeuvresPage,
+        MockComponent(IpadIssueComponent),
+        MockComponent(TransferComponent),
+        MockComponent(OtherReasonComponent),
+      ],
+      imports: [
+        IonicModule,
+        StoreModule.forRoot({
+          journal: () => ({
+            isLoading: false,
+            lastRefreshed: null,
+            slots: {},
+            selectedDate: '',
+            examiner: {
+              staffNumber: '1234567',
+            },
+          }),
+          tests: () => ({
+            currentTest: {
+              slotId: '123',
+            },
+            testStatus: {},
+            startedTests: {
+              123: {
+                vehicleDetails: {},
+                accompaniment: {},
+                testData: {
+                  dangerousFaults: {},
+                  drivingFaults: {},
+                  manoeuvres: {},
+                  seriousFaults: {},
+                  testRequirements: {},
+                  ETA: {},
+                  eco: {},
+                  vehicleChecks: {
+                    showMeQuestion: {
+                      code: 'S3',
+                      description: '',
+                      outcome: '',
+                    },
+                    tellMeQuestion: {
+                      code: '',
+                      description: '',
+                      outcome: '',
+                    },
+                  },
+                  eyesightTest: {},
+                },
+                activityCode: '28',
+                journalData: {
+                  candidate: {
+                    candidateName: 'Joe Bloggs',
+                    driverNumber: '123',
+                  },
+                },
+                rekey: false,
+              },
+            },
+          }),
+          rekeyReason: rekeyReasonReducer,
+        }),
+        AppModule,
+      ],
+      providers: [
+        { provide: NavController, useFactory: () => NavControllerMock.instance() },
+        { provide: Platform, useFactory: () => PlatformMock.instance() },
+        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
+        { provide: Config, useFactory: () => ConfigMock.instance() },
+        { provide: LoadingController, useFactory: () => LoadingControllerMock.instance() },
+        { provide: ModalController, useFactory: () => ModalControllerMock.instance() },
+        { provide: FindUserProvider, useClass: FindUserProviderMock },
+        { provide: NavigationStateProvider, useClass: NavigationStateProviderMock },
+        Store,
+      ],
+    });
+  });
+
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(RekeyReasonCatManoeuvresPage);
+    component = fixture.componentInstance;
+    loadingController = TestBed.get(LoadingController);
+    navContoller = TestBed.get(NavController);
+    modalController = TestBed.get(ModalController);
+    store$ = TestBed.get(Store);
+  }));
+
+  describe('Class', () => {
+    it('should create', () => {
+      expect(component).toBeDefined();
+    });
+
+    describe('handleLoadingUI', () => {
+      it('should setup a loading spinner when isUploading is set to true', () => {
+        component.handleLoadingUI(true);
+
+        expect(component.loadingSpinner).not.toBeNull;
+      });
+      it('should remove the loading spinner when isUploading is set to false', () => {
+        component.loadingSpinner = loadingController.create();
+
+        component.handleLoadingUI(false);
+
+        expect(component.loadingSpinner).toBeNull();
+      });
+    });
+
+    describe('onShowUploadRekeyModal', () => {
+      const options = { cssClass: 'mes-modal-alert text-zoom-regular' };
+      it('should display an upload modal', () => {
+        component.onShowUploadRekeyModal();
+        expect(modalController.create).toHaveBeenCalledWith('UploadRekeyModal', { retryMode: false }, options);
+      });
+      it('should display an upload modal in retry mode', () => {
+        component.onShowUploadRekeyModal(true);
+        expect(modalController.create).toHaveBeenCalledWith('UploadRekeyModal', { retryMode: true }, options);
+      });
+    });
+
+    describe('handleUploadOutcome', () => {
+      beforeEach(() => {
+        spyOn(component, 'handleLoadingUI');
+        spyOn(component, 'onShowUploadRekeyModal');
+      });
+
+      it('should display the loading spiner when an upload is in progress', () => {
+        const action = new SendCurrentTest();
+        const result: RekeyReasonModel = rekeyReasonReducer(null, action);
+        const uploadStatus = getUploadStatus(result);
+
+        component.handleUploadOutcome(uploadStatus);
+
+        expect(component.handleLoadingUI).toHaveBeenCalledWith(true);
+      });
+      it('should display the retry modal when an upload fails', () => {
+        const action = new SendCurrentTestFailure(false);
+        const result: RekeyReasonModel = rekeyReasonReducer(null, action);
+        const uploadStatus = getUploadStatus(result);
+
+        component.handleUploadOutcome(uploadStatus);
+
+        expect(component.handleLoadingUI).toHaveBeenCalledWith(false);
+        expect(component.onShowUploadRekeyModal).toHaveBeenCalledWith(true);
+
+      });
+      it('should navigate to the next page and not display the retry modal when an upload is a duplicate', () => {
+        const action = new SendCurrentTestFailure(true);
+        const result: RekeyReasonModel = rekeyReasonReducer(null, action);
+        const uploadStatus = getUploadStatus(result);
+
+        component.handleUploadOutcome(uploadStatus);
+
+        expect(component.handleLoadingUI).toHaveBeenCalledWith(false);
+        expect(navContoller.push).toHaveBeenCalledWith(CAT_MANOEUVRERS.REKEY_UPLOAD_OUTCOME_PAGE);
+        expect(component.onShowUploadRekeyModal).not.toHaveBeenCalled();
+
+      });
+      it('should navigate to next page and not display the retry modal when an upload succeeds', () => {
+        const action = new SendCurrentTestSuccess();
+        const result: RekeyReasonModel = rekeyReasonReducer(null, action);
+        const uploadStatus = getUploadStatus(result);
+
+        component.handleUploadOutcome(uploadStatus);
+
+        expect(component.handleLoadingUI).toHaveBeenCalledWith(false);
+        expect(navContoller.push).toHaveBeenCalledWith(CAT_MANOEUVRERS.REKEY_UPLOAD_OUTCOME_PAGE);
+        expect(component.onShowUploadRekeyModal).not.toHaveBeenCalled();
+      });
+    });
+  });
+  describe('DOM', () => {
+
+    it('should pass the ipad issue values to the ipad issue subcomponent', () => {
+      store$.dispatch(new IpadIssueSelected(true));
+      store$.dispatch(new IpadIssueLostSelected());
+      fixture.detectChanges();
+      const ipadIssueElement = fixture.debugElement.query(By.css('ipad-issue'))
+        .componentInstance as IpadIssueComponent;
+      expect(ipadIssueElement.selected).toEqual(true);
+      expect(ipadIssueElement.lost).toEqual(true);
+    });
+    it('should pass the transfer values to the transfer subcomponent', () => {
+      store$.dispatch(new TransferSelected(true));
+      store$.dispatch(new SetExaminerConducted(123));
+      fixture.detectChanges();
+      const transferElement = fixture.debugElement.query(By.css('transfer'))
+        .componentInstance as TransferComponent;
+      expect(transferElement.selected).toEqual(true);
+      expect(transferElement.staffNumber).toEqual(123);
+    });
+    it('should pass the other reason values to the reason subcomponent', () => {
+      store$.dispatch(new OtherSelected(true));
+      store$.dispatch(new OtherReasonUpdated('Reason text'));
+      fixture.detectChanges();
+      const otherReasonElement = fixture.debugElement.query(By.css('other-reason'))
+        .componentInstance as OtherReasonComponent;
+      expect(otherReasonElement.selected).toEqual(true);
+      expect(otherReasonElement.reason).toEqual('Reason text');
+    });
+  });
+});

--- a/src/pages/rekey-reason/cat-manoeuvres/rekey-reason.cat-manoeuvres.page.html
+++ b/src/pages/rekey-reason/cat-manoeuvres/rekey-reason.cat-manoeuvres.page.html
@@ -1,0 +1,48 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>Reason for rekey</ion-title>
+    <ion-buttons end>
+      <button ion-button (click)="onExitRekeyPressed()">
+        <span>Exit rekey</span>
+      </button>
+    </ion-buttons>
+  </ion-navbar>
+</ion-header>
+
+<ion-content no-bounce>
+  <ion-card no-padding>
+    <ion-card-header>
+      <h4>Reason for use</h4>
+    </ion-card-header>
+    <div [formGroup]="formGroup">
+      <ion-grid no-padding>
+        
+        <ipad-issue [formGroup]="formGroup" [selected]="(pageState.ipadIssue$ | async).selected" 
+          [technicalFault]="(pageState.ipadIssue$ | async).technicalFault"
+          [lost]="(pageState.ipadIssue$ | async).lost"
+          [stolen]="(pageState.ipadIssue$ | async).stolen"
+          [broken]="(pageState.ipadIssue$ | async).broken"
+          (selectedChange)="ipadIssueSelected($event)"
+          (technicalFaultChange)="ipadIssueTechnicalFaultChanged($event)"
+          (lostChange)="ipadIssueLostChanged($event)"
+          (stolenChange)="ipadIssueStolenChanged($event)"
+          (brokenChange)="ipadIssueBrokenChanged($event)"></ipad-issue>
+
+        <transfer [formGroup]="formGroup" [selected]="(pageState.transfer$ | async).selected"
+          [staffNumber]="examinerConducted" [isStaffNumberInvalid]="isStaffNumberInvalid" 
+          (selectedChange)="transferSelected($event)" (staffNumberChange)="staffNumberChanged($event)"></transfer>
+
+        <other-reason [formGroup]="formGroup" [selected]="(pageState.other$ | async).selected" [reason]="(pageState.other$ | async).reason"
+          (selectedChange)="otherSelected($event)" (reasonChange)="otherReasonChanged($event)"></other-reason>
+
+      </ion-grid>
+    </div>
+  </ion-card>
+</ion-content>
+<ion-footer>
+  <ion-row class="mes-full-width-card box-shadow">
+    <button type="submit" class="mes-primary-button" ion-button (click)="onUploadPressed()">
+      <h3>Upload rekeyed test</h3>
+    </button>
+  </ion-row>
+</ion-footer>

--- a/src/pages/rekey-reason/cat-manoeuvres/rekey-reason.cat-manoeuvres.page.html
+++ b/src/pages/rekey-reason/cat-manoeuvres/rekey-reason.cat-manoeuvres.page.html
@@ -16,8 +16,8 @@
     </ion-card-header>
     <div [formGroup]="formGroup">
       <ion-grid no-padding>
-        
-        <ipad-issue [formGroup]="formGroup" [selected]="(pageState.ipadIssue$ | async).selected" 
+
+        <ipad-issue [formGroup]="formGroup" [selected]="(pageState.ipadIssue$ | async).selected"
           [technicalFault]="(pageState.ipadIssue$ | async).technicalFault"
           [lost]="(pageState.ipadIssue$ | async).lost"
           [stolen]="(pageState.ipadIssue$ | async).stolen"
@@ -29,7 +29,7 @@
           (brokenChange)="ipadIssueBrokenChanged($event)"></ipad-issue>
 
         <transfer [formGroup]="formGroup" [selected]="(pageState.transfer$ | async).selected"
-          [staffNumber]="examinerConducted" [isStaffNumberInvalid]="isStaffNumberInvalid" 
+          [staffNumber]="examinerConducted" [isStaffNumberInvalid]="isStaffNumberInvalid"
           (selectedChange)="transferSelected($event)" (staffNumberChange)="staffNumberChanged($event)"></transfer>
 
         <other-reason [formGroup]="formGroup" [selected]="(pageState.other$ | async).selected" [reason]="(pageState.other$ | async).reason"

--- a/src/pages/rekey-reason/cat-manoeuvres/rekey-reason.cat-manoeuvres.page.module.ts
+++ b/src/pages/rekey-reason/cat-manoeuvres/rekey-reason.cat-manoeuvres.page.module.ts
@@ -1,0 +1,34 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { EffectsModule } from '@ngrx/effects';
+import { ComponentsModule } from '../../../components/common/common-components.module';
+import { RekeyReasonCatManoeuvresPage } from './rekey-reason.cat-manoeuvres.page';
+import { RekeyReasonComponentsModule } from '../components/rekey-reason.components.module';
+import { RekeyReasonAnalyticsEffects } from '../rekey-reason.analytics.effects';
+import { StoreModule } from '@ngrx/store';
+import { RekeyReasonEffects } from '../rekey-reason.effects';
+import { DirectivesModule } from '../../../directives/directives.module';
+import { FindUserProvider } from '../../../providers/find-user/find-user';
+import { rekeyReasonReducer } from '../rekey-reason.reducer';
+
+@NgModule({
+  declarations: [
+    RekeyReasonCatManoeuvresPage,
+  ],
+  imports: [
+    IonicPageModule.forChild(RekeyReasonCatManoeuvresPage),
+    StoreModule.forFeature('rekeyReason', rekeyReasonReducer),
+    EffectsModule.forFeature([
+      RekeyReasonAnalyticsEffects,
+      RekeyReasonEffects,
+    ]),
+    DirectivesModule,
+    ComponentsModule,
+    RekeyReasonComponentsModule,
+  ],
+  providers: [
+    FindUserProvider,
+  ],
+})
+
+export class RekeyReasonCatManoeuvresPageModule { }

--- a/src/pages/rekey-reason/cat-manoeuvres/rekey-reason.cat-manoeuvres.page.ts
+++ b/src/pages/rekey-reason/cat-manoeuvres/rekey-reason.cat-manoeuvres.page.ts
@@ -1,0 +1,297 @@
+import { Component } from '@angular/core';
+import {
+  IonicPage,
+  NavController,
+  Platform,
+  Modal,
+  ModalController,
+  LoadingController,
+  Loading,
+} from 'ionic-angular';
+import { AuthenticationProvider } from '../../../providers/authentication/authentication';
+import { BasePageComponent } from '../../../shared/classes/base-page';
+import { Store, select } from '@ngrx/store';
+import { StoreModel } from '../../../shared/models/store.model';
+import {
+  RekeyReasonViewDidEnter,
+  ValidateTransferRekey,
+  ResetStaffNumberValidationError,
+} from '../rekey-reason.actions';
+import { UploadRekeyModalEvent } from '../components/upload-rekey-modal/upload-rekey-modal.constants';
+import { Observable, Subscription, merge } from 'rxjs';
+import {
+  IpadIssueSelected,
+  IpadIssueTechFaultSelected,
+  IpadIssueLostSelected,
+  IpadIssueStolenSelected,
+  IpadIssueBrokenSelected,
+  OtherSelected,
+  OtherReasonUpdated,
+  TransferSelected,
+} from '../../../modules/tests/rekey-reason/rekey-reason.actions';
+import { REKEY_SEARCH_PAGE, JOURNAL_PAGE, CAT_MANOEUVRERS } from '../../page-names.constants';
+import { getRekeyReasonState } from '../rekey-reason.reducer';
+import { map } from 'rxjs/operators';
+import { SendCurrentTest } from '../../../modules/tests/tests.actions';
+import { RekeyReasonUploadModel } from '../rekey-reason.model';
+import { getUploadStatus } from '../rekey-reason.selector';
+import { FormGroup } from '@angular/forms';
+import {
+  getReasonForRekey,
+  getRekeyIpadIssue,
+  getRekeyTransfer,
+  getRekeyOther,
+} from '../../../modules/tests/rekey-reason/rekey-reason.selector';
+import { getTests } from '../../../modules/tests/tests.reducer';
+import { getCurrentTest } from '../../../modules/tests/tests.selector';
+import { IpadIssue, Transfer, Other } from '@dvsa/mes-test-schema/categories/common';
+import { EndRekey } from '../../../modules/tests/rekey/rekey.actions';
+import { ExitRekeyModalEvent } from '../components/exit-rekey-modal/exit-rekey-modal.constants';
+import { SetExaminerConducted } from '../../../modules/tests/examiner-conducted/examiner-conducted.actions';
+import { SetRekeyDate } from '../../../modules/tests/rekey-date/rekey-date.actions';
+import { getExaminerKeyed } from '../../../modules/tests/examiner-keyed/examiner-keyed.reducer';
+import { getExaminerConducted } from '../../../modules/tests/examiner-conducted/examiner-conducted.reducer';
+
+interface RekeyReasonPageState {
+  uploadStatus$: Observable<RekeyReasonUploadModel>;
+  ipadIssue$: Observable<IpadIssue>;
+  transfer$: Observable<Transfer>;
+  other$: Observable<Other>;
+  examinerConducted$: Observable<number>;
+  examinerKeyed$: Observable<number>;
+}
+
+@IonicPage()
+@Component({
+  selector: '.rekey-reason-cat-manoeuvres-page',
+  templateUrl: 'rekey-reason.cat-manoeuvres.page.html',
+})
+export class RekeyReasonCatManoeuvresPage extends BasePageComponent {
+
+  formGroup: FormGroup;
+
+  pageState: RekeyReasonPageState;
+  subscription: Subscription = Subscription.EMPTY;
+
+  isUploading: boolean = false;
+  hasUploaded: boolean = false;
+  hasTriedUploading: boolean = false;
+  isStaffNumberInvalid: boolean = false;
+  isTransferSelected: boolean = false;
+
+  modal: Modal;
+  loadingSpinner: Loading;
+
+  reasonCharsRemaining: number = null;
+
+  examinerConducted: number = null;
+  examinerKeyed: number = null;
+
+  constructor(
+    public navController: NavController,
+    public platform: Platform,
+    public authenticationProvider: AuthenticationProvider,
+    public store$: Store<StoreModel>,
+    private modalController: ModalController,
+    public loadingController: LoadingController,
+  ) {
+    super(platform, navController, authenticationProvider);
+    this.formGroup = new FormGroup({});
+  }
+
+  ngOnInit(): void {
+    const currentTest$ = this.store$.pipe(
+      select(getTests),
+      select(getCurrentTest),
+    );
+
+    this.pageState = {
+      uploadStatus$: this.store$.pipe(
+        select(getRekeyReasonState),
+        select(getUploadStatus),
+      ),
+      ipadIssue$: currentTest$.pipe(
+        select(getReasonForRekey),
+        select(getRekeyIpadIssue),
+      ),
+      transfer$: currentTest$.pipe(
+        select(getReasonForRekey),
+        select(getRekeyTransfer),
+      ),
+      other$: currentTest$.pipe(
+        select(getReasonForRekey),
+        select(getRekeyOther),
+      ),
+      examinerConducted$: currentTest$.pipe(
+        select(getExaminerConducted),
+      ),
+      examinerKeyed$: currentTest$.pipe(
+        select(getExaminerKeyed),
+      ),
+    };
+
+    const { uploadStatus$, examinerConducted$, examinerKeyed$, transfer$ } = this.pageState;
+
+    this.subscription = merge(
+      uploadStatus$.pipe(map(this.handleUploadOutcome)),
+      examinerConducted$.pipe(map(val => this.examinerConducted = val)),
+      examinerKeyed$.pipe(map(val => this.examinerKeyed = val)),
+      transfer$.pipe(map(transfer => this.isTransferSelected = transfer.selected)),
+    ).subscribe();
+  }
+
+  ionViewDidEnter() {
+    this.store$.dispatch(new RekeyReasonViewDidEnter());
+  }
+
+  ionViewDidLeave(): void {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+  }
+
+  onUploadPressed = (): void => {
+    if (this.isFormValid()) {
+      this.onShowUploadRekeyModal();
+    }
+  }
+
+  onShowUploadRekeyModal = (retryMode: boolean = false): void => {
+    const options = { cssClass: 'mes-modal-alert text-zoom-regular' };
+    this.modal = this.modalController.create('UploadRekeyModal', { retryMode }, options);
+    this.modal.onDidDismiss(this.onUploadRekeyModalDismiss);
+    this.modal.present();
+  }
+
+  onUploadRekeyModalDismiss = (event: UploadRekeyModalEvent): void => {
+    switch (event) {
+      case UploadRekeyModalEvent.UPLOAD:
+        this.store$.dispatch(new SetRekeyDate());
+        if (this.isTransferSelected) {
+          this.store$.dispatch(new ValidateTransferRekey());
+        } else {
+          this.store$.dispatch(new SendCurrentTest());
+        }
+        break;
+    }
+  }
+
+  handleUploadOutcome = (uploadStatus: RekeyReasonUploadModel): void => {
+
+    this.handleLoadingUI(uploadStatus.isUploading);
+    this.isStaffNumberInvalid = uploadStatus.hasStaffNumberFailedValidation;
+
+    if (uploadStatus.hasUploadSucceeded || uploadStatus.isDuplicate) {
+      this.navController.push(CAT_MANOEUVRERS.REKEY_UPLOAD_OUTCOME_PAGE);
+      return;
+    }
+    if (uploadStatus.hasUploadFailed) {
+      this.onShowUploadRekeyModal(true);
+    }
+  }
+
+  handleLoadingUI = (isLoading: boolean): void => {
+    if (isLoading) {
+      if (!this.loadingSpinner) {
+        this.loadingSpinner = this.loadingController.create({
+          spinner: 'circles',
+          content: 'Uploading...',
+        });
+        this.loadingSpinner.present();
+      }
+      return;
+    }
+    if (this.loadingSpinner) {
+      this.loadingSpinner.dismiss();
+      this.loadingSpinner = null;
+    }
+  }
+
+  isFormValid() {
+    if (this.formGroup.valid) {
+      return true;
+    }
+    Object.keys(this.formGroup.controls).forEach((controlName) => {
+      if (this.formGroup.controls[controlName].invalid) {
+        this.formGroup.controls[controlName].markAsDirty();
+      }
+    });
+    return false;
+  }
+
+  ipadIssueSelected(checked: boolean) {
+    this.store$.dispatch(new IpadIssueSelected(checked));
+  }
+
+  ipadIssueTechnicalFaultChanged(selected: boolean) {
+    this.store$.dispatch(new IpadIssueTechFaultSelected());
+  }
+
+  ipadIssueLostChanged(selected: boolean) {
+    this.store$.dispatch(new IpadIssueLostSelected());
+  }
+
+  ipadIssueStolenChanged(selected: boolean) {
+    this.store$.dispatch(new IpadIssueStolenSelected());
+  }
+
+  ipadIssueBrokenChanged(selected: boolean) {
+    this.store$.dispatch(new IpadIssueBrokenSelected());
+  }
+
+  otherSelected(checked: boolean) {
+    this.store$.dispatch(new OtherSelected(checked));
+  }
+
+  otherReasonChanged(reason: string) {
+    this.store$.dispatch(new OtherReasonUpdated(reason));
+  }
+
+  transferSelected(isChecked: boolean) {
+    this.store$.dispatch(new TransferSelected(isChecked));
+    if (isChecked) {
+      this.store$.dispatch(new SetExaminerConducted(null));
+    } else {
+      this.store$.dispatch(new SetExaminerConducted(this.examinerKeyed)); // reset to current user
+      this.store$.dispatch(new ResetStaffNumberValidationError());
+    }
+  }
+
+  staffNumberChanged(staffNumber: number) {
+    if (this.isStaffNumberInvalid) {
+      this.store$.dispatch(new ResetStaffNumberValidationError());
+    }
+    this.store$.dispatch(new SetExaminerConducted(staffNumber));
+  }
+
+  exitRekey = (): void => {
+    const rekeySearchPage = this.navController.getViews().find(view => view.id === REKEY_SEARCH_PAGE);
+    const journalPage = this.navController.getViews().find(view => view.id === JOURNAL_PAGE);
+    if (rekeySearchPage) {
+      this.navController.popTo(rekeySearchPage);
+    } else {
+      this.navController.popTo(journalPage);
+    }
+    this.store$.dispatch(new EndRekey());
+  }
+
+  onExitRekeyPressed(): void {
+    this.showExitRekeyModal();
+  }
+
+  showExitRekeyModal(): void {
+    const options = { cssClass: 'mes-modal-alert text-zoom-regular' };
+    this.modal = this.modalController.create('ExitRekeyModal', {}, options);
+    this.modal.onDidDismiss(this.onExitRekeyModalDismiss);
+    this.modal.present();
+  }
+
+  onExitRekeyModalDismiss = (event: ExitRekeyModalEvent): void => {
+    switch (event) {
+      case ExitRekeyModalEvent.EXIT_REKEY:
+        this.exitRekey();
+        break;
+    }
+  }
+
+}


### PR DESCRIPTION
## Description

add rekey to manoeuvres categories

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional
<img width="590" alt="Screenshot 2021-10-19 at 09 26 49" src="https://user-images.githubusercontent.com/48550267/137877050-8b04f298-dbf2-4824-919f-3c8cd8a47a1c.png">
<img width="620" alt="Screenshot 2021-10-19 at 09 54 07" src="https://user-images.githubusercontent.com/48550267/137877053-0debe8f7-7ef0-4805-89ad-f8fb24889ed5.png">
<img width="606" alt="Screenshot 2021-10-19 at 09 54 17" src="https://user-images.githubusercontent.com/48550267/137877057-2c51bb99-3455-4a73-a47c-63fc1711488b.png">
<img width="619" alt="Screenshot 2021-10-19 at 09 54 25" src="https://user-images.githubusercontent.com/48550267/137877061-704a492f-ca0c-45b2-b529-63c10b14750f.png">
)
