### PR TITLE
MES-7361 change max fault count for C & D

### DIFF
--- a/src/pages/office/cat-c/office.cat-c.page.ts
+++ b/src/pages/office/cat-c/office.cat-c.page.ts
@@ -217,7 +217,7 @@ export class OfficeCatCPage extends BasePageComponent {
   drivingFaultCtrl: string = 'drivingFaultCtrl';
   seriousFaultCtrl: string = 'seriousFaultCtrl';
   dangerousFaultCtrl: string = 'dangerousFaultCtrl';
-  static readonly maxFaultCount = 15;
+  static readonly maxFaultCount = 12;
 
   weatherConditions: WeatherConditionSelection[];
   activityCodeOptions: ActivityCodeModel[];

--- a/src/pages/office/cat-d/office.cat-d.page.ts
+++ b/src/pages/office/cat-d/office.cat-d.page.ts
@@ -222,7 +222,7 @@ export class OfficeCatDPage extends BasePageComponent {
   drivingFaultCtrl: string = 'drivingFaultCtrl';
   seriousFaultCtrl: string = 'seriousFaultCtrl';
   dangerousFaultCtrl: string = 'dangerousFaultCtrl';
-  static readonly maxFaultCount = 15;
+  static readonly maxFaultCount = 12;
 
   weatherConditions: WeatherConditionSelection[];
   activityCodeOptions: ActivityCodeModel[];

--- a/src/providers/test-result/__mocks__/test-result-data.mock.ts
+++ b/src/providers/test-result/__mocks__/test-result-data.mock.ts
@@ -52,6 +52,24 @@ export const sixteenDrivingFaultsMock: TestData = {
   },
 };
 
+export const thirteenDrivingFaultsMock: TestData = {
+  drivingFaults: {
+    useOfMirrorsSignalling: 1,
+    useOfMirrorsChangeDirection: 1,
+    useOfMirrorsChangeSpeed: 1,
+    signalsNecessary: 1,
+    signalsCorrectly: 1,
+    signalsTimed: 1,
+    junctionsApproachSpeed: 1,
+    junctionsObservation: 1,
+    junctionsTurningRight: 1,
+    junctionsTurningLeft: 1,
+    junctionsCuttingCorners: 1,
+    controlsAccelerator: 1,
+    controlsClutch: 1,
+  },
+};
+
 export const adi2SevenDrivingFaultsWithDangerousMock: CatADI2UniqueTypes.TestData = {
   drivingFaults: adi2SevenDrivingFaultsMock.drivingFaults,
   dangerousFaults: {
@@ -70,6 +88,13 @@ export const sixteenDrivingFaultsWithDangerousMock: TestData = {
   },
 };
 
+export const thirteenDrivingFaultsWithDangerousMock: TestData = {
+  drivingFaults: thirteenDrivingFaultsMock.drivingFaults,
+  dangerousFaults: {
+    clearance: true,
+  },
+};
+
 export const adi2SevenDrivingFaultsWithSeriousMock: CatADI2UniqueTypes.TestData = {
   drivingFaults: adi2SevenDrivingFaultsMock.drivingFaults,
   seriousFaults: {
@@ -83,6 +108,13 @@ export const adi2SevenDrivingFaultsWithSeriousMock: CatADI2UniqueTypes.TestData 
 
 export const sixteenDrivingFaultsWithSeriousMock: TestData = {
   drivingFaults: sixteenDrivingFaultsMock.drivingFaults,
+  seriousFaults: {
+    positioningNormalDriving: true,
+  },
+};
+
+export const thirteenDrivingFaultsWithSeriousMock: TestData = {
+  drivingFaults: thirteenDrivingFaultsMock.drivingFaults,
   seriousFaults: {
     positioningNormalDriving: true,
   },
@@ -119,6 +151,23 @@ export const fifteenDrivingFaultsMock: TestData = {
   },
 };
 
+export const twelveDrivingFaultsMock: TestData = {
+  drivingFaults: {
+    useOfMirrorsSignalling: 1,
+    useOfMirrorsChangeDirection: 1,
+    useOfMirrorsChangeSpeed: 1,
+    signalsNecessary: 1,
+    signalsCorrectly: 1,
+    signalsTimed: 1,
+    junctionsApproachSpeed: 1,
+    junctionsObservation: 1,
+    junctionsTurningRight: 1,
+    junctionsTurningLeft: 1,
+    junctionsCuttingCorners: 1,
+    controlsAccelerator: 1,
+  },
+};
+
 export const adi2SixDrivingFaultsWithDangerousMock: CatADI2UniqueTypes.TestData = {
   drivingFaults: sixDrivingFaultsMock.drivingFaults,
   dangerousFaults: {
@@ -132,6 +181,13 @@ export const adi2SixDrivingFaultsWithDangerousMock: CatADI2UniqueTypes.TestData 
 
 export const fifteenDrivingFaultsWithDangerousMock: TestData = {
   drivingFaults: fifteenDrivingFaultsMock.drivingFaults,
+  dangerousFaults: {
+    positioningNormalDriving: true,
+  },
+};
+
+export const twelveDrivingFaultsWithDangerousMock: TestData = {
+  drivingFaults: twelveDrivingFaultsMock.drivingFaults,
   dangerousFaults: {
     positioningNormalDriving: true,
   },
@@ -166,6 +222,13 @@ export const adi2DangerousVehicleCheckFaultsMock: CatADI2UniqueTypes.TestData = 
 
 export const fifteenDrivingFaultsWithSeriousMock: TestData = {
   drivingFaults: fifteenDrivingFaultsMock.drivingFaults,
+  seriousFaults: {
+    positioningNormalDriving: true,
+  },
+};
+
+export const twelveDrivingFaultsWithSeriousMock: TestData = {
+  drivingFaults: twelveDrivingFaultsMock.drivingFaults,
   seriousFaults: {
     positioningNormalDriving: true,
   },

--- a/src/providers/test-result/__tests__/test-result.spec.ts
+++ b/src/providers/test-result/__tests__/test-result.spec.ts
@@ -8,9 +8,16 @@ import * as mocks from '../__mocks__/test-result-data.mock';
 
 describe('TestResultCalculatorProvider', () => {
 
-  const categories: TestCategory[] = [
+  const fifteenCategories: TestCategory[] = [
     TestCategory.B,
     TestCategory.BE,
+    TestCategory.F,
+    TestCategory.G,
+    TestCategory.H,
+    TestCategory.K,
+  ];
+
+  const twelveCategories: TestCategory[] = [
     TestCategory.C,
     TestCategory.C1,
     TestCategory.C1E,
@@ -19,11 +26,6 @@ describe('TestResultCalculatorProvider', () => {
     TestCategory.D1,
     TestCategory.DE,
     TestCategory.D1E,
-    TestCategory.F,
-    TestCategory.G,
-    TestCategory.H,
-    TestCategory.K,
-
   ];
 
   const adiCategories: TestCategory[] = [
@@ -31,7 +33,8 @@ describe('TestResultCalculatorProvider', () => {
   ];
 
   const allCategories: TestCategory[] = [
-    ...categories,
+    ...fifteenCategories,
+    ...twelveCategories,
     ...adiCategories,
   ];
 
@@ -52,7 +55,7 @@ describe('TestResultCalculatorProvider', () => {
 
   describe('calculateTestResult', () => {
     describe(`${allCategories.join(', ')}`, () => {
-      categories.forEach((cat) => {
+      allCategories.forEach((cat) => {
         it(`should return a Pass when there are no driving faults for a Cat ${cat} test`, (done) => {
           testResultProvider.calculateTestResult(cat, mocks.noFaultsMock).subscribe((result) => {
             expect(result).toBe(ActivityCodes.PASS);
@@ -127,8 +130,8 @@ describe('TestResultCalculatorProvider', () => {
       });
     });
 
-    describe(`${categories.join(', ')}`, () => {
-      categories.forEach((cat) => {
+    describe(`${fifteenCategories.join(', ')}`, () => {
+      fifteenCategories.forEach((cat) => {
         it(`should return a Fail when there are 16 driving faults for a Cat ${cat} test`, (done) => {
           testResultProvider.calculateTestResult(cat, mocks.sixteenDrivingFaultsMock).subscribe((result) => {
             expect(result).toBe(ActivityCodes.FAIL);
@@ -167,6 +170,53 @@ describe('TestResultCalculatorProvider', () => {
         });
         it(`should return a Pass when there are 15 driving faults for a Cat ${cat} test`, (done) => {
           testResultProvider.calculateTestResult(cat, mocks.fifteenDrivingFaultsMock).subscribe((result) => {
+            expect(result).toBe(ActivityCodes.PASS);
+            done();
+          });
+        });
+      });
+    });
+
+    describe(`${twelveCategories.join(', ')}`, () => {
+      twelveCategories.forEach((cat) => {
+        it(`should return a Fail when there are 13 driving faults for a Cat ${cat} test`, (done) => {
+          testResultProvider.calculateTestResult(cat, mocks.thirteenDrivingFaultsMock).subscribe((result) => {
+            expect(result).toBe(ActivityCodes.FAIL);
+            done();
+          });
+        });
+        it(`should return a Fail when there are 13 driving faults and a dangerous for a Cat ${cat} test`, (done) => {
+          testResultProvider.calculateTestResult(cat, mocks.thirteenDrivingFaultsWithDangerousMock)
+            .subscribe((result) => {
+              expect(result).toBe(ActivityCodes.FAIL);
+              done();
+            });
+        });
+        it(`should return a Fail when there are 13 driving faults and a serious fault for a Cat ${cat} test`,
+          (done) => {
+            testResultProvider.calculateTestResult(cat, mocks.thirteenDrivingFaultsWithSeriousMock)
+              .subscribe((result) => {
+                expect(result).toBe(ActivityCodes.FAIL);
+                done();
+              });
+          });
+        it(`should return a Fail when there are 12 driving faults and a dangerous for a Cat ${cat} test`, (done) => {
+          testResultProvider.calculateTestResult(cat, mocks.twelveDrivingFaultsWithDangerousMock)
+            .subscribe((result) => {
+              expect(result).toBe(ActivityCodes.FAIL);
+              done();
+            });
+        });
+        it(`should return a Fail when there are 12 driving faults and a serious fault for a Cat ${cat} test`,
+          (done) => {
+            testResultProvider.calculateTestResult(cat, mocks.twelveDrivingFaultsWithSeriousMock)
+              .subscribe((result) => {
+                expect(result).toBe(ActivityCodes.FAIL);
+                done();
+              });
+          });
+        it(`should return a Pass when there are 12 driving faults for a Cat ${cat} test`, (done) => {
+          testResultProvider.calculateTestResult(cat, mocks.twelveDrivingFaultsMock).subscribe((result) => {
             expect(result).toBe(ActivityCodes.PASS);
             done();
           });

--- a/src/providers/test-result/test-result.ts
+++ b/src/providers/test-result/test-result.ts
@@ -134,7 +134,7 @@ export class TestResultProvider {
       return of(ActivityCodes.FAIL);
     }
 
-    if (this.faultCountProvider.getDrivingFaultSumCount(category, testData) > 15) {
+    if (this.faultCountProvider.getDrivingFaultSumCount(category, testData) > 12) {
       return of(ActivityCodes.FAIL);
     }
 
@@ -193,7 +193,7 @@ export class TestResultProvider {
       return of(ActivityCodes.FAIL);
     }
 
-    if (this.faultCountProvider.getDrivingFaultSumCount(category, testData) > 15) {
+    if (this.faultCountProvider.getDrivingFaultSumCount(category, testData) > 12) {
       return of(ActivityCodes.FAIL);
     }
 


### PR DESCRIPTION
ammended fault count max from 15 to 12 for Cat C and Cat D (including sub categories)

## Description

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="601" alt="Screenshot 2021-10-19 at 15 05 11" src="https://user-images.githubusercontent.com/48550267/137936197-04af2d39-83ea-4ddd-9c32-937f69056b4a.png">
<img width="611" alt="Screenshot 2021-10-19 at 15 18 00" src="https://user-images.githubusercontent.com/48550267/137936200-38afabe6-f726-47ed-bce5-fe8ba82ce5c4.png">

